### PR TITLE
Fix two trivial warnings

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -69,7 +69,7 @@ frame_archive::frame_ref* frame_archive::detach_frame_ref(frameset* frameset, rs
     auto new_ref = detached_refs.allocate();
     if (new_ref)
     {
-        *new_ref = std::move(frameset->detach_ref(stream));
+        *new_ref = frameset->detach_ref(stream);
     }
     return new_ref;
 }

--- a/src/zr300.cpp
+++ b/src/zr300.cpp
@@ -815,7 +815,6 @@ namespace rsimpl
     void auto_exposure_algorithm::modify_exposure(float& exposure_value, bool& exp_modified, float& gain_value, bool& gain_modified)
     {
         float total_exposure = exposure * gain;
-        float prev_exposure = exposure;
         LOG_DEBUG("TotalExposure " << total_exposure << ", target_exposure " << target_exposure);
         if (fabs(target_exposure - total_exposure) > eps)
         {


### PR DESCRIPTION
src/archive.cpp:72:20: warning: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
src/zr300.cpp:818:15: warning: unused variable 'prev_exposure' [-Werror,-Wunused-variable]

My name is Raven Black, and I agree to the terms of the Intel® RealSense™ Cross Platform API CLA.