### PR TITLE
Added the linux-headers requirement for arch linux installations in the documentation.

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -76,6 +76,7 @@ Next, build the patched module for the desired machine configuration.<br />
 
   * **Arch-based distributions**
     * You need to install the [base-devel](https://www.archlinux.org/groups/x86_64/base-devel/) package group.
+    * You need to install the according linux-headers as well (i.e.: linux-lts-headers for the linux-lts kernel).
 Then run the following script to patch the uvc module:
     * `./scripts/patch-arch.sh`<br />
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -76,7 +76,7 @@ Next, build the patched module for the desired machine configuration.<br />
 
   * **Arch-based distributions**
     * You need to install the [base-devel](https://www.archlinux.org/groups/x86_64/base-devel/) package group.
-    * You need to install the according linux-headers as well (i.e.: linux-lts-headers for the linux-lts kernel).
+    * You need to install the according linux-headers as well (i.e.: linux-lts-headers for the linux-lts kernel).<br />
     Navigate to the scripts folder:
     * `cd ./scripts/`<br />
     Then run the following script to patch the uvc module:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -77,8 +77,10 @@ Next, build the patched module for the desired machine configuration.<br />
   * **Arch-based distributions**
     * You need to install the [base-devel](https://www.archlinux.org/groups/x86_64/base-devel/) package group.
     * You need to install the according linux-headers as well (i.e.: linux-lts-headers for the linux-lts kernel).
-Then run the following script to patch the uvc module:
-    * `./scripts/patch-arch.sh`<br />
+    Navigate to the scripts folder:
+    * `cd ./scripts/`<br />
+    Then run the following script to patch the uvc module:
+    * `./patch-arch.sh`<br />
 
 Check installation by examining the latest entries in kernel log:
   * `sudo dmesg | tail -n 50`<br />


### PR DESCRIPTION
Without the according linux-headers package, the ./patch-arch.sh script fails.
Thus, it would be good to mention this requirement in the documentation, the headers package not always being installed on all arch systems.