### PR TITLE
Change fourcc codes of INVZ and INVI to Z16 and Y10 respectively

### DIFF
--- a/scripts/0001-Add-video-formats-for-Intel-real-sense-F200-camera-new.patch
+++ b/scripts/0001-Add-video-formats-for-Intel-real-sense-F200-camera-new.patch
@@ -21,7 +21,7 @@ index 47ff9f4..5757bf2 100644
 +	{
 +		.name		= "Depth 16-bit (INVZ)",
 +		.guid		= UVC_GUID_FORMAT_INVZ,
-+		.fcc		= V4L2_PIX_FMT_INVZ,
++		.fcc		= V4L2_PIX_FMT_Z16,
 +	},
 +	{
 +		.name		= "Depth:IR 16:8 24-bit (INZI)",
@@ -41,7 +41,7 @@ index 47ff9f4..5757bf2 100644
 +	{
 +		.name		= "Infrared 8-bit (INVI)",
 +		.guid		= UVC_GUID_FORMAT_INVI,
-+		.fcc		= V4L2_PIX_FMT_INVI,
++		.fcc		= V4L2_PIX_FMT_Y10,
 +	},
 +	{
 +		.name		= "FlickerIR 8-bit (RELI)",
@@ -84,15 +84,13 @@ diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
 index 421d274..b6869f7 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -624,6 +624,12 @@ struct v4l2_pix_format {
+@@ -624,4 +624,10 @@ struct v4l2_pix_format {
  #define V4L2_PIX_FMT_Y8I      v4l2_fourcc('Y', '8', 'I', ' ') /* Greyscale 8-bit L/R interleaved */
  #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
  #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
-+#define V4L2_PIX_FMT_INVZ		v4l2_fourcc('I',  'N',  'V',  'Z') /* 16 Depth */
 +#define V4L2_PIX_FMT_INZI		v4l2_fourcc('I',  'N',  'Z',  'I') /* 24 Depth/IR 16:8 */
 +#define V4L2_PIX_FMT_INVR		v4l2_fourcc('I',  'N',  'V',  'R') /* 16 Depth */
 +#define V4L2_PIX_FMT_INRI		v4l2_fourcc('I',  'N',  'R',  'I') /* 24 Depth/IR 16:8 */
-+#define V4L2_PIX_FMT_INVI		v4l2_fourcc('I',  'N',  'V',  'I') /* 8 IR */
 +#define V4L2_PIX_FMT_RELI		v4l2_fourcc('R',  'E',  'L',  'I') /* 8 IR alternating on off illumination */
  
  /* SDR formats - used only for Software Defined Radio devices */

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -470,12 +470,12 @@ namespace rsimpl
     const native_pixel_format pf_y12i       = { 'Y12I', 1, 3,{  { true,  &unpack_y16_y16_from_y12i_10,      { { RS_STREAM_INFRARED, RS_FORMAT_Y16 },{ RS_STREAM_INFRARED2, RS_FORMAT_Y16 } } } } };
     const native_pixel_format pf_z16        = { 'Z16 ', 1, 2,{  { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 } } },
                                                                 { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH,    RS_FORMAT_DISPARITY16 } } } } };
-    const native_pixel_format pf_invz       = { 'INVZ', 1, 2, { { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH, RS_FORMAT_Z16 } } } } };
-    const native_pixel_format pf_f200_invi  = { 'INVI', 1, 1, { { false, &copy_pixels<1>,                   { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
+    const native_pixel_format pf_invz       = { 'Z16 ', 1, 2, { { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 } } } } };
+    const native_pixel_format pf_f200_invi  = { 'Y10 ', 1, 1, { { false, &copy_pixels<1>,                   { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_y16_from_y8,               { { RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };
     const native_pixel_format pf_f200_inzi  = { 'INZI', 1, 3,{  { true,  &unpack_z16_y8_from_f200_inzi,     { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_z16_y16_from_f200_inzi,    { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };
-    const native_pixel_format pf_sr300_invi = { 'INVI', 1, 2,{  { true,  &unpack_y8_from_y16_10,            { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
+    const native_pixel_format pf_sr300_invi = { 'Y10 ', 1, 2,{  { true,  &unpack_y8_from_y16_10,            { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_y16_from_y16_10,           { { RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };
     const native_pixel_format pf_sr300_inzi = { 'INZI', 2, 2,{  { true,  &unpack_z16_y8_from_sr300_inzi,    { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_z16_y16_from_sr300_inzi,   { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };


### PR DESCRIPTION
With [the official support for SR300 pixel-formats](https://github.com/torvalds/linux/commit/c4a0968aea0d887b15d8df15399f8e0dc614aecf) being part of the upcoming 4.12 kernel, we need to align to the same **fourcc** mapping. 
This change modifies librealsense code so that SR300 should run out-of-the box with 4.12, and modifies the patches we provide for 4.4 accordingly. 
