### PR TITLE
examples: control building of the graphical examples

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -45,7 +45,10 @@ The project requires two external dependencies, *glfw* and *libusb-1.0*. The Cma
   The default build is set to produce the core shared object and unit-tests binaries
   * `cmake ../`<br />
   In order to build *librealsense* along with the demos and tutorials use<br />
-  * `cmake ../ -DBUILD_EXAMPLES=true`
+  * `cmake ../ -DBUILD_EXAMPLES=true`<br />
+  If you don't want to have build dependencies to OpenGL and X11, you can also<br />
+  build only the non-graphical examples:<br />
+  * `cmake ../ -DBUILD_EXAMPLES=true -DBUILD_GRAPHICAL_EXAMPLES=false`
 
   Generate and install binaries:<br />
   * `make && sudo make install`<br />

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # View the makefile commands during build
 #set(CMAKE_VERBOSE_MAKEFILE on)
 
+# This parameter is meant for disabling graphical examples when building for
+# headless targets.
+option(BUILD_GRAPHICAL_EXAMPLES "Build graphical examples." ON)
+
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
 CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
@@ -21,72 +25,54 @@ else()
     message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
 
-find_package(OpenGL REQUIRED)
-set(DEPENDENCIES realsense ${OPENGL_LIBRARIES})
+if(BUILD_GRAPHICAL_EXAMPLES)
+    find_package(OpenGL REQUIRED)
+    set(DEPENDENCIES realsense ${OPENGL_LIBRARIES})
 
-if(WIN32)
-    add_subdirectory(third_party/glfw)
-    list(APPEND DEPENDENCIES glfw3)
+    if(WIN32)
+        add_subdirectory(third_party/glfw)
+        list(APPEND DEPENDENCIES glfw3)
+    else()
+        # Find glfw header
+        find_path(GLFW_INCLUDE_DIR NAMES GLFW/glfw3.h
+            PATHS /usr/X11R6/include
+                  /usr/include/X11
+                  /opt/graphics/OpenGL/include
+                  /opt/graphics/OpenGL/contrib/libglfw
+                  /usr/local/include
+                  /usr/include/GL
+                  /usr/include
+        )
+        # Find glfw library
+        find_library(GLFW_LIBRARIES NAMES glfw glfw3
+                PATHS /usr/lib64
+                      /usr/lib
+                      /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
+                      /usr/local/lib64
+                      /usr/local/lib
+                      /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
+                      /usr/X11R6/lib
+        )
+        list(APPEND DEPENDENCIES m ${GLFW_LIBRARIES} ${LIBUSB1_LIBRARIES})
+        include_directories(${GLFW_INCLUDE_DIR})
+    endif()
 else()
-    # Find glfw header
-    find_path(GLFW_INCLUDE_DIR NAMES GLFW/glfw3.h
-        PATHS /usr/X11R6/include
-              /usr/include/X11
-              /opt/graphics/OpenGL/include
-              /opt/graphics/OpenGL/contrib/libglfw
-              /usr/local/include
-              /usr/include/GL
-              /usr/include
-    )
-    # Find glfw library
-    find_library(GLFW_LIBRARIES NAMES glfw glfw3
-            PATHS /usr/lib64
-                  /usr/lib
-                  /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}
-                  /usr/local/lib64
-                  /usr/local/lib
-                  /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
-                  /usr/X11R6/lib
-    )
-    list(APPEND DEPENDENCIES m ${GLFW_LIBRARIES} ${LIBUSB1_LIBRARIES})
-    include_directories(${GLFW_INCLUDE_DIR})
+    set(DEPENDENCIES realsense)
+    if(NOT WIN32)
+        list(APPEND DEPENDENCIES m ${LIBUSB1_LIBRARIES})
+    endif()
 endif()
 
-# C Tutorials
+# C/C++ tutorials and examples
+
 add_executable(c-tutorial-1-depth c-tutorial-1-depth.c)
 target_link_libraries(c-tutorial-1-depth ${DEPENDENCIES})
 
-add_executable(c-tutorial-2-streams c-tutorial-2-streams.c)
-target_link_libraries(c-tutorial-2-streams ${DEPENDENCIES})
-
-add_executable(c-tutorial-3-pointcloud c-tutorial-3-pointcloud.c)
-target_link_libraries(c-tutorial-3-pointcloud ${DEPENDENCIES})
-
-# C++ Tutorials
 add_executable(cpp-tutorial-1-depth cpp-tutorial-1-depth.cpp)
 target_link_libraries(cpp-tutorial-1-depth ${DEPENDENCIES})
 
-add_executable(cpp-tutorial-2-streams cpp-tutorial-2-streams.cpp)
-target_link_libraries(cpp-tutorial-2-streams ${DEPENDENCIES})
-
-add_executable(cpp-tutorial-3-pointcloud cpp-tutorial-3-pointcloud.cpp)
-target_link_libraries(cpp-tutorial-3-pointcloud ${DEPENDENCIES})
-
-# Examples
-add_executable(cpp-alignimages cpp-alignimages.cpp)
-target_link_libraries(cpp-alignimages ${DEPENDENCIES})
-
 add_executable(cpp-callback cpp-callback.cpp)
 target_link_libraries(cpp-callback ${DEPENDENCIES})
