### PR TITLE
Fix wrong python3 version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
   - npm install -g node-gyp
 
   # Remove duplicated python 2.x, otherwise node-gyp will complain and stop
-  - pyenv uninstall -f 2.7.13
+  - python2_keep=`pyenv versions|sed 's/ //g'|grep "^2"|tail -1`
+  - for i in `pyenv versions|sed 's/ //g'|grep "^2"` ; do if [ $i = "$python2_keep" ]; then continue; else pyenv uninstall -f $i; fi; done
 
   # Run linter
   - git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
@@ -53,8 +54,9 @@ install:
 script:
   # Exit immediately if a command exits with a non-zero status
   - set -e
-  # Build librealsense
-  - pyenv local 3.6.1
+  # Use python3 for python wrapper
+  - pyenv local `pyenv versions|sed 's/ //g'|grep "^3"|tail -1`
+  # Build librealsens
   - mkdir build && cd build
   - cmake .. -DBUILD_EXAMPLES:BOOL=true -DBUILD_PYTHON_BINDINGS:BOOL=true -DBUILD_NODEJS_BINDINGS:BOOL=true
   - make -j $CPU_NUM


### PR DESCRIPTION
Travis service control the python versions via pyenv, it is out our
control which versions will be installed. That cause pyenv local 3.6.1
failed. To resolve this, we use the latest python3 instead.

Same to remove duplicated python2 versions (node-gyp requires), we only
keep lastest python2 version and uninstall others.