### PR TITLE
Bump ROS Version

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
 <package format="2">
   <name>librealsense</name>
   <!-- The version tag needs to be updated with each new release of librealsense -->
-  <version>1.11.0</version>
+  <version>1.11.1</version>
   <description>
   Library for capturing data from the Intel(R) RealSense(TM) F200, SR300, R200, LR200 and ZR300 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project, including multi-camera capture.
   </description>


### PR DESCRIPTION
Planning new release of librealsense as a ROS Debian package
which includes the small code change for the USB Id.
-- See PR #348