### PR TITLE
Fix a non utf-8 character in types.h

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -29,7 +29,7 @@ const int RS_USER_QUEUE_SIZE = 20;
 // Timestamp syncronization settings:
 const int RS_MAX_EVENT_QUEUE_SIZE = 500;  // Max number of timestamp events to keep for all streams
 const int RS_MAX_EVENT_TIME_OUT = 20;     // Max timeout in milliseconds that a frame can wait for its corresponding timestamp event
-// Usually timestamp events arrive much faster then frames, but due to USB arbitration the QoS isn’t guaranteed. 
+// Usually timestamp events arrive much faster then frames, but due to USB arbitration the QoS isn't guaranteed.
 // RS_MAX_EVENT_TIME_OUT controls how much time the user is willing to wait before "giving-up" on a particular frame
 
 namespace rsimpl


### PR DESCRIPTION
There is a weird character in "types.h". 

Vim can not display it

![char](https://cloud.githubusercontent.com/assets/1241736/24603293/7a99beda-1860-11e7-900a-83d27dc37f92.png)

and GDB fails to show source listing with:

```
Cannot display "/home/sergey/Workspace/librealsense/src/types.h" ('utf-8' codec can't decode byte 0x92 in position 1553: invalid start byte)
```

This commit replaces it with a normal ASCII apostrophe.

I agree to the terms of the Intel® RealSense™ Cross Platform API CLA.