### PR TITLE
Add Missing Dependency for build

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,5 +22,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>pkg-config</build_depend>
+
   <depend>libusb-1.0-dev</depend>
 </package>


### PR DESCRIPTION
The Makefile also requires the use of pkg-config which is
not a standard package on the build system. Adding as a
requirement.