### PR TITLE
quick fix to the makefile adding dependency from o to headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,12 @@ else
 GLFW3_FLAGS := `pkg-config --cflags --libs glfw3 glu gl`
 endif
 
+# Compute a list of all header files
+INCLUDES := $(wildcard src/*.hpp)
+INCLUDES += $(wildcard src/*.h)
+INCLUDES += $(wildcard include/librealsense/*.hpp)
+INCLUDES += $(wildcard include/librealsense/*.h)
+
 # Compute a list of all example program binaries
 EXAMPLES := $(wildcard examples/*.c)
 EXAMPLES += $(wildcard examples/*.cpp)
@@ -92,7 +98,7 @@ lib/librealsense.a: $(OBJECTS) | lib
 	ar rvs $@ `find obj/ -name "*.o"`
 
 # Rules for compiling librealsense source
-obj/%.o: src/%.cpp | obj
+obj/%.o: src/%.cpp $(INCLUDES) | obj
 	$(CXX) $< $(CXXFLAGS) -c -o $@
 
 # Rules for compiling libuvc source


### PR DESCRIPTION
Up until now, any time there was a change to header file only, librealsense would require make clean to ensure the change is registered. 
This quick fix is adding dependency from any source file to all header files. 
Optimally, gcc could generate dependency tree for us using the -MM flag, but implementing this solution would require some extra testing and time. 