### PR TITLE
Remove uvcmodule check from Linux backend

### DIFF
--- a/include/librealsense/rs.h
+++ b/include/librealsense/rs.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define RS_API_MAJOR_VERSION    1
 #define RS_API_MINOR_VERSION    12
-#define RS_API_PATCH_VERSION    1
+#define RS_API_PATCH_VERSION    2
 
 #define STRINGIFY(arg) #arg
 #define VAR_ARG_STRING(arg) STRINGIFY(arg)

--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -725,16 +725,6 @@ namespace rsimpl
 
         std::vector<std::shared_ptr<device>> query_devices(std::shared_ptr<context> context)
         {
-            // Check if the uvcvideo kernel module is loaded
-	    struct stat info;
-	    int err = stat("/sys/module/uvcvideo/", &info);
-
-	    if (err == -1  // errno==ENOENT, typically
-		|| (info.st_mode & S_IFMT != S_IFDIR))
-            {
-                throw std::runtime_error("uvcvideo kernel module is not loaded");
-            }
-
             // Enumerate all subdevices present on the system
             std::vector<std::unique_ptr<subdevice>> subdevices;
             DIR * dir = opendir("/sys/class/video4linux");


### PR DESCRIPTION
the test was inefficient, additionally switching from /proc/modules to /sys/module/uvcvideo/, as was introduced from [here](https://github.com/IntelRealSense/librealsense/pull/442) created inconsistency with the former.
Bump version to 1.12.2
