### PR TITLE
Added patch compilation for Arch and Manjaro Linux.

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -3,7 +3,7 @@
 * [Apple OSX Installation](#apple-osx-installation)
 * [Windows 8.1/10 Installation](#windows-81-installation)
 
-**Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the librealsense team does not recommend or support installation in a VM. 
+**Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the librealsense team does not recommend or support installation in a VM.
 
 # Ubuntu Installation - for Ubuntu 14.04 and 16.04
 
@@ -34,10 +34,10 @@ Installation of cameras on Linux is lengthy compared to other supported platform
 ## Video4Linux backend
 
 1. Ensure no cameras are presently plugged into the system.
-2. Install udev rules 
+2. Install udev rules
   * `sudo cp config/99-realsense-libusb.rules /etc/udev/rules.d/`
   * Reboot or run `sudo udevadm control --reload-rules && udevadm trigger` to enforce the new udev rules
-3. Next, choose one of the following subheadings based on desired machine configuration / kernel version (and remember to complete step 4 after). **Note: ** Multi-camera support is currently NOT supported on 3.19.xx kernels. Please update to 4.4 stable. 
+3. Next, choose one of the following subheadings based on desired machine configuration / kernel version (and remember to complete step 4 after). **Note: ** Multi-camera support is currently NOT supported on 3.19.xx kernels. Please update to 4.4 stable.
   * **Updated 4.4 Stable Kernel**
     * Run the following script to install necessary dependencies (GCC 4.9 compiler and openssl) and update kernel to v4.4-wily
       * `./scripts/install_dependencies-4.4.sh`
@@ -50,14 +50,17 @@ Installation of cameras on Linux is lengthy compared to other supported platform
     * (R200 Only with 3.19.xx Kernel) Install connectivity workaround
       * `./scripts/install-r200-udev-fix.sh`
       * This udev fix is not necessary for kernels >= 4.2
-      * Use of 3.19.xx Kernel is not recommended. 
+      * Use of 3.19.xx Kernel is not recommended.
   * **(OR) Kernel in 16.04.xx**
     * `/scripts/patch-uvcvideo-16.04.simple.sh`
+  * **(OR) Arch based distributions**
+    * You need to install the [base-devel](https://www.archlinux.org/groups/x86_64/base-devel/) package group. Then run the following script to patch the uvc module.
+      * `/scripts/patch-arch.sh
 4. Reload the uvcvideo driver
   * `sudo modprobe uvcvideo`
 5. Check installation by examining the last 50 lines of the dmesg log:
   * `sudo dmesg | tail -n 50`
-  * The log should indicate that a new uvcvideo driver has been registered. If any errors have been noted, first attempt the patching process again, and then file an issue if not successful on the second attempt (and make sure to copy the specific error in dmesg). 
+  * The log should indicate that a new uvcvideo driver has been registered. If any errors have been noted, first attempt the patching process again, and then file an issue if not successful on the second attempt (and make sure to copy the specific error in dmesg).
 
 ## LibUVC backend
 
@@ -65,7 +68,7 @@ Installation of cameras on Linux is lengthy compared to other supported platform
 
 The libuvc backend requires that the default linux uvcvideo.ko driver be unloaded before libusb can touch the device. This is because uvcvideo will 'own' a UVC device the moment is is plugged in (user-space applications do not have permission to access the devuce handle). Follow the instructions below to install the udev permissions script.
 
-The libuvc backend has known incompatibilities with some versions of SR300 and R200 firmware (1.0.71.xx series of firmwares are problematic). 
+The libuvc backend has known incompatibilities with some versions of SR300 and R200 firmware (1.0.71.xx series of firmwares are problematic).
 
 1. Grant appropriate permissions to detach the kernel UVC driver when a device is plugged in:
   * `sudo cp config/99-realsense-libusb.rules /etc/udev/rules.d/`
@@ -77,7 +80,7 @@ The libuvc backend has known incompatibilities with some versions of SR300 and R
 
 ---
 
-# Apple OSX Installation  
+# Apple OSX Installation
 
 1. Install XCode 6.0+ via the AppStore
 2. Install the Homebrew package manager via terminal - [link](http://brew.sh/)
@@ -90,4 +93,4 @@ The libuvc backend has known incompatibilities with some versions of SR300 and R
 
 # Windows 8.1 & Windows 10 Installation
 
-librealsense should compile out of the box with Visual Studio 2013 Release 4, both Professional and Community editions. Particular C++11 features are known to be incompatible with earlier VS2013 releases due to internal compiler errors. 
+librealsense should compile out of the box with Visual Studio 2013 Release 4, both Professional and Community editions. Particular C++11 features are known to be incompatible with earlier VS2013 releases due to internal compiler errors.

--- a/scripts/patch-arch.sh
+++ b/scripts/patch-arch.sh
@@ -1,0 +1,116 @@
+#!/bin/bash -e
+
+SRC_VERSION_NAME=linux
+
+## from
+## http://stackoverflow.com/questions/9293887/in-bash-how-do-i-convert-a-space-delimited-string-into-an-array
+
+FULL_NAME=$( uname -r | tr "-" "\n")
+read -a VERSION <<< $FULL_NAME
+
+SRC_VERSION_ID=${VERSION[0]}  ## e.g. : 4.5.6
+SRC_VERSION_REL=${VERSION[1]} ## e.g. : 1
+LINUX_TYPE=${VERSION[2]}      ## e.g. : ARCH
+
+LINUX_BRANCH=archlinux-$SRC_VERSION_ID
+KERNEL_NAME=linux-$SRC_VERSION_ID
+PATCH_NAME=patch-$SRC_VERSION_ID
+
+# ARCH Linux --  KERNEL_NAME=linux-$SRC_VERSION_ID-$SRC_VERSION_REL-$ARCH.pkg.tar.xz
+
+mkdir kernel
+cd kernel
+
+## Get the kernel
+wget https://www.kernel.org/pub/linux/kernel/v4.x/$KERNEL_NAME.tar.xz
+wget https://www.kernel.org/pub/linux/kernel/v4.x/$PATCH_NAME.xz
+wget https://www.kernel.org/pub/linux/kernel/v4.x/$PATCH_NAME.sign
+
+echo "Extract the kernel"
+tar xf $KERNEL_NAME.tar.xz
+
+cd $KERNEL_NAME
+
+## Get the patch
+
+# echo "Patching the kernel..."
+### patch  not working ?
+# xz -dc ../$PATCH_NAME.xz  | patch -p1
+
+
+echo "RealSense patch..."
+
+# Apply our RealSense specific patch
+patch -p1 < ../../realsense-camera-formats.patch
+
+# Prepare to compile modules
+
+## Get the config
+# zcat /proc/config.gz > .config  ## Not the good one ?
+
+cp /usr/lib/modules/`uname -r`/build/.config .
+cp /usr/lib/modules/`uname -r`/build/Module.symvers .
+
+echo "Prepare the build"
+
+make scripts oldconfig modules_prepare
+
+# Compile UVC modules
+echo "Beginning compilation of uvc..."
+#make modules
+KBASE=`pwd`
+cd drivers/media/usb/uvc
+cp $KBASE/Module.symvers .
+make -C $KBASE M=$KBASE/drivers/media/usb/uvc/ modules
+
+# Copy to sane location
+#sudo cp $KBASE/drivers/media/usb/uvc/uvcvideo.ko ~/$LINUX_BRANCH-uvcvideo.ko
+cd ../../../../../
+
+cp $KBASE/drivers/media/usb/uvc/uvcvideo.ko ../uvcvideo.ko
+
+# Unload existing module if installed
+echo "Unloading existing uvcvideo driver..."
+sudo modprobe -r uvcvideo
+
+cd ..
+
+## Not sure yet about deleting and copying...
+
+# save the existing module
+
+MODULE_NAME=/lib/modules/`uname -r`/kernel/drivers/media/usb/uvc/uvcvideo.ko
+
+if [ -e $MODULE_NAME ]; then
+    sudo cp $MODULE_NAME $MODULE_NAME.backup
+    sudo rm $MODULE_NAME
+
+    sudo cp uvcvideo.ko $MODULE_NAME
+fi
+
+if [ -e $MODULE_NAME.xz ]; then
+    sudo cp $MODULE_NAME.xz $MODULE_NAME.xz.backup
+    sudo rm $MODULE_NAME.xz
+
+    # compress
+    xz uvcvideo.ko
+    sudo cp uvcvideo.ko.xz $MODULE_NAME
+fi
+
+if [ -e $MODULE_NAME.gz ]; then
+    sudo cp $MODULE_NAME.gz $MODULE_NAME.gz.backup
+    sudo rm $MODULE_NAME.gz
+
+    # compress
+    gzip uvcvideo.ko
+    sudo cp uvcvideo.ko.gz $MODULE_NAME.gz
+fi
+
+# Copy out to module directory
+
+
+sudo modprobe uvcvideo
+
+rm -rf kernel
+
+echo "Script has completed. Please consult the installation guide for further instruction."


### PR DESCRIPTION
Hello, 
I create a script to patch the  UVC kernel module for Arch-based distributions. 
It is tested on manjaro, and follows the Ubuntu patch:  download the kernel, apply the patch, compile the module, backup & remove the previous module, install the new one. 

It does not ask to install any depedencies, they should be handled in the PKGBUILD of the arch building system. 

Cheers, 
Jeremy. 