### PR TITLE
Add snap install instructions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -2,6 +2,14 @@
 
 **Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the *librealsense* team does not recommend or support installation in a VM.
 
+## Install pre-built snap
+
+Install librealsense in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+    snap install librealsense
+
+Snaps contain all necessary dependencies required to run. The snap will get automatically updated when a new version is pushed to the store. 
+
 ## 3rd-party dependencies
 
 The project requires two external dependencies, *glfw* and *libusb-1.0*. The Cmake build environment additionally requires *pkg-config*.


### PR DESCRIPTION
This pull request adds installation instructions for users of snap enabled Linux distributions ( https://snapcraft.io/docs/core/install ). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of desktop applications will also be available via the desktop Software Center, improving the discover-ability of your software. Your software can be installed with a simple `snap install librealsense` simplifying the installation instructions for your users.