### PR TITLE
Let multiple users share ownership over rs_context object

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -15,9 +15,13 @@ struct rs_context
 
                                                     rs_context();
                                                     ~rs_context();
+
+    static rs_context*                              acquire_instance();
+    static void                                     release_instance();
 private:
-                                                    rs_context(int);
-    static bool                                     singleton_alive;
+    static int                                      ref_count;
+    static std::mutex                               instance_lock;
+    static rs_context*                              instance;
 };
 
 #endif

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -45,14 +45,14 @@ namespace rsimpl
 rs_context * rs_create_context(int api_version, rs_error ** error) try
 {
     if (api_version != RS_API_VERSION) throw std::runtime_error("api version mismatch");
-    return new rs_context();
+    return rs_context::acquire_instance();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version)
 
 void rs_delete_context(rs_context * context, rs_error ** error) try
 {
     VALIDATE_NOT_NULL(context);
-    delete context;
+    rs_context::release_instance();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, context)
 

--- a/unit-tests/unit-tests-common.h
+++ b/unit-tests/unit-tests-common.h
@@ -77,6 +77,8 @@ public:
         }
     }
 
+    bool operator == (const safe_context& other) const { return context == other.context; }
+
     operator rs_context * () const { return context; }
 };
 

--- a/unit-tests/unit-tests-offline.cpp
+++ b/unit-tests/unit-tests-offline.cpp
@@ -378,5 +378,6 @@ TEST_CASE( "rs_create_context() returns a valid context", "[offline] [validation
 TEST_CASE( "rs_context has singleton semantics", "[offline] [validation]" )
 {
     safe_context ctx;
-    REQUIRE(rs_create_context(RS_API_VERSION, require_error("rs_context has singleton semantics, only one may exist at a time")) == nullptr);
+    safe_context second_ctx;
+    REQUIRE(second_ctx == ctx);
 }


### PR DESCRIPTION
Removed "singleton semantics" limitation from rs_context in order to let multiple users simultaneously  consume librealsense services (https://github.com/IntelRealSense/librealsense/pull/141). Did it through shared ownership instead of global / static to let users release all claimed interfaces once they are done using them. 