### PR TITLE
GNU Install Directories For CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,9 @@ if(UNIX)
     endif(${MACHINE} MATCHES "arm-linux-gnueabihf")
 endif()
 
+# Set CMAKE_INSTALL_* if not defined
+include(GNUInstallDirs)
+
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 if(BUILD_SHARED_LIBS)
     add_library(realsense SHARED ${REALSENSE_CPP} ${REALSENSE_HPP} ${REALSENSE_DEF})
@@ -166,11 +169,11 @@ endif()
 target_include_directories(realsense PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/ ${LIBUSB1_INCLUDE_DIRS})
 
 install( TARGETS realsense
-    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
-    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/librealsense DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/librealsense DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 option(BUILD_EXAMPLES "Build realsense examples." OFF)
 if(BUILD_EXAMPLES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -133,7 +133,7 @@ install(
     cpp-stride
 
     RUNTIME DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/bin
+    ${CMAKE_INSTALL_BINDIR}
 )
 
 


### PR DESCRIPTION
Currently the install locations when using CMake are hard-coded which doesn't work for multi-arch distributions which install libs to '/usr/lib64' for example. It's recommended to use the GNU install directories cmake plugin which uses variables set by the distributions own CMake package to define where to install certain files. 

The GNU plugin also takes into account CMAKE_PREFIX_PATH so this shouldn't break the build for ROS.

More information: [GNUInstallDirs](https://cmake.org/cmake/help/v3.4/module/GNUInstallDirs.html)