### PR TITLE
Make docker detection more host distro independent

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -25,14 +25,14 @@ OLDHEADER="/usr/local/include/librealsense"
 OLDUDEV="/etc/udev/rules.d/99-realsense-libusb.rules"
 
 # Are we running in a Docker Environment?
-docker_cnt=$(awk -F/ '$2 == "docker"' /proc/1/cgroup  | wc -l)
-# docker_cnt > 0 we are in a docker environment
+docker_cnt=$(awk '$2 == "(1,"' /proc/1/sched  | wc -l)
+# docker_cnt == 0 we are in a docker environment
 
 case "$1" in
 
   configure)
     # Set FORCE_UDEV_IN_DOCKER to non-empty to override
-    if [ ${docker_cnt} -gt 0 -a -z "${FORCE_UDEV_IN_DOCKER}" ]
+    if [ ${docker_cnt} -eq 0 -a -z "${FORCE_UDEV_IN_DOCKER}" ]
     then
       echo "INFO: Docker environment not supported for udevadm; skipping."
     else
@@ -59,7 +59,7 @@ case "$1" in
     fi
 
     # Set FORCE_DKMS_IN_DOCKER to non-empty to override
-    if [ ${docker_cnt} -gt 0 -a -z "${FORCE_DKMS_IN_DOCKER}" ]
+    if [ ${docker_cnt} -eq 0 -a -z "${FORCE_DKMS_IN_DOCKER}" ]
     then
       echo "INFO: Docker environment not supported for DKMS; skipping."
     else


### PR DESCRIPTION
The code in debian/postinst detecting if it runs inside a container
```
awk -F/ '$2 == "docker"' /proc/1/cgroup | wc -l
```
is

1) specific to Docker and can't detect containers of other types;
2) working only on host systems running Ubuntu like distro.

E.g. under Fedora23 the file /proc/1/cgroup inside a docker container contains lines like
```
11:memory:/system.slice/docker-38cf0544a77cfa11567aba5d19fb2a2f02a1dd85a5a803785d40df5ea5939d32.scope
```
where the second field extracted by awk would be "system.slice", not "docker". This prevents installing the package ros-kinetic-librealsense inside a Docker container when the container runs on top of a Fedora host.

As result I get the error
```
Setting up linux-headers-generic (4.4.0.45.48) ...
Setting up menu (2.1.47ubuntu1) ...
Setting up ros-kinetic-librealsense (1.11.0-1xenial-20161020-181724-0700) ...
/var/lib/dpkg/info/ros-kinetic-librealsense.postinst: 40: /var/lib/dpkg/info/ros-kinetic-librealsense.postinst: udevadm: not found

Creating symlink /var/lib/dkms/uvcvideo/1.1.1-3-realsense/source ->
                 /usr/src/uvcvideo-1.1.1-3-realsense

DKMS: add completed.
Error! Your kernel headers for kernel 4.7.5-100.fc23.x86_64 cannot be found.
Please install the linux-headers-4.7.5-100.fc23.x86_64 package,
or use the --kernelsourcedir option to tell DKMS where it's located
libkmod: ERROR ../libkmod/libkmod.c:586 kmod_search_moddep: could not open moddep file '/lib/modules/4.7.5-100.fc23.x86_64/modules.dep.bin'
modinfo: ERROR: Module alias uvcvideo not found.
dpkg: error processing package ros-kinetic-librealsense (--configure):
 subprocess installed post-installation script returned error exit status 1
Processing triggers for systemd (229-4ubuntu10) ...
Processing triggers for libc-bin (2.23-0ubuntu3) ...
Processing triggers for menu (2.1.47ubuntu1) ...
Errors were encountered while processing:
 ros-kinetic-librealsense
E: Sub-process /usr/bin/dpkg returned an error code (1)
Invocation failed without any known error condition, printing all lines to debug known error detection:
...
```
The patch makes container detection independent from host OS distro.

