### PR TITLE
Recording option changes

### DIFF
--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -95,6 +95,7 @@ typedef enum rs2_extension
     RS2_EXTENSION_RECORD,
     RS2_EXTENSION_VIDEO_PROFILE,
     RS2_EXTENSION_PLAYBACK,
+    RS2_EXTENSION_OPTION,
     RS2_EXTENSION_COUNT
 } rs2_extension;
 const char* rs2_extension_type_to_string(rs2_extension type);

--- a/src/api.h
+++ b/src/api.h
@@ -55,14 +55,14 @@ namespace librealsense
         catch (...) { if (error) *error = new rs2_error{ "unknown error", name, move(args) }; }
     }
 
-    #define NOEXCEPT_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); rs2_error* e; librealsense::translate_exception(__FUNCTION__, ss.str(), &e); LOG_WARNING(rs2_get_error_message(e)); rs2_free_error(e); return R; }
-    #define HANDLE_EXCEPTIONS_AND_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); librealsense::translate_exception(__FUNCTION__, ss.str(), error); return R; }
-    #define VALIDATE_NOT_NULL(ARG) if(!(ARG)) throw std::runtime_error("null pointer passed for argument \"" #ARG "\"");
-    #define VALIDATE_ENUM(ARG) if(!librealsense::is_valid(ARG)) { std::ostringstream ss; ss << "invalid enum value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
-    #define VALIDATE_RANGE(ARG, MIN, MAX) if((ARG) < (MIN) || (ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
-    #define VALIDATE_LE(ARG, MAX) if((ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw std::runtime_error(ss.str()); }
+#define NOEXCEPT_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); rs2_error* e; librealsense::translate_exception(__FUNCTION__, ss.str(), &e); LOG_WARNING(rs2_get_error_message(e)); rs2_free_error(e); return R; }
+#define HANDLE_EXCEPTIONS_AND_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); librealsense::translate_exception(__FUNCTION__, ss.str(), error); return R; }
+#define VALIDATE_NOT_NULL(ARG) if(!(ARG)) throw std::runtime_error("null pointer passed for argument \"" #ARG "\"");
+#define VALIDATE_ENUM(ARG) if(!librealsense::is_valid(ARG)) { std::ostringstream ss; ss << "invalid enum value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
+#define VALIDATE_RANGE(ARG, MIN, MAX) if((ARG) < (MIN) || (ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
+#define VALIDATE_LE(ARG, MAX) if((ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw std::runtime_error(ss.str()); }
     //#define VALIDATE_NATIVE_STREAM(ARG) VALIDATE_ENUM(ARG); if(ARG >= RS2_STREAM_NATIVE_COUNT) { std::ostringstream ss; ss << "argument \"" #ARG "\" must be a native stream"; throw rsimpl2::wrong_value_exception(ss.str()); }
-    #define VALIDATE_INTERFACE_NO_THROW(X, T)                                                   \
+#define VALIDATE_INTERFACE_NO_THROW(X, T)                                                       \
     ([&]() -> T* {                                                                              \
         T* p = dynamic_cast<T*>(&(*X));                                                         \
         if (p == nullptr)                                                                       \
@@ -71,12 +71,15 @@ namespace librealsense
             if (ext == nullptr) return nullptr;                                                 \
             else                                                                                \
             {                                                                                   \
-                if(!ext->extend_to(TypeToExtensionn<T>::value, (void**)&p))                      \
+                T* p2;                                                                          \
+                if(!ext->extend_to(TypeToExtension<T>::value, (void**)&p2))                     \
                     return nullptr;                                                             \
+                return p2;                                                                      \
             }                                                                                   \
         }                                                                                       \
         return p;                                                                               \
     })()
+
     #define VALIDATE_INTERFACE(X,T)                                                             \
         ([&]() -> T* {                                                                          \
             T* p = VALIDATE_INTERFACE_NO_THROW(X,T);                                            \

--- a/src/archive.h
+++ b/src/archive.h
@@ -286,7 +286,7 @@ namespace librealsense
                     {
                         //For playback sensors
                         auto extendable = As<librealsense::extendable_interface>(sensor);
-                        if (extendable && extendable->extend_to(TypeToExtensionn<librealsense::depth_sensor>::value, (void**)(&depth_sensor)))
+                        if (extendable && extendable->extend_to(TypeToExtension<librealsense::depth_sensor>::value, (void**)(&depth_sensor)))
                         {
                             return depth_sensor->get_depth_scale();
                         }

--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -53,7 +53,7 @@ namespace librealsense
     MAP_ADVANCED_MODE(STCensusRadius, etCencusRadius9);
 
 
-    class ds5_advanced_mode_interface : public virtual device_interface
+    class ds5_advanced_mode_interface
     {
     public:
         virtual bool is_enabled() const = 0;

--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -8,7 +8,7 @@
 
 namespace librealsense
 {
-    class debug_interface : public virtual recordable<debug_interface>
+    class debug_interface : public recordable<debug_interface>
     {
     public:
         virtual std::vector<uint8_t> send_receive_raw_data(const std::vector<uint8_t>& input) = 0;

--- a/src/core/info.h
+++ b/src/core/info.h
@@ -19,46 +19,18 @@ namespace librealsense
 
     MAP_EXTENSION(RS2_EXTENSION_INFO, librealsense::info_interface);
 
-    class info_container : public virtual info_interface
+    class info_container : public virtual info_interface , public extension_snapshot
     {
     public:
         const std::string& get_info(rs2_camera_info info) const override;
         bool supports_info(rs2_camera_info info) const override;
 
         void register_info(rs2_camera_info info, const std::string& val);
-        void create_snapshot(std::shared_ptr<info_interface>& snapshot) override;
-        void create_recordable(std::shared_ptr<info_interface>& recordable,
-            std::function<void(std::shared_ptr<extension_snapshot>)> record_action) override;
-
+        void create_snapshot(std::shared_ptr<info_interface>& snapshot) const override;
+        void enable_recording(std::function<void(const info_interface&)> record_action) override;
+        void update(std::shared_ptr<extension_snapshot> ext) override;
     private:
         std::map<rs2_camera_info, std::string> _camera_info;
     };
 
-    class info_snapshot : public extension_snapshot_base<info_interface>, public info_container
-    {
-    public:
-        info_snapshot(const std::map<rs2_camera_info, std::string>& values)
-        {
-            for (auto value : values)
-            {
-                register_info(value.first, value.second);
-            }
-        }
-        info_snapshot(info_interface* info_api)
-        {
-            update_self(info_api);
-        }
-    private:
-        void update_self(info_interface* info_api)
-        {
-            for (int i = 0; i < RS2_CAMERA_INFO_COUNT; ++i)
-            {
-                rs2_camera_info info = static_cast<rs2_camera_info>(i);
-                if (info_api->supports_info(info))
-                {
-                    register_info(info, info_api->get_info(info));
-                }
-            }
-        }
-    };
 }

--- a/src/core/motion.h
+++ b/src/core/motion.h
@@ -7,7 +7,7 @@
 
 namespace librealsense
 {
-    class motion_sensor_interface : public virtual sensor_interface
+    class motion_sensor_interface
     {
     public:
         virtual rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream stream) const = 0;

--- a/src/core/options.h
+++ b/src/core/options.h
@@ -17,7 +17,7 @@ namespace librealsense
         float def;
     };
 
-    class option
+    class option : public recordable<option>
     {
     public:
         virtual void set(float value) = 0;
@@ -25,14 +25,17 @@ namespace librealsense
         virtual option_range get_range() const = 0;
         virtual bool is_enabled() const = 0;
         virtual bool is_read_only() const { return false; }
-
+        virtual rs2_option type() const = 0;
         virtual const char* get_description() const = 0;
         virtual const char* get_value_description(float) const { return nullptr; }
+        virtual void create_snapshot(std::shared_ptr<option>& snapshot) const override;
 
         virtual ~option() = default;
     };
 
-    class options_interface
+    MAP_EXTENSION(RS2_EXTENSION_OPTION, librealsense::option);
+
+    class options_interface : public recordable<options_interface>
     {
     public:
         virtual option& get_option(rs2_option id) = 0;
@@ -44,7 +47,7 @@ namespace librealsense
 
     MAP_EXTENSION(RS2_EXTENSION_OPTIONS, librealsense::options_interface);
 
-    class options_container : public virtual options_interface
+    class options_container : public virtual options_interface, public extension_snapshot
     {
     public:
         bool supports_option(rs2_option id) const override
@@ -68,22 +71,37 @@ namespace librealsense
 
         const option& get_option(rs2_option id) const override
         {
-            auto it = _options.find(id);
-            if (it == _options.end())
-            {
-                throw invalid_value_exception(to_string()
-                    << "Device does not support option "
-                    << rs2_option_to_string(id) << "!");
-            }
-            return *it->second;
+            return const_cast<const option&>(const_cast<options_container*>(this)->get_option(id));
         }
 
         void register_option(rs2_option id, std::shared_ptr<option> option)
         {
             _options[id] = option;
+            recording_function(*this);
+        }
+
+        void create_snapshot(std::shared_ptr<options_interface>& snapshot) const override
+        {
+            snapshot = std::make_shared<options_container>(*this);
+        }
+        
+        void enable_recording(std::function<void(const options_interface&)> record_action) override
+        {
+            recording_function = recording_function;
+        }
+        
+        void update(std::shared_ptr<extension_snapshot> ext) override
+        {
+            auto ctr = As<options_container>(ext);
+            if (!ctr) return;
+            for(auto&& opt : ctr->_options)
+            {
+                _options[opt.first] = opt.second;
+            }
         }
 
     private:
         std::map<rs2_option, std::shared_ptr<option>> _options;
+        std::function<void(const options_interface&)> recording_function = [](const options_interface&) {};
     };
 }

--- a/src/core/roi.h
+++ b/src/core/roi.h
@@ -25,7 +25,7 @@ namespace librealsense
         virtual ~region_of_interest_method() = default;
     };
 
-    class roi_sensor_interface : public virtual sensor_interface
+    class roi_sensor_interface
     {
     public:
         virtual region_of_interest_method& get_roi_method() const = 0;

--- a/src/core/serialization.h
+++ b/src/core/serialization.h
@@ -37,9 +37,116 @@ namespace librealsense
         {
             return std::make_tuple(lhs.device_index, lhs.sensor_index, lhs.stream_type, lhs.stream_index) < std::make_tuple(rhs.device_index, rhs.sensor_index, rhs.stream_type, rhs.stream_index);
         }
+        inline std::ostream& operator<<(std::ostream& os, const stream_identifier& id)
+        {
+            os << id.device_index << "/" << id.sensor_index << "/" << id.stream_type << "/" << id.stream_index;
+            return os;
+        }
 
         using nanoseconds = std::chrono::duration<uint64_t, std::nano>;
 
+        class serialized_data : public std::enable_shared_from_this<serialized_data>
+        {
+        protected:
+            enum serialized_data_type
+            {
+                invalid,
+                end_of_file,
+                frame,
+                option,
+                max
+            };
+        public:
+            serialized_data(device_serializer::nanoseconds timestamp = device_serializer::nanoseconds::max()) : 
+                _timestamp(timestamp) 
+            {
+            }
+            virtual ~serialized_data() = default;
+
+
+            template <typename T>
+            bool is() const
+            {
+                return T::get_type() == type();
+            }
+
+            template <typename T>
+            std::shared_ptr<T> as() const
+            {
+                if (!is<T>())
+                    return nullptr;
+
+                switch (T::get_type())
+                {
+                    case end_of_file: 
+                    case frame:       
+                    case option:      
+                        return std::static_pointer_cast<T>(std::const_pointer_cast<serialized_data>(shared_from_this()));
+                }
+                return nullptr;
+            }
+
+            virtual device_serializer::nanoseconds get_timestamp() const
+            {
+                return _timestamp;
+            }
+
+            virtual serialized_data_type type() const = 0;
+
+        private:
+            device_serializer::nanoseconds _timestamp;
+        };
+
+        class serialized_frame : public serialized_data
+        {
+        public:
+            serialized_frame(device_serializer::nanoseconds time, stream_identifier id, frame_holder f) :
+                serialized_data(time),
+                stream_id(id),
+                frame(std::move(f))
+            {}
+            stream_identifier stream_id;
+            frame_holder frame;
+            static serialized_data_type get_type()
+            {
+                return serialized_data_type::frame;
+            }
+            serialized_data_type type() const override
+            {
+                return serialized_frame::get_type();
+            }
+        };
+        class serialized_option : public serialized_data
+        {
+        public:
+            serialized_option(device_serializer::nanoseconds time, sensor_identifier id, std::shared_ptr<librealsense::option> o) :
+                serialized_data(time),
+                sensor_id(id), option(o)
+            {}
+            sensor_identifier sensor_id;
+            std::shared_ptr<librealsense::option> option;
+            static serialized_data_type get_type()
+            {
+                return serialized_data_type::option;
+            }
+            serialized_data_type type() const override
+            {
+                return serialized_option::get_type();
+            }
+        };
+        class serialized_end_of_file : public serialized_data
+        {
+        public:
+            serialized_end_of_file() {}
+            static serialized_data_type get_type()
+            {
+                return serialized_data_type::end_of_file;
+            }
+            serialized_data_type type() const override
+            {
+                return serialized_end_of_file::get_type();
+            }
+        };
 
         class snapshot_collection
         {
@@ -50,7 +157,7 @@ namespace librealsense
             {
             }
 
-            std::shared_ptr<extension_snapshot> find(rs2_extension t)
+            std::shared_ptr<extension_snapshot> find(rs2_extension t) const
             {
                 auto snapshot_it = m_snapshots.find(t);
                 if (snapshot_it == std::end(m_snapshots))
@@ -80,17 +187,15 @@ namespace librealsense
         class sensor_snapshot
         {
         public:
-            sensor_snapshot(uint32_t index, const snapshot_collection& sensor_extensions, const std::map<rs2_option, float>& options) :
+            sensor_snapshot(uint32_t index, const snapshot_collection& sensor_extensions) :
                 m_snapshots(sensor_extensions),
-                m_options(options),
                 m_index(index)
             {
             }
 
-            sensor_snapshot(uint32_t index, const snapshot_collection& sensor_extensions, const std::map<rs2_option, float>& options, stream_profiles streams) :
+            sensor_snapshot(uint32_t index, const snapshot_collection& sensor_extensions, stream_profiles streams) :
                 m_snapshots(sensor_extensions),
                 m_streams(streams),
-                m_options(options),
                 m_index(index)
             {
             }
@@ -108,10 +213,6 @@ namespace librealsense
                 return m_streams;
             }
 
-            std::map<rs2_option, float> get_options() const
-            {
-                return m_options;
-            }
             uint32_t get_sensor_index() const
             {
                 return m_index;
@@ -119,7 +220,6 @@ namespace librealsense
         private:
             snapshot_collection m_snapshots;
             stream_profiles m_streams;
-            std::map<rs2_option, float> m_options;
             uint32_t m_index;
         };
         using device_extrinsics = std::map<std::tuple<size_t, rs2_stream, size_t, rs2_stream>, rs2_extrinsics>;
@@ -136,6 +236,10 @@ namespace librealsense
 
             }
             std::vector<sensor_snapshot> get_sensors_snapshots() const
+            {
+                return m_sensors_snapshot;
+            }
+            std::vector<sensor_snapshot>& get_sensors_snapshots()
             {
                 return m_sensors_snapshot;
             }
@@ -183,8 +287,9 @@ namespace librealsense
         public:
             virtual void write_device_description(const device_snapshot& device_description) = 0;
             virtual void write_frame(const stream_identifier& stream_id, const nanoseconds& timestamp, frame_holder&& frame) = 0;
-            virtual void write_snapshot(uint32_t device_index, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot > snapshot) = 0;
-            virtual void write_snapshot(const sensor_identifier& sensor_id, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot > snapshot) = 0;
+            virtual void write_snapshot(uint32_t device_index, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot>& snapshot) = 0;
+            virtual void write_snapshot(const sensor_identifier& sensor_id, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot>& snapshot) = 0;
+            virtual const std::string& get_file_name() const = 0;
             virtual ~writer() = default;
         };
 
@@ -192,8 +297,8 @@ namespace librealsense
         {
         public:
             virtual ~reader() = default;
-            virtual device_snapshot query_device_description() = 0;
-            virtual status read_frame(nanoseconds& timestamp, stream_identifier& sensor_index, frame_holder& frame) = 0;
+            virtual device_snapshot query_device_description(const nanoseconds& time) = 0;
+            virtual std::shared_ptr<serialized_data> read_next_data() = 0;
             virtual void seek_to_time(const nanoseconds& time) = 0;
             virtual nanoseconds query_duration() const = 0;
             virtual void reset() = 0;

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -144,7 +144,7 @@ namespace librealsense
 
     };
 
-    class depth_sensor
+    class depth_sensor : public recordable<depth_sensor>
     {
     public:
         virtual float get_depth_scale() const = 0;
@@ -164,12 +164,18 @@ namespace librealsense
 
         void update(std::shared_ptr<extension_snapshot> ext) override
         {
-            auto p = As<depth_sensor>(ext);
-            if (p == nullptr)
+            if (auto api = As<depth_sensor>(ext))
             {
-                return;
+                m_depth_units = api->get_depth_scale();
             }
-            m_depth_units = p->get_depth_scale();
+        }
+        void create_snapshot(std::shared_ptr<depth_sensor>& snapshot) const  override
+        {
+            snapshot = std::make_shared<depth_sensor_snapshot>(*this);
+        }
+        void enable_recording(std::function<void(const depth_sensor&)> recording_function) override
+        {
+            //empty
         }
     private:
         float m_depth_units;

--- a/src/core/video.h
+++ b/src/core/video.h
@@ -8,7 +8,7 @@ namespace librealsense
 {
     struct stream_profile;
 
-    class video_sensor_interface : public virtual sensor_interface
+    class video_sensor_interface
     {
     public:
         virtual rs2_intrinsics get_intrinsics(const stream_profile& profile) const = 0;

--- a/src/ds5/advanced_mode/advanced_mode.cpp
+++ b/src/ds5/advanced_mode/advanced_mode.cpp
@@ -715,7 +715,7 @@ namespace librealsense
 
     advanced_mode_preset_option::advanced_mode_preset_option(ds5_advanced_mode_base& advanced,
         uvc_sensor& ep, const option_range& opt_range)
-        : option_base(opt_range),
+        : option_base(opt_range, RS2_OPTION_VISUAL_PRESET),
         _ep(ep),
         _advanced(advanced),
         _last_preset(RS2_RS400_VISUAL_PRESET_CUSTOM)
@@ -753,6 +753,7 @@ namespace librealsense
         auto configurations = uvc_sensor->get_configuration();
         _advanced.apply_preset(configurations, preset);
         _last_preset = preset;
+        _recording_function(*this);
     }
 
     float advanced_mode_preset_option::query() const

--- a/src/ds5/ds5-active.cpp
+++ b/src/ds5/ds5-active.cpp
@@ -32,11 +32,13 @@ namespace librealsense
         auto laser_power = std::make_shared<uvc_xu_option<uint16_t>>(depth_ep,
                                                                      depth_xu,
                                                                      DS5_LASER_POWER,
-                                                                     "Manual laser power in mw. applicable only when laser power mode is set to Manual");
+                                                                     "Manual laser power in mw. applicable only when laser power mode is set to Manual",
+                                                                     RS2_OPTION_LASER_POWER);
         depth_ep.register_option(RS2_OPTION_LASER_POWER,
                                  std::make_shared<auto_disabling_control>(
                                  laser_power,
                                  emitter_enabled,
+                                 RS2_OPTION_LASER_POWER,
                                  std::vector<float>{0.f, 2.f}, 1.f));
 
         depth_ep.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE,

--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -71,7 +71,8 @@ namespace librealsense
         color_ep->register_option(RS2_OPTION_WHITE_BALANCE,
             std::make_shared<auto_disabling_control>(
                 white_balance_option,
-                auto_white_balance_option));
+                auto_white_balance_option,
+                RS2_OPTION_WHITE_BALANCE));
 
         auto exposure_option = std::make_shared<uvc_pu_option>(*color_ep, RS2_OPTION_EXPOSURE);
         auto auto_exposure_option = std::make_shared<uvc_pu_option>(*color_ep, RS2_OPTION_ENABLE_AUTO_EXPOSURE);
@@ -80,7 +81,8 @@ namespace librealsense
         color_ep->register_option(RS2_OPTION_EXPOSURE,
             std::make_shared<auto_disabling_control>(
                 exposure_option,
-                auto_exposure_option));
+                auto_exposure_option,
+                RS2_OPTION_EXPOSURE));
 
         color_ep->register_option(RS2_OPTION_POWER_LINE_FREQUENCY,
             std::make_shared<uvc_pu_option>(*color_ep, RS2_OPTION_POWER_LINE_FREQUENCY,

--- a/src/ds5/ds5-device.h
+++ b/src/ds5/ds5-device.h
@@ -30,9 +30,8 @@ namespace librealsense
         std::vector<uint8_t> send_receive_raw_data(const std::vector<uint8_t>& input) override;
 
         void hardware_reset() override;
-        void create_snapshot(std::shared_ptr<debug_interface>& snapshot) override;
-        void create_recordable(std::shared_ptr<debug_interface>& recordable,
-                               std::function<void(std::shared_ptr<extension_snapshot>)> record_action) override;
+        void create_snapshot(std::shared_ptr<debug_interface>& snapshot) const override;
+        void enable_recording(std::function<void(const debug_interface&)> record_action) override;
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
 

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -216,8 +216,8 @@ namespace librealsense
         auto gain_option =  std::make_shared<uvc_pu_option>(*uvc_ep, RS2_OPTION_GAIN);
 
         auto exposure_option =  std::make_shared<uvc_xu_option<uint16_t>>(*uvc_ep,
-                *fisheye_xu,
-                librealsense::ds::FISHEYE_EXPOSURE, "Exposure time of Fisheye camera");
+                *fisheye_xu,                          
+                librealsense::ds::FISHEYE_EXPOSURE, "Exposure time of Fisheye camera", RS2_OPTION_EXPOSURE);
 
         auto ae_state = std::make_shared<auto_exposure_state>();
         auto auto_exposure = std::make_shared<auto_exposure_mechanism>(*gain_option, *exposure_option, *ae_state);
@@ -247,12 +247,14 @@ namespace librealsense
         uvc_ep->register_option(RS2_OPTION_GAIN,
                                     std::make_shared<auto_disabling_control>(
                                     gain_option,
-                                    auto_exposure_option));
+                                    auto_exposure_option, 
+                                    RS2_OPTION_GAIN));
 
         uvc_ep->register_option(RS2_OPTION_EXPOSURE,
                                     std::make_shared<auto_disabling_control>(
                                     exposure_option,
-                                    auto_exposure_option));
+                                    auto_exposure_option,
+                                    RS2_OPTION_EXPOSURE));
 
         return auto_exposure;
     }
