### PR TITLE
Ignore inaccessible cameras during detection.

### DIFF
--- a/src/uvc-libuvc.cpp
+++ b/src/uvc-libuvc.cpp
@@ -269,7 +269,12 @@ namespace rsimpl
             
             uvc_device_t ** list;
             CALL_UVC(uvc_get_device_list, context->ctx, &list);
-            for(auto it = list; *it; ++it) devices.push_back(std::make_shared<device>(context, *it));
+            for(auto it = list; *it; ++it) try {
+                devices.push_back(std::make_shared<device>(context, *it));
+            } catch(std::runtime_error &e) {
+                LOG_WARNING("usb:" << (int)uvc_get_bus_number(*it) << ':' <<
+                        (int)uvc_get_device_address(*it) << ": " << e.what());
+            }
             uvc_free_device_list(list, 1);
             return devices;
         }


### PR DESCRIPTION
Previously this would throw an exception, preventing the use of any RealSense device when other USB cameras are present but not accessible by the user.  This probably covers other situations, too, printing out the errors, but ultimately allows the detection of actual RealSense devices to succeed.

I, Eric Joseph Mulvaney, a citizen of Toronto Canada, acting on behalf of Aevena, Inc., agree to the terms of the Intel® RealSense™ Cross Platform API CLA.