### PR TITLE
Moved error behavior out of header.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,4 @@
 Sterling Orsten, sterling.g.orsten@intel.com
 Dimitri Diakopoulos, dimitri.diakopoulos@intel.com
+Google Inc., ravenblack@google.com
+

--- a/include/librealsense/rs.hpp
+++ b/include/librealsense/rs.hpp
@@ -247,15 +247,10 @@ namespace rs
     {
         std::string function, args;
     public:
-        error(rs_error * err) : std::runtime_error(rs_get_error_message(err))
-        { 
-            function = (nullptr != rs_get_failed_function(err)) ? rs_get_failed_function(err) : std::string();
-            args = (nullptr != rs_get_failed_args(err)) ? rs_get_failed_args(err) : std::string();
-            rs_free_error(err); 
-        }
-        const std::string & get_failed_function() const { return function; }
-        const std::string & get_failed_args() const { return args; }
-        static void handle(rs_error * e) { if(e) throw error(e); }
+        error(rs_error * err);
+        const std::string & get_failed_function() const;
+        const std::string & get_failed_args() const;
+        static void handle(rs_error * e);
     };
 
     class context

--- a/librealsense.vc12/realsense-s/realsense-s.vcxproj
+++ b/librealsense.vc12/realsense-s/realsense-s.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\..\src\device.cpp" />
     <ClCompile Include="..\..\src\ds-device.cpp" />
     <ClCompile Include="..\..\src\ds-private.cpp" />
+    <ClCompile Include="..\..\src\error.cpp" />
     <ClCompile Include="..\..\src\f200.cpp" />
     <ClCompile Include="..\..\src\hw-monitor.cpp" />
     <ClCompile Include="..\..\src\image.cpp" />

--- a/librealsense.vc12/realsense-s/realsense-s.vcxproj.filters
+++ b/librealsense.vc12/realsense-s/realsense-s.vcxproj.filters
@@ -10,6 +10,9 @@
     <ClCompile Include="..\..\src\device.cpp">
       <Filter>sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\error.cpp">
+      <Filter>sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\f200.cpp">
       <Filter>sources</Filter>
     </ClCompile>

--- a/librealsense.vc14/realsense-s/realsense-s.vcxproj
+++ b/librealsense.vc14/realsense-s/realsense-s.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\..\src\device.cpp" />
     <ClCompile Include="..\..\src\ds-private.cpp" />
     <ClCompile Include="..\..\src\ds-device.cpp" />
+    <ClCompile Include="..\..\src\error.cpp" />
     <ClCompile Include="..\..\src\f200.cpp" />
     <ClCompile Include="..\..\src\hw-monitor.cpp" />
     <ClCompile Include="..\..\src\image.cpp" />

--- a/librealsense.vc14/realsense-s/realsense-s.vcxproj.filters
+++ b/librealsense.vc14/realsense-s/realsense-s.vcxproj.filters
@@ -15,6 +15,9 @@
     <ClCompile Include="..\..\src\device.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\error.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\f200.cpp">
       <Filter>src</Filter>
     </ClCompile>

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,0 +1,22 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+
+#include <string>
+#include "../include/librealsense/rs.hpp"
+
+namespace rs
+{
+
+    error::error(rs_error * err) : std::runtime_error(rs_get_error_message(err))
+    {
+        function = (nullptr != rs_get_failed_function(err)) ? rs_get_failed_function(err) : std::string();
+        args = (nullptr != rs_get_failed_args(err)) ? rs_get_failed_args(err) : std::string();
+        rs_free_error(err);
+    }
+
+    const std::string & error::get_failed_function() const { return function; }
+    const std::string & error::get_failed_args() const { return args; }
+    void error::handle(rs_error * e) { if(e) throw error(e); }
+
+}
+


### PR DESCRIPTION
Having a 'throw' in the header file requires library clients to be compiled
with exceptions enabled. Moving it into a source file allows clients to be
built with or without exceptions enabled.

My name is Raven Black,
I agree to the terms of the Intel® RealSense™ Cross Platform API CLA.