@@ -310,7 +312,8 @@ namespace librealsense
                                         std::make_shared<uvc_xu_option<uint16_t>>(*fisheye_ep.get(),
                                                                                   fisheye_xu,
                                                                                   librealsense::ds::FISHEYE_EXPOSURE,
-                                                                                  "Exposure time of Fisheye camera"));
+                                                                                  "Exposure time of Fisheye camera",
+                                                                                   RS2_OPTION_EXPOSURE));
         }
 
         // Metadata registration

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -162,8 +162,6 @@ namespace librealsense
     {
     public:
         depth_scale_option(hw_monitor& hwm);
-        //TODO: remove:
-        depth_scale_option() :_hwm(*((hw_monitor*)(nullptr))) {}
         virtual ~depth_scale_option() = default;
         virtual void set(float value) override;
         virtual float query() const override;
@@ -174,10 +172,17 @@ namespace librealsense
         {
             return "Number of meters represented by a single depth unit";
         }
-
+        void enable_recording(std::function<void(const option &)> record_action)
+        {
+            _record_action = record_action;
+        }
+        rs2_option type() const override
+        {
+            return RS2_OPTION_DEPTH_UNITS;
+        }
     private:
         ds::depth_table_control get_depth_table(ds::advanced_query_mode mode) const;
-
+        std::function<void(const option &)> _record_action;
         lazy<option_range> _range;
         hw_monitor& _hwm;
     };

--- a/src/ds5/ds5-rolling-shutter.cpp
+++ b/src/ds5/ds5-rolling-shutter.cpp
@@ -31,7 +31,8 @@ namespace librealsense
                 std::make_shared<uvc_xu_option<uint8_t>>(get_depth_sensor(),
                                                          depth_xu,
                                                          DS5_ENABLE_AUTO_WHITE_BALANCE,
-                                                         "Enable Auto White Balance"));
+                                                         "Enable Auto White Balance",
+                                                         RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE));
 
             // RS400 rolling-shutter Skus allow to get low-quality color image from the same viewport as the depth
             get_depth_sensor().register_pixel_format(pf_uyvyl);

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -224,23 +224,20 @@ namespace librealsense
         register_stream_to_extrinsic_group(*_color_stream, 0);
 
         get_depth_sensor().register_option(RS2_OPTION_DEPTH_UNITS,
-                                           std::make_shared<const_value_option>("Number of meters represented by a single depth unit",
+                                           std::make_shared<const_value_option>(RS2_OPTION_DEPTH_UNITS, "Number of meters represented by a single depth unit",
                                             lazy<float>([this]() {
                                                 auto c = get_calibration();
                                                 return (c.Rmax / 1000 / 0xFFFF);
                                             })));
 
     }
-    void sr300_camera::create_snapshot(std::shared_ptr<debug_interface>& snapshot)
+    void sr300_camera::create_snapshot(std::shared_ptr<debug_interface>& snapshot) const
     {
         //TODO: implement
-        throw std::runtime_error("Not Implemented");
     }
-    void sr300_camera::create_recordable(std::shared_ptr<debug_interface>& recordable,
-        std::function<void(std::shared_ptr<extension_snapshot>)> record_action)
+    void sr300_camera::enable_recording(std::function<void(const debug_interface&)> record_action)
     {
         //TODO: implement
-        throw std::runtime_error("Not Implemented");
     }
 
 

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -28,21 +28,11 @@ playback_device::playback_device(std::shared_ptr<context> ctx, std::shared_ptr<d
     (*m_read_thread)->start();
 
     //Read header and build device from recorded device snapshot
-    m_device_description = m_reader->query_device_description();
-    auto info_snapshot = m_device_description.get_device_extensions_snapshots().find(RS2_EXTENSION_INFO);
-    if(info_snapshot == nullptr)
-    {
-        throw io_exception("Recorded file does not contain device information");
-    }
-    auto info_api = As<info_interface>(info_snapshot);
-    if (info_api == nullptr)
-    {
-        throw invalid_value_exception("Failed to get info interface from device snapshots");
-    }
-    register_device_info(info_api);
+    m_device_description = m_reader->query_device_description(nanoseconds(0));
+
+    register_device_info(m_device_description);
     //Create playback sensor that simulate the recorded sensors
     m_sensors = create_playback_sensors(m_device_description);
-
     register_extrinsics(m_device_description);
 }
 
@@ -190,36 +180,19 @@ void playback_device::hardware_reset()
 bool playback_device::extend_to(rs2_extension extension_type, void** ext)
 {
     std::shared_ptr<extension_snapshot> e = m_device_description.get_device_extensions_snapshots().find(extension_type);
-    if (e == nullptr)
-    {
-        return false;
-    }
-    switch (extension_type)
-    {
-    case RS2_EXTENSION_UNKNOWN: return false;
-    case RS2_EXTENSION_DEBUG : return try_extend<debug_interface>(e, ext);
-    case RS2_EXTENSION_INFO : return try_extend<info_interface>(e, ext);
-    case RS2_EXTENSION_MOTION : return try_extend<motion_sensor_interface>(e, ext);;
-    case RS2_EXTENSION_OPTIONS : return try_extend<options_interface>(e, ext);;
-    case RS2_EXTENSION_VIDEO : return try_extend<video_sensor_interface>(e, ext);;
-    case RS2_EXTENSION_ROI : return try_extend<roi_sensor_interface>(e, ext);;
-    case RS2_EXTENSION_VIDEO_FRAME : return try_extend<video_frame>(e, ext);
-    //TODO: add: case RS2_EXTENSION_MOTION_FRAME : return try_extend<motion_frame>(e, ext);
-    case RS2_EXTENSION_COUNT :
-        //[[fallthrough]];
-    default:
-        LOG_WARNING("Unsupported extension type: " << extension_type);
-        return false;
-    }
+    return try_extend_snapshot(e, extension_type, ext);
 }
 
 std::shared_ptr<matcher> playback_device::create_matcher(const frame_holder& frame) const
 {
-    return nullptr; //TOOD: WTD?
+    //TOOD: Use future implementation of matcher factory with the device's name (or other unique identifier)
+    LOG_WARNING("Playback device does not provide a matcher");
+    return nullptr;
 }
 
 void playback_device::set_frame_rate(double rate)
 {
+    LOG_INFO("Request to change playback frame rate to: " << rate);
     if(rate < 0)
     {
         throw invalid_value_exception(to_string() << "Failed to set frame rate to " << std::to_string(rate) << ", value is less than 0");
@@ -234,14 +207,21 @@ void playback_device::set_frame_rate(double rate)
 
 void playback_device::seek_to_time(std::chrono::nanoseconds time)
 {
+    LOG_INFO("Request to seek to: " << time.count());
     (*m_read_thread)->invoke([this, time](dispatcher::cancellable_timer t)
     {
         LOG_INFO("Seek to time: " << time.count());
         m_reader->seek_to_time(time);
+        m_device_description = m_reader->query_device_description(time);
+        update_extensions(m_device_description);
         m_prev_timestamp = time; //Updating prev timestamp to make get_position return true indication even when playbakc is paused
         catch_up();
     });
-    (*m_read_thread)->flush();
+    if ((*m_read_thread)->flush() == false)
+    {
+        LOG_ERROR("Error - timeout waiting for seek_to_time, possible deadlock detected");
+        assert(0); //Detect this immediately in debug
+    }
 }
 
 rs2_playback_status playback_device::get_current_status() const
@@ -285,7 +265,11 @@ void playback_device::pause()
        LOG_DEBUG("Notifying RS2_PLAYBACK_STATUS_PAUSED");
        playback_status_changed(RS2_PLAYBACK_STATUS_PAUSED);
     });
