### PR TITLE
Fixed set_control for Windows Build 1607

### DIFF
--- a/src/uvc-wmf.cpp
+++ b/src/uvc-wmf.cpp
@@ -561,7 +561,8 @@ namespace rsimpl
             node.Property.Flags = KSPROPERTY_TYPE_SET | KSPROPERTY_TYPE_TOPOLOGY;
             node.NodeId = xu.node;
                 
-            check("IKsControl::KsProperty", ks_control->KsProperty((PKSPROPERTY)&node, sizeof(KSP_NODE), data, len, nullptr));
+			ULONG bytes_received = 0;
+            check("IKsControl::KsProperty", ks_control->KsProperty((PKSPROPERTY)&node, sizeof(KSP_NODE), data, len, &bytes_received));
         }
 
         void claim_interface(device & device, const guid & interface_guid, int interface_number)


### PR DESCRIPTION
Fixed #243
KSProperty does not accept nullpointer in Windows Build 1607 (anniversary build)