### PR TITLE
Enable Debian Package Build for ROS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+# This file is only used to enable the building librealsense
+# as a debian package for use with ROS (http://ros.org)
+# via catkin_make (which invokes cmake)
+
+cmake_minimum_required(VERSION 2.8.3)
+
+project(librealsense)
+
+include(ExternalProject)
+
+find_package(catkin REQUIRED)
+
+externalproject_add(${PROJECT_NAME}_extern
+  PREFIX "external_proj"
+
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+
+  CONFIGURE_COMMAND echo "No Configuration Step"
+
+  BUILD_IN_SOURCE 1
+  BUILD_COMMAND $(MAKE) lib/${PROJECT_NAME}.so
+
+  INSTALL_DIR ${CATKIN_DEVEL_PREFIX}
+  INSTALL_COMMAND cp <SOURCE_DIR>/lib/${PROJECT_NAME}.so <INSTALL_DIR>/lib/ COMMAND cp -r <SOURCE_DIR>/include/${PROJECT_NAME} <INSTALL_DIR>/include/
+)
+
+# Need to ensure the include directory exists before the catkin_package macro
+execute_process(COMMAND mkdir -p ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME})
+
+# Declare this project as a catkin package
+# Export the include files and library for other packages in this workspace
+catkin_package(
+  INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}
+  LIBRARIES realsense
+)
+
+# Install library
+install(FILES ${CATKIN_DEVEL_PREFIX}/lib/${PROJECT_NAME}.so
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+# Install include files
+install(DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+
+<!-- This file is only used to enable the building librealsense -->
+<!-- as a debian package for use with ROS (http://ros.org) -->
+<!-- via catkin_make (which invokes cmake) -->
+
+<package format="2">
+  <name>librealsense</name>
+  <!-- The version tag needs to be updated with each new release of librealsense -->
+  <version>0.9.2</version>
+  <description>
+  This project is a cross-platform library (Linux, OSX, Windows) for capturing data from the Intel® RealSense™ F200, SR300 and R200 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense™ devices are implemented in this project, including multi-camera capture. 
+  </description>
+
+  <maintainer email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</maintainer>
+  <maintainer email="mark.d.horn@intel.com">Mark Horn</maintainer>
+  <maintainer email="reagan.lopez@intel.com">Reagan Lopez</maintainer>
+
+  <url type="website">https://github.com/IntelRealSense/librealsense/</url>
+
+  <license>Apache License, Version 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>libusb-1.0-dev</depend>
+</package>


### PR DESCRIPTION
Add needed files to enable ROS catkin_make to build
librealsense in the ROS build farm as a debian package.

NOTE: package.xml needs to have the version string updated
with each new librealsense release. ROS only supports
version strings as x.y.z.