-    (*m_read_thread)->flush();
+    if ((*m_read_thread)->flush() == false)
+    {
+        LOG_ERROR("Error - timeout waiting for pause, possible deadlock detected");
+        assert(0); //Detect this immediately in debug
+    }
     LOG_INFO("Playback Paused");
 }
 
@@ -303,7 +287,11 @@ void playback_device::resume()
 
         try_looping();
     });
-    (*m_read_thread)->flush();
+    if ((*m_read_thread)->flush() == false)
+    {
+        LOG_ERROR("Error - timeout waiting for resume, possible deadlock detected");
+        assert(0); //Detect this immediately in debug
+    }
     LOG_INFO("Playback Resumed");
 }
 
@@ -390,7 +378,11 @@ void playback_device::stop()
         LOG_DEBUG("playback stop invoked");
         stop_internal();
     });
-    (*m_read_thread)->flush();
+    if ((*m_read_thread)->flush() == false)
+    {
+        LOG_ERROR("Error - timeout waiting for flush, possible deadlock detected");
+        assert(0); //Detect this immediately in debug
+    }
     LOG_INFO("Playback stoped");
 
 }
@@ -477,21 +469,14 @@ void playback_device::try_looping()
 
         //Read next data from the serializer, on success: 'obj' will be a valid object that came from
         // sensor number 'sensor_index' with a timestamp equal to 'timestamp'
-        device_serializer::stream_identifier stream_id;
-        device_serializer::nanoseconds timestamp = device_serializer::nanoseconds::max();
-        frame_holder frame;
-        auto retval = m_reader->read_frame(timestamp, stream_id, frame);
-        if (retval == device_serializer::status_file_eof)
+        std::shared_ptr<serialized_data> data = m_reader->read_next_data();
+        if (data->as<serialized_end_of_file>())
         {
             LOG_INFO("End of file reached");
             return false;
         }
-        if(retval != device_serializer::status_no_error || timestamp == std::chrono::nanoseconds::max() || frame == nullptr)
-        {
-            LOG_ERROR("Failed to read next frame. retval: " << retval << ", timestamp = " << timestamp.count());
-            throw librealsense::io_exception("Failed to read frame");
-        }
 
+        auto timestamp = data->get_timestamp();
         m_prev_timestamp = timestamp;
         //Objects with timestamp of 0 are non streams.
         if (m_base_timestamp.count() == 0)
@@ -511,16 +496,26 @@ void playback_device::try_looping()
                 std::this_thread::sleep_for(sleep_time);
             }
         }
-
-        if (stream_id.device_index != get_device_index() || stream_id.sensor_index >= m_sensors.size())
+        if (auto frame = data->as<serialized_frame>())
         {
-            LOG_ERROR("Unexpected sensor index while playing file (Read index = " << stream_id.sensor_index << ")");
-            throw invalid_value_exception(to_string() << "Unexpected sensor index while playing file (Read index = " << stream_id.sensor_index << ")");
+            if (frame->stream_id.device_index != get_device_index() || frame->stream_id.sensor_index >= m_sensors.size())
+            {
+                std::string error_msg = to_string() << "Unexpected sensor index while playing file (Read index = " << frame->stream_id.sensor_index << ")";
+                LOG_ERROR(error_msg);
+                throw invalid_value_exception(error_msg);
+            }
+            LOG_DEBUG("Dispatching frame " << frame->stream_id);
+            //Dispatch frame to the relevant sensor
+            m_sensors[frame->stream_id.sensor_index]->handle_frame(std::move(frame->frame), m_real_time);
+            return true;
         }
-        LOG_DEBUG("Dispatching frame " << stream_id.device_index << "/" << stream_id.sensor_index << "/" << stream_id.stream_type << "/" << stream_id.stream_index);
-        //Dispatch frame to the relevant sensor
-        m_sensors[stream_id.sensor_index]->handle_frame(std::move(frame), m_real_time);
-        return true;
+
+        if (auto option_data = data->as<serialized_option>())
+        {
+            m_sensors[option_data->sensor_id.sensor_index]->update_option(option_data->option);
+            return true;
+        }
+        return false;
     };
     do_loop(read_action);
 }
@@ -540,8 +535,19 @@ void playback_device::catch_up()
     LOG_DEBUG("Catching up");
 }
 
-void playback_device::register_device_info(const std::shared_ptr<info_interface>& info_api)
+void playback_device::register_device_info(const device_serializer::device_snapshot& device_description)
 {
+    auto info_snapshot = device_description.get_device_extensions_snapshots().find(RS2_EXTENSION_INFO);
+    if (info_snapshot == nullptr)
+    {
+        throw io_exception("Recorded file does not contain device information");
+    }
+
+    auto info_api = As<info_interface>(info_snapshot);
+    if (info_api == nullptr)
+    {
+        throw invalid_value_exception("Failed to get info interface from device snapshots");
+    }
     for (int i = 0; i < RS2_CAMERA_INFO_COUNT; ++i)
     {
         rs2_camera_info info = static_cast<rs2_camera_info>(i);
@@ -577,5 +583,39 @@ void playback_device::register_extrinsics(const device_serializer::device_snapsh
             environment::get_instance().get_extrinsics_graph().register_extrinsics(*p1, *p2, extrinsic_fetcher);
             m_extrinsics_fetchers.push_back(extrinsic_fetcher);  //Caching the lazy<rs2_extrinsics> since context holds weak_ptr
         }
+    }
+}
+
+bool playback_device::try_extend_snapshot(std::shared_ptr<extension_snapshot>& e, rs2_extension extension_type, void** ext)
+{
+    if (e == nullptr)
+    {
+        return false;
+    }
+
+    switch (extension_type)
+    {
+    case RS2_EXTENSION_DEBUG:   return try_extend<debug_interface>(e, ext);
+    case RS2_EXTENSION_INFO:    return try_extend<info_interface>(e, ext);
+    case RS2_EXTENSION_MOTION:  return try_extend<motion_sensor_interface>(e, ext);
+    case RS2_EXTENSION_OPTIONS: return try_extend<options_interface>(e, ext);
+    case RS2_EXTENSION_VIDEO:   return try_extend<video_sensor_interface>(e, ext);
+    case RS2_EXTENSION_ROI:     return try_extend<roi_sensor_interface>(e, ext);
+    case RS2_EXTENSION_DEPTH_SENSOR: return try_extend<depth_sensor>(e, ext);
+    case RS2_EXTENSION_UNKNOWN: //[[fallthrough]]
+    case RS2_EXTENSION_COUNT:   //[[fallthrough]]
+    default:
+        LOG_WARNING("Unsupported extension type: " << extension_type);
+    }
+    return false;
+}
+
+void playback_device::update_extensions(const device_serializer::device_snapshot& device_description)
+{
+    //TODO: Need to update all extensions not just options
+    for (auto sensor_snapshot : device_description.get_sensors_snapshots())
+    {
+        auto sensor_index = sensor_snapshot.get_sensor_index();
+        m_sensors[sensor_index]->update(sensor_snapshot);
     }
 }