-
-add_executable(cpp-callback-2 cpp-callback-2.cpp)
-target_link_libraries(cpp-callback-2 ${DEPENDENCIES})
-
-add_executable(cpp-capture cpp-capture.cpp)
-target_link_libraries(cpp-capture ${DEPENDENCIES})
-
-add_executable(cpp-config-ui cpp-config-ui.cpp)
-target_link_libraries(cpp-config-ui ${DEPENDENCIES})
 
 add_executable(cpp-enumerate-devices cpp-enumerate-devices.cpp)
 target_link_libraries(cpp-enumerate-devices ${DEPENDENCIES})
@@ -97,43 +83,76 @@ target_link_libraries(cpp-headless ${DEPENDENCIES})
 add_executable(cpp-motion-module cpp-motion-module.cpp)
 target_link_libraries(cpp-motion-module ${DEPENDENCIES})
 
-add_executable(cpp-multicam cpp-multicam.cpp)
-target_link_libraries(cpp-multicam ${DEPENDENCIES})
+if(BUILD_GRAPHICAL_EXAMPLES)
+    add_executable(c-tutorial-2-streams c-tutorial-2-streams.c)
+    target_link_libraries(c-tutorial-2-streams ${DEPENDENCIES})
 
-add_executable(cpp-pointcloud cpp-pointcloud.cpp)
-target_link_libraries(cpp-pointcloud ${DEPENDENCIES})
+    add_executable(c-tutorial-3-pointcloud c-tutorial-3-pointcloud.c)
+    target_link_libraries(c-tutorial-3-pointcloud ${DEPENDENCIES})
 
-add_executable(cpp-restart cpp-restart.cpp)
-target_link_libraries(cpp-restart ${DEPENDENCIES})
+    add_executable(cpp-tutorial-2-streams cpp-tutorial-2-streams.cpp)
+    target_link_libraries(cpp-tutorial-2-streams ${DEPENDENCIES})
 
-add_executable(cpp-stride cpp-stride.cpp)
-target_link_libraries(cpp-stride ${DEPENDENCIES})
+    add_executable(cpp-tutorial-3-pointcloud cpp-tutorial-3-pointcloud.cpp)
+    target_link_libraries(cpp-tutorial-3-pointcloud ${DEPENDENCIES})
+
+    add_executable(cpp-alignimages cpp-alignimages.cpp)
+    target_link_libraries(cpp-alignimages ${DEPENDENCIES})
+
+    add_executable(cpp-callback-2 cpp-callback-2.cpp)
+    target_link_libraries(cpp-callback-2 ${DEPENDENCIES})
+
+    add_executable(cpp-capture cpp-capture.cpp)
+    target_link_libraries(cpp-capture ${DEPENDENCIES})
+
+    add_executable(cpp-config-ui cpp-config-ui.cpp)
+    target_link_libraries(cpp-config-ui ${DEPENDENCIES})
+
+    add_executable(cpp-multicam cpp-multicam.cpp)
+    target_link_libraries(cpp-multicam ${DEPENDENCIES})
+
+    add_executable(cpp-pointcloud cpp-pointcloud.cpp)
+    target_link_libraries(cpp-pointcloud ${DEPENDENCIES})
+
+    add_executable(cpp-restart cpp-restart.cpp)
+    target_link_libraries(cpp-restart ${DEPENDENCIES})
+
+    add_executable(cpp-stride cpp-stride.cpp)
+    target_link_libraries(cpp-stride ${DEPENDENCIES})
+
+    install(
+        TARGETS
+        c-tutorial-2-streams
+        c-tutorial-3-pointcloud
+
+        cpp-tutorial-2-streams
+        cpp-tutorial-3-pointcloud
+
+        cpp-alignimages
+        cpp-callback-2
+        cpp-capture
+        cpp-config-ui
+        cpp-multicam
+        cpp-pointcloud
+        cpp-restart
+        cpp-stride
+
+        RUNTIME DESTINATION
+        ${CMAKE_INSTALL_BINDIR}
+    )
+endif()
 
 install(
     TARGETS
     c-tutorial-1-depth
-    c-tutorial-2-streams
-    c-tutorial-3-pointcloud
 
     cpp-tutorial-1-depth
-    cpp-tutorial-2-streams
-    cpp-tutorial-3-pointcloud
 
-    cpp-alignimages
     cpp-callback
-    cpp-callback-2
-    cpp-capture
-    cpp-config-ui
     cpp-enumerate-devices
     cpp-headless
     cpp-motion-module
-    cpp-multicam
-    cpp-pointcloud
-    cpp-restart
-    cpp-stride
 
     RUNTIME DESTINATION
     ${CMAKE_INSTALL_BINDIR}
 )
-
-


### PR DESCRIPTION
The graphical examples require a graphical environment, while the standard examples can be run in a headless system. Separate the two with a compile switch. If you want to disable building of the graphical
examples, use

    -DBUILD_GRAPHICAL_EXAMPLES=off

in the cmake command line. By default the graphical examples are built if `BUILD_EXAMPLES` is selected, so the default behavior does not change.

I didn't test the configuration and build on a WIN32 system.