### PR TITLE
Fixed cpp-capture SIGSEGV

### DIFF
--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -809,7 +809,7 @@ namespace rsimpl
                 // Look for a video device whose busnum/devnum matches this USB device
                 for(auto & dev : devices)
                 {
-                    if (subdevices.size() >=4)      // Make sure that four subdevices present
+                    if (subdevices.size() >=4 && dev->subdevices.size() >= 4)      // Make sure that four subdevices present
                     {
                         // First, handle the special case of FishEye
                         bool bFishEyeDevice = ((busnum == dev->subdevices[3]->busnum) && (devnum == dev->subdevices[3]->devnum));


### PR DESCRIPTION
Thread 1 "cpp-capture" received signal SIGSEGV, Segmentation fault.
0x00007ffff7b0ff77 in rsimpl::uvc::query_devices (context=std::shared_ptr (count 4, weak 0) 0x65ebf0) at src/uvc-v4l2.cpp:815
815 bool bFishEyeDevice = ((busnum == dev->subdevices[3]->busnum) && (devnum == dev->subdevices[3]->devnum));

(gdb) print dev->subdevices
$1 = std::vector of length 3, capacity 4 = {std::unique_ptr<rsimpl::uvc::subdevice> containing 0x695e10,
  std::unique_ptr<rsimpl::uvc::subdevice> containing 0x68d3c0, std::unique_ptr<rsimpl::uvc::subdevice> containing 0x68d470}

Signed-off-by: Hong Yang <yanghong@thundersoft.com>