### PR TITLE
Remove 32-bit ARM flags from 64-bit build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifeq (arm-linux-gnueabihf,$(machine))
 CXXFLAGS += -mfpu=neon -mfloat-abi=hard -ftree-vectorize
 else
 ifeq (aarch64-linux-gnu,$(machine))
-CXXFLAGS += -mfpu=neon -mfloat-abi=hard -ftree-vectorize
+CXXFLAGS += -mstrict-align -ftree-vectorize
 else
 CXXFLAGS += -mssse3
 endif


### PR DESCRIPTION
ARM-64 doesn't allow the same CFLAGs.

verified this build in a docker ARM-64 build image.