### PR TITLE
Add missing includes for <sys/time.h> and <functional>

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <sstream>
 #include <iostream>
+#include <functional>
 
 using namespace rsimpl;
 using namespace rsimpl::motion_module;

--- a/src/libuvc/libuvc.h
+++ b/src/libuvc/libuvc.h
@@ -8,6 +8,7 @@ extern "C" {
 #include <stdio.h> // FILE
 #include <errno.h>
 #include <libusb.h>
+#include <sys/time.h> // timeval
 #include "libuvc_config.h"
     
 /** UVC error types, based on libusb errors

--- a/src/types.h
+++ b/src/types.h
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <map>          
 #include <algorithm>
+#include <functional>
 
 const uint8_t RS_STREAM_NATIVE_COUNT    = 5;
 const int RS_USER_QUEUE_SIZE = 20;


### PR DESCRIPTION
This fixes two separate issues:

1. With newer GCC versions (>= 7), including `<functional>` is required when using `std::function`. Without the include, the build fails with

        error: 'function' in namespace 'std' does not name a template type
    See [this Fedora build](https://thofmann.fedorapeople.org/librealsense/std-function/build.log) for an example.
1. On PPC64, using `timeval` requires to include `<sys/time.h>`. Without the include, the build fails with

        error: field 'capture_time' has incomplete type struct timeval capture_time;
    See [this Fedora build](https://thofmann.fedorapeople.org/librealsense/timeval/build.log) for an example.