### PR TITLE
Updating Mac OS X documentation

### DIFF
--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -2,25 +2,37 @@
 
 **Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the librealsense team does not recommend or support installation in a VM.
 
-The simplest method of installation uses the [Homebrew package manager](http://brew.sh/):
+The simplest method of installation uses the [Homebrew package manager](http://brew.sh/). First install [Homebrew](http://brew.sh/) via terminal and confirm it's working with ```$ brew doctor```
 
- 1. Install XCode 6.0+ via the AppStore
- 2. Install the [Homebrew package manager](http://brew.sh/) via terminal and confirm it's working with ```$ brew doctor```
+## Installation via Homebrew
 
-Then, to install librealsense, you can then install either the latest release of librealsense:
+To install librealsense, you can then install either the latest release of librealsense:
 
     $ brew install librealsense
 
-Or you can install the head version from Github:
+Or you can install the head version from GitHub:
 
     $ brew install librealsense --HEAD
 
 To install with examples, add the ```--with-examples``` flag. Use ```$ brew info librealsense``` to retrieve the location of the installation.
 
-Alternatively, if you would like to compile librealsense from source:
+## Installation from source
 
-    $ brew install cmake pkg-config libusb
+If you would like to compile librealsense from source:
+
+    $ brew install cmake pkg-config libusb glfw
     $ git clone https://github.com/IntelRealSense/librealsense.git
     $ cd librealsense
-    $ cmake .
+    $ mkdir build && cd build
+
+For the default build:
+
+    $ cmake ../
+
+Alternatively, to also build examples:
+
+    $ cmake ../ -DBUILD_EXAMPLES=true
+
+Finally, generate and install binaries:
+
     $ make && make install

--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -2,9 +2,25 @@
 
 **Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the librealsense team does not recommend or support installation in a VM.
 
-1. Install XCode 6.0+ via the AppStore
-2. Install the Homebrew package manager via terminal - [link](http://brew.sh/)
-3. Install pkg-config and libusb via brew:
-  * `brew install libusb pkg-config`
-4. Install glfw3 via brew:
-  * `brew install homebrew/versions/glfw3`
+The simplest method of installation uses the [Homebrew package manager](http://brew.sh/):
+
+ 1. Install XCode 6.0+ via the AppStore
+ 2. Install the [Homebrew package manager](http://brew.sh/) via terminal and confirm it's working with ```$ brew doctor```
+
+Then, to install librealsense, you can then install either the latest release of librealsense:
+
+    $ brew install librealsense
+
+Or you can install the head version from Github:
+
+    $ brew install librealsense --HEAD
+
+To install with examples, add the ```--with-examples``` flag. Use ```$ brew info librealsense``` to retrieve the location of the installation.
+
+Alternatively, if you would like to compile librealsense from source:
+
+    $ brew install cmake pkg-config libusb
+    $ git clone https://github.com/IntelRealSense/librealsense.git
+    $ cd librealsense
+    $ cmake .
+    $ make && make install


### PR DESCRIPTION
librealsense can now be easily installed via Homebrew. I've updated the documentation to reflect this and cleared up how to install from source.

---

Name: Steven Cholewiak
I agree to the terms of the Intel® RealSense™ Cross Platform API CLA.