### PR TITLE
Added generic, non-SSSE3 colourspace conversion.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-# Detect OS
+# Detect OS and CPU
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+machine := $(shell sh -c "$(CC) -dumpmachine || echo unknown")
 
 # Specify BACKEND=V4L2 or BACKEND=LIBUVC to build a specific backend
 BACKEND := V4L2
@@ -12,13 +13,19 @@ endif
 LIBUSB_FLAGS := `pkg-config --cflags --libs libusb-1.0`
 
 CFLAGS := -std=c11 -fPIC -pedantic -DRS_USE_$(BACKEND)_BACKEND $(LIBUSB_FLAGS) 
-CXXFLAGS := -std=c++11 -fPIC -pedantic -mssse3 -Ofast -Wno-missing-field-initializers
+CXXFLAGS := -std=c++11 -fPIC -pedantic -Ofast -Wno-missing-field-initializers
 CXXFLAGS += -Wno-switch -Wno-multichar -DRS_USE_$(BACKEND)_BACKEND $(LIBUSB_FLAGS) 
 
 # Add specific include paths for OSX
 ifeq ($(uname_S),Darwin)
 CFLAGS   += -I/usr/local/include
 CXXFLAGS += -I/usr/local/include
+endif
+
+ifeq (arm-linux-gnueabihf,$(machine))
+CXXFLAGS += -mfpu=neon -mfloat-abi=hard -ftree-vectorize
+else
+CXXFLAGS += -mssse3
 endif
 
 # Compute list of all *.o files that participate in librealsense.so

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -8,7 +8,9 @@
 #include <cmath>
 #include <algorithm>
 
+#ifdef __SSSE3__
 #include <tmmintrin.h> // For SSE3 intrinsics used in unpack_yuy2_sse
+#endif
 
 #pragma pack(push, 1) // All structs in this file are assumed to be byte-packed
 namespace rsimpl
@@ -65,6 +67,7 @@ namespace rsimpl
     template<rs_format FORMAT> void unpack_yuy2(byte * const d [], const byte * s, int n)
     {
         assert(n % 16 == 0); // All currently supported color resolutions are multiples of 16 pixels. Could easily extend support to other resolutions by copying final n<16 pixels into a zero-padded buffer and recursively calling self for final iteration.
+#ifdef __SSSE3__
         auto src = reinterpret_cast<const __m128i *>(s);
         auto dst = reinterpret_cast<__m128i *>(d[0]);
         for(; n; n -= 16)
@@ -206,6 +209,139 @@ namespace rsimpl
                 }
             }
         }    
