### PR TITLE
split pkg-config flags for USB in compile and link for building under…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ ifeq ($(uname_S),Darwin)
 BACKEND := LIBUVC
 endif
 
-LIBUSB_FLAGS := `pkg-config --cflags --libs libusb-1.0`
+LIBUSB_FLAGS := `pkg-config --cflags libusb-1.0`
+LIBUSB_LDFLAGS := `pkg-config --libs libusb-1.0`
 
 CFLAGS := -std=c11 -fPIC -pedantic -DRS_USE_$(BACKEND)_BACKEND $(LIBUSB_FLAGS) 
 CXXFLAGS := -std=c++11 -fPIC -pedantic -mssse3 -O3 -Wno-missing-field-initializers
@@ -73,7 +74,7 @@ bin/cpp-%: examples/cpp-%.cpp library
 
 # Rules for building the library itself
 lib/librealsense.so: prepare $(OBJECTS)
-	$(CXX) -std=c++11 -shared $(OBJECTS) $(LIBUSB_FLAGS) -o $@
+	$(CXX) -std=c++11 -shared $(OBJECTS) $(LIBUSB_LDFLAGS) -o $@
 
 lib/librealsense.a: prepare $(OBJECTS)
 	ar rvs $@ `find obj/ -name "*.o"`

--- a/src/libuvc/libuvc.h
+++ b/src/libuvc/libuvc.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <stdio.h> // FILE
 #include <errno.h>
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 #include "libuvc_config.h"
     
 /** UVC error types, based on libusb errors


### PR DESCRIPTION
Builds under OSX Yosemite with LLVM 6.1.0

Tested with libusb under MacPort and built with: PKG_CONFIG_PATH=/opt/local/lib/pkgconfig make