### PR TITLE
Adding UI Scale Factor for 4K displays

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2504,9 +2504,10 @@ namespace rs2
         }
     }
 
-    void viewer_model::render_3d_view(const rect& viewer_rect)
+    void viewer_model::render_3d_view(const rect& viewer_rect, float scale_factor)
     {
-        glViewport(viewer_rect.x, viewer_rect.y, viewer_rect.w, viewer_rect.h);
+        glViewport(viewer_rect.x * scale_factor, viewer_rect.y * scale_factor, 
+                   viewer_rect.w * scale_factor, viewer_rect.h * scale_factor);
 
         glClearColor(0, 0, 0, 1);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -483,7 +483,7 @@ namespace rs2
         void update_3d_camera(const rect& viewer_rect,
                               mouse_info& mouse, bool force = false);
 
-        void render_3d_view(const rect& view_rect);
+        void render_3d_view(const rect& view_rect, float scale_factor);
 
         void gc_streams();
 

--- a/third-party/imgui/imgui_impl_glfw.cpp
+++ b/third-party/imgui/imgui_impl_glfw.cpp
@@ -249,8 +249,11 @@ void ImGui_ImplGlfw_NewFrame(float scale_factor)
     int w, h;
     int display_w, display_h;
     glfwGetWindowSize(g_Window, &w, &h);
-    w = w / scale_factor;
-    h = h / scale_factor;
+    if (scale_factor > 0.f)
+    {
+        w = w / scale_factor;
+        h = h / scale_factor;
+    }
     glfwGetFramebufferSize(g_Window, &display_w, &display_h);
     io.DisplaySize = ImVec2((float)w, (float)h);
     io.DisplayFramebufferScale = ImVec2(w > 0 ? ((float)display_w / w) : 0, h > 0 ? ((float)display_h / h) : 0);

--- a/third-party/imgui/imgui_impl_glfw.cpp
+++ b/third-party/imgui/imgui_impl_glfw.cpp
@@ -238,7 +238,7 @@ void ImGui_ImplGlfw_Shutdown()
     ImGui::Shutdown();
 }
 
-void ImGui_ImplGlfw_NewFrame()
+void ImGui_ImplGlfw_NewFrame(float scale_factor)
 {
     if (!g_FontTexture)
         ImGui_ImplGlfw_CreateDeviceObjects();
@@ -249,6 +249,8 @@ void ImGui_ImplGlfw_NewFrame()
     int w, h;
     int display_w, display_h;
     glfwGetWindowSize(g_Window, &w, &h);
+    w = w / scale_factor;
+    h = h / scale_factor;
     glfwGetFramebufferSize(g_Window, &display_w, &display_h);
     io.DisplaySize = ImVec2((float)w, (float)h);
     io.DisplayFramebufferScale = ImVec2(w > 0 ? ((float)display_w / w) : 0, h > 0 ? ((float)display_h / h) : 0);
@@ -264,7 +266,7 @@ void ImGui_ImplGlfw_NewFrame()
     {
         double mouse_x, mouse_y;
         glfwGetCursorPos(g_Window, &mouse_x, &mouse_y);
-        io.MousePos = ImVec2((float)mouse_x, (float)mouse_y);   // Mouse position in screen coordinates (set to -1,-1 if no mouse / on another screen, etc.)
+        io.MousePos = ImVec2((float)mouse_x / scale_factor, (float)mouse_y / scale_factor);   // Mouse position in screen coordinates (set to -1,-1 if no mouse / on another screen, etc.)
     }
     else
     {

--- a/third-party/imgui/imgui_impl_glfw.h
+++ b/third-party/imgui/imgui_impl_glfw.h
@@ -14,7 +14,7 @@ struct GLFWwindow;
 
 IMGUI_API bool        ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks);
 IMGUI_API void        ImGui_ImplGlfw_Shutdown();
-IMGUI_API void        ImGui_ImplGlfw_NewFrame();
+IMGUI_API void        ImGui_ImplGlfw_NewFrame(float scale_factor);
 
 // Use if you want to reset your rendering device without losing ImGui state.
 IMGUI_API void        ImGui_ImplGlfw_InvalidateDeviceObjects();

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -39,8 +39,11 @@ int main(int, char**) try
     rs2_error* e = nullptr;
     std::string title = to_string() << "RealSense Viewer v" << api_version_to_string(rs2_get_api_version(&e));
 
+    auto primary = glfwGetPrimaryMonitor();
+    const auto mode = glfwGetVideoMode(primary);
+
     // Create GUI Windows
-    auto window = glfwCreateWindow(1280, 720, title.c_str(), nullptr, nullptr);
+    auto window = glfwCreateWindow(int(mode->width * 0.7f), int(mode->height * 0.7f), title.c_str(), nullptr, nullptr);
     glfwMakeContextCurrent(window);
     ImGui_ImplGlfw_Init(window, true);
 
@@ -98,13 +101,6 @@ int main(int, char**) try
         data->mouse->mouse_wheel = yoffset;
         data->mouse->ui_wheel += yoffset;
     });