--- a/src/media/playback/playback_device.h
+++ b/src/media/playback/playback_device.h
@@ -14,20 +14,9 @@
 
 namespace librealsense
 {
-    /*
-     * Internal members meaning:
-     *
-     *               m_is_started  |     True     |      False
-     *  m_is_paused                |              |
-     *  ---------------------------|--------------|---------------
-     *      True                   |    Paused    |   Stopped
-     *      False                  |    Playing   |   Stopped
-     *
-     */
-
     class playback_device : public device_interface,
-        public extendable_interface,
-        public info_container
+                            public extendable_interface,
+                            public info_container
     {
     public:
         playback_device(std::shared_ptr<context> context, std::shared_ptr<device_serializer::reader> serializer);
@@ -56,6 +45,7 @@ namespace librealsense
         signal<playback_device, rs2_playback_status> playback_status_changed;
         platform::backend_device_group get_device_data() const override;
         std::pair<uint32_t, rs2_extrinsics> get_extrinsics(const stream_interface& stream) const override;
+        static bool try_extend_snapshot(std::shared_ptr<extension_snapshot>& e, rs2_extension extension_type, void** ext);
 
     private:
         void update_time_base(device_serializer::nanoseconds base_timestamp);
@@ -68,8 +58,9 @@ namespace librealsense
         std::shared_ptr<stream_profile_interface> get_stream(const std::map<unsigned, std::shared_ptr<playback_sensor>>& sensors_map, device_serializer::stream_identifier stream_id);
         rs2_extrinsics calc_extrinsic(const rs2_extrinsics& from, const rs2_extrinsics& to);
         void catch_up();
-        void register_device_info(const std::shared_ptr<info_interface>& shared);
+        void register_device_info(const device_serializer::device_snapshot& device_description);
         void register_extrinsics(const device_serializer::device_snapshot& device_description);
+        void update_extensions(const device_serializer::device_snapshot& device_description);
 
     private:
         lazy<std::shared_ptr<dispatcher>> m_read_thread;

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -9,6 +9,17 @@
 #include "ds5/ds5-options.h"
 #include "media/ros/ros_reader.h"
 
+std::string profile_to_string(std::shared_ptr<stream_profile_interface> s)
+{
+    std::ostringstream os;
+    os << s->get_unique_id() << ", " <<
+        s->get_format() << ", " <<
+        s->get_stream_type() << "_" <<
+        s->get_stream_index() << " @ " <<
+        s->get_framerate();
+    return os.str();
+}
+
 playback_sensor::playback_sensor(const device_interface& parent_device, const device_serializer::sensor_snapshot& sensor_description):
     m_user_notification_callback(nullptr, [](rs2_notifications_callback* n) {}),
     m_is_started(false),
@@ -18,7 +29,8 @@ playback_sensor::playback_sensor(const device_interface& parent_device, const de
 {
     register_sensor_streams(m_sensor_description.get_stream_profiles());
     register_sensor_infos(m_sensor_description);
-    register_sensor_options(m_sensor_description.get_options());
+    register_sensor_options(m_sensor_description);
+    LOG_DEBUG("Created Playback Sensor " << m_sensor_id);
 }
 playback_sensor::~playback_sensor()
 {
@@ -33,6 +45,7 @@ void playback_sensor::open(const stream_profiles& requests)
 {
     //Playback can only play the streams that were recorded. 
     //Go over the requested profiles and see if they are available
+    LOG_DEBUG("Open Sensor " << m_sensor_id);
 
     for (auto&& r : requests)
     {
@@ -40,7 +53,7 @@ void playback_sensor::open(const stream_profiles& requests)
             std::end(m_available_profiles),
             [r](const std::shared_ptr<stream_profile_interface>& s) { return r->get_unique_id() == s->get_unique_id(); }) == std::end(m_available_profiles))
         {
-            throw std::runtime_error("Failed to open sensor, requested profile is not available");
+            throw std::runtime_error(to_string() << "Failed to open sensor, requested profile: " << profile_to_string(r) << " is not available");
         }
     }
     std::vector<device_serializer::stream_identifier> opened_streams;
@@ -58,6 +71,7 @@ void playback_sensor::open(const stream_profiles& requests)
 
 void playback_sensor::close()
 {
+    LOG_DEBUG("Close sensor " << m_sensor_id);
     std::vector<device_serializer::stream_identifier> closed_streams;
     for (auto dispatcher : m_dispatchers)
     {
@@ -76,11 +90,13 @@ void playback_sensor::close()
 
 void playback_sensor::register_notifications_callback(notifications_callback_ptr callback)
 {
+    LOG_DEBUG("register_notifications_callback for sensor " << m_sensor_id);
     m_user_notification_callback = std::move(callback);
 }
 
 void playback_sensor::start(frame_callback_ptr callback)
 {
+    LOG_DEBUG("Start sensor " << m_sensor_id);
     if (m_is_started == false)
     {
         started(m_sensor_id, callback);
@@ -90,6 +106,8 @@ void playback_sensor::start(frame_callback_ptr callback)
 }
 void playback_sensor::stop(bool invoke_required)
 {
+    LOG_DEBUG("Stop sensor " << m_sensor_id);
+
     if (m_is_started == true)
     {
         stopped(m_sensor_id, invoke_required);
@@ -108,29 +126,7 @@ bool playback_sensor::is_streaming() const
 bool playback_sensor::extend_to(rs2_extension extension_type, void** ext)
 {
     std::shared_ptr<extension_snapshot> e = m_sensor_description.get_sensor_extensions_snapshots().find(extension_type);
-    if(e == nullptr)
-    {
-        return false;
-    }
-    switch (extension_type)
-    {
-    case RS2_EXTENSION_UNKNOWN: return false;
-    case RS2_EXTENSION_DEBUG : return try_extend<debug_interface>(e, ext);
-    case RS2_EXTENSION_INFO : return try_extend<info_interface>(e, ext);
-    case RS2_EXTENSION_MOTION : return try_extend<motion_sensor_interface>(e, ext);;
-    case RS2_EXTENSION_OPTIONS : return try_extend<options_interface>(e, ext);;
-    case RS2_EXTENSION_VIDEO : return try_extend<video_sensor_interface>(e, ext);;
-    case RS2_EXTENSION_ROI : return try_extend<roi_sensor_interface>(e, ext);;
-    case RS2_EXTENSION_VIDEO_FRAME : return try_extend<video_frame>(e, ext);
- //TODO: RS2_EXTENSION_MOTION_FRAME : return try_extend<motion_frame>(e, ext);
-    case RS2_EXTENSION_DEPTH_SENSOR:  return try_extend<depth_sensor>(e, ext);
-    case RS2_EXTENSION_COUNT :
-        //[[fallthrough]];
-    default:
-        LOG_WARNING("Unsupported extension type: " << extension_type);
-        assert(0);
-        return false;
-    }
+    return playback_device::try_extend_snapshot(e, extension_type, ext);
 }
 
 const device_interface& playback_sensor::get_device()
@@ -171,6 +167,10 @@ void playback_sensor::handle_frame(frame_holder frame, bool is_real_time)
         }
     }
 }
+void playback_sensor::update_option(std::shared_ptr<option> option)
+{
+    register_option(option->type(), option);
+}
 void playback_sensor::flush_pending_frames()
 {
     for (auto&& dispatcher : m_dispatchers)
@@ -186,6 +186,7 @@ void playback_sensor::register_sensor_streams(const stream_profiles& profiles)
         profile->set_unique_id(environment::get_instance().generate_stream_id());
         m_available_profiles.push_back(profile);
         m_streams[std::make_pair(profile->get_stream_type(), static_cast<uint32_t>(profile->get_stream_index()))] = profile;
+        LOG_DEBUG("Added new stream: " << profile_to_string(profile));
     }
 }
 
@@ -194,27 +195,62 @@ void playback_sensor::register_sensor_infos(const device_serializer::sensor_snap
     auto info_snapshot = sensor_snapshot.get_sensor_extensions_snapshots().find(RS2_EXTENSION_INFO);
     if (info_snapshot == nullptr)
     {
-        throw io_exception("Recorded file does not contain sensor information");
+        LOG_WARNING("Recorded file does not contain sensor information");
+        return;
     }
     auto info_api = As<info_interface>(info_snapshot);
     if (info_api == nullptr)
     {
         throw invalid_value_exception("Failed to get info interface from sensor snapshots");
     }
+
     for (int i = 0; i < RS2_CAMERA_INFO_COUNT; ++i)
     {
         rs2_camera_info info = static_cast<rs2_camera_info>(i);
         if (info_api->supports_info(info))
         {
-            register_info(info, info_api->get_info(info));
+            const std::string& str = info_api->get_info(info);
+            register_info(info, str);
+            LOG_DEBUG("Registered " << info << " for sensor " << m_sensor_id << " with value: " << str);
         }
     }
 }
 
-void playback_sensor::register_sensor_options(const std::map<rs2_option, float>& options)
+void playback_sensor::register_sensor_options(const device_serializer::sensor_snapshot& sensor_snapshot)
 {
-    for (auto option : options)
+    auto options_snapshot = sensor_snapshot.get_sensor_extensions_snapshots().find(RS2_EXTENSION_OPTIONS);
+    if (options_snapshot == nullptr)
     {
-        register_option(option.first, std::make_shared<read_only_playback_option>(option.first, option.second));
+        LOG_WARNING("Recorded file does not contain sensor options");
+        return;
     }
+    auto options_api = As<options_interface>(options_snapshot);
+    if (options_api == nullptr)
+    {
+        throw invalid_value_exception("Failed to get options interface from sensor snapshots");
+    }
+
+    for (int i = 0; i < static_cast<int>(RS2_OPTION_COUNT); i++)
+    {
+        auto option_id = static_cast<rs2_option>(i);
+        try
+        {
+            if (options_api->supports_option(option_id))
+            {
+                auto&& option = options_api->get_option(option_id);
+                float value = option.query();
+                register_option(option_id, std::make_shared<const_value_option>(option.type(), option.get_description(), option.query()));
+                LOG_DEBUG("Registered " << rs2_option_to_string(option_id) << " for sensor " << m_sensor_id << " with value: " << option.query());
+            }
+        }
+        catch (std::exception& e)
+        {
+            LOG_WARNING("Failed to register option " << option_id << ". Exception: " << e.what());
+        }
+    }
+}
+
+void playback_sensor::update(const device_serializer::sensor_snapshot& sensor_snapshot)
+{
+    register_sensor_options(sensor_snapshot);
 }

--- a/src/media/playback/playback_sensor.h
+++ b/src/media/playback/playback_sensor.h
@@ -39,12 +39,14 @@ namespace librealsense
         bool extend_to(rs2_extension extension_type, void** ext) override;
         const device_interface& get_device() override;
         void handle_frame(frame_holder frame, bool is_real_time);
+        void update_option(std::shared_ptr<option> option);
         void stop(bool invoke_required);
         void flush_pending_frames();
+        void update(const device_serializer::sensor_snapshot& sensor_snapshot);
     private:
         void register_sensor_streams(const stream_profiles& vector);
         void register_sensor_infos(const device_serializer::sensor_snapshot& sensor_snapshot);
-        void register_sensor_options(const std::map<rs2_option, float>& options);
+        void register_sensor_options(const device_serializer::sensor_snapshot& sensor_snapshot);
 
         frame_callback_ptr m_user_callback;
         librealsense::notifications_callback_ptr m_user_notification_callback;

--- a/src/media/readme.md
+++ b/src/media/readme.md
@@ -135,79 +135,79 @@ The following table depicts the Topics that are supported by RealSense file form
   <tr>
     <td>File Version</td>
     <td>/file_version</td>
-    <td><a href="http://docs.ros.org/api/std_msgs/html/msg/UInt32.html">std_msgs::UInt32</a></td>
-    <td>version of file format<br>A single message for entire file</td>
+    <td><a href="http://docs.ros.org/api/std_msgs/html/msg/UInt32.html">std_msgs/UInt32</a></td>
+    <td>Version of file format.<br>A single message for entire file</td>
   </tr>
   <tr>
     <td>Device Information</td>
     <td>/device_&lt;device_id&gt;/info</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
-    <td>device information<br>Many messages to a single topic</td>
+    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue</a></td>
+    <td>Device information.<br>Many messages to a single topic</td>
   </tr>
   <tr>
     <td>Sensor Information</td>
     <td>/device_&lt;device_id&gt;/info</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
-    <td>sensor information<br>Many messages to a single topic</td>
+    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue</a></td>
+    <td>Sensor information.<br>Many messages to a single topic</td>
   </tr>
   <tr>
     <td>Stream Information</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/info</td>
-    <td><a href="#stream-info">realsense_msg::StreamInfo</a></td>
+    <td><a href="#stream-info">realsense_msg/StreamInfo</a></td>
     <td>generic-stream information<br>A single messages to a single topic</td>
   </tr>
   <tr>
     <td>Video Stream Info</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/info/camera_info</td>
-    <td><a href="http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html">sensor_msgs::camera_info</a></td>
-    <td>Image information<br>A single messages to a single topic</td>
+    <td><a href="http://docs.ros.org/api/sensor_msgs/html/msg/CameraInfo.html">sensor_msgs/camera_info</a></td>
+    <td>Image information.<br>A single messages to a single topic</td>
   </tr>
   <tr>
     <td>IMU Intrinsics</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/info/imu_intrinsic</td>
-    <td><a href="#motion-intrinsic">realsense_msgs::ImuIntrinsic</a></td>
-    <td>Intrinsic of a motion stream<br>A single messages to a single topic</td>
+    <td><a href="#motion-intrinsic">realsense_msgs/ImuIntrinsic</a></td>
+    <td>Intrinsic of a motion stream.<br>A single messages to a single topic</td>
   </tr>
   <tr>
-    <td>Properties</td>
-    <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/property</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
-    <td><br>Properties of a sensor<br>Many messages to a single topic<br></td>
+    <td>Options</td>
+    <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/option/&lt;option name&gt;/value<br>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/option/&lt;option name&gt;/description</td>
+    <td><a href="http://docs.ros.org/api/std_msgs/html/msg/Float32.html">std_msgs/Float32</a><br><a href="http://docs.ros.org/api/std_msgs/html/msg/String.html">std_msgs/String</a></td>
+    <td>Options of a sensor.<br>values represent the value of the option and has many messages to a single topic<br>description is a human readable description of the option, with a single messages to a single topic</td>
   </tr>
   <tr>
     <td>Image Data</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/image/data</td>
-    <td><a href="http://docs.ros.org/api/sensor_msgs/html/msg/Image.html">sensor_msgs::Image</a></td>
+    <td><a href="http://docs.ros.org/api/sensor_msgs/html/msg/Image.html">sensor_msgs/Image</a></td>
     <td>The data of a single image. A single messages to a single topic</td>
   </tr>
   <tr>
     <td>Image Information</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/image/metadata</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
+    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue</a></td>
     <td>Additional information of a single image. Many message to a single topic</td>
   </tr>
   <tr>
     <td>IMU Data</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/imu/data</td>
-    <td><a href="http://docs.ros.org/api/sensor_msgs/html/msg/Imu.html">sensor_msgs::Imu</a></td>
+    <td><a href="http://docs.ros.org/api/sensor_msgs/html/msg/Imu.html">sensor_msgs/Imu</a></td>
     <td>The data of a single imu frame.<br>A single messages to a single topic</td>
   </tr>
   <tr>
     <td>IMU Information</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/imu/metadata</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
+    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue</a></td>
     <td>Additional information of a single imu frame. Many message to a single topic</td>
   </tr>
   <tr>
     <td>6DOF Data</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/6dof/data</td>
-    <td>realsense_msgs::6DoF (TBD)</td>
+    <td>realsense_msgs/6DoF (TBD)</td>
     <td>Six DOF data</td>
   </tr>
   <tr>
     <td>6DOF Information</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/6dof/metadata</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
+    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue</a></td>
     <td>Additional information of a single image. Many message to a single topic</td>
   </tr>
   <tr>
@@ -219,19 +219,19 @@ The following table depicts the Topics that are supported by RealSense file form
   <tr>
     <td>Occupancy Map Information</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/&lt;stream_type&gt;_&lt;stream_id&gt;/occupancy_map/metadata</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
+    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue</a></td>
     <td>Additional </td>
   </tr>
   <tr>
     <td>Time Stream</td>
     <td>/device_&lt;device_id&gt;/sensor_&lt;sensor_id&gt;/time</td>
-    <td><a href="http://docs.ros.org/jade/api/sensor_msgs/html/msg/TimeReference.html">sensor_msgs::TimeReference</a></td>
+    <td><a href="http://docs.ros.org/jade/api/sensor_msgs/html/msg/TimeReference.html">sensor_msgs/TimeReference</a></td>
     <td></td>
   </tr>
   <tr>
     <td>Log</td>
     <td>/log</td>
-    <td><a href="http://docs.ros.org/jade/api/rosgraph_msgs/html/msg/Log.html">rosgraph_msgs::Log</a></td>
+    <td><a href="http://docs.ros.org/jade/api/rosgraph_msgs/html/msg/Log.html">rosgraph_msgs/Log</a></td>
     <td>Log messages</td>
   </tr>
   <tr>
@@ -243,7 +243,7 @@ The following table depicts the Topics that are supported by RealSense file form
   <tr>
     <td>Additional Info</td>
     <td>/additional_info</td>
-    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue.msg</a></td>
+    <td><a href="http://docs.ros.org/api/diagnostic_msgs/html/msg/KeyValue.html">diagnostic_msgs/KeyValue</a></td>
     <td>Additinal information of any kind. Can be useful for application that require additional metadata on the recorded file (such as program name, version etc...)</td>
   </tr>
 </table>
@@ -284,15 +284,15 @@ The following are the new messages created by the SDK:
   </tr>
   <tr>
     <td>encoding</td>
-    <td>Stream's data format<br>
-    [Supported encodings are listed below](#supported-encoding)</td>
+    <td>Stream's data format. 
+    Supported encodings are listed below</td>
     <td>string</td>
   </tr>
 </table>
 
 ###### Supported Encoding
 
-For video streams, the supported encoding types can be found at <a href="http://docs.ros.org/jade/api/sensor_msgs/html/namespacesensor__msgs_1_1image__encodings.html">ros documentation</a><br>
+For video streams, the supported encoding types can be found at <a href="http://docs.ros.org/jade/api/sensor_msgs/html/namespacesensor__msgs_1_1image__encodings.html">ros documentation</a>. Additional supported encodings are listed under [rs_sensor.h](../../../include/librealsense2/h/rs_sensor.h) as the `rs2_format` enumeration. Note that some of the encodings appear in both locations.
 
 --------------
 
@@ -349,6 +349,26 @@ For video streams, the supported encoding types can be found at <a href="http://
 
 ----------
 
+### Versioning
+
+Each bag file recorded using this SDK should contains a version message.
+Version number is a single integer which indicates the version of topics and messages that were used to record the file.
+The above messages and topics reflect the current version.
+Changes from previous versions will appear at the end of this section.
+
+> Current file version: ***3***
+
+Changes from previous version:
+
+- Removed:
+	- ***Property*** topic
+- Added:
+	- ***Options*** topic
+
+
+
+----------
+
 
 Recording
 ----------
@@ -359,16 +379,38 @@ A record device is like a wrapper around a real device, that delegates actions t
 When a record device is created, a record sensor is created per real sensor of the real device. 
 A record sensor will record newly arriving frames for each of its streams, and changes to extensions' data (snapshots). 
 
+Recording related files are:
+ - [record/record_device.cpp](record/record_device.cpp)
+ - [record/record_device.h](record/record_device.h)
+ - [record/record_sensor.cpp](record/record_sensor.cpp)
+ - [record/record_sensor.h](record/record_sensor.h)
+ - [ros/ros_writer.h](ros/ros_writer.h)
+
+A `librealsense::record_device` is constructed with a "live" device and a `device_serializer::writer`. At the moment the only `device_serializer::writer` we use is a `ros_writer` which writes device information to a rosbag file.
+
+When constructing a `ros_writer` the requested file is created if it does not exist, and then opened for writing. In addition, a single message containing the realsense file format version is written to the file. 
+The `ros_writer` implements the `device_serializer::writer` interface which has only 4 functions:
+ - write_device_description
+	 - Used to record the initial state of the device. This includes writing all of the device's and sensor's extensions. 
+ - write_frame
+	 - Used to record a single frame to file
+ - write_snapshot (2 overloads)
+	 - Used to record a snapshot of an extension to file.
+
+#### Recording device description
+A device description (or device snapshot) is the set of data that is available for any `librealsense::device`. It contains all of the device's extensions snapshots, and a collection of each  of the device's sensors' extensions snapshots. In addition it holds a mapping of extrinsic information for all streams of the device.
+
+A single `librealsense::device_snapshot` instance is enough to understand the a device's topology: Which extensions it supports, how many sensors it has, which extensions each sensor supports, which streams each sensor supports and which streams share calibration information (extrinsic).
+
 #### Recording Frames
-Frame are usually merely a container of raw data. 
-Each frames is stored to file with all of its additional information (such as metadata, timestamp, etc...).
+Each frame in the SDK implements the  `librealsense::frame_interface` interface. This means that frames are polymorphic and represent all types of data that streams provide.
+Frames are recorded to file with all of their additional information (such as metadata, timestamp, etc...), and the time that they arrived from the backend to the sensor.
 
 
 #### Recording Snapshots 
-Upon creation, the record device goes over all of the extensions of the real device and its sensors, and saves snapshots of those extensions to the file. These snapshots will allow the playback device to recreate the topology of the recorded device, and will serve as the initial data of their extensions.
-To allow record sensors to save changes to extensions' data over the life time of the program, when a user asks a record sensor for an extension, a record-able extension would be provided. 
-A record-able version of an extension holds an action to perform whenever the extension's data changes. This action is provided by the record sensor, and will usually be the action of writing the extension's snapshot to file.
-Note: After resuming a paused recordig, the states of the device and its extensions are not updated to their current state. Thus, only changes made after resuming recording will appear in the file when playing it.
+Upon creation, the record device goes over all of the extensions of the real device and its sensors, and saves snapshots of those extensions to the file (This is the data that is passed to `write_device_description(..)`) . These snapshots will allow the playback device to recreate the topology of the recorded device, and will serve as the initial data of their extensions.
+To allow record sensors to save changes to extensions' data over the life time of the program, when a user asks a record sensor for an extension, a record-able extension is provided. 
+A record-able version of an extension holds an action to perform whenever the extension's data changes. This action is provided by the record device (or sensor), and requires extensions to pass a reference of themselves to the device, which will usually create a snapshot from them and record them to file with the time at which they occurred.
 
 ----------
 

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -28,6 +28,7 @@ librealsense::record_device::record_device(std::shared_ptr<librealsense::device_
     m_ros_writer = serializer;
     m_sensors = create_record_sensors(m_device);
     (*m_write_thread)->start();
+    LOG_DEBUG("Created record_device");
 }
 
 std::vector<std::shared_ptr<record_sensor>> record_device::create_record_sensors(std::shared_ptr<device_interface> device)
@@ -73,31 +74,17 @@ size_t librealsense::record_device::get_sensors_count() const
 
 void librealsense::record_device::write_header()
 {
+    
     auto device_extensions_md = get_extensions_snapshots(m_device.get());
+    LOG_DEBUG("Created device snapshot with " << device_extensions_md.get_snapshots().size() << " snapshots");
 
     std::vector<sensor_snapshot> sensors_snapshot;
     for (size_t j = 0; j < m_device->get_sensors_count(); ++j)
     {
         auto& sensor = m_device->get_sensor(j);
         auto sensor_extensions_snapshots = get_extensions_snapshots(&sensor);
-        std::map<rs2_option, float> options;
-        for (int i = 0; i < static_cast<int>(RS2_OPTION_COUNT); i++)
-        {
-            auto option_id = static_cast<rs2_option>(i);
-            try
-            {
-                if (sensor.supports_option(option_id))
-                {
-                    auto& option = sensor.get_option(option_id);
-                    options[option_id] = option.query();
-                }
-            }
-            catch(std::exception& e)
-            {
-                LOG_WARNING("Failed to get option " << option_id << " for sensor #" << i << ". Exception: " << e.what());
-            }
-        }
-        sensors_snapshot.emplace_back(static_cast<uint32_t>(j), sensor_extensions_snapshots, options);
+        sensors_snapshot.emplace_back(static_cast<uint32_t>(j), sensor_extensions_snapshots);
+        LOG_DEBUG("Created sensor " << j << " snapshot with " << device_extensions_md.get_snapshots().size() << " snapshots");
     }
     
     m_ros_writer->write_device_description({ device_extensions_md, sensors_snapshot, {/*extrinsics are written by ros_writer*/} });
@@ -113,6 +100,8 @@ std::chrono::nanoseconds librealsense::record_device::get_capture_time() const
 void librealsense::record_device::write_data(size_t sensor_index, librealsense::frame_holder frame, std::function<void(std::string const&)> on_error)
 {
     //write_data is called from the sensors, when the live sensor raises a frame
+    
+    LOG_DEBUG("write frame " << (frame ? std::to_string(frame.frame->get_frame_number()) : "") <<  " from sensor " << sensor_index);
 
     std::call_once(m_first_call_flag, [this]()
     {
@@ -214,15 +203,23 @@ void librealsense::record_device::try_add_snapshot(T* extendable, snapshot_colle
     if (api != nullptr)
     {
         std::shared_ptr<Ext> p;
-        api->create_snapshot(p); //might need to add: "recordable<Ext>::"
-        auto snapshot = std::dynamic_pointer_cast<extension_snapshot>(p);
-        if (snapshot != nullptr)
+        try
         {
-            snapshots[TypeToExtensionn<Ext>::value] = snapshot;
+            api->create_snapshot(p);
+            auto snapshot = std::dynamic_pointer_cast<extension_snapshot>(p);
+            if (snapshot != nullptr)
+            {
+                snapshots[TypeToExtension<Ext>::value] = snapshot;
+                LOG_INFO("Added snapshot of type: " << TypeToExtension<Ext>::to_string());
+            }
+            else
+            {
+                LOG_ERROR("Failed to downcast snapshot of type " << TypeToExtension<Ext>::to_string());
+            }
         }
-        else
+        catch (const std::exception& e)
         {
-            LOG_ERROR("Failed to downcast snapshot of type " << TypeToExtensionn<Ext>::to_string());
+            LOG_ERROR("Failed to add snapshot of type " << TypeToExtension<Ext>::to_string() << ". Exception: " << e.what());
         }
     }
 }
@@ -243,38 +240,116 @@ snapshot_collection librealsense::record_device::get_extensions_snapshots(T* ext
         rs2_extension ext = static_cast<rs2_extension>(i);
         switch (ext)
         {
-            case RS2_EXTENSION_UNKNOWN         : break;
-//TODO: uncomment            case RS2_EXTENSION_DEBUG           : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_DEBUG          >::type>(extendable, snapshots);
-            case RS2_EXTENSION_INFO            : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_INFO           >::type>(extendable, snapshots);
-//TODO: uncomment            case RS2_EXTENSION_MOTION          : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_MOTION         >::type>(extendable, snapshots);
-//TODO: uncomment            case RS2_EXTENSION_OPTIONS         : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_OPTIONS        >::type>(extendable, snapshots);
-//TODO: uncomment            case RS2_EXTENSION_VIDEO           : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_VIDEO          >::type>(extendable, snapshots);
-//TODO: uncomment            case RS2_EXTENSION_ROI             : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_ROI            >::type>(extendable, snapshots);
-//TODO: uncomment            case RS2_EXTENSION_DEPTH_SENSOR    : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_DEPTH_SENSOR   >::type>(extendable, snapshots);
+            case RS2_EXTENSION_DEBUG           : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEBUG          >::type>(extendable, snapshots);
+            case RS2_EXTENSION_INFO            : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_INFO           >::type>(extendable, snapshots);
+            case RS2_EXTENSION_OPTIONS         : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_OPTIONS        >::type>(extendable, snapshots);
+            //case RS2_EXTENSION_MOTION          : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_MOTION         >::type>(extendable, snapshots);
+            //case RS2_EXTENSION_VIDEO           : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_VIDEO          >::type>(extendable, snapshots);
+            //case RS2_EXTENSION_ROI             : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_ROI            >::type>(extendable, snapshots);
+            case RS2_EXTENSION_DEPTH_SENSOR    : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEPTH_SENSOR   >::type>(extendable, snapshots);
+            //case RS2_EXTENSION_ADVANCED_MODE   : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_ADVANCED_MODE  >::type>(extendable, snapshots);
             case RS2_EXTENSION_VIDEO_FRAME     : break;
             case RS2_EXTENSION_MOTION_FRAME    : break;
             case RS2_EXTENSION_COMPOSITE_FRAME : break;
             case RS2_EXTENSION_POINTS          : break;
-//TODO: uncomment            case RS2_EXTENSION_ADVANCED_MODE   : try_add_snapshot<T, ExtensionsToTypes<RS2_EXTENSION_ADVANCED_MODE  >::type>(extendable, snapshots);
             case RS2_EXTENSION_RECORD          : break;
             case RS2_EXTENSION_PLAYBACK        : break;
             case RS2_EXTENSION_COUNT           : break;
+            case RS2_EXTENSION_UNKNOWN         : break;
             default:
-                LOG_WARNING("Extensions type is unhandled: " << static_cast<int>(ext));
+                LOG_WARNING("Extensions type is unhandled: " << ext);
         }
     }
     return snapshots;
 }
 
+template <typename T>
+void librealsense::record_device::write_device_extension_changes(const T& ext)
+{
+    std::shared_ptr<T> snapshot;
+    ext.create_snapshot(snapshot);
+    auto ext_snapshot = As<extension_snapshot>(snapshot);
+    if (!ext_snapshot)
+    {
+        assert(0);
+        return;
+    }
+    auto capture_time = get_capture_time();
+    (*m_write_thread)->invoke([this, capture_time, ext_snapshot](dispatcher::cancellable_timer t)
+    {
+        try
+        {
+            const uint32_t device_index = 0;
+            m_ros_writer->write_snapshot(device_index, capture_time, TypeToExtension<T>::value, ext_snapshot);
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR(e.what());
+        }
+    });
+}
+template <rs2_extension E, typename P> 
+bool librealsense::record_device::extend_to_aux(std::shared_ptr<P> p, void** ext)
+{
+    using EXT_TYPE = typename ExtensionToType<E>::type;
+    auto ptr = As<EXT_TYPE>(p);
+    if (!ptr)
+        return false;
+
+    if (auto recordable = As<librealsense::recordable<EXT_TYPE>>(p))
+    {
+        recordable->enable_recording([this](const EXT_TYPE& ext) {
+            write_device_extension_changes(ext);
+        });
+    }
+    
+    *ext = &ptr;
+    return true;
+}
+
 bool librealsense::record_device::extend_to(rs2_extension extension_type, void** ext)
 {
-    return false;
+    /**************************************************************************************
+     A record device wraps the live device, and should have the same functionalities.
+     To do that, the record device implements the extendable_interface and when the user tries to
+     treat the device as some extension, this function is called, and we return a pointer to the 
+     live device's extension. If that extension is a recordable one, we also enable_recording for it.
+    **************************************************************************************/
+    
+    switch (extension_type)
+    {
+    case RS2_EXTENSION_INFO:    // [[fallthrough]]
+    case RS2_EXTENSION_RECORD:
+        *ext = this;
+        return true;
+    case RS2_EXTENSION_OPTIONS         : return extend_to_aux<RS2_EXTENSION_OPTIONS        >(m_device, ext);
+    case RS2_EXTENSION_DEBUG           : return extend_to_aux<RS2_EXTENSION_DEBUG          >(m_device, ext);
+    //TODO: Add once implements recordable: case RS2_EXTENSION_MOTION          : return extend_to_aux<RS2_EXTENSION_MOTION         >(m_device, ext);
+    //case RS2_EXTENSION_VIDEO           : return extend_to_aux<RS2_EXTENSION_VIDEO          >(m_device, ext);
+    //case RS2_EXTENSION_ROI             : return extend_to_aux<RS2_EXTENSION_ROI            >(m_device, ext);
+    //case RS2_EXTENSION_DEPTH_SENSOR    : return extend_to_aux<RS2_EXTENSION_DEPTH_SENSOR   >(m_device, ext);
+    //case RS2_EXTENSION_VIDEO_FRAME     : return extend_to_aux<RS2_EXTENSION_VIDEO_FRAME    >(m_device, ext);
+    //TODO: Add once interface created: case RS2_EXTENSION_MOTION_FRAME    : return extend_to_aux<RS2_EXTENSION_MOTION_FRAME   >(m_device, ext);
+    //case RS2_EXTENSION_COMPOSITE_FRAME : return extend_to_aux<RS2_EXTENSION_COMPOSITE_FRAME>(m_device, ext);
+    //case RS2_EXTENSION_POINTS          : return extend_to_aux<RS2_EXTENSION_POINTS         >(m_device, ext);
+    //case RS2_EXTENSION_DEPTH_FRAME     : return extend_to_aux<RS2_EXTENSION_DEPTH_FRAME    >(m_device, ext);
+    //case RS2_EXTENSION_ADVANCED_MODE   : return extend_to_aux<RS2_EXTENSION_ADVANCED_MODE  >(m_device, ext);
+    //case RS2_EXTENSION_VIDEO_PROFILE   : return extend_to_aux<RS2_EXTENSION_VIDEO_PROFILE  >(m_device, ext);
+    //case RS2_EXTENSION_PLAYBACK        : return extend_to_aux<RS2_EXTENSION_PLAYBACK       >(m_device, ext);
+    case RS2_EXTENSION_OPTION          : return extend_to_aux<RS2_EXTENSION_OPTION         >(m_device, ext);
+    default:
+        LOG_WARNING("Extensions type is unhandled: " << extension_type);
+        return false;
+    }
 }
 
 void librealsense::record_device::pause_recording()
 {
+    LOG_INFO("Record Pause called");
+
     (*m_write_thread)->invoke([this](dispatcher::cancellable_timer c)
     {
+        LOG_DEBUG("Record pause invoked");
 
         if (m_is_recording == false)
             return;
@@ -282,19 +357,25 @@ void librealsense::record_device::pause_recording()
         //unregister_callbacks();
         m_time_of_pause = std::chrono::high_resolution_clock::now();
         m_is_recording = false;
+        LOG_DEBUG("Time of pause: " << m_time_of_pause.time_since_epoch().count());
     });
     (*m_write_thread)->flush();
+    LOG_INFO("Record paused");
 }
 void librealsense::record_device::resume_recording()
 {
+    LOG_INFO("Record resume called");
     (*m_write_thread)->invoke([this](dispatcher::cancellable_timer c)
     {
+        LOG_DEBUG("Record resume invoked");
         if (m_is_recording)
             return;
 
         m_record_pause_time += (std::chrono::high_resolution_clock::now() - m_time_of_pause);
         //register_callbacks();
         m_is_recording = true;
+        LOG_DEBUG("Total pause time: " << m_record_pause_time.count());
+        LOG_INFO("Record resumed");
     });
 }
 
@@ -316,7 +397,6 @@ void record_device::stop_gracefully(to_string error_msg)
         sensor->stop();
         sensor->close();
     }
-
 }
 
 std::pair<uint32_t, rs2_extrinsics> record_device::get_extrinsics(const stream_interface& stream) const

--- a/src/media/record/record_device.h
+++ b/src/media/record/record_device.h
@@ -42,6 +42,9 @@ namespace librealsense
         std::pair<uint32_t, rs2_extrinsics> get_extrinsics(const stream_interface& stream) const override;
 
     private:
+        template <typename T> void write_device_extension_changes(const T& ext);
+        template <rs2_extension E, typename P> bool extend_to_aux(std::shared_ptr<P> p, void** ext);
+
         void write_header();
         std::chrono::nanoseconds get_capture_time() const;
         void write_data(size_t sensor_index, frame_holder f, std::function<void(std::string const&)> on_error);

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -13,9 +13,9 @@
 namespace librealsense
 {
     class record_sensor : public sensor_interface,
-        public extendable_interface,  //Allows extension for any of the given device's extensions
-        public info_container,
-        public options_container//TODO: consider deriving from recordable_options_container
+                          public extendable_interface,  //Allows extension for any of the given device's extensions
+                          public info_container,
+                          public options_container
     {
     public:
         using frame_interface_callback_t = std::function<void(frame_holder, std::function<void(const std::string&)>)>;
@@ -41,23 +41,25 @@ namespace librealsense
         bool is_streaming() const override;
         bool extend_to(rs2_extension extension_type, void** ext) override;
         const device_interface& get_device() override;
-    private:
+        
+    private /*methods*/:
         void raise_user_notification(const std::string& str);
-        void record_snapshot(rs2_extension extension_type, const std::shared_ptr<extension_snapshot>& snapshot);
-        std::vector<platform::stream_profile> convert_profiles(const std::vector<stream_profile>& vector);
-
+        template <typename T> void record_snapshot(rs2_extension extension_type, const T& snapshot);
+        template <rs2_extension E, typename P> bool extend_to_aux(P* p, void** ext);
+        void stop_with_error(const std::string& basic_string);
+        void record_frame(frame_holder holder);
+        
+    private /*members*/:
         snapshot_callback_t m_device_record_snapshot_handler;
         sensor_interface& m_sensor;
+        std::set<rs2_option> m_recording_options;
         librealsense::notifications_callback_ptr m_user_notification_callback;
         frame_interface_callback_t m_record_callback;
         std::atomic_bool m_is_recording;
         bool m_is_pause;
         frame_callback_ptr m_frame_callback;
-        std::vector<platform::stream_profile> m_curr_configurations;
         const device_interface& m_parent_device;
-        std::map<rs2_option, std::shared_ptr<option>> m_recordable_options_cache;
-        void stop_with_error(const std::string& basic_string);
-        void record_frame(frame_holder holder);
+
     };
 
     class notification_callback : public rs2_notifications_callback

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -11,6 +11,8 @@
 #include "sensor_msgs/Image.h"
 #include "diagnostic_msgs/KeyValue.h"
 #include "std_msgs/UInt32.h"
+#include "std_msgs/Float32.h"
+#include "std_msgs/String.h"
 #include "realsense_msgs/StreamInfo.h"
 #include "sensor_msgs/CameraInfo.h"
 #include "ros_file_format.h"
@@ -26,41 +28,57 @@ namespace librealsense
             m_total_duration(0),
             m_file_path(file),
             m_context(ctx),
+            m_version(0),
             m_metadata_parser_map(create_metadata_parser_map())
         {
-            reset(); //Note: calling a virtual function inside c'tor, safe while base function is pure virtual
-            m_total_duration = get_file_duration();
-        }
-
-        device_snapshot query_device_description() override
-        {
-            return m_device_description;
-        }
-
-        status read_frame(nanoseconds& timestamp, stream_identifier& stream_id, frame_holder& frame) override
-        {
-            while(m_samples_view != nullptr && m_samples_itrator != m_samples_view->end())
+            try
             {
-                rosbag::MessageInstance next_frame_msg = *m_samples_itrator;
-                ++m_samples_itrator;
-                if (next_frame_msg.isType<sensor_msgs::Image>())
-                {
-                    stream_id = ros_topic::get_stream_identifier(next_frame_msg.getTopic());
-                    timestamp = nanoseconds(next_frame_msg.getTime().toNSec());
-                    frame = read_image_from_message(next_frame_msg);
-                    return status::status_no_error;
-                }
-
-                if (next_frame_msg.isType<sensor_msgs::Imu>())
-                {
-                    //stream_id = ros_topic::get_stream_identifier(next_frame_msg.getTopic());
-                    //timestamp = nanoseconds(next_frame_msg.getTime().toNSec());
-                    //frame = create_motion_sample(sample_msg);
-                    return status::status_no_error;
-                }
-                LOG_WARNING("Unknown frame type: " << next_frame_msg.getDataType() << "(Topic: " << next_frame_msg.getTopic() << ")");
+                reset(); //Note: calling a virtual function inside c'tor, safe while base function is pure virtual
+                m_total_duration = get_file_duration(m_file);
             }
-            return status_file_eof;
+            catch (const std::exception& e)
+            {
+                //Rethrowing with better clearer message
+                throw io_exception(to_string() << "Failed to create ros reader: " << e.what());
+            }
+        }
+
+        device_snapshot query_device_description(const nanoseconds& time) override
+        {
+            return read_device_description(time);
+        }
+
+        std::shared_ptr<serialized_data> read_next_data() override
+        {
+            if (m_samples_view == nullptr || m_samples_itrator == m_samples_view->end())
+            {
+                LOG_DEBUG("End of file reached");
+                return std::make_shared<serialized_end_of_file>();
+            }
+
+            rosbag::MessageInstance next_msg = *m_samples_itrator;
+            ++m_samples_itrator;
+
+            if (next_msg.isType<sensor_msgs::Image>() || next_msg.isType<sensor_msgs::Imu>())
+            {
+                LOG_DEBUG("Next message is a frame");
+                return create_frame(next_msg);
+            }
+
+            if (m_version >= 3)
+            {
+                if (next_msg.isType<std_msgs::Float32>())
+                {
+                    auto timestamp = to_nanoseconds(next_msg.getTime());
+                    auto sensor_id = ros_topic::get_sensor_identifier(next_msg.getTopic());
+                    auto option = create_option(m_file, next_msg);
+                    return std::make_shared<serialized_option>(timestamp, sensor_id, option);
+                }
+            }
+
+            std::string err_msg = to_string() << "Unknown message type: " << next_msg.getDataType() << "(Topic: " << next_msg.getTopic() << ")";
+            LOG_ERROR(err_msg);
+            throw invalid_value_exception(err_msg);
         }
 
         void seek_to_time(const nanoseconds& seek_time) override
@@ -73,6 +91,7 @@ namespace librealsense
             auto seek_time_as_rostime = ros::Time(seek_time_as_secs.count());
 
             m_samples_view.reset(new rosbag::View(m_file, FalseQuery()));
+            
             //Using cached topics here and not querying them (before reseting) since a previous call to seek
             // could have changed the view and some streams that should be streaming were dropped.
             //E.g:  Recording Depth+Color, stopping Depth, starting IR, stopping IR and Color. Play IR+Depth: will play only depth, then only IR, then we seek to a point only IR was streaming, and then to 0.
@@ -88,29 +107,13 @@ namespace librealsense
             return m_total_duration;
         }
 
-        static std::shared_ptr<metadata_parser_map> create_metadata_parser_map()
-        {
-            auto md_parser_map = std::make_shared<metadata_parser_map>();
-            for (int i = 0; i < static_cast<int>(rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT); ++i)
-            {
-                auto frame_md_type = static_cast<rs2_frame_metadata_value>(i);
-                md_parser_map->insert(std::make_pair(frame_md_type, std::make_shared<md_constant_parser>(frame_md_type)));
-            }
-            return md_parser_map;
-        }
-
         void reset() override
         {
             m_file.close();
             m_file.open(m_file_path, rosbag::BagMode::Read);
 
-            uint32_t version = 0;
-            if (get_file_version_from_file(version) == false)
-            {
-                throw std::runtime_error("failed to read file version");
-            }
-
-            if (version != get_file_version())
+            m_version = read_file_version(m_file);
+            if (m_version < get_minimum_supported_file_version())
             {
                 throw std::runtime_error("unsupported file version");
             }
@@ -118,24 +121,26 @@ namespace librealsense
             m_samples_view = nullptr;
             m_frame_source = std::make_shared<frame_source>();
             m_frame_source->init(m_metadata_parser_map);
-            m_device_description = read_device_description();
+            m_initial_device_description = read_device_description(get_static_file_info_timestamp(), true);
         }
 
         virtual void enable_stream(const std::vector<device_serializer::stream_identifier>& stream_ids) override
         {
-            ros::Time start_time = ros::TIME_MIN;
-            if (m_samples_view == nullptr)
+            ros::Time start_time = ros::TIME_MIN + ros::Duration{ 0, 1 }; //first non 0 timestamp and afterward
+            if (m_samples_view == nullptr) //Starting to stream
             {
                 m_samples_view = std::unique_ptr<rosbag::View>(new rosbag::View(m_file, FalseQuery()));
+                m_samples_view->addQuery(m_file, OptionsQuery(), start_time);
                 m_samples_itrator = m_samples_view->begin();
             }
-
-            if (m_samples_itrator != m_samples_view->end())
+            else //Already streaming
             {
-                rosbag::MessageInstance sample_msg = *m_samples_itrator;
-                start_time = sample_msg.getTime();
+                if (m_samples_itrator != m_samples_view->end())
+                {
+                    rosbag::MessageInstance sample_msg = *m_samples_itrator;
+                    start_time = sample_msg.getTime();
+                }
             }
-
             auto currently_streaming = get_topics(m_samples_view);
             //empty the view
             m_samples_view = std::unique_ptr<rosbag::View>(new rosbag::View(m_file, FalseQuery()));
@@ -197,20 +202,69 @@ namespace librealsense
 
     private:
 
-        nanoseconds get_file_duration() const
+        template <typename ROS_TYPE>      
+        static typename ROS_TYPE::ConstPtr instantiate_msg(const rosbag::MessageInstance& msg)
         {
-            rosbag::View all_frames_view(m_file, FrameQuery());
+            typename ROS_TYPE::ConstPtr msg_instnance_ptr = msg.instantiate<ROS_TYPE>();
+            if (msg_instnance_ptr == nullptr)
+            {
+                throw io_exception(to_string() 
+                    << "Invalid file format, expected " 
+                    << ros::message_traits::DataType<ROS_TYPE>::value()
+                    << " message but got: " << msg.getDataType()
+                    << "(Topic: " << msg.getTopic() << ")");
+            }
+            return msg_instnance_ptr;
+        }
+        
+        std::shared_ptr<serialized_frame> create_frame(const rosbag::MessageInstance& msg)
+        {
+            auto next_msg_topic = msg.getTopic();
+            auto next_msg_time = msg.getTime();
+
+            nanoseconds timestamp = to_nanoseconds(next_msg_time);
+            stream_identifier stream_id = ros_topic::get_stream_identifier(next_msg_topic);
+
+            if (msg.isType<sensor_msgs::Image>())
+            {
+                frame_holder frame = create_image_from_message(msg);
+                return std::make_shared<serialized_frame>(timestamp, stream_id, std::move(frame));
+            }
+
+            if (msg.isType<sensor_msgs::Imu>())
+            {
+                //frame = create_motion_sample(msg);
+                //return std::make_shared<serialized_frame>(timestamp, stream_id, std::move(frame));
+            }
+
+            std::string err_msg = to_string() << "Unknown frame type: " << msg.getDataType() << "(Topic: " << next_msg_topic << ")";
+            LOG_ERROR(err_msg);
+            throw invalid_value_exception(err_msg);
+        }
+
+        static std::shared_ptr<metadata_parser_map> create_metadata_parser_map()
+        {
+            auto md_parser_map = std::make_shared<metadata_parser_map>();
+            for (int i = 0; i < static_cast<int>(rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT); ++i)
+            {
+                auto frame_md_type = static_cast<rs2_frame_metadata_value>(i);
+                md_parser_map->insert(std::make_pair(frame_md_type, std::make_shared<md_constant_parser>(frame_md_type)));
+            }
+            return md_parser_map;
+        }
+
+        static nanoseconds get_file_duration(const rosbag::Bag& file)
+        {
+            rosbag::View all_frames_view(file, FrameQuery());
             auto streaming_duration = all_frames_view.getEndTime() - all_frames_view.getBeginTime();
             return nanoseconds(streaming_duration.toNSec());
         }
 
-        frame_holder read_image_from_message(const rosbag::MessageInstance &image_data) const
+        frame_holder create_image_from_message(const rosbag::MessageInstance &image_data) const
         {
-            sensor_msgs::ImagePtr msg = image_data.instantiate<sensor_msgs::Image>();
-            if (msg == nullptr)
-            {
-                throw io_exception(to_string() << "Expected image message but got " << image_data.getDataType());
-            }
+            LOG_DEBUG("Trying to create an image frame from message");
+
+            auto msg = instantiate_msg<sensor_msgs::Image>(image_data);
 
             frame_additional_data additional_data {};
             std::chrono::duration<double, std::milli> timestamp_us(std::chrono::duration<double>(msg->header.stamp.toSec()));
@@ -224,11 +278,8 @@ namespace librealsense
             uint32_t total_md_size = 0;
             for (auto message_instance : frame_metadata_view)
             {
-                auto key_val_msg = message_instance.instantiate<diagnostic_msgs::KeyValue>();
-                if (key_val_msg == nullptr)
-                {
-                    throw io_exception(to_string() << "Expected KeyValue message but got: " << message_instance.getDataType() << "(Topic: " << message_instance.getTopic() << ")");
-                }
+                auto key_val_msg = instantiate_msg<diagnostic_msgs::KeyValue>(message_instance);
+
                 if(key_val_msg->key == "timestamp_domain") //TODO: use constants
                 {
                     convert(key_val_msg->value, additional_data.timestamp_domain);
@@ -280,26 +331,24 @@ namespace librealsense
             frame->get_stream()->set_stream_type(stream_id.stream_type);
             video_frame->data = msg->data;
             librealsense::frame_holder fh{ video_frame };
+            LOG_DEBUG("Created image frame: " << stream_format << " " << video_frame->get_width() << "x" << video_frame->get_height() << " " << stream_format);
+
             return std::move(fh);
         }
 
-        bool get_file_version_from_file(uint32_t& version) const
+        static uint32_t read_file_version(const rosbag::Bag& file)
         {
-            rosbag::View view(m_file, rosbag::TopicQuery(ros_topic::file_version_topic()));
+            auto version_topic = ros_topic::file_version_topic();
+            rosbag::View view(file, rosbag::TopicQuery(version_topic));
             if (view.size() == 0)
             {
-                return false;
+                throw io_exception(to_string() << "Invalid file format, file does not contain topic \"" << version_topic << "\"");
             }
+            assert(view.size() == 1); //version message is expected to be a single one
 
             auto item = *view.begin();
-            std_msgs::UInt32Ptr msg = item.instantiate<std_msgs::UInt32>();
-            if (msg == nullptr)
-            {
-                return false;
-            }
-            version = msg->data;
-
-            return true;
+            auto msg = instantiate_msg<std_msgs::UInt32>(item);
+            return msg->data;
         }
 
         bool try_read_stream_extrinsic(const stream_identifier& stream_id, uint32_t& group_id, rs2_extrinsics& extrinsic) const
@@ -311,70 +360,92 @@ namespace librealsense
             }
             assert(tf_view.size() == 1); //There should be 1 message per stream
             auto msg = *tf_view.begin();
-            auto tf_msg = msg.instantiate<geometry_msgs::Transform>();
-            if (tf_msg == nullptr)
-            {
-                throw io_exception(to_string() << "Expected KeyValue message but got " << msg.getDataType() << "(Topic: " << msg.getTopic() << ")");
-            }
+            auto tf_msg = instantiate_msg<geometry_msgs::Transform>(msg);
             group_id = ros_topic::get_extrinsic_group_index(msg.getTopic());
             convert(*tf_msg, extrinsic);
             return true;
         }
 
-        device_snapshot read_device_description() const
+        static void update_sensor_options(const rosbag::Bag& file, uint32_t sensor_index, const nanoseconds& time, uint32_t file_version, snapshot_collection& sensor_extensions)
         {
-            snapshot_collection device_extensions;
-
-            std::shared_ptr<info_snapshot> info = read_info_snapshot(ros_topic::device_info_topic(get_device_index()));
-            device_extensions[RS2_EXTENSION_INFO ] = info;
-            std::vector<sensor_snapshot> sensor_descriptions;
-            auto sensor_indices = read_sensor_indices(get_device_index());
-            std::map<stream_identifier, std::pair<uint32_t, rs2_extrinsics>> extrinsics_map;
-            for (auto sensor_index : sensor_indices)
+            auto sensor_options = read_sensor_options(file, { get_device_index(), sensor_index }, time, file_version);
+            sensor_extensions[RS2_EXTENSION_OPTIONS] = sensor_options;
+            if (sensor_options->supports_option(RS2_OPTION_DEPTH_UNITS))
             {
-                snapshot_collection sensor_extensions;
-                auto streams_snapshots = read_stream_info(get_device_index(), sensor_index);
-                for (auto stream_profile : streams_snapshots)
-                {
-                    auto stream_id = stream_identifier{ get_device_index(), sensor_index, stream_profile->get_stream_type(), static_cast<uint32_t>(stream_profile->get_stream_index()) };
-                    uint32_t reference_id;
-                    rs2_extrinsics stream_extrinsic;
-                    if(try_read_stream_extrinsic(stream_id, reference_id, stream_extrinsic))
-                    {
-                        extrinsics_map[stream_id] = std::make_pair(reference_id, stream_extrinsic);
-                    }
-                }
-
-                std::shared_ptr<info_snapshot> sensor_info = read_info_snapshot(ros_topic::sensor_info_topic({ get_device_index(), sensor_index }));
-                sensor_extensions[RS2_EXTENSION_INFO] = sensor_info;
-                std::map<enum rs2_option, float> sensor_options = read_sensor_options(ros_topic::property_topic({ get_device_index(), sensor_index }));
-                auto depth_scale_it = sensor_options.find(RS2_OPTION_DEPTH_UNITS);
-                if(depth_scale_it != sensor_options.end())
-                {
-                    sensor_extensions[RS2_EXTENSION_DEPTH_SENSOR] = std::make_shared<depth_sensor_snapshot>(depth_scale_it->second);
-                }
-                sensor_descriptions.emplace_back(sensor_index, sensor_extensions, sensor_options, streams_snapshots);
+                auto&& dpt_opt = sensor_options->get_option(RS2_OPTION_DEPTH_UNITS);
+                sensor_extensions[RS2_EXTENSION_DEPTH_SENSOR] = std::make_shared<depth_sensor_snapshot>(dpt_opt.query());
             }
-
-            return device_snapshot(device_extensions, sensor_descriptions, extrinsics_map);
         }
 
-        std::shared_ptr<info_snapshot> read_info_snapshot(const std::string& topic) const
+        device_snapshot read_device_description(const nanoseconds& time, bool reset = false)
         {
+            if (time == get_static_file_info_timestamp())
+            {
+                if (reset)
+                {
+                    snapshot_collection device_extensions;
+
+                    auto info = read_info_snapshot(ros_topic::device_info_topic(get_device_index()));
+                    device_extensions[RS2_EXTENSION_INFO] = info;
+
+                    std::vector<sensor_snapshot> sensor_descriptions;
+                    auto sensor_indices = read_sensor_indices(get_device_index());
+                    std::map<stream_identifier, std::pair<uint32_t, rs2_extrinsics>> extrinsics_map;
+
+                    for (auto sensor_index : sensor_indices)
+                    {
+                        snapshot_collection sensor_extensions;
+                        auto streams_snapshots = read_stream_info(get_device_index(), sensor_index);
+                        for (auto stream_profile : streams_snapshots)
+                        {
+                            auto stream_id = stream_identifier{ get_device_index(), sensor_index, stream_profile->get_stream_type(), static_cast<uint32_t>(stream_profile->get_stream_index()) };
+                            uint32_t reference_id;
+                            rs2_extrinsics stream_extrinsic;
+                            if (try_read_stream_extrinsic(stream_id, reference_id, stream_extrinsic))
+                            {
+                                extrinsics_map[stream_id] = std::make_pair(reference_id, stream_extrinsic);
+                            }
+                        }
+                        
+                        //Update infos
+                        auto sensor_info = read_info_snapshot(ros_topic::sensor_info_topic({ get_device_index(), sensor_index }));
+                        sensor_extensions[RS2_EXTENSION_INFO] = sensor_info;
+                        //Update options
+                        update_sensor_options(m_file, sensor_index, time, m_version, sensor_extensions);
+
+                        sensor_descriptions.emplace_back(sensor_index, sensor_extensions, streams_snapshots);
+                    }
+
+                    m_initial_device_description = device_snapshot(device_extensions, sensor_descriptions, extrinsics_map);
+                }
+                return m_initial_device_description;
+            }
+            else
+            {
+                //update only:
+                auto device_snapshot = m_initial_device_description;
+                for (auto& sensor : device_snapshot.get_sensors_snapshots())
+                {
+                    auto& sensor_extensions = sensor.get_sensor_extensions_snapshots();
+                    update_sensor_options(m_file, sensor.get_sensor_index(), time, m_version, sensor_extensions);
+                }
+                return device_snapshot;
+            }
+        }
+
+        std::shared_ptr<info_container> read_info_snapshot(const std::string& topic) const
+        {
+            auto infos = std::make_shared<info_container>();
             std::map<rs2_camera_info, std::string> values;
             rosbag::View view(m_file, rosbag::TopicQuery(topic));
             for (auto message_instance : view)
             {
-                diagnostic_msgs::KeyValueConstPtr info_msg = message_instance.instantiate<diagnostic_msgs::KeyValue>();
-                if (info_msg == nullptr)
-                {
-                    throw io_exception(to_string() << "Expected KeyValue Message but got " << message_instance.getDataType());
-                }
+                diagnostic_msgs::KeyValueConstPtr info_msg = instantiate_msg<diagnostic_msgs::KeyValue>(message_instance);
                 try
                 {
                     rs2_camera_info info;
                     convert(info_msg->key, info);
-                    values[info] = info_msg->value;
+                    infos->register_info(info, info_msg->value);
                 }
                 catch (const std::exception& e)
                 {
@@ -382,7 +453,7 @@ namespace librealsense
                 }
             }
 
-            return std::make_shared<info_snapshot>(values);
+            return infos;
         }
 
         std::set<uint32_t> read_sensor_indices(uint32_t device_index) const
@@ -391,11 +462,7 @@ namespace librealsense
             std::set<uint32_t> sensor_indices;
             for (auto sensor_info : sensor_infos)
             {
-                auto msg = sensor_info.instantiate<diagnostic_msgs::KeyValue>();
-                if(msg == nullptr)
-                {
-                    throw io_exception(to_string() << "Expected KeyValue message but got " << sensor_info.getDataType() << "(Topic: " << sensor_info.getTopic() << ")");
-                }
+                auto msg = instantiate_msg<diagnostic_msgs::KeyValue>(sensor_info);
                 sensor_indices.insert(static_cast<uint32_t>(ros_topic::get_sensor_index(sensor_info.getTopic())));
             }
             return sensor_indices;
@@ -415,12 +482,7 @@ namespace librealsense
                     continue;
                 }
 
-                auto stream_info_msg = infos_view.instantiate<realsense_msgs::StreamInfo>();
-                if (stream_info_msg == nullptr)
-                {
-                    throw io_exception(to_string() << "Expected realsense_msgs::StreamInfo message but got " << infos_view.getDataType() << "(Topic: " << infos_view.getTopic() << ")");
-                }
-
+                auto stream_info_msg = instantiate_msg<realsense_msgs::StreamInfo>(infos_view);
                 //auto is_recommended = stream_info_msg->is_recommended;
                 auto fps = stream_info_msg->fps;
                 rs2_format format;
@@ -432,13 +494,9 @@ namespace librealsense
                 {
                     assert(video_stream_infos_view.size() == 1);
                     auto video_stream_msg_ptr = *video_stream_infos_view.begin();
-                    auto video_stream_msg = video_stream_msg_ptr.instantiate<sensor_msgs::CameraInfo>();
-                    if (video_stream_msg == nullptr)
-                    {
-                        throw io_exception(to_string() << "Expected sensor_msgs::CameraInfo message but got " << video_stream_msg_ptr.getDataType() << "(Topic: " << video_stream_msg_ptr.getTopic() << ")");
-                    }
-
+                    auto video_stream_msg = instantiate_msg<sensor_msgs::CameraInfo>(video_stream_msg_ptr);
                     auto profile = std::make_shared<video_stream_profile>(platform::stream_profile{ video_stream_msg->width ,video_stream_msg->height, fps, static_cast<uint32_t>(format) });
+
                     rs2_intrinsics intrinsics{};
                     intrinsics.height = video_stream_msg->height;
                     intrinsics.width = video_stream_msg->width;
@@ -474,27 +532,80 @@ namespace librealsense
             }
             return streams;
         }
-        std::map<enum rs2_option, float> read_sensor_options(const std::string& topic) const
-        {
-            rosbag::View sensor_options_view(m_file, rosbag::TopicQuery(topic));
-            std::map<enum rs2_option, float> options;
-            for (auto message_instance : sensor_options_view)
-            {
-                auto property_msg = message_instance.instantiate<diagnostic_msgs::KeyValue>();
-                if(property_msg == nullptr)
-                {
-                    throw io_exception(to_string() << "Expected KeyValue message but got: " << message_instance.getDataType() << "(Topic: " << message_instance.getTopic() << ")");
-                }
-                rs2_option id;
-                convert(property_msg->key, id);
-                options[id] = std::stof(property_msg->value);
 
+        static std::string read_option_description(const rosbag::Bag& file, const std::string& topic)
+        {
+            rosbag::View option_description_view(file, rosbag::TopicQuery(topic));
+            if (option_description_view.size() == 0)
+            {
+                LOG_ERROR("File does not contain topics for: " << topic);
+                return "N/A";
+            }
+            assert(option_description_view.size() == 1); //There should be only 1 message for each option
+            auto description_message_instance = *option_description_view.begin();
+            auto option_desc_msg = instantiate_msg<std_msgs::String>(description_message_instance);
+            return option_desc_msg->data;
+        }
+        
+        /*Until Version 2 (including)*/
+        static std::shared_ptr<librealsense::option> create_property(const rosbag::MessageInstance& property_message_instance)
+        {
+            auto property_msg = instantiate_msg<diagnostic_msgs::KeyValue>(property_message_instance);
+            rs2_option id;
+            convert(property_msg->key, id);
+            float value = std::stof(property_msg->value);
+            std::string description = to_string() << "Read only option of " << id;
+            return std::make_shared<const_value_option>(id, description, value);
+        }
+
+        /*Starting version 3*/
+        static std::shared_ptr<librealsense::option> create_option(const rosbag::Bag& file, const rosbag::MessageInstance& value_message_instance)
+        {
+            auto option_value_msg = instantiate_msg<std_msgs::Float32>(value_message_instance);
+            std::string option_name = ros_topic::get_option_name(value_message_instance.getTopic());
+            device_serializer::sensor_identifier sensor_id = ros_topic::get_sensor_identifier(value_message_instance.getTopic());
+            rs2_option id;
+            convert(option_name, id);
+            float value = option_value_msg->data;
+            std::string description = read_option_description(file, ros_topic::option_description_topic(sensor_id, id));
+            return std::make_shared<const_value_option>(id, description, value);
+        }
+
+        static std::shared_ptr<options_container> read_sensor_options(const rosbag::Bag& file, device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, uint32_t file_version)
+        {
+            auto options = std::make_shared<options_container>();
+            if (file_version == 2)
+            {
+                rosbag::View sensor_options_view(file, rosbag::TopicQuery(ros_topic::property_topic(sensor_id)));
+                for (auto message_instance : sensor_options_view)
+                {
+                    auto option = create_property(message_instance);
+                    options->register_option(option->type(), option);
+                }
+            }
+            else
+            {
+                //Taking all messages from the beginning of the bag until the time point requested
+                for (int i = 0; i < static_cast<int>(RS2_OPTION_COUNT); i++)
+                {
+                    rs2_option id = static_cast<rs2_option>(i);
+                    std::string option_topic = ros_topic::option_value_topic(sensor_id, id);
+                    rosbag::View option_view(file, rosbag::TopicQuery(option_topic), to_rostime(get_static_file_info_timestamp()), to_rostime(timestamp));
+                    auto it = option_view.begin();
+                    if (it == option_view.end())
+                    {
+                        continue;
+                    }
+                    rosbag::View::iterator last_item;
+                    while (it != option_view.end())
+                    {
+                        last_item = it++;
+                    }
+                    auto option = create_option(file, *last_item);
+                    options->register_option(option->type(), option);
+                }
             }
             return options;
-        }
-        std::shared_ptr<options_container> read_options()
-        {
-            return nullptr;
         }
 
         static std::vector<std::string> get_topics(std::unique_ptr<rosbag::View>& view)
@@ -508,7 +619,7 @@ namespace librealsense
             return topics;
         }
 
-        device_snapshot                         m_device_description;
+        device_snapshot                         m_initial_device_description;
         nanoseconds                             m_total_duration;
         std::string                             m_file_path;
         std::shared_ptr<frame_source>           m_frame_source;
@@ -518,6 +629,7 @@ namespace librealsense
         std::vector<std::string>                m_enabled_streams_topics;
         std::shared_ptr<metadata_parser_map>    m_metadata_parser_map;
         std::shared_ptr<context>                m_context;
+        uint32_t                                m_version;
     };
 
 

--- a/src/media/ros/ros_writer.h
+++ b/src/media/ros/ros_writer.h
@@ -12,6 +12,8 @@
 #include "stream.h"
 #include "rosbag/bag.h"
 #include "std_msgs/UInt32.h"
+#include "std_msgs/Float32.h"
+#include "std_msgs/String.h"
 #include "diagnostic_msgs/KeyValue.h"
 #include "sensor_msgs/Image.h"
 #include "realsense_msgs/StreamInfo.h"
@@ -25,7 +27,7 @@ namespace librealsense
     class ros_writer: public writer
     {
     public:
-        explicit ros_writer(const std::string& file)
+        explicit ros_writer(const std::string& file) : m_file_path(file)
         {
             m_bag.open(file, rosbag::BagMode::Write);
             m_bag.setCompression(rosbag::CompressionType::LZ4);
@@ -45,11 +47,10 @@ namespace librealsense
                 {
                     write_extension_snapshot(get_device_index(), sensors_snapshot.get_sensor_index(), get_static_file_info_timestamp(), sensor_extension_snapshot.first, sensor_extension_snapshot.second);
                 }
-                write_sensor_options(ros_topic::property_topic({ get_device_index(),  sensors_snapshot.get_sensor_index() }), get_static_file_info_timestamp(), sensors_snapshot.get_options());
             }
         }
 
-        void write_frame(const stream_identifier& stream_id, const nanoseconds& timestamp, frame_holder&& frame) override
+        void write_frame(const stream_identifier& stream_id, const nanoseconds& timestamp, frame_holder&& frame) 
         {
             if (Is<video_frame>(frame.frame))
             {
@@ -70,14 +71,19 @@ namespace librealsense
             }*/
         }
 
-        void write_snapshot(uint32_t device_index, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot > snapshot) override
+        void write_snapshot(uint32_t device_index, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot>& snapshot) override
         {
             write_extension_snapshot(device_index, -1, timestamp, type, snapshot);
         }
 
-        void write_snapshot(const sensor_identifier& sensor_id, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot > snapshot) override
+        void write_snapshot(const sensor_identifier& sensor_id, const nanoseconds& timestamp, rs2_extension type, const std::shared_ptr<extension_snapshot>& snapshot) override
         {
             write_extension_snapshot(sensor_id.device_index, sensor_id.sensor_index, timestamp, type, snapshot);
+        }
+
+        const std::string& get_file_name() const
+        {
+            return m_file_path;
         }
 
     private:
@@ -210,17 +216,23 @@ namespace librealsense
             write_extension_snapshot(device_id, sensor_id, timestamp, type, snapshot, false);
         }
 
+        template <rs2_extension E>
+        std::shared_ptr<typename ExtensionToType<E>::type> SnapshotAs(std::shared_ptr<librealsense::extension_snapshot> snapshot)
+        {
+            auto as_type = As<typename ExtensionToType<E>::type>(snapshot);
+            if (as_type == nullptr)
+            {
+                throw invalid_value_exception(to_string() << "Failed to cast snapshot to \"" << E << "\" (as \"" << ExtensionToType<E>::to_string() << "\")");
+            }
+            return as_type;
+        }
         void write_extension_snapshot(uint32_t device_id, uint32_t sensor_id, const nanoseconds& timestamp, rs2_extension type, std::shared_ptr<librealsense::extension_snapshot> snapshot, bool is_device)
         {
             switch (type)
             {
             case RS2_EXTENSION_INFO:
             {
-                auto info = As<info_interface>(snapshot);
-                if (info == nullptr)
-                {
-                    throw invalid_value_exception(to_string() << "Failed to cast snapshot with given type \"" << type << "\" to \"" << TypeToExtensionn<info_interface>::to_string() << "\"");
-                }
+                auto info = SnapshotAs<RS2_EXTENSION_INFO>(snapshot);
                 if (is_device)
                 {
                     write_vendor_info(ros_topic::device_info_topic(device_id), timestamp, info);
@@ -233,23 +245,36 @@ namespace librealsense
             }
             case RS2_EXTENSION_DEBUG:
             case RS2_EXTENSION_MOTION:
+                break;
+            case RS2_EXTENSION_OPTION:
+            {
+                auto option = SnapshotAs<RS2_EXTENSION_OPTION>(snapshot);
+                write_sensor_option({ device_id, sensor_id }, timestamp, *option);
+                break;
+            }
             case RS2_EXTENSION_OPTIONS:
+            {
+                auto options = SnapshotAs<RS2_EXTENSION_OPTIONS>(snapshot);
+                write_sensor_options({ device_id, sensor_id }, timestamp, options);
+                break;
+            }
             case RS2_EXTENSION_VIDEO:
             case RS2_EXTENSION_ROI:
                 break;
+            case RS2_EXTENSION_DEPTH_SENSOR:
+            {
+                auto dpt = SnapshotAs<RS2_EXTENSION_DEPTH_SENSOR>(snapshot);
+                //write_depth_sensor(ros_topic::property_topic({ device_id, sensor_id }), timestamp, dpt);
+                break;
+            }
             case RS2_EXTENSION_VIDEO_PROFILE:
             {
-                auto profile = As<video_stream_profile_interface>(snapshot);
-                if (profile == nullptr)
-                {
-                    throw invalid_value_exception(to_string() << "Failed to cast snapshot with given type \"" << type << "\" to \"" << TypeToExtensionn<info_interface>::to_string() << "\"");
-                }
+                auto profile = SnapshotAs<RS2_EXTENSION_VIDEO_PROFILE>(snapshot);
                 write_streaming_info(timestamp, { device_id, sensor_id }, profile);
                 break;
             }
             default:
                 throw invalid_value_exception(to_string() << "Failed to Write Extension Snapshot: Unsupported extension \"" << type << "\"");
-
             }
         }
 
@@ -267,15 +292,46 @@ namespace librealsense
                 }
             }
         }
-
-        void write_sensor_options(const std::string& topic, const nanoseconds& timestamp, const std::map<enum rs2_option, float>& options)
+        
+        void write_sensor_option(device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, const librealsense::option& option)
         {
-            for (auto key_val : options)
+            rs2_option type = option.type();
+            float value = option.query();
+            const char* str = option.get_description();
+            std::string description = str ? std::string(str) : (to_string() << "Read only option of " << type);
+
+            //One message for value
+            std_msgs::Float32 option_msg;
+            option_msg.data = value;
+            write_message(ros_topic::option_value_topic(sensor_id, type), timestamp, option_msg);
+
+            //Another message for description, should be written once per topic
+
+            if (m_written_options_descriptions[sensor_id.sensor_index].find(type) == m_written_options_descriptions[sensor_id.sensor_index].end())
             {
-                diagnostic_msgs::KeyValue option_msg;
-                option_msg.key = rs2_option_to_string(key_val.first);
-                option_msg.value = std::to_string(key_val.second);
-                write_message(topic, timestamp, option_msg);
+                std_msgs::String option_msg_desc;
+                option_msg_desc.data = description;
+                write_message(ros_topic::option_description_topic(sensor_id, type), get_static_file_info_timestamp(), option_msg_desc);
+                m_written_options_descriptions[sensor_id.sensor_index].insert(type);
+            }
+        }
+
+        void write_sensor_options(device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, std::shared_ptr<options_interface> options)
+        {
+            for (int i = 0; i < static_cast<int>(RS2_OPTION_COUNT); i++)
+            {
+                auto option_id = static_cast<rs2_option>(i);
+                try
+                {
+                    if (options->supports_option(option_id))
+                    {
+                        write_sensor_option(sensor_id, timestamp, options->get_option(option_id));
+                    }
+                }
+                catch (std::exception& e)
+                {
+                    LOG_WARNING("Failed to get or write option " << option_id << " for sensor " << sensor_id.sensor_index << ". Exception: " << e.what());
+                }
             }
         }
         template <typename T>
@@ -283,15 +339,8 @@ namespace librealsense
         {
             try
             {
-                if (time == get_static_file_info_timestamp())
-                {
-                    m_bag.write(topic, ros::TIME_MIN, msg);
-                }
-                else
-                {
-                    auto secs = std::chrono::duration_cast<std::chrono::duration<double>>(time);
-                    m_bag.write(topic, ros::Time(secs.count()), msg);
-                }
+                m_bag.write(topic, to_rostime(time), msg);
+                LOG_DEBUG("Recorded: \"" << topic << "\" . TS: " << time.count());
             }
             catch (rosbag::BagIOException& e)
             {
@@ -304,8 +353,10 @@ namespace librealsense
             int num = 1;
             return (*reinterpret_cast<char*>(&num) == 1) ? 0 : 1; //Little Endian: (char)0x0001 => 0x01, Big Endian: (char)0x0001 => 0x00,
         }
+
         std::map<stream_identifier, geometry_msgs::Transform> m_extrinsics_msgs;
         std::string m_file_path;
         rosbag::Bag m_bag;
+        std::map<uint32_t, std::set<rs2_option>> m_written_options_descriptions;
     };
 }

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -5,6 +5,12 @@
 #include "sensor.h"
 #include "error-handling.h"
 
+
+void option::create_snapshot(std::shared_ptr<option>& snapshot) const
+{
+    snapshot = std::make_shared<const_value_option>(type(), get_description(), query());
+}
+
 void librealsense::uvc_pu_option::set(float value)
 {
     _ep.invoke_powered(
@@ -12,6 +18,7 @@ void librealsense::uvc_pu_option::set(float value)
         {
             if (!dev.set_pu(_id, static_cast<int32_t>(value)))
                 throw invalid_value_exception(to_string() << "set_pu(id=" << std::to_string(_id) << ") failed!" << " Last Error: " << strerror(errno));
+            _record(*this);
         });
 }
 
@@ -118,6 +125,7 @@ void librealsense::polling_errors_disable::set(float value)
         _polling_error_handler->start();
         _value = 1;
     }
