### PR TITLE
Mark utility functions as inline

### DIFF
--- a/include/librealsense/rs.hpp
+++ b/include/librealsense/rs.hpp
@@ -559,7 +559,7 @@ namespace rs
     }
 
     // Additional utilities
-    void apply_depth_control_preset(device * device, int preset) { rs_apply_depth_control_preset((rs_device *)device, preset); }
-    void apply_ivcam_preset(device * device, int preset) { rs_apply_ivcam_preset((rs_device *)device, preset); }
+    inline void apply_depth_control_preset(device * device, int preset) { rs_apply_depth_control_preset((rs_device *)device, preset); }
+    inline void apply_ivcam_preset(device * device, int preset) { rs_apply_ivcam_preset((rs_device *)device, preset); }
 }
 #endif


### PR DESCRIPTION
These two helper functions are defined in the header file, which causes linker errors if this header file is included in more than one place. The solution is to mark both functions as inline.