-
-    auto primary = glfwGetPrimaryMonitor();
-    const auto mode = glfwGetVideoMode(primary);
-    int widthMM, heightMM;
-    glfwGetMonitorPhysicalSize(primary, &widthMM, &heightMM);
-    const double dpi = mode->width / (widthMM / 25.4);
-    std::cout << dpi;
 
     // TODO: Implement same logic as when doing this from GUI
     //glfwSetDropCallback(window, [](GLFWwindow* w, int count, const char** paths)
@@ -429,7 +425,7 @@ int main(int, char**) try
         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, is_3d_view ? grey : white);
         if (ImGui::Button((data.scale_factor < 1.5) ? u8"\uf00e" : u8"\uf010", { panel_y,panel_y }))
         {
-            data.scale_factor = (data.scale_factor < 1.5) ? 2.f : 1.f;
+            data.scale_factor = (data.scale_factor < 1.5) ? 2.2f : 1.f;
         }
         ImGui::PopStyleColor(2);
         ImGui::SameLine();

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -28,6 +28,7 @@ struct user_data
     mouse_info* mouse = nullptr;
     context ctx;
     viewer_model* model = nullptr;
+    float scale_factor = 1.f;
 };
 
 int main(int, char**) try
@@ -84,7 +85,7 @@ int main(int, char**) try
     glfwSetCursorPosCallback(window, [](GLFWwindow* w, double cx, double cy)
     {
         auto data = reinterpret_cast<user_data*>(glfwGetWindowUserPointer(w));
-        data->mouse->cursor = { (float)cx, (float)cy };
+        data->mouse->cursor = { (float)cx / data->scale_factor, (float)cy / data->scale_factor };
     });
     glfwSetMouseButtonCallback(window, [](GLFWwindow* w, int button, int action, int mods)
     {
@@ -97,6 +98,13 @@ int main(int, char**) try
         data->mouse->mouse_wheel = yoffset;
         data->mouse->ui_wheel += yoffset;
     });
+
+    auto primary = glfwGetPrimaryMonitor();
+    const auto mode = glfwGetVideoMode(primary);
+    int widthMM, heightMM;
+    glfwGetMonitorPhysicalSize(primary, &widthMM, &heightMM);
+    const double dpi = mode->width / (widthMM / 25.4);
+    std::cout << dpi;
 
     // TODO: Implement same logic as when doing this from GUI
     //glfwSetDropCallback(window, [](GLFWwindow* w, int count, const char** paths)
@@ -247,7 +255,8 @@ int main(int, char**) try
         glfwPollEvents();
         int w, h;
         glfwGetWindowSize(window, &w, &h);
-
+        w = w / data.scale_factor;
+        h = h / data.scale_factor;
 
         const float panel_width = 320.f;
         const float panel_y = 44.f;
@@ -263,7 +272,7 @@ int main(int, char**) try
         ImGui::GetIO().MouseWheel = mouse.ui_wheel;
         mouse.ui_wheel = 0.f;
 
-        ImGui_ImplGlfw_NewFrame();
+        ImGui_ImplGlfw_NewFrame(data.scale_factor);
 
         // Flags for pop-up window - no window resize, move or collaps
         auto flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
@@ -414,6 +423,17 @@ int main(int, char**) try
         ImGui::Begin("Toolbar Panel", nullptr, flags);
 
         ImGui::PushStyleColor(ImGuiCol_Border, black);
+
+        ImGui::SetCursorPosX(w - panel_width - panel_y * 3.f);
+        ImGui::PushStyleColor(ImGuiCol_Text, (data.scale_factor < 1.5) ? grey : white);
+        ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, is_3d_view ? grey : white);
+        if (ImGui::Button((data.scale_factor < 1.5) ? u8"\uf00e" : u8"\uf010", { panel_y,panel_y }))
+        {
+            data.scale_factor = (data.scale_factor < 1.5) ? 2.f : 1.f;
+        }
+        ImGui::PopStyleColor(2);
+        ImGui::SameLine();
+
         ImGui::SetCursorPosX(w - panel_width - panel_y * 2);
         ImGui::PushStyleColor(ImGuiCol_Text, is_3d_view ? grey : white);
         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, is_3d_view ? grey : white);
@@ -986,14 +1006,13 @@ int main(int, char**) try
 
         // Rendering
         glViewport(0, 0,
-            static_cast<int>(ImGui::GetIO().DisplaySize.x),
-            static_cast<int>(ImGui::GetIO().DisplaySize.y));
+            static_cast<int>(ImGui::GetIO().DisplaySize.x * data.scale_factor),
+            static_cast<int>(ImGui::GetIO().DisplaySize.y * data.scale_factor));
         glClearColor(0,0,0,1);
         glClear(GL_COLOR_BUFFER_BIT);
 
         if (!is_3d_view)
         {
-            glfwGetWindowSize(window, &w, &h);
             glLoadIdentity();
             glOrtho(0, w, h, 0, -1, +1);
 
@@ -1037,7 +1056,7 @@ int main(int, char**) try
 
             viewer_model.update_3d_camera(viewer_rect, mouse);
 
-            viewer_model.render_3d_view(viewer_rect);
+            viewer_model.render_3d_view(viewer_rect, data.scale_factor);
 
         }
 


### PR DESCRIPTION
On monitors with very high DPI (4K laptops), the RealSense Viewer UI looks too small to be functional. Introduced "UI Scale-Factor" to compensate without changing the actual layout code. 