### PR TITLE
Casts to build with clang on OSX

### DIFF
--- a/src/libuvc/ctrl.c
+++ b/src/libuvc/ctrl.c
@@ -93,7 +93,7 @@ int uvc_get_ctrl(uvc_device_handle_t *devh, uint8_t unit, uint8_t ctrl, void *da
     REQ_TYPE_GET, req_code,
     ctrl << 8,
     unit << 8,
-    data,
+    (unsigned char *)data,
     len,
     0 /* timeout */);
 }
@@ -116,7 +116,7 @@ int uvc_set_ctrl(uvc_device_handle_t *devh, uint8_t unit, uint8_t ctrl, void *da
     REQ_TYPE_SET, UVC_SET_CUR,
     ctrl << 8,
     unit << 8,
-    data,
+    (unsigned char *)data,
     len,
     0 /* timeout */);
 }
@@ -126,7 +126,7 @@ uvc_error_t uvc_get_power_mode(uvc_device_handle_t *devh, enum uvc_device_power_
   uint8_t mode_char;
   uvc_error_t ret;
 
-  ret = libusb_control_transfer(
+  ret = (uvc_error_t)libusb_control_transfer(
     devh->usb_devh,
     REQ_TYPE_GET, req_code,
     UVC_VC_VIDEO_POWER_MODE_CONTROL << 8,
@@ -136,7 +136,7 @@ uvc_error_t uvc_get_power_mode(uvc_device_handle_t *devh, enum uvc_device_power_
     0);
 
   if (ret == 1) {
-    *mode = mode_char;
+    *mode = (uvc_device_power_mode)mode_char;
     return UVC_SUCCESS;
   } else {
     return ret;
@@ -147,7 +147,7 @@ uvc_error_t uvc_set_power_mode(uvc_device_handle_t *devh, enum uvc_device_power_
   uint8_t mode_char = mode;
   uvc_error_t ret;
 
-  ret = libusb_control_transfer(
+  ret = (uvc_error_t)libusb_control_transfer(
     devh->usb_devh,
     REQ_TYPE_SET, UVC_SET_CUR,
     UVC_VC_VIDEO_POWER_MODE_CONTROL << 8,

--- a/src/libuvc/ctrl.c
+++ b/src/libuvc/ctrl.c
@@ -136,7 +136,7 @@ uvc_error_t uvc_get_power_mode(uvc_device_handle_t *devh, enum uvc_device_power_
     0);
 
   if (ret == 1) {
-    *mode = (uvc_device_power_mode)mode_char;
+    *mode = (uvc_device_power_mode_t)mode_char;
     return UVC_SUCCESS;
   } else {
     return ret;

--- a/src/libuvc/dev.c
+++ b/src/libuvc/dev.c
@@ -796,7 +796,7 @@ uvc_error_t uvc_claim_if(uvc_device_handle_t *devh, int idx) {
   }
 
   UVC_EXIT(ret);
-  return (uvc_error)ret;
+  return (uvc_error_t)ret;
 }
 
 /** @internal
@@ -969,7 +969,7 @@ uvc_error_t uvc_parse_vc_input_terminal(uvc_device_t *dev,
   term = (uvc_input_terminal_t *)calloc(1, sizeof(*term));
 
   term->bTerminalID = block[3];
-  term->wTerminalType = (uvc_it_type)SW_TO_SHORT(&block[4]);
+  term->wTerminalType = (uvc_it_type_t)SW_TO_SHORT(&block[4]);
   term->wObjectiveFocalLengthMin = SW_TO_SHORT(&block[8]);
   term->wObjectiveFocalLengthMax = SW_TO_SHORT(&block[10]);
   term->wOcularFocalLength = SW_TO_SHORT(&block[12]);
@@ -1154,7 +1154,7 @@ uvc_error_t uvc_parse_vs_format_uncompressed(uvc_streaming_interface_t *stream_i
   uvc_format_desc_t *format = (uvc_format_desc_t *)calloc(1, sizeof(*format));
 
   format->parent = stream_if;
-  format->bDescriptorSubtype = (uvc_vs_desc_subtype)block[2];
+  format->bDescriptorSubtype = (uvc_vs_desc_subtype_t)block[2];
   format->bFormatIndex = block[3];
   //format->bmCapabilities = block[4];
   //format->bmFlags = block[5];
@@ -1184,7 +1184,7 @@ uvc_error_t uvc_parse_vs_frame_format(uvc_streaming_interface_t *stream_if,
   uvc_format_desc_t *format = (uvc_format_desc_t *)calloc(1, sizeof(*format));
 
   format->parent = stream_if;
-  format->bDescriptorSubtype = (uvc_vs_desc_subtype)block[2];
+  format->bDescriptorSubtype = (uvc_vs_desc_subtype_t)block[2];
   format->bFormatIndex = block[3];
   format->bNumFrameDescriptors = block[4];
   memcpy(format->guidFormat, &block[5], 16);
@@ -1214,7 +1214,7 @@ uvc_error_t uvc_parse_vs_format_mjpeg(uvc_streaming_interface_t *stream_if,
   uvc_format_desc_t *format = (uvc_format_desc_t *)calloc(1, sizeof(*format));
 
   format->parent = stream_if;
-  format->bDescriptorSubtype = (uvc_vs_desc_subtype)block[2];
+  format->bDescriptorSubtype = (uvc_vs_desc_subtype_t)block[2];
   format->bFormatIndex = block[3];
   memcpy(format->fourccFormat, "MJPG", 4);
   format->bmFlags = block[5];
@@ -1251,7 +1251,7 @@ uvc_error_t uvc_parse_vs_frame_frame(uvc_streaming_interface_t *stream_if,
 
   frame->parent = format;
 
-  frame->bDescriptorSubtype = (uvc_vs_desc_subtype)block[2];
+  frame->bDescriptorSubtype = (uvc_vs_desc_subtype_t)block[2];
   frame->bFrameIndex = block[3];
   frame->bmCapabilities = block[4];
   frame->wWidth = block[5] + (block[6] << 8);
@@ -1303,7 +1303,7 @@ uvc_error_t uvc_parse_vs_frame_uncompressed(uvc_streaming_interface_t *stream_if
 
   frame->parent = format;
 
-  frame->bDescriptorSubtype = (uvc_vs_desc_subtype)block[2];
+  frame->bDescriptorSubtype = (uvc_vs_desc_subtype_t)block[2];
   frame->bFrameIndex = block[3];
   frame->bmCapabilities = block[4];
   frame->wWidth = block[5] + (block[6] << 8);
@@ -1530,7 +1530,7 @@ void uvc_process_status_xfer(uvc_device_handle_t *devh, struct libusb_transfer *
       return;
     }
 
-    attribute = (uvc_status_attribute)transfer->buffer[4];
+    attribute = (uvc_status_attribute_t)transfer->buffer[4];
     data = transfer->buffer + 5;
     data_len = transfer->actual_length - 5;
     break;

--- a/src/libuvc/frame.c
+++ b/src/libuvc/frame.c
@@ -62,7 +62,7 @@ uvc_error_t uvc_ensure_frame_size(uvc_frame_t *frame, size_t need_bytes) {
  * @return New frame, or NULL on error
  */
 uvc_frame_t *uvc_allocate_frame(size_t data_bytes) {
-  uvc_frame_t *frame = malloc(sizeof(*frame));
+  uvc_frame_t *frame = (uvc_frame_t *)malloc(sizeof(*frame));
 
   if (!frame)
     return NULL;

--- a/src/libuvc/init.c
+++ b/src/libuvc/init.c
@@ -107,10 +107,10 @@ void *_uvc_handle_events(void *arg) {
  */
 uvc_error_t uvc_init(uvc_context_t **pctx, struct libusb_context *usb_ctx) {
   uvc_error_t ret = UVC_SUCCESS;
-  uvc_context_t *ctx = calloc(1, sizeof(*ctx));
+  uvc_context_t *ctx = (uvc_context_t *)calloc(1, sizeof(*ctx));
 
   if (usb_ctx == NULL) {
-    ret = libusb_init(&ctx->usb_ctx);
+    ret = (uvc_error_t)libusb_init(&ctx->usb_ctx);
     ctx->own_usb_ctx = 1;
     if (ret != UVC_SUCCESS) {
       free(ctx);

--- a/src/libuvc/libuvc.h
+++ b/src/libuvc/libuvc.h
@@ -51,7 +51,7 @@ typedef enum uvc_error {
 } uvc_error_t;
 
 /** VideoStreaming interface descriptor subtype (A.6) */
-enum uvc_vs_desc_subtype {
+typedef enum uvc_vs_desc_subtype {
   UVC_VS_UNDEFINED = 0x00,
   UVC_VS_INPUT_HEADER = 0x01,
   UVC_VS_OUTPUT_HEADER = 0x02,
@@ -66,7 +66,7 @@ enum uvc_vs_desc_subtype {
   UVC_VS_FORMAT_FRAME_BASED = 0x10,
   UVC_VS_FRAME_FRAME_BASED = 0x11,
   UVC_VS_FORMAT_STREAM_BASED = 0x12
-};
+} uvc_vs_desc_subtype_t;
 
 struct uvc_format_desc;
 struct uvc_frame_desc;
@@ -160,10 +160,10 @@ enum uvc_req_code {
   UVC_GET_DEF = 0x87
 };
 
-enum uvc_device_power_mode {
+typedef enum uvc_device_power_mode {
   UVC_VC_VIDEO_POWER_MODE_FULL = 0x000b,
   UVC_VC_VIDEO_POWER_MODE_DEVICE_DEPENDENT = 0x001b,
-};
+} uvc_device_power_mode_t;
 
 /** Camera terminal control selector (A.9.4) */
 enum uvc_ct_ctrl_selector {
@@ -221,11 +221,11 @@ enum uvc_term_type {
 };
 
 /** Input terminal type (B.2) */
-enum uvc_it_type {
+typedef enum uvc_it_type {
   UVC_ITT_VENDOR_SPECIFIC = 0x0200,
   UVC_ITT_CAMERA = 0x0201,
   UVC_ITT_MEDIA_TRANSPORT_INPUT = 0x0202
-};
+} uvc_it_type_t;
 
 /** Output terminal type (B.3) */
 enum uvc_ot_type {
@@ -321,12 +321,12 @@ enum uvc_status_class {
   UVC_STATUS_CLASS_CONTROL_PROCESSING = 0x12,
 };
 
-enum uvc_status_attribute {
+typedef enum uvc_status_attribute {
   UVC_STATUS_ATTRIBUTE_VALUE_CHANGE = 0x00,
   UVC_STATUS_ATTRIBUTE_INFO_CHANGE = 0x01,
   UVC_STATUS_ATTRIBUTE_FAILURE_CHANGE = 0x02,
   UVC_STATUS_ATTRIBUTE_UNKNOWN = 0xff
-};
+} uvc_status_attribute_t;
 
 /** A callback function to accept status updates
  * @ingroup device

--- a/src/libuvc/stream.c
+++ b/src/libuvc/stream.c
@@ -822,7 +822,7 @@ uvc_error_t uvc_stream_start(
 
     /* Set up the transfers */
     strmh->num_transfer_bufs = num_transfer_buffers;
-    strmh->transfers = (libusb_transfer **)malloc(sizeof(struct libusb_transfer *) * num_transfer_buffers);
+    strmh->transfers = (struct libusb_transfer **)malloc(sizeof(struct libusb_transfer *) * num_transfer_buffers);
     strmh->transfer_bufs = (uint8_t **)malloc(sizeof(uint8_t **) * num_transfer_buffers);
     for (transfer_id = 0; transfer_id < num_transfer_buffers; ++transfer_id)
     {
@@ -842,7 +842,7 @@ uvc_error_t uvc_stream_start(
   else
   {
     strmh->num_transfer_bufs = num_transfer_buffers;
-    strmh->transfers = (libusb_transfer **)malloc(sizeof(struct libusb_transfer *) * num_transfer_buffers);
+    strmh->transfers = (struct libusb_transfer **)malloc(sizeof(struct libusb_transfer *) * num_transfer_buffers);
     strmh->transfer_bufs = (uint8_t **)malloc(sizeof(uint8_t **) * num_transfer_buffers);
     for (transfer_id = 0; transfer_id < num_transfer_buffers; ++transfer_id)
     {


### PR DESCRIPTION
I needed to add the following casts to build with clang on OSX. Mainly malloc and error return type casting were necessary.