### PR TITLE
Fix to get_usb_port_id to handle devices connected through USB Hub

### DIFF
--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -491,9 +491,15 @@ namespace rsimpl
 
         std::string get_usb_port_id(const device & device)
         {
-            std::string usb_port = std::to_string(libusb_get_bus_number(device.usb_device)) + "-" +
-                std::to_string(libusb_get_port_number(device.usb_device));
-            return usb_port;
+            auto usb_port = std::to_string(libusb_get_bus_number(device.usb_device));
+            std::string port_numbers = "";
+            auto parent = device.usb_device;
+            while (parent != nullptr)
+            {
+                port_numbers = "-" + std::to_string(libusb_get_port_number(parent)) + port_numbers;
+                parent = libusb_get_parent(parent);
+            }
+            return usb_port + port_numbers;
         }
 
         void get_control(const device & device, const extension_unit & xu, uint8_t ctrl, void * data, int len)


### PR DESCRIPTION
When the device is connected through a Hub printing just Bus-ID and Port-ID is not enough to uniquely identify the device, so this commit will concatenate Port-IDs of all device parents to get truly unique identifier. Similar recursive handling is already implemented for the Windows back-end, so no need to change there as well.  
This fix should resolve #220, as I assume the cameras in questions contain a USB Hub on board. 