### PR TITLE
Change fourcc codes of INVZ and INVI to Z16 and Y10 respectively

### DIFF
--- a/scripts/0001-Add-video-formats-for-Intel-real-sense-F200-camera-new.patch
+++ b/scripts/0001-Add-video-formats-for-Intel-real-sense-F200-camera-new.patch
@@ -21,7 +21,7 @@ index 47ff9f4..5757bf2 100644
 +	{
 +		.name		= "Depth 16-bit (INVZ)",
 +		.guid		= UVC_GUID_FORMAT_INVZ,
-+		.fcc		= V4L2_PIX_FMT_INVZ,
++		.fcc		= V4L2_PIX_FMT_Z16,
 +	},
 +	{
 +		.name		= "Depth:IR 16:8 24-bit (INZI)",
@@ -41,7 +41,7 @@ index 47ff9f4..5757bf2 100644
 +	{
 +		.name		= "Infrared 8-bit (INVI)",
 +		.guid		= UVC_GUID_FORMAT_INVI,
-+		.fcc		= V4L2_PIX_FMT_INVI,
++		.fcc		= V4L2_PIX_FMT_Y10,
 +	},
 +	{
 +		.name		= "FlickerIR 8-bit (RELI)",
@@ -81,22 +81,19 @@ index 7e4d3ee..fad3eb5 100644
  /* ------------------------------------------------------------------------
   * Driver specific constants.
 diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
-index 421d274..b6869f7 100644
+index 421d274..c32f2cd 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -624,6 +624,12 @@ struct v4l2_pix_format {
+@@ -624,6 +624,10 @@ struct v4l2_pix_format {
  #define V4L2_PIX_FMT_Y8I      v4l2_fourcc('Y', '8', 'I', ' ') /* Greyscale 8-bit L/R interleaved */
  #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
  #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
-+#define V4L2_PIX_FMT_INVZ		v4l2_fourcc('I',  'N',  'V',  'Z') /* 16 Depth */
-+#define V4L2_PIX_FMT_INZI		v4l2_fourcc('I',  'N',  'Z',  'I') /* 24 Depth/IR 16:8 */
-+#define V4L2_PIX_FMT_INVR		v4l2_fourcc('I',  'N',  'V',  'R') /* 16 Depth */
-+#define V4L2_PIX_FMT_INRI		v4l2_fourcc('I',  'N',  'R',  'I') /* 24 Depth/IR 16:8 */
-+#define V4L2_PIX_FMT_INVI		v4l2_fourcc('I',  'N',  'V',  'I') /* 8 IR */
-+#define V4L2_PIX_FMT_RELI		v4l2_fourcc('R',  'E',  'L',  'I') /* 8 IR alternating on off illumination */
++#define V4L2_PIX_FMT_INZI     v4l2_fourcc('I',  'N',  'Z',  'I') /* 24 Depth/IR 16:8 */
++#define V4L2_PIX_FMT_INVR     v4l2_fourcc('I',  'N',  'V',  'R') /* 16 Depth */
++#define V4L2_PIX_FMT_INRI     v4l2_fourcc('I',  'N',  'R',  'I') /* 24 Depth/IR 16:8 */
++#define V4L2_PIX_FMT_RELI     v4l2_fourcc('R',  'E',  'L',  'I') /* 8 IR alternating on off illumination */
  
  /* SDR formats - used only for Software Defined Radio devices */
  #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */
 -- 
 2.7.4
-

--- a/scripts/0002-LR200-ZR300-and-SR300-Pixel-Formats.patch
+++ b/scripts/0002-LR200-ZR300-and-SR300-Pixel-Formats.patch
@@ -1,86 +1,91 @@
-From ccc513a3a69607fae553738a701340ea35f80858 Mon Sep 17 00:00:00 2001
+From 4b56855d67fbbf2cac85c4280cb0de81611a900e Mon Sep 17 00:00:00 2001
 From: Elad Zucker <eladz@hexsys-solutions.com>
 From: Evgeni Raikhel <eraikhel@intel.com>
-Date: Mon, 6 Feb 2017 16:33:55 +0200
-Subject: [PATCH 2/2] LR200 ZR300 and SR300 Formats
+Date: Thu, 15 Jun 2017 13:46:15 +0300
+Subject: [PATCH] [PATCH] LR200 and ZR300 Pixel formats patch
 
+Signed-off-by: Sergey Dorodnicov <dorodnic@gmail.com>
+Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 12 +++++++++++-
+ drivers/media/usb/uvc/uvc_driver.c | 16 +++++++++++++---
  drivers/media/usb/uvc/uvcvideo.h   |  6 ++++++
- include/uapi/linux/videodev2.h     |  8 +++++++-
- 3 files changed, 24 insertions(+), 2 deletions(-)
+ include/uapi/linux/videodev2.h     |  1 +
+ 3 files changed, 20 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
-index a6da397..abb0389 100644
+index c8035f8..712a352 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -169,12 +169,22 @@ static struct uvc_format_desc uvc_fmts[] = {
+@@ -169,12 +169,12 @@ static struct uvc_format_desc uvc_fmts[] = {
  		.fcc		= V4L2_PIX_FMT_SRGGB10P,
  	},
  	{
+-		.name		= "Depth 16-bit (INVZ)",
++		.name		= "Depth data 16-bit (Z16)",
+ 		.guid		= UVC_GUID_FORMAT_INVZ,
+ 		.fcc		= V4L2_PIX_FMT_Z16,
+ 	},
+ 	{
+-		.name		= "Depth:IR 16:8 24-bit (INZI)",
++		.name		= "IR:Depth 26-bit (INZI)",
+ 		.guid		= UVC_GUID_FORMAT_INZI,
+ 		.fcc		= V4L2_PIX_FMT_INZI,
+ 	},
+@@ -189,7 +189,7 @@ static struct uvc_format_desc uvc_fmts[] = {
+ 		.fcc		= V4L2_PIX_FMT_INRI,
+ 	},
+ 	{
+-		.name		= "Infrared 8-bit (INVI)",
++		.name		= "Greyscale 10-bit (Y10 )",
+ 		.guid		= UVC_GUID_FORMAT_INVI,
+ 		.fcc		= V4L2_PIX_FMT_Y10,
+ 	},
+@@ -198,6 +198,16 @@ static struct uvc_format_desc uvc_fmts[] = {
+ 		.guid		= UVC_GUID_FORMAT_RELI,
+ 		.fcc		= V4L2_PIX_FMT_RELI,
+ 	},
++	{
 +		.name		= "Raw data 8-bit (RAW8)",
 +		.guid		= UVC_GUID_FORMAT_RAW8,
-+		.fcc		= V4L2_PIX_FMT_RAW8,
++		.fcc		= V4L2_PIX_FMT_GREY,
 +	},
 +	{
 +		.name		= "Raw data 16-bit (RW16)",
 +		.guid		= UVC_GUID_FORMAT_RW16,
 +		.fcc		= V4L2_PIX_FMT_RW16,
 +	},
-+	{
- 		.name		= "Depth 16-bit (INVZ)",
- 		.guid		= UVC_GUID_FORMAT_INVZ,
- 		.fcc		= V4L2_PIX_FMT_INVZ,
- 	},
- 	{
--		.name		= "Depth:IR 16:8 24-bit (INZI)",
-+		.name		= "Depth:IR 16:10 26-bit (INZI)",
- 		.guid		= UVC_GUID_FORMAT_INZI,
- 		.fcc		= V4L2_PIX_FMT_INZI,
- 	},
+ };
+ 
+ /* ------------------------------------------------------------------------
 diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
-index fad3eb5..7969389 100644
+index fad3eb5..10050a2 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -128,9 +128,15 @@
- #define UVC_GUID_FORMAT_Z16 \
- 	{ 'Z',  '1',  '6',  ' ', 0x00, 0x00, 0x10, 0x00, \
- 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
+@@ -149,6 +149,12 @@
+ #define UVC_GUID_FORMAT_RELI \
+ 	{ 'R',  'E',  'L',  'I', 0x14, 0x13, 0x43, 0xf9, \
+ 	 0xa7, 0x5a, 0xee, 0x6b, 0xbf, 0x01, 0x2e, 0x23}
 +#define UVC_GUID_FORMAT_RAW8 \
 +	{ 'R',  'A',  'W',  '8', 0x66, 0x1a, 0x42, 0xa2, \
 +	 0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
- #define UVC_GUID_FORMAT_RW10 \
- 	{ 'R',  'W',  '1',  '0', 0x00, 0x00, 0x10, 0x00, \
- 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
 +#define UVC_GUID_FORMAT_RW16 \
 +	{ 'R',  'W',  '1',  '6', 0x00, 0x00, 0x10, 0x00, \
 +	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
- #define UVC_GUID_FORMAT_INVZ \
- 	{ 'I',  'N',  'V',  'Z', 0x90, 0x2d, 0x58, 0x4a, \
- 	 0x92, 0x0b, 0x77, 0x3f, 0x1f, 0x2c, 0x55, 0x6b}
+ 
+ /* ------------------------------------------------------------------------
+  * Driver specific constants.
 diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
-index 6bf0018..703ccbf 100644
+index c32f2cd..fccc6a3 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -624,11 +624,17 @@ struct v4l2_pix_format {
- #define V4L2_PIX_FMT_Y8I      v4l2_fourcc('Y', '8', 'I', ' ') /* Greyscale 8-bit L/R interleaved */
- #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
- #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
-+#define V4L2_PIX_FMT_Y8 		v4l2_fourcc('Y',  '8',  ' ',  ' ') /* Greyscale 8-bit */
-+#define V4L2_PIX_FMT_Y10		v4l2_fourcc('Y',  '1',  '0',  ' ') /* Greyscale 10-bit */
-+#define V4L2_PIX_FMT_Y12		v4l2_fourcc('Y',  '1',  '2',  ' ') /* Greyscale 12-bit */
-+#define V4L2_PIX_FMT_Y16		v4l2_fourcc('Y',  '1',  '6',  ' ') /* Greyscale 16-bit */
-+#define V4L2_PIX_FMT_RAW8		v4l2_fourcc('R',  'A',  'W',  '8') /* Raw data 8-bit */
-+#define V4L2_PIX_FMT_RW16		v4l2_fourcc('R',  'W',  '1',  '6') /* Raw data 16-bit */
- #define V4L2_PIX_FMT_INVZ		v4l2_fourcc('I',  'N',  'V',  'Z') /* 16 Depth */
- #define V4L2_PIX_FMT_INZI		v4l2_fourcc('I',  'N',  'Z',  'I') /* 24 Depth/IR 16:8 */
- #define V4L2_PIX_FMT_INVR		v4l2_fourcc('I',  'N',  'V',  'R') /* 16 Depth */
- #define V4L2_PIX_FMT_INRI		v4l2_fourcc('I',  'N',  'R',  'I') /* 24 Depth/IR 16:8 */
--#define V4L2_PIX_FMT_INVI		v4l2_fourcc('I',  'N',  'V',  'I') /* 8 IR */
-+#define V4L2_PIX_FMT_INVI		v4l2_fourcc('I',  'N',  'V',  'I') /* 10 IR */
- #define V4L2_PIX_FMT_RELI		v4l2_fourcc('R',  'E',  'L',  'I') /* 8 IR alternating on off illumination */
-
+@@ -628,6 +628,7 @@ struct v4l2_pix_format {
+ #define V4L2_PIX_FMT_INVR     v4l2_fourcc('I',  'N',  'V',  'R') /* 16 Depth */
+ #define V4L2_PIX_FMT_INRI     v4l2_fourcc('I',  'N',  'R',  'I') /* 24 Depth/IR 16:8 */
+ #define V4L2_PIX_FMT_RELI     v4l2_fourcc('R',  'E',  'L',  'I') /* 8 IR alternating on off illumination */
++#define V4L2_PIX_FMT_RW16     v4l2_fourcc('R', 'W', '1', '6') /* Raw data 16-bit */
+ 
  /* SDR formats - used only for Software Defined Radio devices */
---
-1.9.1
+ #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */
+-- 
+2.7.4
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -470,12 +470,12 @@ namespace rsimpl
     const native_pixel_format pf_y12i       = { 'Y12I', 1, 3,{  { true,  &unpack_y16_y16_from_y12i_10,      { { RS_STREAM_INFRARED, RS_FORMAT_Y16 },{ RS_STREAM_INFRARED2, RS_FORMAT_Y16 } } } } };
     const native_pixel_format pf_z16        = { 'Z16 ', 1, 2,{  { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 } } },
                                                                 { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH,    RS_FORMAT_DISPARITY16 } } } } };
