### PR TITLE
Add SONAME support for Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@
 # ubuntu 16.04 LTS cmake version 3.5.1
 cmake_minimum_required(VERSION 2.8.3)
 
+set(REALSENSE_VERSION_MAJOR 1)
+set(REALSENSE_VERSION_MINOR 11)
+set(REALSENSE_VERSION_PATCH 1)
+set(REALSENSE_VERSION_STRING ${REALSENSE_VERSION_MAJOR}.${REALSENSE_VERSION_MINOR}.${REALSENSE_VERSION_PATCH})
+
 IF(DEFINED ENV{CMAKE_PREFIX_PATH})
   IF($ENV{CMAKE_PREFIX_PATH} MATCHES "/opt/ros")
     set(ROS_BUILD_TYPE TRUE)
@@ -161,6 +166,8 @@ include(GNUInstallDirs)
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 if(BUILD_SHARED_LIBS)
     add_library(realsense SHARED ${REALSENSE_CPP} ${REALSENSE_HPP} ${REALSENSE_DEF})
+    set_target_properties(realsense PROPERTIES VERSION ${REALSENSE_VERSION_STRING}
+                                    SOVERSION ${REALSENSE_VERSION_MAJOR})
     target_link_libraries(realsense ${LIBUSB1_LIBRARIES})
 else()
     add_library(realsense STATIC ${REALSENSE_CPP} ${REALSENSE_HPP})

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# Define version and soname
+REALSENSE_VERSION_MAJOR = 1
+REALSENSE_VERSION_MINOR = 11
+REALSENSE_VERSION_PATCH = 1
+REALSENSE_LIBRARY_SONAME = librealsense.so.${REALSENSE_VERSION_MAJOR}
+REALSENSE_LIBRARY_TARGET_NAME = librealsense.so.${REALSENSE_VERSION_MAJOR}.${REALSENSE_VERSION_MINOR}.${REALSENSE_VERSION_PATCH}
+
 # Detect OS and CPU
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 machine := $(shell sh -c "$(CC) -dumpmachine || echo unknown")
@@ -70,12 +77,12 @@ all: examples $(EXAMPLES) all-tests
 install: lib/librealsense.so
 	install -m755 -d /usr/local/include/librealsense
 	cp -r include/librealsense/* /usr/local/include/librealsense
-	cp lib/librealsense.so /usr/local/lib
+	cp lib/librealsense.so* /usr/local/lib
 	ldconfig
 
 uninstall:
 	rm -rf /usr/local/include/librealsense
-	rm /usr/local/lib/librealsense.so
+	rm /usr/local/lib/librealsense.so*
 	ldconfig
 
 clean:
@@ -99,8 +106,13 @@ bin/cpp-%: examples/cpp-%.cpp lib/librealsense.so | bin
 	$(CXX) $< -std=c++11 $(REALSENSE_FLAGS) $(GLFW3_FLAGS) -o $@
 
 # Rules for building the library itself
-lib/librealsense.so: $(OBJECTS) | lib
-	$(CXX) -std=c++11 -shared $(OBJECTS) $(LIBUSB_FLAGS) -o $@
+lib/librealsense.so: lib/${REALSENSE_LIBRARY_TARGET_NAME}
+	cd lib; \
+	ldconfig -v -n .; \
+	ln -s ${REALSENSE_LIBRARY_SONAME} librealsense.so
+
+lib/${REALSENSE_LIBRARY_TARGET_NAME}: $(OBJECTS) | lib
+	$(CXX) -std=c++11 -shared $(OBJECTS) $(LIBUSB_FLAGS) -Wl,-soname,${REALSENSE_LIBRARY_SONAME} -o $@
 
 lib/librealsense.a: $(OBJECTS) | lib
 	ar rvs $@ `find obj/ -name "*.o"`


### PR DESCRIPTION
SONAME is often used to provide version backwards-compatibility information,
quoted from https://en.wikipedia.org/wiki/Soname. librealsense.so should do
the same thing.

Fixes #364