### PR TITLE
Improvements to the get_usb_hub method

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -160,5 +160,7 @@ void rs_device::get_option_range(rs_option option, double & min, double & max, d
 
 const char * rs_device::get_usb_port_id() const
 {
-    return rsimpl::uvc::get_usb_port_id(*device);
+    std::lock_guard<std::mutex> lock(usb_port_mutex);
+    if (usb_port_id == "") usb_port_id = rsimpl::uvc::get_usb_port_id(*device);
+    return usb_port_id.c_str();
 }

--- a/src/device.h
+++ b/src/device.h
@@ -36,6 +36,9 @@ private:
     std::chrono::high_resolution_clock::time_point capture_started;
 
     std::shared_ptr<rsimpl::frame_archive>      archive;
+
+    mutable std::string                         usb_port_id;
+    mutable std::mutex                          usb_port_mutex;
 protected:
     const rsimpl::uvc::device &                 get_device() const { return *device; }
     rsimpl::uvc::device &                       get_device() { return *device; }

--- a/src/uvc-libuvc.cpp
+++ b/src/uvc-libuvc.cpp
@@ -81,11 +81,11 @@ namespace rsimpl
         int get_vendor_id(const device & device) { return device.vid; }
         int get_product_id(const device & device) { return device.pid; }
 
-        const char * get_usb_port_id(const device & device)
+        sdt::string get_usb_port_id(const device & device)
         {
             std::string usb_port = std::to_string(libusb_get_bus_number(device.uvcdevice->usb_dev)) + "-" +
                 std::to_string(libusb_get_port_number(device.uvcdevice->usb_dev));
-            return usb_port.c_str();
+            return usb_port;
         }
 
         void get_control(const device & dev, const extension_unit & xu, uint8_t ctrl, void * data, int len)

--- a/src/uvc-libuvc.cpp
+++ b/src/uvc-libuvc.cpp
@@ -81,7 +81,7 @@ namespace rsimpl
         int get_vendor_id(const device & device) { return device.vid; }
         int get_product_id(const device & device) { return device.pid; }
 
-        sdt::string get_usb_port_id(const device & device)
+        std::string get_usb_port_id(const device & device)
         {
             std::string usb_port = std::to_string(libusb_get_bus_number(device.uvcdevice->usb_dev)) + "-" +
                 std::to_string(libusb_get_port_number(device.uvcdevice->usb_dev));

--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -404,11 +404,11 @@ namespace rsimpl
         int get_vendor_id(const device & device) { return device.subdevices[0]->get_vid(); }
         int get_product_id(const device & device) { return device.subdevices[0]->get_pid(); }
 
-        const char * get_usb_port_id(const device & device)
+        std::string get_usb_port_id(const device & device)
         {
             std::string usb_port = std::to_string(libusb_get_bus_number(device.usb_device)) + "-" +
                 std::to_string(libusb_get_port_number(device.usb_device));
-            return usb_port.c_str();
+            return usb_port;
         }
 
         void get_control(const device & device, const extension_unit & xu, uint8_t ctrl, void * data, int len)

--- a/src/uvc-wmf.cpp
+++ b/src/uvc-wmf.cpp
@@ -7,6 +7,10 @@
     #error At least Visual Studio 2013 Update 4 is required to compile this backend
 #endif
 
+#include <windows.h>
+#include <usbioctl.h>
+#include <sstream>
+
 #include "uvc.h"
 
 #include <Shlwapi.h>        // For QISearch, etc.
@@ -30,6 +34,9 @@
 #include <ksproxy.h>
 
 #include <Cfgmgr32.h>
+
+#pragma comment(lib, "cfgmgr32.lib")
+
 #include <SetupAPI.h>
 #include <WinUsb.h>
 
@@ -40,6 +47,9 @@
 #include <map>
 
 #include <strsafe.h>
+
+DEFINE_GUID(GUID_DEVINTERFACE_USB_DEVICE, 0xA5DCBF10L, 0x6530, 0x11D2, 0x90, 0x1F, 0x00, \
+    0xC0, 0x4F, 0xB9, 0x51, 0xED);
 
 namespace rsimpl
 {
@@ -747,7 +757,285 @@ namespace rsimpl
             return devices;
         }
 
-        std::string get_usb_port_id(const device & device) { throw std::exception("Not Implemented"); } // Not implemented for Windows at this point
+        std::wstring getPath(HANDLE h, ULONG index)
+        {
+            // get name length
+            USB_NODE_CONNECTION_NAME name;
+            name.ConnectionIndex = index;
+            if (!DeviceIoControl(h, IOCTL_USB_GET_NODE_CONNECTION_NAME, &name, sizeof(name), &name, sizeof(name), nullptr, nullptr))
+            {
+                return std::wstring(L"");
+            }
+
+            // alloc space
+            if (name.ActualLength < sizeof(name)) return std::wstring(L"");
+            auto alloc = std::malloc(name.ActualLength);
+            auto pName = std::shared_ptr<USB_NODE_CONNECTION_NAME>(reinterpret_cast<USB_NODE_CONNECTION_NAME *>(alloc), std::free);
+
+            // get name
+            pName->ConnectionIndex = index;
+            if (DeviceIoControl(h, IOCTL_USB_GET_NODE_CONNECTION_NAME, pName.get(), name.ActualLength, pName.get(), name.ActualLength, nullptr, nullptr))
+            {
+                return std::wstring(pName->NodeName);
+            }
+
+            return std::wstring(L"");
+        }
+
+        bool handleNode(const std::wstring & targetKey, HANDLE h, ULONG index)
+        {
+            USB_NODE_CONNECTION_DRIVERKEY_NAME key;
+            key.ConnectionIndex = index;
+
+            if (!DeviceIoControl(h, IOCTL_USB_GET_NODE_CONNECTION_DRIVERKEY_NAME, &key, sizeof(key), &key, sizeof(key), nullptr, nullptr))
+            {
+                return false;
+            }
+
+            if (key.ActualLength < sizeof(key)) return false;
+
+            auto alloc = std::malloc(key.ActualLength);
+            if (!alloc) throw std::bad_alloc();
+            auto pKey = std::shared_ptr<USB_NODE_CONNECTION_DRIVERKEY_NAME>(reinterpret_cast<USB_NODE_CONNECTION_DRIVERKEY_NAME *>(alloc), std::free);
+
+            pKey->ConnectionIndex = index;
+            if (DeviceIoControl(h, IOCTL_USB_GET_NODE_CONNECTION_DRIVERKEY_NAME, pKey.get(), key.ActualLength, pKey.get(), key.ActualLength, nullptr, nullptr))
+            {
+                //std::wcout << pKey->DriverKeyName << std::endl;
+                if (targetKey == pKey->DriverKeyName) {
+                    return true;
+                }
+                else return false;
+            }
+
+            return false;
+        }
+
+        std::string handleHub(const std::wstring & targetKey, const std::wstring & path)
+        {
+            if (path == L"") return "";
+            std::wstring fullPath = L"\\\\.\\" + path;
+
+            HANDLE h = CreateFile(fullPath.c_str(), GENERIC_WRITE, FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+            if (h == INVALID_HANDLE_VALUE) return "";
+            auto h_gc = std::shared_ptr<void>(h, CloseHandle);
+
+            USB_NODE_INFORMATION info;
+            if (!DeviceIoControl(h, IOCTL_USB_GET_NODE_INFORMATION, &info, sizeof(info), &info, sizeof(info), nullptr, nullptr))
+                return "";
+
+            // for each port on the hub
+            for (ULONG i = 1; i <= info.u.HubInformation.HubDescriptor.bNumberOfPorts; ++i)
+            {
+                // allocate something or other (commented out parts exist in virtualbox source but appear unused
+                char buf[sizeof(USB_NODE_CONNECTION_INFORMATION_EX) /* + (sizeof(USB_PIPE_INFO) * 20) */] = { 0 };
+                PUSB_NODE_CONNECTION_INFORMATION_EX pConInfo = (PUSB_NODE_CONNECTION_INFORMATION_EX)buf;
+                /* PUSB_PIPE_INFO paPipeInfo = (PUSB_PIPE_INFO)(buf + sizeof(PUSB_NODE_CONNECTION_INFORMATION_EX)); */
+
+                // get info about port i
+                pConInfo->ConnectionIndex = i;
+                if (!DeviceIoControl(h, IOCTL_USB_GET_NODE_CONNECTION_INFORMATION_EX, pConInfo, sizeof(buf), pConInfo, sizeof(buf), nullptr, nullptr))
+                {
+                    // virtual box makes a distinction, but said distinction is buried deeper than I could follow in their error logging macros
+                    if (GetLastError() != ERROR_DEVICE_NOT_CONNECTED) {
+                        continue;
+                    }
+                    // i guess the difference could be if the user happens to disconnect the device at this exact second?
+                    continue;
+                }
+
+                // check if device is connected
+                if (pConInfo->ConnectionStatus != DeviceConnected)
+                {
+                    continue; // almost assuredly silently. I think this flag gets set for any port without a device
+                }
+
+                // if connected, handle correctly, setting the location info if the device is found
+                std::string ret = "";
+                if (pConInfo->DeviceIsHub) ret = handleHub(targetKey, getPath(h, i));
+                else
+                {
+                    if (handleNode(targetKey, h, i))
+                    {
+                        ret = win_to_utf(fullPath.c_str()) + " " + std::to_string(i);
+                    }
+                }
+                if (ret != "") return ret;
+            }
+
+            return "";
+        }
+
+        std::string get_usb_port_id(const device & device) // Not implemented for Windows at this point
+        {
+            const guid IVCAM_WIN_USB_DEVICE_GUID = { 0x175695CD, 0x30D9, 0x4F87,{ 0x8B, 0xE3, 0x5A, 0x82, 0x70, 0xF4, 0x9A, 0x31 } };
+            static_assert(sizeof(guid) == sizeof(GUID), "struct packing error"); // not sure this is needed. maybe because the original function gets the guid object from outside?
+
+            HDEVINFO device_info = SetupDiGetClassDevs((const GUID *)&IVCAM_WIN_USB_DEVICE_GUID, nullptr, nullptr, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+            if (device_info == INVALID_HANDLE_VALUE) throw std::runtime_error("SetupDiGetClassDevs");
+            auto di = std::shared_ptr<void>(device_info, SetupDiDestroyDeviceInfoList);
+
+            for (int member_index = 0; ; ++member_index)
+            {
+                // Enumerate all the device interfaces in the device information set. 
+                SP_DEVICE_INTERFACE_DATA interfaceData = { sizeof(SP_DEVICE_INTERFACE_DATA) };
+                if (SetupDiEnumDeviceInterfaces(device_info, nullptr, (const GUID *)&IVCAM_WIN_USB_DEVICE_GUID, member_index, &interfaceData) == FALSE)
+                {
+                    if (GetLastError() == ERROR_NO_MORE_ITEMS) break; // stop when none left
+                    continue; // silently ignore other errors
+                }
+
+
+                // Allocate space for a detail data struct 
+                unsigned long buf_size = 0;
+                SetupDiGetDeviceInterfaceDetail(device_info, &interfaceData, nullptr, 0, &buf_size, nullptr);
+                if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+                {
+                    //LOG_ERROR("SetupDiGetDeviceInterfaceDetail failed"); 
+                    continue;
+                }
+                auto alloc = std::malloc(buf_size);
+                if (!alloc) throw std::bad_alloc();
+                // Retrieve the detail data struct 
+                auto detail_data = std::shared_ptr<SP_DEVICE_INTERFACE_DETAIL_DATA>(reinterpret_cast<SP_DEVICE_INTERFACE_DETAIL_DATA *>(alloc), std::free);
+                detail_data->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+                // get the SP_DEVICE_INTERFACE_DETAIL_DATA object, and also grab the SP_DEVINFO_DATA object for the device
+                SP_DEVINFO_DATA devinfo_data = { sizeof(SP_DEVINFO_DATA) };
+                if (!SetupDiGetDeviceInterfaceDetail(device_info, &interfaceData, detail_data.get(), buf_size, nullptr, &devinfo_data))
+                {
+                    //LOG_ERROR("SetupDiGetDeviceInterfaceDetail failed"); 
+                    continue;
+                }
+                if (detail_data->DevicePath == nullptr) continue;
+
+                // Check if this is our device 
+                int usb_vid, usb_pid, usb_mi; std::string usb_unique_id;
+                if (!parse_usb_path(usb_vid, usb_pid, usb_mi, usb_unique_id, std::string(win_to_utf(detail_data->DevicePath)))) continue;
+                if (usb_vid != device.vid || usb_pid != device.pid || /* usb_mi != device->mi || */ usb_unique_id != device.unique_id) continue;
+
+                // get parent (composite device) instance
+                DEVINST instance;
+                if (CM_Get_Parent(&instance, devinfo_data.DevInst, 0) != CR_SUCCESS)
+                {
+                    LOG_ERROR("CM_Get_Parent failed");
+                    return "";
+                }
+
+                // get composite device instance id
+                if (CM_Get_Device_ID_Size(&buf_size, instance, 0) != CR_SUCCESS)
+                {
+                    LOG_ERROR("CM_Get_Device_ID_Size failed");
+                    return "";
+                }
+                alloc = std::malloc(buf_size*sizeof(WCHAR) + sizeof(WCHAR));
+                if (!alloc) throw std::bad_alloc();
+                auto pInstID = std::shared_ptr<WCHAR>(reinterpret_cast<WCHAR *>(alloc), std::free);
+                if (CM_Get_Device_ID(instance, pInstID.get(), buf_size * sizeof(WCHAR) + sizeof(WCHAR), 0) != CR_SUCCESS) {
+                    LOG_ERROR("CM_Get_Device_ID failed");
+                    return "";
+                }
+
+                // upgrade to DEVINFO_DATA for SetupDiGetDeviceRegistryProperty
+                HDEVINFO device_info = SetupDiGetClassDevs(nullptr, pInstID.get(), nullptr, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE | DIGCF_ALLCLASSES);
+                if (device_info == INVALID_HANDLE_VALUE) {
+                    LOG_ERROR("SetupDiGetClassDevs failed");
+                    return "";
+                }
+                auto di_gc = std::shared_ptr<void>(device_info, SetupDiDestroyDeviceInfoList);
+
+                interfaceData = { sizeof(SP_DEVICE_INTERFACE_DATA) };
+                if (SetupDiEnumDeviceInterfaces(device_info, nullptr, &GUID_DEVINTERFACE_USB_DEVICE, 0, &interfaceData) == FALSE)
+                {
+                    LOG_ERROR("SetupDiEnumDeviceInterfaces failed");
+                    return "";
+                }
+
+                // get the SP_DEVICE_INTERFACE_DETAIL_DATA object, and also grab the SP_DEVINFO_DATA object for the device
+                buf_size = 0;
+                SetupDiGetDeviceInterfaceDetail(device_info, &interfaceData, nullptr, 0, &buf_size, nullptr);
+                if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+                {
+                    LOG_ERROR("SetupDiGetDeviceInterfaceDetail failed");
+                    return "";
+                }
+                alloc = std::malloc(buf_size);
+                if (!alloc) throw std::bad_alloc();
+                detail_data = std::shared_ptr<SP_DEVICE_INTERFACE_DETAIL_DATA>(reinterpret_cast<SP_DEVICE_INTERFACE_DETAIL_DATA *>(alloc), std::free);
+                detail_data->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+                SP_DEVINFO_DATA parent_data = { sizeof(SP_DEVINFO_DATA) };
+                if (!SetupDiGetDeviceInterfaceDetail(device_info, &interfaceData, detail_data.get(), buf_size, nullptr, &parent_data))
+                {
+                    LOG_ERROR("SetupDiGetDeviceInterfaceDetail failed");
+                    return "";
+                }
+
+                // get driver key for composite device
+                buf_size = 0;
+                SetupDiGetDeviceRegistryProperty(device_info, &parent_data, SPDRP_DRIVER, nullptr, nullptr, 0, &buf_size);
+                if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+                {
+                    LOG_ERROR("SetupDiGetDeviceRegistryProperty failed in an unexpected manner");
+                    return "";
+                }
+                alloc = std::malloc(buf_size);
+                if (!alloc) throw std::bad_alloc();
+                auto driver_key = std::shared_ptr<BYTE>(reinterpret_cast<BYTE*>(alloc), std::free);
+                if (!SetupDiGetDeviceRegistryProperty(device_info, &parent_data, SPDRP_DRIVER, nullptr, driver_key.get(), buf_size, nullptr))
+                {
+                    LOG_ERROR("SetupDiGetDeviceRegistryProperty failed");
+                    return "";
+                }
+
+                // contains composite device key
+                std::wstring targetKey(reinterpret_cast<const wchar_t*>(driver_key.get()));
+
+                // recursively check all hubs, searching for composite device
+                std::wstringstream buf;
+                for (int i = 0;; i++)
+                { // VBox thinks 10 is enough
+                    buf << "\\\\.\\HCD" << i;
+                    std::wstring hcd = buf.str();
+
+                    // grab handle
+                    HANDLE h = CreateFile(hcd.c_str(), GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, 0, nullptr);
+                    auto h_gc = std::shared_ptr<void>(h, CloseHandle);
+                    if (h == INVALID_HANDLE_VALUE)
+                    {
+                        LOG_ERROR("CreateFile failed");
+                        break;
+                    }
+                    else
+                    {
+                        USB_ROOT_HUB_NAME name;
+
+                        // get required space
+                        if (!DeviceIoControl(h, IOCTL_USB_GET_ROOT_HUB_NAME, nullptr, 0, &name, sizeof(name), nullptr, nullptr)) {
+                            LOG_ERROR("DeviceIoControl failed");
+                            return ""; // alt: fail silently and hope its on a different root hub
+                        }
+
+                        // alloc space
+                        alloc = std::malloc(name.ActualLength);
+                        if (!alloc) throw std::bad_alloc();
+                        auto pName = std::shared_ptr<USB_ROOT_HUB_NAME>(reinterpret_cast<USB_ROOT_HUB_NAME *>(alloc), std::free);
+
+                        // get name
+                        if (!DeviceIoControl(h, IOCTL_USB_GET_ROOT_HUB_NAME, nullptr, 0, pName.get(), name.ActualLength, nullptr, nullptr)) {
+                            LOG_ERROR("DeviceIoControl failed");
+                            return ""; // alt: fail silently and hope its on a different root hub
+                        }
+
+                        // return location if device is connected under this root hub
+                        std::string ret = handleHub(targetKey, std::wstring(pName->RootHubName));
+                        if (ret != "") return ret;
+                    }
+
+                }
+
+                throw std::exception("could not find camera in windows device tree");
+            }
+            throw std::exception("Not Implemented");
+        }
     }
 }
 

--- a/src/uvc-wmf.cpp
+++ b/src/uvc-wmf.cpp
@@ -747,7 +747,7 @@ namespace rsimpl
             return devices;
         }
 
-        const char * get_usb_port_id(const device & device) { throw std::exception("Not Implemented"); } // Not implemented for Windows at this point
+        std::string get_usb_port_id(const device & device) { throw std::exception("Not Implemented"); } // Not implemented for Windows at this point
     }
 }
 

--- a/src/uvc.h
+++ b/src/uvc.h
@@ -28,7 +28,7 @@ namespace rsimpl
         // Static device properties
         int get_vendor_id(const device & device);
         int get_product_id(const device & device);
-        const char * get_usb_port_id(const device & device);
+        std::string get_usb_port_id(const device & device);
 
         // Direct USB controls
         void claim_interface(device & device, const guid & interface_guid, int interface_number);


### PR DESCRIPTION
Merging two changes from the development branch:

1. Fixed unsafe implementation of get_usb_hub method on Linux / OSX, that was previously returning reference to stack variable. impact on [ROS RealSense](https://github.com/intel-ros/realsense), @mdhorn

2. Provided windows implementation to ensure cross-platform support, as pointed out by @leonidk

The format of the string is slightly different between Windows and Linux versions but they accomplish the same job: classifying peripheral devices based on their physical location. This is particularly useful in multi-cam setups where the application need to distinguish between cameras based on their function (front / side / ...)

Windows implementation is using SetupAPI to find Hub and Port ID. 