### PR TITLE
Fixed flickering in pointcloud example

### DIFF
--- a/examples/pointcloud/rs-pointcloud.cpp
+++ b/examples/pointcloud/rs-pointcloud.cpp
@@ -113,7 +113,7 @@ void register_glfw_callbacks(window& app, state& app_state)
 // Handles all the OpenGL calls needed to display the point cloud
 void draw_pointcloud(window& app, state& app_state, rs2::points& points)
 {
-    if (!static_cast<GLFWwindow*>(app) || !points)
+    if (!points)
         return;
 
     // OpenGL commands that prep screen for the pointcloud

--- a/examples/pointcloud/rs-pointcloud.cpp
+++ b/examples/pointcloud/rs-pointcloud.cpp
@@ -113,7 +113,7 @@ void register_glfw_callbacks(window& app, state& app_state)
 // Handles all the OpenGL calls needed to display the point cloud
 void draw_pointcloud(window& app, state& app_state, rs2::points& points)
 {
-    if (!app || !points)
+    if (!static_cast<GLFWwindow*>(app) || !points)
         return;
 
     // OpenGL commands that prep screen for the pointcloud


### PR DESCRIPTION
Fixed flickering in pointcloud app. parameter validation `if(!app || !points)` used the `operator bool` of the `window` class which re-rendered, and there is no need to check that `app` is valid since it is inside called from inside the main loop