### PR TITLE
Add ROS Issue Tracking to ROS Wiki

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,8 @@
   <maintainer email="mark.d.horn@intel.com">Mark Horn</maintainer>
   <maintainer email="reagan.lopez@intel.com">Reagan Lopez</maintainer>
 
-  <url type="website">https://github.com/IntelRealSense/librealsense/</url>
+  <url type="website">http://www.ros.org/wiki/RealSense</url>
+  <url type="bugtracker">https://github.com/intel-ros/realsense/issues</url>
 
   <license>Apache License, Version 2.0</license>
 


### PR DESCRIPTION
Point users of the ROS librealsense package to the intel-ros site for submitting issues.
Updated the website reference on the ROS Wiki to the RealSense page.