-    const native_pixel_format pf_invz       = { 'INVZ', 1, 2, { { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH, RS_FORMAT_Z16 } } } } };
-    const native_pixel_format pf_f200_invi  = { 'INVI', 1, 1, { { false, &copy_pixels<1>,                   { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
+    const native_pixel_format pf_invz       = { 'Z16 ', 1, 2, { { false, &copy_pixels<2>,                   { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 } } } } };
+    const native_pixel_format pf_f200_invi  = { 'Y10 ', 1, 1, { { false, &copy_pixels<1>,                   { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_y16_from_y8,               { { RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };
     const native_pixel_format pf_f200_inzi  = { 'INZI', 1, 3,{  { true,  &unpack_z16_y8_from_f200_inzi,     { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_z16_y16_from_f200_inzi,    { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };
-    const native_pixel_format pf_sr300_invi = { 'INVI', 1, 2,{  { true,  &unpack_y8_from_y16_10,            { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
+    const native_pixel_format pf_sr300_invi = { 'Y10 ', 1, 2,{  { true,  &unpack_y8_from_y16_10,            { { RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_y16_from_y16_10,           { { RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };
     const native_pixel_format pf_sr300_inzi = { 'INZI', 2, 2,{  { true,  &unpack_z16_y8_from_sr300_inzi,    { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y8 } } },
                                                                 { true,  &unpack_z16_y16_from_sr300_inzi,   { { RS_STREAM_DEPTH,    RS_FORMAT_Z16 },{ RS_STREAM_INFRARED, RS_FORMAT_Y16 } } } } };


### PR DESCRIPTION
Adjusting Liberalsense FourCC codes to the upstreamed formats