+    _recording_function(*this);
 }
 
 float librealsense::polling_errors_disable::query() const

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1400,12 +1400,13 @@ void rs2_start_pipeline_with_callback( rs2_pipeline* pipe,  rs2_frame_callback_p
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, pipe, on_frame, user)
 
-void rs2_stop_pipeline(rs2_pipeline* pipe, rs2_error ** error)
+void rs2_stop_pipeline(rs2_pipeline* pipe, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(pipe);
 
     pipe->pipe->stop();
 }
+HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
 
 void rs2_enable_pipeline_stream(rs2_pipeline* pipe, rs2_stream stream, int index, int width, int height, rs2_format format, int framerate, rs2_error ** error) try
 {

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -556,14 +556,28 @@ namespace librealsense
 
         return it->second;
     }
-    void info_container::create_snapshot(std::shared_ptr<info_interface>& snapshot)
+    void info_container::create_snapshot(std::shared_ptr<info_interface>& snapshot) const
     {
-        snapshot = std::make_shared<info_snapshot>(this);
+        snapshot = std::make_shared<info_container>(*this);
     }
-    void info_container::create_recordable(std::shared_ptr<info_interface>& recordable,
-                                           std::function<void(std::shared_ptr<extension_snapshot>)> record_action)
+    void info_container::enable_recording(std::function<void(const info_interface&)> record_action)
     {
-        recordable = std::make_shared<info_container>(*this);
+       //info container is a read only class, nothing to record
+    }
+
+    void info_container::update(std::shared_ptr<extension_snapshot> ext)
+    {
+        if (auto info_api = As<info_interface>(ext))
+        {
+            for (int i = 0; i < RS2_CAMERA_INFO_COUNT; ++i)
+            {
+                rs2_camera_info info = static_cast<rs2_camera_info>(i);
+                if (info_api->supports_info(info))
+                {
+                    register_info(info, info_api->get_info(info));
+                }
+            }
+        }
     }
 
     void uvc_sensor::register_pu(rs2_option id)

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -11,7 +11,7 @@ namespace librealsense
     {
     public:
         frame_queue_size(std::atomic<uint32_t>* ptr, const option_range& opt_range)
-            : option_base(opt_range),
+            : option_base(opt_range, RS2_OPTION_FRAMES_QUEUE_SIZE),
               _ptr(ptr)
         {}
 
@@ -21,6 +21,7 @@ namespace librealsense
                 throw invalid_value_exception(to_string() << "set(frame_queue_size) failed! Given value " << value << " is out of range.");
 
             *_ptr = static_cast<uint32_t>(value);
+            _recording_function(*this);
         }
 
         float query() const override { return static_cast<float>(_ptr->load()); }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -110,5 +110,15 @@ namespace librealsense
     {
         _c_ptr = wrapper;
     }
