### PR TITLE
Remove non-ASCII characters

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
   <!-- The version tag needs to be updated with each new release of librealsense -->
   <version>0.9.2</version>
   <description>
-  This project is a cross-platform library (Linux, OSX, Windows) for capturing data from the Intel® RealSense™ F200, SR300 and R200 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense™ devices are implemented in this project, including multi-camera capture. 
+  This project is a cross-platform library (Linux, OSX, Windows) for capturing data from the Intel&reg; RealSense&#153; F200, SR300 and R200 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense&#153; devices are implemented in this project, including multi-camera capture.
   </description>
 
   <maintainer email="sergey.dorodnicov@intel.com">Sergey Dorodnicov</maintainer>


### PR DESCRIPTION
The bloom-release script failed due to non-ASCII characters in the
Description field.