### PR TITLE
[nodejs] Re-enable linter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
   - export OLDPATH=$PATH && export PATH=$PATH:$(pwd)/depot_tools;
   - cd wrappers/nodejs/tools && npm install && cd ..
-  # - node ./tools/linter.js
+  - node ./tools/linter.js
   - export PATH=$OLDPATH && unset OLDPATH && cd ../../
 
   # Get logical CPU number

--- a/wrappers/nodejs/.eslintrc.json
+++ b/wrappers/nodejs/.eslintrc.json
@@ -8,16 +8,8 @@
   ],
   "rules": {
     "header/header": [2, "tools/header.js"],
-    "max-len": ["error",
-      // Following Google Javascript 100 char line limit
-      100,
-      // Use 2-space as tab width
-      2,
-      { "ignoreUrls": true }
-    ],
-    // Prefer to use single quotes
+    "max-len": ["error", 100, 2, { "ignoreUrls": true }],
     "quotes": ["error", "single"],
-    // Disable JSDoc
     "require-jsdoc": ["error", {
       "require": {
         "FunctionDeclaration": false,

--- a/wrappers/nodejs/tools/package.json
+++ b/wrappers/nodejs/tools/package.json
@@ -9,7 +9,7 @@
   "author": "Halton Huo <halton.huo@intel.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "eslint": "^4.6.1",
+    "eslint": "4.6.1",
     "eslint-config-google": "^0.9.1",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-header": "^1.1.0",


### PR DESCRIPTION
A regression of eslint 4.7.0 was hit in index.js,
https://github.com/eslint/eslint/issues/9318.

We simply keep older version 4.6.1. Once above eslint bug get resolved,
we can retry and decide whether to update to latest version of eslint.