### PR TITLE
Update getting_started_with_openCV.md

### DIFF
--- a/doc/stepbystep/getting_started_with_openCV.md
+++ b/doc/stepbystep/getting_started_with_openCV.md
@@ -114,7 +114,7 @@ int main()
 Compile and run the program from the terminal, with the following command:
 
 ```shell
-g++ -std=c++11 IR_sample.cpp -lrealsense -lopencv_core -lopencv_omgproc -lopencv_contrib -o ir && ./ir
+g++ -std=c++11 IR_sample.cpp -lrealsense -lopencv_core -lopencv_imgproc -lopencv_highgui -o ir && ./ir
 ```
 
 **Result :**


### PR DESCRIPTION
Fixed typo in `opencv_omgproc` => `opencv_imgproc`
I've also replaced `opencv_contrib` with `opencv_highgui` so that the code will build on Intel Aero board (also to be consistent with the example above).