### PR TITLE
scripts: removed bashisms.

### DIFF
--- a/config/usb-R200-in
+++ b/config/usb-R200-in
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 lockdir="/dswork.lock"
 if mkdir "$lockdir" 
     then 
         # Successfully acquired lock
         for i in $(ls /sys/bus/usb/drivers/uvcvideo/|grep :) ; do
-             echo $i >/sys/bus/usb/drivers/uvcvideo/unbind
-            echo $i >/sys/bus/usb/drivers/uvcvideo/bind
-            echo "Reseting" $i
+            echo "$i" >/sys/bus/usb/drivers/uvcvideo/unbind
+            echo "$i" >/sys/bus/usb/drivers/uvcvideo/bind
+            echo "Reseting" "$i"
         done    
 
         sleep 2

--- a/config/usb-R200-in_udev
+++ b/config/usb-R200-in_udev
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 /usr/local/bin/usb-R200-in &


### PR DESCRIPTION
The udev configuration scripts might be used on systems which don't have bash installed. Change the scripts to use "any shell" instead of bash. Also fix a few issues found by shellcheck.