### PR TITLE
Fixing R200 RAW10 format

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -48,6 +48,11 @@ namespace rsimpl
         memcpy(dest[0], source, SIZE * count);
     }
 
+    void copy_raw10(byte * const dest[], const byte * source, int count)
+    {
+        memcpy(dest[0], source, (5 * (count/4)));
+    }
+
     template<class SOURCE, class UNPACK> void unpack_pixels(byte * const dest[], int count, const SOURCE * source, UNPACK unpack)
     {
         auto out = reinterpret_cast<decltype(unpack(SOURCE())) *>(dest[0]);
@@ -410,7 +415,7 @@ namespace rsimpl
     // Native pixel formats //
     //////////////////////////
 
-    const native_pixel_format pf_rw10       = {'RW10', 1, 1, {{&copy_pixels<1>,                 {{RS_STREAM_COLOR,    RS_FORMAT_RAW10}}}}};
+    const native_pixel_format pf_rw10       = {'RW10', 1, 1, {{&copy_raw10,                     {{RS_STREAM_COLOR,    RS_FORMAT_RAW10}}}}};
     const native_pixel_format pf_yuy2       = {'YUY2', 1, 2, {{&copy_pixels<2>,                 {{RS_STREAM_COLOR,    RS_FORMAT_YUYV }}},
                                                               {&unpack_yuy2<RS_FORMAT_Y8   >,   {{RS_STREAM_COLOR,    RS_FORMAT_Y8   }}},
                                                               {&unpack_yuy2<RS_FORMAT_Y16  >,   {{RS_STREAM_COLOR,    RS_FORMAT_Y16  }}},


### PR DESCRIPTION
Using copy_pixels<1> was causing the right-most 1/5-th of the image to be cropped.
Instead copy_raw10 is properly copying count pixels with 1.2 bpp.