### PR TITLE
Check for uvcvideo existence via the /sys kernel filesystem

### DIFF
--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -726,23 +726,14 @@ namespace rsimpl
         std::vector<std::shared_ptr<device>> query_devices(std::shared_ptr<context> context)
         {
             // Check if the uvcvideo kernel module is loaded
-            std::ifstream modules("/proc/modules");
-            std::string modulesline;
-            std::regex regex("uvcvideo.* - Live.*");
-            std::smatch match;
-            bool module_found = false;
+	    struct stat info;
+	    int err = stat("/sys/module/uvcvideo/", &info);
 
-
-            while(std::getline(modules,modulesline) && !module_found)
-            {
-                module_found = std::regex_match(modulesline, match, regex);
-            }
-
-            if(!module_found)
+	    if (err == -1  // errno==ENOENT, typically
+		|| (info.st_mode & S_IFMT != S_IFDIR))
             {
                 throw std::runtime_error("uvcvideo kernel module is not loaded");
             }
-
 
             // Enumerate all subdevices present on the system
             std::vector<std::unique_ptr<subdevice>> subdevices;


### PR DESCRIPTION
The ARM boards I work with (here a Toradex Apalis TK1), kernels are mostly monolithic, so uvcvideo cannot be found in the list of loaded modules from /proc/modules while /sys/module/* holds meta data for all modules in the kernel.
Besides, startup is a little bit more efficient.