+    void stream_profile_base::create_snapshot(std::shared_ptr<stream_profile_interface>& snapshot) const
+    {
+        auto ptr = std::const_pointer_cast<stream_interface>(shared_from_this());
+        snapshot = std::dynamic_pointer_cast<stream_profile_interface>(ptr);
+    }
+    void stream_profile_base::enable_recording(std::function<void(const stream_profile_interface&)> record_action)
+    {
+        //TODO: implement or remove inheritance from recordable<T>
+        throw not_implemented_exception(__FUNCTION__);
+    }
 }
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -76,15 +76,8 @@ namespace librealsense
 
         void set_c_wrapper(rs2_stream_profile* wrapper) override;
 
-        void create_snapshot(std::shared_ptr<stream_profile_interface>& snapshot) override
-        {
-            snapshot = std::dynamic_pointer_cast<stream_profile_interface>(shared_from_this());
-        }
-        void create_recordable(std::shared_ptr<stream_profile_interface>& recordable, std::function<void(std::shared_ptr<extension_snapshot>)> record_action) override
-        {
-            //TODO: implement or remove inheritance from recordable<T>
-            throw not_implemented_exception(__FUNCTION__);
-        }
+        void create_snapshot(std::shared_ptr<stream_profile_interface>& snapshot) const override;
+        void enable_recording(std::function<void(const stream_profile_interface&)> record_action) override;
     private:
         int _index = 1;
         int _uid = 0;

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -266,7 +266,7 @@ int pick_scale_factor(GLFWwindow* window)
 }
 
 int main(int argv, const char** argc) try
