### PR TITLE
Fixing spurious 'FFFFFF' in serial numbers

### DIFF
--- a/src/f200-private.cpp
+++ b/src/f200-private.cpp
@@ -526,7 +526,7 @@ namespace rsimpl { namespace f200
     {
         std::vector<char> gvd(1024);
         get_gvd(device, mutex, 1024, gvd.data());
-        char ss[8];
+        unsigned char ss[8];
         memcpy(ss, gvd.data() + offset, 8);
         char formattedBuffer[64];
         if (offset == 96)


### PR DESCRIPTION
As described in issue #65 librealsense would sometimes return serial numbers containing the substring 'FFFFFF' and being six characters longer than usual aswell. Howerver, inspecting serial number with udevadm reveals those extra 'FF' should actually not be in there.

The cause was a `signed char` was passed to `sprintf` with the "%X" format specifier which expects unsigned values.

This change fixes this problem. I've tested live with a camera that has a serial number that get messed up.

I agree to the terms of the librealsense CLA.