### PR TITLE
Arm64 Builds and warnings clean-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ endif
 ifeq (arm-linux-gnueabihf,$(machine))
 CXXFLAGS += -mfpu=neon -mfloat-abi=hard -ftree-vectorize
 else
+ifeq (aarch64-linux-gnu,$(machine))
+CXXFLAGS += -mfpu=neon -mfloat-abi=hard -ftree-vectorize
+else
 CXXFLAGS += -mssse3
+endif
 endif
 
 # Compute list of all *.o files that participate in librealsense.so

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,9 @@ BACKEND := LIBUVC
 endif
 
 LIBUSB_FLAGS := `pkg-config --cflags --libs libusb-1.0`
-
-CFLAGS := -std=c11 -fPIC -pedantic -DRS_USE_$(BACKEND)_BACKEND $(LIBUSB_FLAGS) 
+CFLAGS := -std=c11 -D_BSD_SOURCE -fPIC -pedantic -DRS_USE_$(BACKEND)_BACKEND $(LIBUSB_FLAGS)
 CXXFLAGS := -std=c++11 -fPIC -pedantic -Ofast -Wno-missing-field-initializers
-CXXFLAGS += -Wno-switch -Wno-multichar -DRS_USE_$(BACKEND)_BACKEND $(LIBUSB_FLAGS) 
+CXXFLAGS += -Wno-switch -Wno-multichar -DRS_USE_$(BACKEND)_BACKEND $(LIBUSB_FLAGS)
 
 # Add specific include paths for OSX
 ifeq ($(uname_S),Darwin)
@@ -33,7 +32,7 @@ endif
 endif
 
 # Compute list of all *.o files that participate in librealsense.so
-OBJECTS = verify 
+OBJECTS = verify
 OBJECTS += $(notdir $(basename $(wildcard src/*.cpp)))
 OBJECTS += $(addprefix libuvc/, $(notdir $(basename $(wildcard src/libuvc/*.c))))
 OBJECTS := $(addprefix obj/, $(addsuffix .o, $(OBJECTS)))
@@ -93,7 +92,7 @@ lib/librealsense.so: prepare $(OBJECTS)
 
 lib/librealsense.a: prepare $(OBJECTS)
 	ar rvs $@ `find obj/ -name "*.o"`
- 
+
 # Rules for compiling librealsense source
 obj/%.o: src/%.cpp
 	$(CXX) $< $(CXXFLAGS) -c -o $@

--- a/src/libuvc/dev.c
+++ b/src/libuvc/dev.c
@@ -269,7 +269,7 @@ uvc_error_t uvc_open2(
     UVC_DEBUG("libusb_submit_transfer() = %d", ret);
 
     if (ret) {
-      UVC_DEBUG("device has a status interrupt endpoint, but unable to read from it");
+      UVC_DEBUG("device has a status interrupt endpoint, but unable to read from it",);
       goto fail;
     }
   }
@@ -1493,7 +1493,7 @@ void uvc_process_status_xfer(uvc_device_handle_t *devh, struct libusb_transfer *
     selector = transfer->buffer[3];
 
     if (originator == 0) {
-      UVC_DEBUG("Unhandled update from VC interface");
+      UVC_DEBUG("Unhandled update from VC interface", );
       UVC_EXIT_VOID();
       return;  /* @todo VideoControl virtual entity interface updates */
     }
@@ -1537,7 +1537,7 @@ void uvc_process_status_xfer(uvc_device_handle_t *devh, struct libusb_transfer *
     break;
   }
   case 2:  /* VideoStreaming interface */
-    UVC_DEBUG("Unhandled update from VideoStreaming interface");
+    UVC_DEBUG("Unhandled update from VideoStreaming interface",);
     UVC_EXIT_VOID();
     return;  /* @todo VideoStreaming updates */
   }
@@ -1546,7 +1546,7 @@ void uvc_process_status_xfer(uvc_device_handle_t *devh, struct libusb_transfer *
     status_class, event, selector, attribute, data_len);
 
   if(devh->status_cb) {
-    UVC_DEBUG("Running user-supplied status callback");
+    UVC_DEBUG("Running user-supplied status callback",);
     devh->status_cb(status_class,
                     event,
                     selector,

--- a/src/libuvc/diag.c
+++ b/src/libuvc/diag.c
@@ -181,7 +181,7 @@ void uvc_print_diag(uvc_device_handle_t *devh, FILE *stream) {
           case UVC_VS_FORMAT_MJPEG:
           case UVC_VS_FORMAT_FRAME_BASED:
             fprintf(stream,
-                "\t\%s(%d)\n"
+                "\t\t%s(%d)\n"
                 "\t\t  bits per pixel: %d\n"
                 "\t\t  GUID: ",
                 _uvc_name_for_format_subtype(fmt_desc->bDescriptorSubtype),

--- a/src/libuvc/stream.c
+++ b/src/libuvc/stream.c
@@ -453,7 +453,7 @@ void _uvc_process_payload(uvc_stream_handle_t *strmh, uint8_t *payload, size_t p
     header_info = payload[1];
 
     if (header_info & 0x40) {
-      UVC_DEBUG("bad packet: error bit set");
+      UVC_DEBUG("bad packet: error bit set",);
       return;
     }
 
@@ -816,7 +816,7 @@ uvc_error_t uvc_stream_start(
                                            altsetting->bInterfaceNumber,
                                            altsetting->bAlternateSetting);
     if (ret != UVC_SUCCESS) {
-      UVC_DEBUG("libusb_set_interface_alt_setting failed");
+      UVC_DEBUG("libusb_set_interface_alt_setting failed",);
       goto fail;
     }
 
@@ -874,7 +874,7 @@ uvc_error_t uvc_stream_start(
     ret = libusb_submit_transfer(strmh->transfers[transfer_id]);
     if (ret != UVC_SUCCESS)
     {
-      UVC_DEBUG("libusb_submit_transfer failed");
+      UVC_DEBUG("libusb_submit_transfer failed",);
       break;
     }
   }

--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -30,6 +30,8 @@
 
 #include <libusb.h>
 
+#pragma GCC diagnostic ignored "-Woverflow"
+
 namespace rsimpl
 {
     namespace uvc


### PR DESCRIPTION
Enable builds for 64-ARM in ROS build Farm.
Clean up many compiler warnings