### PR TITLE
Install headers on make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ EXAMPLES := $(addprefix bin/, $(notdir $(basename $(EXAMPLES))))
 all: examples $(EXAMPLES)
 
 install: library
+	install -m755 -d /usr/local/include/librealsense
+	cp -r include/librealsense/* /usr/local/include/librealsense
 	cp lib/librealsense.so /usr/local/lib
 	ldconfig
 


### PR DESCRIPTION
Besides the library itself, also install the header files on 'make
install'.

Rodrigo Chiossi
I agree to the terms of the librealsense CLA.