-{
+{    
     // Init GUI
     if (!glfwInit()) exit(1);
 
@@ -976,7 +976,7 @@ int main(int argv, const char** argc) try
 
                         for (auto& opt : drawing_order)
                         {
-                            if (sub->draw_option(opt, update_read_only_options, error_message, viewer_model.not_model))
+                            if (sub->draw_option(opt, dev_model.dev.is<playback>() || update_read_only_options, error_message, viewer_model.not_model))
                             {
                                 dev_model.get_curr_advanced_controls = true;
                             }
@@ -990,7 +990,7 @@ int main(int argv, const char** argc) try
                                 auto opt = static_cast<rs2_option>(i);
                                 if (std::find(drawing_order.begin(), drawing_order.end(), opt) == drawing_order.end())
                                 {
-                                    if (sub->draw_option(opt, update_read_only_options, error_message, viewer_model.not_model))
+                                    if (sub->draw_option(opt, dev_model.dev.is<playback>() || update_read_only_options, error_message, viewer_model.not_model))
                                     {
                                         dev_model.get_curr_advanced_controls = true;
                                     }


### PR DESCRIPTION
Added support for recording extensions (in the future) and options.
Changed recordable interface and changed extensions inheritance heirarchy
Added support for reading different messages from reader, enabled update of sensor options while playback.
Made options container and extension.
Added get_type() to option interface, implemented for all options.
Added support for seek with options updates.
Some code refactoring.
Advanced realsense file version.
Updated record-playback readme