### PR TITLE
Skip DKMS enablement when kernel is fully patched

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -63,56 +63,79 @@ case "$1" in
     then
       echo "INFO: Docker environment not supported for DKMS; skipping."
     else
-      IS_DKMS_INSTALLED=$(dkms status uvcvideo/1.1.1-3-realsense)
-      case "${IS_DKMS_INSTALLED}" in
-          *Installed*|*installed*)
-              echo "INFO: DKMS module already installed"
-              ;;
-          *Added*|*added*)
-              dkms build -m uvcvideo -v "1.1.1-3-realsense" && dkms install -m uvcvideo -v "1.1.1-3-realsense" || true
-              ;;
-          *)
-              dkms add -m uvcvideo -v "1.1.1-3-realsense"
-              dkms build -m uvcvideo -v "1.1.1-3-realsense" && dkms install -m uvcvideo -v "1.1.1-3-realsense" || true
-              ;;
-      esac
-
       # Check for uvcvideo loadable kernel module patches in the running kernel
       UVC_MODULE=$(modinfo -F filename uvcvideo)
       PATCHED_FORMATS=$(/usr/bin/strings ${UVC_MODULE} | \
         /bin/egrep '\((Y8I|Y12I|Z16|SRGGB10P|RAW8|RW16|INVZ|INZI|INVR|INRI|INVI|RELI|L8|L16|D16)\)' | \
         /usr/bin/wc -l)
-      case "${PATCHED_FORMATS}" in
-        15)
-          echo "INFO: Intel RealSense(TM) F200, SR300, R200, LR200, and ZR300 cameras are supported."
-        ;;
-        4)
-          echo "WARNING: Only Intel RealSense(TM) R200 camera is supported!"
-          echo "    Visit https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md"
-          echo "    to enable additional camera types."
-        ;;
-        0)
-          echo "WARNING: No Intel RealSense(TM) cameras are supported!"
-          echo "    Visit https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md"
-          echo "    to enable Intel RealSense (TM) camera types."
-        ;;
-        *)
-          echo "WARNING: Unknown configuration for Intel RealSense(TM) cameras!"
-          echo "    Visit https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md"
-          echo "    to enable Intel RealSense (TM) camera types."
-        ;;
-      esac
+
+      if [ ${PATCHED_FORMATS} -eq 15 ]
+      then
+        echo "INFO: Intel RealSense(TM) F200, SR300, R200, LR200, and ZR300 cameras are already supported."
+        echo "       DKMS will not be enabled for this system."
+      else
+        IS_DKMS_INSTALLED=$(dkms status uvcvideo/1.1.1-3-realsense)
+        case "${IS_DKMS_INSTALLED}" in
+          *Installed*|*installed*)
+            echo "INFO: DKMS module already installed"
+            ;;
+          *Added*|*added*)
+            dkms build -m uvcvideo -v "1.1.1-3-realsense" && dkms install -m uvcvideo -v "1.1.1-3-realsense" || true
+            ;;
+          *)
+            dkms add -m uvcvideo -v "1.1.1-3-realsense" && \
+            dkms build -m uvcvideo -v "1.1.1-3-realsense" && dkms install -m uvcvideo -v "1.1.1-3-realsense" || true
+            ;;
+        esac
+
+        IS_DKMS_INSTALLED=$(dkms status uvcvideo/1.1.1-3-realsense)
+        case "${IS_DKMS_INSTALLED}" in
+          *Installed*|*installed*)
+            echo "INFO: DKMS module installed successfully."
+            ;;
+          *Added*|*added*)
+            echo "WARNING: DKMS module failed to installed; removing..."
+            dkms remove -m uvcvideo -v "1.1.1-3-realsense" --all || true
+            ;;
+        esac
+
+        # Check for uvcvideo loadable kernel module patches in the running kernel
+        UVC_MODULE=$(modinfo -F filename uvcvideo)
+        PATCHED_FORMATS=$(/usr/bin/strings ${UVC_MODULE} | \
+          /bin/egrep '\((Y8I|Y12I|Z16|SRGGB10P|RAW8|RW16|INVZ|INZI|INVR|INRI|INVI|RELI|L8|L16|D16)\)' | \
+          /usr/bin/wc -l)
+        case "${PATCHED_FORMATS}" in
+          15)
+            echo "INFO: Intel RealSense(TM) F200, SR300, R200, LR200, and ZR300 cameras are supported."
+            ;;
+          4)
+            echo "WARNING: Only Intel RealSense(TM) R200 camera is supported!"
+            echo "       To resolve, please follow the installation directions at:"
+            echo "           http://wiki.ros.org/librealsense#Installation"
+            ;;
+          0)
+            echo "WARNING: No Intel RealSense(TM) cameras are supported!"
+            echo "       To resolve, please follow the installation directions at:"
+            echo "           http://wiki.ros.org/librealsense#Installation"
+            ;;
+          *)
+            echo "WARNING: Unknown configuration for Intel RealSense(TM) cameras!"
+            echo "       To resolve, please follow the installation directions at:"
+            echo "           http://wiki.ros.org/librealsense#Installation"
+            ;;
+        esac
+      fi
     fi
-  ;;
+    ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)
     exit 0
-  ;;
+    ;;
 
   *)
     echo "postinst called with unknown argument \`$1'" >&2
     exit 1
-  ;;
+    ;;
 
 esac
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -20,7 +20,13 @@ set -e
 case "$1" in
 
   remove|upgrade)
-    dkms remove -m uvcvideo -v "1.1.1-3-realsense" --all || true
+    IS_DKMS_INSTALLED=$(dkms status uvcvideo/1.1.1-3-realsense)
+    case "${IS_DKMS_INSTALLED}" in
+      *Installed*|*installed*|*Added*|*added*)
+        echo "INFO: Removing DKMS module ..."
+        dkms remove -m uvcvideo -v "1.1.1-3-realsense" --all || true
+        ;;
+    esac
   ;;
 
   failed-upgrade|deconfigure)


### PR DESCRIPTION
In the case of a fully patched kernel, no need to enable DKMS.
If an older, unpatched kernel is installed the user will need
to manually reinstall the librealsense package to patch the kernel.

Added error checking to ensure DKMS is installed before removing.

If DKMS failed to install, remove the DKMS module.
