### PR TITLE
Modified rs_context singleton pattern to return instance

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -6,7 +6,7 @@
 #include "r200.h"
 #include "f200.h"
 
-rs_context::rs_context() : rs_context(0)
+rs_context::rs_context()
 {
     context = rsimpl::uvc::create_context();
 
@@ -26,18 +26,7 @@ rs_context::rs_context() : rs_context(0)
     }
 }
 
-// Enforce singleton semantics on rs_context
-
-bool rs_context::singleton_alive = false;
-
-rs_context::rs_context(int)
-{
-    if(singleton_alive) throw std::runtime_error("rs_context has singleton semantics, only one may exist at a time");
-    singleton_alive = true;
-}
-
 rs_context::~rs_context()
 {
-    assert(singleton_alive);
-    singleton_alive = false;
+
 }

--- a/src/context.h
+++ b/src/context.h
@@ -15,9 +15,6 @@ struct rs_context
 
                                                     rs_context();
                                                     ~rs_context();
-private:
-                                                    rs_context(int);
-    static bool                                     singleton_alive;
 };
 
 #endif

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -17,6 +17,8 @@ struct rs_error
     std::string args;
 };
 
+static rs_context * rs_context_instance;
+
 // This facility allows for translation of exceptions to rs_error structs at the API boundary
 namespace rsimpl
 {
@@ -45,7 +47,11 @@ namespace rsimpl
 rs_context * rs_create_context(int api_version, rs_error ** error) try
 {
     if (api_version != RS_API_VERSION) throw std::runtime_error("api version mismatch");
-    return new rs_context();
+    if (rs_context_instance == NULL)
+    {
+        rs_context_instance = new rs_context();
+    }
+    return rs_context_instance;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version)
 


### PR DESCRIPTION
Modified rs_context singleton pattern to return rs_context instance instead of throwing error.
This pull request is also to test if the changes pass the librealsense CI tests.