+#else  // Generic code for when SSSE3 is not available.
+        auto src = reinterpret_cast<const uint8_t *>(s);
+        auto dst = reinterpret_cast<uint8_t *>(d[0]);
+        for(; n; n -= 16, src += 32)
+        {
+            if(FORMAT == RS_FORMAT_Y8)
+            {
+                uint8_t out[16] = {
+                    src[ 0], src[ 2], src[ 4], src[ 6],
+                    src[ 8], src[10], src[12], src[14],
+                    src[16], src[18], src[20], src[22],
+                    src[24], src[26], src[28], src[30],
+                };
+                memcpy(dst, out, sizeof out);
+                dst += sizeof out;
+                continue;
+            }
+
+            if(FORMAT == RS_FORMAT_Y16)
+            {
+                // Y16 is little-endian.  We output Y << 8.
+                uint8_t out[32] = {
+                    0, src[ 0], 0, src[ 2], 0, src[ 4], 0, src[ 6],
+                    0, src[ 8], 0, src[10], 0, src[12], 0, src[14],
+                    0, src[16], 0, src[18], 0, src[20], 0, src[22],
+                    0, src[24], 0, src[26], 0, src[28], 0, src[30],
+                };
+                memcpy(dst, out, sizeof out);
+                dst += sizeof out;
+                continue;
+            }
+
+            int16_t y[16] = {
+                src[ 0], src[ 2], src[ 4], src[ 6],
+                src[ 8], src[10], src[12], src[14],
+                src[16], src[18], src[20], src[22],
+                src[24], src[26], src[28], src[30],
+            }, u[16] = {
+                src[ 1], src[ 1], src[ 5], src[ 5],
+                src[ 9], src[ 9], src[13], src[13],
+                src[17], src[17], src[21], src[21],
+                src[25], src[25], src[29], src[29],
+            }, v[16] = {
+                src[ 3], src[ 3], src[ 7], src[ 7],
+                src[11], src[11], src[15], src[15],
+                src[19], src[19], src[23], src[23],
+                src[27], src[27], src[31], src[31],
+            };
+
+            uint8_t r[16], g[16], b[16];
+            for(int i = 0; i < 16; i++)
+            {
+                int32_t c = y[i] - 16;
+                int32_t d = u[i] - 128;
+                int32_t e = v[i] - 128;
+
+                int32_t t;
+                #define clamp(x)  ((t=(x)) > 255 ? 255 : t < 0 ? 0 : t)
+                r[i] = clamp((298 * c           + 409 * e + 128) >> 8);
+                g[i] = clamp((298 * c - 100 * d - 409 * e + 128) >> 8);
+                b[i] = clamp((298 * c + 516 * d           + 128) >> 8);
+                #undef clamp
+            }
+
+            if(FORMAT == RS_FORMAT_RGB8)
+            {
+                uint8_t out[16*3] = {
+                    r[ 0], g[ 0], b[ 0], r[ 1], g[ 1], b[ 1],
+                    r[ 2], g[ 2], b[ 2], r[ 3], g[ 3], b[ 3],
+                    r[ 4], g[ 4], b[ 4], r[ 5], g[ 5], b[ 5],
+                    r[ 6], g[ 6], b[ 6], r[ 7], g[ 7], b[ 7],
+                    r[ 8], g[ 8], b[ 8], r[ 9], g[ 9], b[ 9],
+                    r[10], g[10], b[10], r[11], g[11], b[11],
+                    r[12], g[12], b[12], r[13], g[13], b[13],
+                    r[14], g[14], b[14], r[15], g[15], b[15],
+                };
+                memcpy(dst, out, sizeof out);
+                dst += sizeof out;
+                continue;
+            }
+
+            if(FORMAT == RS_FORMAT_BGR8)
+            {
+                uint8_t out[16*3] = {
+                    b[ 0], g[ 0], r[ 0], b[ 1], g[ 1], r[ 1],
+                    b[ 2], g[ 2], r[ 2], b[ 3], g[ 3], r[ 3],
+                    b[ 4], g[ 4], r[ 4], b[ 5], g[ 5], r[ 5],
+                    b[ 6], g[ 6], r[ 6], b[ 7], g[ 7], r[ 7],
+                    b[ 8], g[ 8], r[ 8], b[ 9], g[ 9], r[ 9],
+                    b[10], g[10], r[10], b[11], g[11], r[11],
+                    b[12], g[12], r[12], b[13], g[13], r[13],
+                    b[14], g[14], r[14], b[15], g[15], r[15],
+                };
+                memcpy(dst, out, sizeof out);
+                dst += sizeof out;
+                continue;
+            }
+
+            if(FORMAT == RS_FORMAT_RGBA8)
+            {
+                uint8_t out[16*4] = {
+                    r[ 0], g[ 0], b[ 0], 255, r[ 1], g[ 1], b[ 1], 255,
+                    r[ 2], g[ 2], b[ 2], 255, r[ 3], g[ 3], b[ 3], 255,
+                    r[ 4], g[ 4], b[ 4], 255, r[ 5], g[ 5], b[ 5], 255,
+                    r[ 6], g[ 6], b[ 6], 255, r[ 7], g[ 7], b[ 7], 255,
+                    r[ 8], g[ 8], b[ 8], 255, r[ 9], g[ 9], b[ 9], 255,
+                    r[10], g[10], b[10], 255, r[11], g[11], b[11], 255,
+                    r[12], g[12], b[12], 255, r[13], g[13], b[13], 255,
+                    r[14], g[14], b[14], 255, r[15], g[15], b[15], 255,
+                };
+                memcpy(dst, out, sizeof out);
+                dst += sizeof out;
+                continue;
+            }
+
+            if(FORMAT == RS_FORMAT_BGRA8)
+            {
+                uint8_t out[16*4] = {
+                    b[ 0], g[ 0], r[ 0], 255, b[ 1], g[ 1], r[ 1], 255,
+                    b[ 2], g[ 2], r[ 2], 255, b[ 3], g[ 3], r[ 3], 255,
+                    b[ 4], g[ 4], r[ 4], 255, b[ 5], g[ 5], r[ 5], 255,
+                    b[ 6], g[ 6], r[ 6], 255, b[ 7], g[ 7], r[ 7], 255,
+                    b[ 8], g[ 8], r[ 8], 255, b[ 9], g[ 9], r[ 9], 255,
+                    b[10], g[10], r[10], 255, b[11], g[11], r[11], 255,
+                    b[12], g[12], r[12], 255, b[13], g[13], r[13], 255,
+                    b[14], g[14], r[14], 255, b[15], g[15], r[15], 255,
+                };
+                memcpy(dst, out, sizeof out);
+                dst += sizeof out;
+                continue;
+            }
+        }
+#endif
     }
     
     //////////////////////////////////////


### PR DESCRIPTION
These can be automatically vectorized by the compiler for many platforms.  The target machine is now detected in the Makefile, and NEON vectorization is selected for arm-linux-gnueabihf (ARM32).  Other target machines can be easily handled in a similar way.  If it does not detect a known platform, SSSE3 support is assumed.

I, Eric Joseph Mulvaney, a citizen of Toronto Canada, acting on behalf of Aevena, Inc., agree to the terms of the Intel® RealSense™ Cross Platform API CLA.