### PR TITLE
Subst README.md for npm package

### DIFF
--- a/wrappers/nodejs/package.json
+++ b/wrappers/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-librealsense",
-  "version": "0.279.1",
+  "version": "0.279.2",
   "description": "Node.js API for Intel® RealSense™ SDK 2.0",
   "main": "index.js",
   "directories": {

--- a/wrappers/nodejs/scripts/npm_dist/gen-dist.sh
+++ b/wrappers/nodejs/scripts/npm_dist/gen-dist.sh
@@ -18,6 +18,7 @@ rsync -a . $MODULEDIR --exclude build --exclude dist --exclude node_modules
 
 cp -f scripts/npm_dist/binding.gyp $MODULEDIR
 cp -f scripts/npm_dist/package.json $MODULEDIR
+cp -f scripts/npm_dist/README.md $MODULEDIR
 
 pushd . > /dev/null
 cd $WORKDIR


### PR DESCRIPTION
This is a bug fixing... we should use an NPM-oriented README.md version for npm package. The file resides in `scripts/npm_dist` dir but due to a bug in the generation script, it was not copied in the past.