### PR TITLE
Pipeline changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,8 @@ script:
       sudo "PATH=$PATH" make install;
 
       export LRS_LOG_LEVEL="DEBUG";
-      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc4;
-      ./unit-tests/live-test from awgc4 -d yes;
+      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/live_test_awgc;
+      ./unit-tests/live-test from live_test_awgc -d yes;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       mkdir build && cd build;

--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -198,32 +198,32 @@ EXPORTS
     rs2_playback_device_set_status_changed_callback
     rs2_playback_device_get_current_status
     rs2_playback_device_set_playback_speed
-	rs2_playback_device_stop
+    rs2_playback_device_stop
 
     rs2_create_align
 
-	rs2_create_pipeline
-	rs2_pipeline_stop
-	rs2_pipeline_wait_for_frames
-	rs2_pipeline_poll_for_frames
-	rs2_delete_pipeline
-	rs2_pipeline_start
-	rs2_pipeline_start_with_config
-	rs2_pipeline_get_active_profile
-	rs2_pipeline_profile_get_device
-	rs2_pipeline_profile_get_streams
-	rs2_delete_pipeline_profile
-	rs2_create_config
-	rs2_delete_config
-	rs2_config_enable_stream
-	rs2_config_enable_all_stream
-	rs2_config_enable_device
-	rs2_config_enable_device_from_file
-	rs2_config_enable_record_to_file
-	rs2_config_disable_stream
-	rs2_config_disable_all_streams
-	rs2_config_resolve
-	rs2_config_can_resolve
+    rs2_create_pipeline
+    rs2_pipeline_stop
+    rs2_pipeline_wait_for_frames
+    rs2_pipeline_poll_for_frames
+    rs2_delete_pipeline
+    rs2_pipeline_start
+    rs2_pipeline_start_with_config
+    rs2_pipeline_get_active_profile
+    rs2_pipeline_profile_get_device
+    rs2_pipeline_profile_get_streams
+    rs2_delete_pipeline_profile
+    rs2_create_config
+    rs2_delete_config
+    rs2_config_enable_stream
+    rs2_config_enable_all_stream
+    rs2_config_enable_device
+    rs2_config_enable_device_from_file
+    rs2_config_enable_record_to_file
+    rs2_config_disable_stream
+    rs2_config_disable_all_streams
+    rs2_config_resolve
+    rs2_config_can_resolve
 
     rs2_create_device_hub
     rs2_device_hub_is_device_connected

--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -208,10 +208,10 @@ EXPORTS
 	rs2_pipeline_poll_for_frames
 	rs2_delete_pipeline
 	rs2_pipeline_start
-	rs2_pipeline_start_with_record
+	rs2_pipeline_start_with_config
 	rs2_pipeline_get_active_profile
 	rs2_pipeline_profile_get_device
-	rs2_pipeline_profile_get_active_streams
+	rs2_pipeline_profile_get_streams
 	rs2_delete_pipeline_profile
 	rs2_create_config
 	rs2_delete_config
@@ -219,6 +219,7 @@ EXPORTS
 	rs2_config_enable_all_stream
 	rs2_config_enable_device
 	rs2_config_enable_device_from_file
+	rs2_config_enable_record_to_file
 	rs2_config_disable_stream
 	rs2_config_disable_all_streams
 	rs2_config_resolve

--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -213,15 +213,15 @@ EXPORTS
 	rs2_pipeline_profile_get_device
 	rs2_pipeline_profile_get_active_streams
 	rs2_delete_pipeline_profile
-	rs2_create_configurator
-	rs2_delete_configurator
-	rs2_configurator_enable_stream
-	rs2_configurator_enable_all_stream
-	rs2_configurator_enable_device
-	rs2_configurator_enable_device_from_file
-	rs2_configurator_disable_stream
-	rs2_configurator_disable_all_streams
-	rs2_configurator_resolve
+	rs2_create_config
+	rs2_delete_config
+	rs2_config_enable_stream
+	rs2_config_enable_all_stream
+	rs2_config_enable_device
+	rs2_config_enable_device_from_file
+	rs2_config_disable_stream
+	rs2_config_disable_all_streams
+	rs2_config_resolve
 	rs2_config_can_resolve
 
     rs2_create_device_hub

--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -201,22 +201,28 @@ EXPORTS
 	rs2_playback_device_stop
 
     rs2_create_align
-    rs2_create_pipeline
-    rs2_pipeline_get_device
-    rs2_start_pipeline_with_callback
-    rs2_start_pipeline_with_callback_cpp
-    rs2_start_pipeline
-    rs2_open_pipeline
-    rs2_stop_pipeline
-    rs2_enable_pipeline_stream
-    rs2_enable_pipeline_device
-    rs2_disable_stream_pipeline
-    rs2_disable_all_streams_pipeline
-    rs2_pipeline_wait_for_frames
-    rs2_pipeline_poll_for_frames
-    rs2_pipeline_get_active_streams
-    rs2_pipeline_get_stream_type_selection
-    rs2_delete_pipeline
+
+	rs2_create_pipeline
+	rs2_pipeline_stop
+	rs2_pipeline_wait_for_frames
+	rs2_pipeline_poll_for_frames
+	rs2_delete_pipeline
+	rs2_pipeline_start
+	rs2_pipeline_start_with_record
+	rs2_pipeline_get_active_profile
+	rs2_pipeline_profile_get_device
+	rs2_pipeline_profile_get_active_streams
+	rs2_delete_pipeline_profile
+	rs2_create_configurator
+	rs2_delete_configurator
+	rs2_configurator_enable_stream
+	rs2_configurator_enable_all_stream
+	rs2_configurator_enable_device
+	rs2_configurator_enable_device_from_file
+	rs2_configurator_disable_stream
+	rs2_configurator_disable_all_streams
+	rs2_configurator_resolve
+	rs2_config_can_resolve
 
     rs2_create_device_hub
     rs2_device_hub_is_device_connected

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,14 +32,14 @@ build:
   verbosity: minimal
 test_script:
 - ps: >-
-    $url = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc4"
+    $url = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/live_test_awgc"
 
-    $output = "C:/projects/librealsense/build/Debug/awgc4"
+    $output = "C:/projects/librealsense/build/Debug/live_test_awgc"
 
     Invoke-WebRequest -Uri $url -OutFile $output
 
 
-    & cmd.exe /c C:/projects/librealsense/build/Debug/live-test.exe from C:/projects/librealsense/build/Debug/awgc4 -d yes
+    & cmd.exe /c C:/projects/librealsense/build/Debug/live-test.exe from C:/projects/librealsense/build/Debug/live_test_awgc -d yes
 
     if ($LASTEXITCODE -ne 0)
 

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -59,8 +59,8 @@ void rs2_delete_pipeline(rs2_pipeline* pipe);
 //TODO: Document all below:
 
 //pipeline
-rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_configurator* config, rs2_error ** error);
-rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_configurator* config, const char* file, rs2_error ** error);
+rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_config* config, rs2_error ** error);
+rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_config* config, const char* file, rs2_error ** error);
 rs2_pipeline_profile* rs2_pipeline_get_active_profile(rs2_pipeline* pipe, rs2_error ** error);
 
 //pipeline_profile
@@ -68,17 +68,24 @@ rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_e
 rs2_stream_profile_list* rs2_pipeline_profile_get_active_streams(rs2_pipeline_profile* profile, rs2_error** error);
 void rs2_delete_pipeline_profile(rs2_pipeline_profile* profile);
 
-//configurator
-rs2_configurator* rs2_create_configurator(rs2_error ** error);
-void rs2_delete_configurator(rs2_configurator* config);
-void rs2_configurator_enable_stream(rs2_configurator* config, rs2_stream stream, int index, int width, int height, rs2_format format, int framerate, rs2_error ** error);
-void rs2_configurator_enable_all_stream(rs2_configurator* config, rs2_error ** error);
-void rs2_configurator_enable_device(rs2_configurator* config, const char* serial, rs2_error ** error);
-void rs2_configurator_enable_device_from_file(rs2_configurator* config, const char* file, rs2_error ** error);
-void rs2_configurator_disable_stream(rs2_configurator* config, rs2_stream stream, rs2_error ** error);
-void rs2_configurator_disable_all_streams(rs2_configurator* config, rs2_error ** error);
-rs2_pipeline_profile* rs2_configurator_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error);
-int rs2_config_can_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error);
+//config
+rs2_config* rs2_create_config(rs2_error** error);
+void rs2_delete_config(rs2_config* config);
+void rs2_config_enable_stream(rs2_config* config,
+                              rs2_stream stream,
+                              int index,
+                              int width,
+                              int height,
+                              rs2_format format,
+                              int framerate,
+                              rs2_error** error);
+void rs2_config_enable_all_stream(rs2_config* config, rs2_error ** error);
+void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error ** error);
+void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error);
+void rs2_config_disable_stream(rs2_config* config, rs2_stream stream, rs2_error ** error);
+void rs2_config_disable_all_streams(rs2_config* config, rs2_error ** error);
+rs2_pipeline_profile* rs2_config_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error);
+int rs2_config_can_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error);
 
 #ifdef __cplusplus
 }

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -1,5 +1,5 @@
 /* License: Apache 2.0. See LICENSE file in root directory.
-   Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
+Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 
 /** \file rs2_processing.h
 * \brief
@@ -16,76 +16,280 @@ extern "C" {
 
 #include "rs_types.h"
 
-/**
-* create pipeline
-* \param[in]  ctx    context
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-*/
-rs2_pipeline* rs2_create_pipeline(rs2_context* ctx, rs2_error ** error);
+    /**
+    * Create a pipeline instance
+    * The pipeline simplifies the user interaction with the device and computer vision processing modules.
+    * The class abstracts the camera configuration and streaming, and the vision modules triggering and threading.
+    * It lets the application focus on the computer vision output of the modules, or the device output data.
+    * The pipeline can manage computer vision modules, which are implemented as a processing blocks.
+    * The pipeline is the consumer of the processing block interface, while the application consumes the
+    * computer vision interface.
+    * \param[in]  ctx    context
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    rs2_pipeline* rs2_create_pipeline(rs2_context* ctx, rs2_error ** error);
 
-/**
-* stop streaming will not change the pipeline configuration
-* \param[in] pipe  pipeline
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-*/
-void rs2_pipeline_stop(rs2_pipeline* pipe, rs2_error ** error);
+    /**
+    * Stop the pipeline streaming.
+    * The pipeline stops delivering samples to the attached computer vision modules and processing blocks, stops the device streaming
+    * and releases the device resources used by the pipeline. It is the application's responsibility to release any frame reference it owns.
+    * The method takes effect only after \c start() was called, otherwise an exception is raised.
+    * \param[in] pipe  pipeline
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_pipeline_stop(rs2_pipeline* pipe, rs2_error ** error);
 
-/**
-* wait until new frame becomes available
-* \param[in] pipe the pipeline
-* \param[in] timeout_ms   Max time in milliseconds to wait until an exception will be thrown
-* \return Set of coherent frames
-*/
-rs2_frame* rs2_pipeline_wait_for_frames(rs2_pipeline* pipe, unsigned int timeout_ms, rs2_error ** error);
+    /**
+    * Wait until a new set of frames becomes available.
+    * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
+    * The method blocks the calling thread, and fetches the latest unread frames set.
+    * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method should be called
+    * as fast as the device frame rate.
+    * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
+    * may lack memory resources to produce new frames, and the following call to this method shall fail to retrieve new frames, until resources
+    * are retained.
+    * \param[in] pipe the pipeline
+    * \param[in] timeout_ms   Max time in milliseconds to wait until an exception will be thrown
+    * \return Set of coherent frames
+    */
+    rs2_frame* rs2_pipeline_wait_for_frames(rs2_pipeline* pipe, unsigned int timeout_ms, rs2_error ** error);
 
-/**
-* poll if a new frame is available and dequeue if it is
-* \param[in] pipe the pipeline
-* \param[out] output_frame frame handle to be released using rs2_release_frame
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-* \return true if new frame was stored to output_frame
-*/
-int rs2_pipeline_poll_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, rs2_error ** error);
+    /**
+    * Check if a new set of frames is available and retrieve the latest undelivered set.
+    * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
+    * The method returns without blocking the calling thread, with status of new frames available or not. If available, it fetches the
+    * latest frames set.
+    * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method should be called
+    * as fast as the device frame rate.
+    * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
+    * may lack memory resources to produce new frames, and the following calls to this method shall return no new frames, until resources are
+    * retained.
+    * \param[in] pipe the pipeline
+    * \param[out] output_frame frame handle to be released using rs2_release_frame
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return true if new frame was stored to output_frame
+    */
+    int rs2_pipeline_poll_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, rs2_error ** error);
 
 
-/**
-* delete pipeline
-* \param[in] pipeline to delete
-*/
-void rs2_delete_pipeline(rs2_pipeline* pipe);
+    /**
+    * Delete a pipeline instance.
+    * Upon destruction, the pipeline will implicitly stop itself
+    * \param[in] pipeline to delete
+    */
+    void rs2_delete_pipeline(rs2_pipeline* pipe);
 
+    /**
+    * Start the pipeline streaming.
+    * The pipeline streaming loop captures samples from the device, and delivers them to the attached computer vision modules
+    * and processing blocks, according to each module requirements and threading model.
+    * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or \c poll_for_frames().
+    * The streaming loop runs until the pipeline is stopped.
+    * Starting the pipeline is possible only when it is not started. If the pipeline was started, an exception is raised.
+    * The pipeline selects and activates the device upon start, according to application selected configuration or a default configuration.
+    * If a rs2::config is provided to the method, the pipeline tries to activate the config \c resolve() result. If the application
+    * requests are conflicting with pipeline computer vision modules or no matching device is available on the platform, the method fails.
+    * Available configurations and devices may change between config \c resolve() call and pipeline start, in case devices are connected
+    * or disconnected, or another application acquires ownership of a device.
+    *
+    * \param[in] pipe    a pointer to an instance of the pipeline
+    * \param[in] config   A rs2::config with requested filters on the pipeline configuration. By default no filters are applied.
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return             The actual pipeline device and streams profile, which was successfully configured to the streaming device.
+    */
+    rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_config* config, rs2_error ** error);
 
+    /**
+    * Start the pipeline streaming and record the session to a file.
+    * The method behaves the same as the non recording \c start() method, and creates a file with the caller's filename, which
+    * records the pipeline streaming device state and streams data.
+    *
+    * \param[in] pipe    a pointer to an instance of the pipeline
+    * \param[in] config               A rs2::config with requested filters on the pipeline configuration. By default no filters are applied.
+    * \param[in] record_to_filename   The output file for the device recording.
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return                         The actual pipeline device and streams profile, which was successfully configured to the streaming device.
+    */
+    rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_config* config, const char* file, rs2_error ** error);
 
-//TODO: Document all below:
+    /**
+    * Return the active device and streams profiles, used by the pipeline.
+    * The pipeline streams profiles are selected during \c start(). The method returns a valid result only when the pipeline is active -
+    * between calls to \c start() and \c stop().
+    * After \c stop() is called, the pipeline doesn't own the device, thus, the pipeline selected device may change in subsequent activations.
+    *
+    * \param[in] pipe    a pointer to an instance of the pipeline
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return  The actual pipeline device and streams profile, which was successfully configured to the streaming device on start.
+    */
+    rs2_pipeline_profile* rs2_pipeline_get_active_profile(rs2_pipeline* pipe, rs2_error ** error);
 
-//pipeline
-rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_config* config, rs2_error ** error);
-rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_config* config, const char* file, rs2_error ** error);
-rs2_pipeline_profile* rs2_pipeline_get_active_profile(rs2_pipeline* pipe, rs2_error ** error);
+    /**
+    * Retrieve the device used by the pipeline.
+    * The device class provides the application access to control camera additional settings -
+    * get device information, sensor options information, options value query and set, sensor specific extensions.
+    * Since the pipeline controls the device streams configuration, activation state and frames reading, calling
+    * the device API functions, which execute those operations, results in unexpected behavior.
+    * The pipeline streaming device is selected during pipeline \c start(). Devices of profiles, which are not returned by
+    * pipeline \c start() or \c get_active_profile(), are not guaranteed to be used by the pipeline.
+    *
+    * \param[in] pipe    A pointer to an instance of a pipeline profile
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return rs2_device* The pipeline selected device
+    */
+    rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_error ** error);
 
-//pipeline_profile
-rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_error ** error);
-rs2_stream_profile_list* rs2_pipeline_profile_get_active_streams(rs2_pipeline_profile* profile, rs2_error** error);
-void rs2_delete_pipeline_profile(rs2_pipeline_profile* profile);
+    /**
+    * Return the selected streams profiles, which are enabled in this profile.
+    *
+    * \param[in] pipe    A pointer to an instance of a pipeline profile
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return   list of stream profiles
+    */
+    rs2_stream_profile_list* rs2_pipeline_profile_get_active_streams(rs2_pipeline_profile* profile, rs2_error** error);
 
-//config
-rs2_config* rs2_create_config(rs2_error** error);
-void rs2_delete_config(rs2_config* config);
-void rs2_config_enable_stream(rs2_config* config,
-                              rs2_stream stream,
-                              int index,
-                              int width,
-                              int height,
-                              rs2_format format,
-                              int framerate,
-                              rs2_error** error);
-void rs2_config_enable_all_stream(rs2_config* config, rs2_error ** error);
-void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error ** error);
-void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error);
-void rs2_config_disable_stream(rs2_config* config, rs2_stream stream, rs2_error ** error);
-void rs2_config_disable_all_streams(rs2_config* config, rs2_error ** error);
-rs2_pipeline_profile* rs2_config_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error);
-int rs2_config_can_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error);
+    /**
+    * Deletes an instance of a pipeline profile
+    *
+    * \param[in] pipe    A pointer to an instance of a pipeline profile
+    */
+    void rs2_delete_pipeline_profile(rs2_pipeline_profile* profile);
+
+    /**
+    * Create a config instance
+    * The config allows pipeline users to request filters for the pipeline streams and device selection and configuration.
+    * This is an optional step in pipeline creation, as the pipeline resolves its streaming device internally.
+    * Config provides its users a way to set the filters and test if there is no conflict with the pipeline requirements
+    * from the device. It also allows the user to find a matching device for the config filters and the pipeline, in order to
+    * select a device explicitly, and modify its controls before streaming starts.
+    *
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return rs2_config*  A pointer to a new config instance
+    */
+    rs2_config* rs2_create_config(rs2_error** error);
+
+    /**
+    * Deletes an instance of a config
+    *
+    * \param[in] pipe    A pointer to an instance of a config
+    */
+    void rs2_delete_config(rs2_config* config);
+
+    /**
+    * Enable a device stream explicitly, with selected stream parameters.
+    * The method allows the application to request a stream with specific configuration. If no stream is explicitly enabled, the pipeline
+    * configures the device and its streams according to the attached computer vision modules and processing blocks requirements, or
+    * default configuration for the first available device.
+    * The application can configure any of the input stream parameters according to its requirement, or set to 0 for don't care value.
+    * The config accumulates the application calls for enable configuration methods, until the configuration is applied. Multiple enable
+    * stream calls for the same stream with conflicting parameters override each other, and the last call is maintained.
+    * Upon calling \c resolve(), the config checks for conflicts between the application configuration requests and the attached computer
+    * vision modules and processing blocks requirements, and fails if conflicts are found. Before \c resolve() is called, no conflict
+    * check is done.
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[in] stream    Stream type to be enabled
+    * \param[in] index     Stream index, used for multiple streams of the same type. 0 selects the default.
+    * \param[in] width     Stream image width - for images streams
+    * \param[in] height    Stream image height - for images streams
+    * \param[in] format    Stream data format - pixel format for images streams, of data type for other streams
+    * \param[in] framerate Stream frames per second
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_config_enable_stream(rs2_config* config,
+        rs2_stream stream,
+        int index,
+        int width,
+        int height,
+        rs2_format format,
+        int framerate,
+        rs2_error** error);
+
+    /**
+    * Enable all device streams explicitly.
+    * The conditions and behavior of this method are similar to those of \c enable_stream().
+    * This filter enables all raw streams of the selected device. The device is either selected explicitly by the application,
+    * or by the pipeline requirements or default. The list of streams is device dependent.
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_config_enable_all_stream(rs2_config* config, rs2_error ** error);
+
+    /**
+    * Select a specific device explicitly by its serial number, to be used by the pipeline.
+    * The conditions and behavior of this method are similar to those of \c enable_stream().
+    * This method is required if the application needs to set device or sensor settings prior to pipeline streaming, to enforce
+    * the pipeline to use the configured device.
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[in] Serial device serial number, as returned by RS2_CAMERA_INFO_SERIAL_NUMBER
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error ** error);
+
+    /**
+    * Select a recorded device from a file, to be used by the pipeline through playback.
+    * The device available streams are as recorded to the file, and \c resolve() considers only this device and configuration
+    * as available.
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[in] file_name  The playback file of the device
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error);
+
+    /**
+    * Disable a device stream explicitly, to remove any requests on this stream profile.
+    * The stream can still be enabled due to pipeline computer vision module request. This call removes any filter on the
+    * stream configuration.
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[in] stream    Stream type, for which the filters are cleared
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_config_disable_stream(rs2_config* config, rs2_stream stream, rs2_error ** error);
+
+    /**
+    * Disable all device stream explicitly, to remove any requests on the streams profiles.
+    * The streams can still be enabled due to pipeline computer vision module request. This call removes any filter on the
+    * streams configuration.
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_config_disable_all_streams(rs2_config* config, rs2_error ** error);
+
+    /**
+    * Resolve the configuration filters, to find a matching device and streams profiles.
+    * The method resolves the user configuration filters for the device and streams, and combines them with the requirements of
+    * the computer vision modules and processing blocks attached to the pipeline. If there are no conflicts of requests, it looks
+    * for an available device, which can satisfy all requests, and selects the first matching streams configuration. In the absence
+    * of any request, the rs2::config selects the first available device and the first color and depth streams configuration.
+    * The pipeline profile selection during \c start() follows the same method. Thus, the selected profile is the same, if no
+    * change occurs to the available devices occurs.
+    * Resolving the pipeline configuration provides the application access to the pipeline selected device for advanced control.
+    * The returned configuration is not applied to the device, so the application doesn't own the device sensors. However, the
+    * application can call \c enable_device(), to enforce the device returned by this method is selected by pipeline \c start(),
+    * and configure the device and sensors options or extensions before streaming starts.
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[in] p  The pipeline for which the selected filters are applied
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return       A matching device and streams profile, which satisfies the filters and pipeline requests.
+    */
+    rs2_pipeline_profile* rs2_config_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error);
+
+    /**
+    * Check if the config can resolve the configuration filters, to find a matching device and streams profiles.
+    * The resolution conditions are as described in \c resolve().
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[in] p  The pipeline for which the selected filters are applied
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return       True if a valid profile selection exists, false if no selection can be found under the config filters and the available devices.
+    */
+    int rs2_config_can_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error);
 
 #ifdef __cplusplus
 }

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -24,67 +24,11 @@ extern "C" {
 rs2_pipeline* rs2_create_pipeline(rs2_context* ctx, rs2_error ** error);
 
 /**
-* Retrieved the device used by the pipeline
-* \param[in] ctx   context
-* \param[in] pipe  pipeline
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-* \return the device used by the pipeline
-*/
-rs2_device* rs2_pipeline_get_device(rs2_context* ctx, rs2_pipeline* pipe, rs2_error ** error);
-
-/**
-* start streaming with default configuration or commited configuration
-* \param[in] pipe  pipeline
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-*/
-void rs2_start_pipeline(rs2_pipeline* pipe, rs2_error ** error);
-
-void rs2_open_pipeline(rs2_pipeline* pipe, rs2_error ** error);
-/**
-* start streaming with default configuration or commited configuration and user callback
-* \param[in] pipe  pipeline
-* \param[in] on_frame function pointer to register as per-frame callback
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-*/
-void rs2_start_pipeline_with_callback( rs2_pipeline* pipe,  rs2_frame_callback_ptr on_frame, void* user, rs2_error** error);
-
-/**
-* start streaming with default configuration or commited configuration and user callback
-* \param[in] pipe  pipeline
-* \param[in] callback object created from c++ application. ownership over the callback object is moved into the relevant streaming lock
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-*/
-void rs2_start_pipeline_with_callback_cpp( rs2_pipeline* pipe, rs2_frame_callback* callback, rs2_error** error);
-
-/**
 * stop streaming will not change the pipeline configuration
 * \param[in] pipe  pipeline
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
-void rs2_stop_pipeline(rs2_pipeline* pipe, rs2_error ** error);
-/**
-* committing a configuration to pipeline
-* \param[in] stream    stream type
-* \param[in] index     stream index
-* \param[in] width     width
-* \param[in] height    height
-* \param[in] format    stream format
-* \param[in] framerate    stream framerate
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-*/
-void rs2_enable_pipeline_stream(rs2_pipeline* pipe, rs2_stream stream, int index, int width, int height, rs2_format format, int framerate, rs2_error ** error);
-
-void rs2_enable_pipeline_device(rs2_pipeline* pipe, const char* serial, rs2_error ** error);
-/**
-*  remove a configuration from the pipeline
-* \param[in] stream    stream type
-*/
-void rs2_disable_stream_pipeline(rs2_pipeline* pipe, rs2_stream stream, rs2_error ** error);
-
-/**
-*  remove all configurations from the pipeline
-*/
-void rs2_disable_all_streams_pipeline(rs2_pipeline* pipe, rs2_error ** error);
+void rs2_pipeline_stop(rs2_pipeline* pipe, rs2_error ** error);
 
 /**
 * wait until new frame becomes available
@@ -103,52 +47,38 @@ rs2_frame* rs2_pipeline_wait_for_frames(rs2_pipeline* pipe, unsigned int timeout
 */
 int rs2_pipeline_poll_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, rs2_error ** error);
 
-/**
-* return the selected profiles of the pipeline
-* \param[in] pipe the pipeline
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-* \return       list of stream profiles
-*/
-rs2_stream_profile_list* rs2_pipeline_get_active_streams(rs2_pipeline * pipe, rs2_error** error);
-
-/**
-* return the selected profile's count of the pipeline
-* \param[in] list the selected profiles list of the pipeline
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-* \return       list of stream profiles
-*/
-int rs2_pipeline_get_selection_count(const rs2_stream_profile_list* list, rs2_error** error);
-
-/**
-* return the specific profile from the selected profiles of the pipeline
-* \param[in] list the selected profiles list
-* \param[in] index the required stream index
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-* \return       the request stream profile
-*/
-const rs2_stream_profile* rs2_pipeline_get_stream_selection(const rs2_stream_profile_list* list, int index, rs2_error** error);
-
-/**
-* Return the specific profile from the selected profiles of the pipeline
-* \param[in] list the selected profiles list
-* \param[in] stream the required stream
-* \param[in] stream the required stream index
-* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-* \return       the request stream profile
-*/
-const rs2_stream_profile* rs2_pipeline_get_stream_type_selection(const rs2_stream_profile_list* list, rs2_stream stream, int index, rs2_error** error);
-
-/**
-* delete stream profiles list
-* \param[in] list        the list of supported profiles returned by rs2_get_supported_profiles
-*/
-void rs2_pipeline_delete_selection(rs2_stream_profile_list* list);
 
 /**
 * delete pipeline
 * \param[in] pipeline to delete
 */
-void rs2_delete_pipeline(rs2_pipeline* block);
+void rs2_delete_pipeline(rs2_pipeline* pipe);
+
+
+
+//TODO: Document all below:
+
+//pipeline
+rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_configurator* config, rs2_error ** error);
+rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_configurator* config, const char* file, rs2_error ** error);
+rs2_pipeline_profile* rs2_pipeline_get_active_profile(rs2_pipeline* pipe, rs2_error ** error);
+
+//pipeline_profile
+rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_error ** error);
+rs2_stream_profile_list* rs2_pipeline_profile_get_active_streams(rs2_pipeline_profile* profile, rs2_error** error);
+void rs2_delete_pipeline_profile(rs2_pipeline_profile* profile);
+
+//configurator
+rs2_configurator* rs2_create_configurator(rs2_error ** error);
+void rs2_delete_configurator(rs2_configurator* config);
+void rs2_configurator_enable_stream(rs2_configurator* config, rs2_stream stream, int index, int width, int height, rs2_format format, int framerate, rs2_error ** error);
+void rs2_configurator_enable_all_stream(rs2_configurator* config, rs2_error ** error);
+void rs2_configurator_enable_device(rs2_configurator* config, const char* serial, rs2_error ** error);
+void rs2_configurator_enable_device_from_file(rs2_configurator* config, const char* file, rs2_error ** error);
+void rs2_configurator_disable_stream(rs2_configurator* config, rs2_stream stream, rs2_error ** error);
+void rs2_configurator_disable_all_streams(rs2_configurator* config, rs2_error ** error);
+rs2_pipeline_profile* rs2_configurator_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error);
+int rs2_config_can_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error);
 
 #ifdef __cplusplus
 }

--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -106,6 +106,8 @@ typedef struct rs2_raw_data_buffer rs2_raw_data_buffer;
 typedef struct rs2_frame rs2_frame;
 typedef struct rs2_frame_queue rs2_frame_queue;
 typedef struct rs2_pipeline rs2_pipeline;
+typedef struct rs2_pipeline_profile rs2_pipeline_profile;
+typedef struct rs2_configurator rs2_configurator;
 typedef struct rs2_device_list rs2_device_list;
 typedef struct rs2_stream_profile_list rs2_stream_profile_list;
 typedef struct rs2_stream_profile rs2_stream_profile;

--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -107,7 +107,7 @@ typedef struct rs2_frame rs2_frame;
 typedef struct rs2_frame_queue rs2_frame_queue;
 typedef struct rs2_pipeline rs2_pipeline;
 typedef struct rs2_pipeline_profile rs2_pipeline_profile;
-typedef struct rs2_configurator rs2_configurator;
+typedef struct rs2_config rs2_config;
 typedef struct rs2_device_list rs2_device_list;
 typedef struct rs2_stream_profile_list rs2_stream_profile_list;
 typedef struct rs2_stream_profile rs2_stream_profile;

--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -131,7 +131,7 @@ namespace rs2
     protected:
         friend context;
         friend device_list;
-        friend class pipeline;
+        friend class pipeline_profile;
         friend class device_hub;
 
         std::shared_ptr<rs2_device> _dev;

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -72,7 +72,7 @@ namespace rs2
     protected:
         friend class sensor;
         friend class frame;
-        friend class pipeline;
+        friend class pipeline_profile;
 
         explicit stream_profile(const rs2_stream_profile* profile) : _profile(profile)
         {

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -13,6 +13,7 @@ namespace rs2
     class pipeline_profile
     {
     public:
+        pipeline_profile() : _pipeline_profile(nullptr) {}
         std::vector<stream_profile> get_active_streams() const
         {
             std::vector<stream_profile> results;
@@ -48,8 +49,13 @@ namespace rs2
             return device(dev);
         }
 
+        operator bool() const
+        {
+            return _pipeline_profile != nullptr;
+        }
+
     private:
-        pipeline_profile(std::shared_ptr<rs2_pipeline_profile> profile = nullptr) :
+        pipeline_profile(std::shared_ptr<rs2_pipeline_profile> profile) :
             _pipeline_profile(profile)
         {
 

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -11,8 +11,9 @@
 namespace rs2
 {
     /**
-    * The pipeline profile includes a device and a selection of active streams, with specific profile. The profile is a selection
-    * of the above under filters and conditions defined by the pipeline. Streams may belong to more than one sensor of the device.
+    * The pipeline profile includes a device and a selection of active streams, with specific profile. 
+    * The profile is a selection of the above under filters and conditions defined by the pipeline. 
+    * Streams may belong to more than one sensor of the device.
     */
     class pipeline_profile
     {
@@ -73,7 +74,7 @@ namespace rs2
         }
 
         /**
-        * Coversion to boolean value to test for the object's validity
+        * Conversion to boolean value to test for the object's validity
         *
         * \return true iff the profile is valid
         */
@@ -116,15 +117,17 @@ namespace rs2
 
         /**
         * Enable a device stream explicitly, with selected stream parameters.
-        * The method allows the application to request a stream with specific configuration. If no stream is explicitly enabled, the pipeline
-        * configures the device and its streams according to the attached computer vision modules and processing blocks requirements, or
-        * default configuration for the first available device.
-        * The application can configure any of the input stream parameters according to its requirement, or set to 0 for don't care value.
-        * The config accumulates the application calls for enable configuration methods, until the configuration is applied. Multiple enable
-        * stream calls for the same stream with conflicting parameters override each other, and the last call is maintained.
-        * Upon calling \c resolve(), the config checks for conflicts between the application configuration requests and the attached computer
-        * vision modules and processing blocks requirements, and fails if conflicts are found. Before \c resolve() is called, no conflict
-        * check is done.
+        * The method allows the application to request a stream with specific configuration. If no stream is explicitly enabled,
+        * the pipeline configures the device and its streams according to the attached computer vision modules and processing 
+        * blocks requirements, or default configuration for the first available device.
+        * The application can configure any of the input stream parameters according to its requirement, or set to 0 for don't 
+        * care value.
+        * The config accumulates the application calls for enable configuration methods, until the configuration is applied. 
+        * Multiple enable stream calls for the same stream with conflicting parameters override each other, and the last call is
+        * maintained.
+        * Upon calling \c resolve(), the config checks for conflicts between the application configuration requests and the 
+        * attached computer vision modules and processing blocks requirements, and fails if conflicts are found. 
+        * Before \c resolve() is called, no conflict check is done.
         *
         * \param[in] stream_type    Stream type to be enabled
         * \param[in] stream_index   Stream index, used for multiple streams of the same type. -1 indicates any.
@@ -167,8 +170,8 @@ namespace rs2
         /**
         * Enable all device streams explicitly.
         * The conditions and behavior of this method are similar to those of \c enable_stream().
-        * This filter enables all raw streams of the selected device. The device is either selected explicitly by the application,
-        * or by the pipeline requirements or default. The list of streams is device dependent.
+        * This filter enables all raw streams of the selected device. The device is either selected explicitly by the 
+        * application, or by the pipeline requirements or default. The list of streams is device dependent.
         */
         void enable_all_streams()
         {
@@ -180,8 +183,8 @@ namespace rs2
         /**
         * Select a specific device explicitly by its serial number, to be used by the pipeline.
         * The conditions and behavior of this method are similar to those of \c enable_stream().
-        * This method is required if the application needs to set device or sensor settings prior to pipeline streaming, to enforce
-        * the pipeline to use the configured device.
+        * This method is required if the application needs to set device or sensor settings prior to pipeline streaming, 
+        * to enforce the pipeline to use the configured device.
         *
         * \param[in] Serial device serial number, as returned by RS2_CAMERA_INFO_SERIAL_NUMBER
         */
@@ -194,8 +197,8 @@ namespace rs2
 
         /**
         * Select a recorded device from a file, to be used by the pipeline through playback.
-        * The device available streams are as recorded to the file, and \c resolve() considers only this device and configuration
-        * as available.
+        * The device available streams are as recorded to the file, and \c resolve() considers only this device and 
+        * configuration as available.
         * This request cannot be used if enable_record_to_file() is called for the current config, and vise versa
         *
         * \param[in] file_name  The playback file of the device
@@ -249,16 +252,18 @@ namespace rs2
 
         /**
         * Resolve the configuration filters, to find a matching device and streams profiles.
-        * The method resolves the user configuration filters for the device and streams, and combines them with the requirements of
-        * the computer vision modules and processing blocks attached to the pipeline. If there are no conflicts of requests, it looks
-        * for an available device, which can satisfy all requests, and selects the first matching streams configuration. In the absence
-        * of any request, the rs2::config selects the first available device and the first color and depth streams configuration.
+        * The method resolves the user configuration filters for the device and streams, and combines them with the requirements
+        * of the computer vision modules and processing blocks attached to the pipeline. If there are no conflicts of requests,
+        * it looks for an available device, which can satisfy all requests, and selects the first matching streams configuration.
+        * In the absence of any request, the rs2::config selects the first available device and the first color and depth 
+        * streams configuration.
         * The pipeline profile selection during \c start() follows the same method. Thus, the selected profile is the same, if no
         * change occurs to the available devices occurs.
-        * Resolving the pipeline configuration provides the application access to the pipeline selected device for advanced control.
-        * The returned configuration is not applied to the device, so the application doesn't own the device sensors. However, the
-        * application can call \c enable_device(), to enforce the device returned by this method is selected by pipeline \c start(),
-        * and configure the device and sensors options or extensions before streaming starts.
+        * Resolving the pipeline configuration provides the application access to the pipeline selected device for advanced 
+        * control.
+        * The returned configuration is not applied to the device, so the application doesn't own the device sensors. However, 
+        * the application can call \c enable_device(), to enforce the device returned by this method is selected by pipeline \c 
+        * start(), and configure the device and sensors options or extensions before streaming starts.
         *
         * \param[in] p  The pipeline for which the selected filters are applied
         * \return       A matching device and streams profile, which satisfies the filters and pipeline requests.
@@ -331,9 +336,10 @@ namespace rs2
 
         /**
         * Start the pipeline streaming with its default configuration.
-        * The pipeline streaming loop captures samples from the device, and delivers them to the attached computer vision modules
-        * and processing blocks, according to each module requirements and threading model.
-        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or \c poll_for_frames().
+        * The pipeline streaming loop captures samples from the device, and delivers them to the attached computer vision 
+        * modules and processing blocks, according to each module requirements and threading model.
+        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or 
+        * \c poll_for_frames().
         * The streaming loop runs until the pipeline is stopped.
         * Starting the pipeline is possible only when it is not started. If the pipeline was started, an exception is raised.
         *
@@ -354,14 +360,16 @@ namespace rs2
         * Start the pipeline streaming according to the configuraion.
         * The pipeline streaming loop captures samples from the device, and delivers them to the attached computer vision modules
         * and processing blocks, according to each module requirements and threading model.
-        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or \c poll_for_frames().
+        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or 
+        * \c poll_for_frames().
         * The streaming loop runs until the pipeline is stopped.
         * Starting the pipeline is possible only when it is not started. If the pipeline was started, an exception is raised.
         * The pipeline selects and activates the device upon start, according to configuration or a default configuration.
-        * When the rs2::config is provided to the method, the pipeline tries to activate the config \c resolve() result. If the application
-        * requests are conflicting with pipeline computer vision modules or no matching device is available on the platform, the method fails.
-        * Available configurations and devices may change between config \c resolve() call and pipeline start, in case devices are connected
-        * or disconnected, or another application acquires ownership of a device.
+        * When the rs2::config is provided to the method, the pipeline tries to activate the config \c resolve() result. 
+        * If the application requests are conflicting with pipeline computer vision modules or no matching device is available on
+        * the platform, the method fails.
+        * Available configurations and devices may change between config \c resolve() call and pipeline start, in case devices 
+        * are connected or disconnected, or another application acquires ownership of a device.
         *
         * \param[in] config   A rs2::config with requested filters on the pipeline configuration. By default no filters are applied.
         * \return             The actual pipeline device and streams profile, which was successfully configured to the streaming device.
@@ -380,8 +388,9 @@ namespace rs2
 
         /**
         * Stop the pipeline streaming.
-        * The pipeline stops delivering samples to the attached computer vision modules and processing blocks, stops the device streaming
-        * and releases the device resources used by the pipeline. It is the application's responsibility to release any frame reference it owns.
+        * The pipeline stops delivering samples to the attached computer vision modules and processing blocks, stops the device 
+        * streaming and releases the device resources used by the pipeline. It is the application's responsibility to release any
+        * frame reference it owns.
         * The method takes effect only after \c start() was called, otherwise an exception is raised.
         */
         void stop()
@@ -395,11 +404,11 @@ namespace rs2
         * Wait until a new set of frames becomes available.
         * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
         * The method blocks the calling thread, and fetches the latest unread frames set.
-        * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method should be called
-        * as fast as the device frame rate.
-        * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
-        * may lack memory resources to produce new frames, and the following call to this method shall fail to retrieve new frames, until resources
-        * are retained.
+        * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method 
+        * should be called as fast as the device frame rate.
+        * The application can maintain the frames handles to defer processing. However, if the application maintains too long 
+        * history, the device may lack memory resources to produce new frames, and the following call to this method shall fail 
+        * to retrieve new frames, until resources are retained.
         *
         * \param[in] timeout_ms   Max time in milliseconds to wait until an exception will be thrown
         * \return                 Set of time synchronized frames, one from each active stream
@@ -416,13 +425,13 @@ namespace rs2
         /**
         * Check if a new set of frames is available and retrieve the latest undelivered set.
         * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
-        * The method returns without blocking the calling thread, with status of new frames available or not. If available, it fetches the
-        * latest frames set.
-        * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method should be called
-        * as fast as the device frame rate.
-        * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
-        * may lack memory resources to produce new frames, and the following calls to this method shall return no new frames, until resources are
-        * retained.
+        * The method returns without blocking the calling thread, with status of new frames available or not. 
+        * If available, it fetches the latest frames set.
+        * Device frames, which were produced while the function wasn't called, are dropped. 
+        * To avoid frame drops, this method should be called as fast as the device frame rate.
+        * The application can maintain the frames handles to defer processing. However, if the application maintains too long
+        * history, the device may lack memory resources to produce new frames, and the following calls to this method shall 
+        * return no new frames, until resources are retained.
         *
         * \param[out] f     Frames set handle
         * \return           True if new set of time synchronized frames was stored to f, false if no new frames set is available
@@ -446,7 +455,8 @@ namespace rs2
         * Return the active device and streams profiles, used by the pipeline.
         * The pipeline streams profiles are selected during \c start(). The method returns a valid result only when the pipeline is active -
         * between calls to \c start() and \c stop().
-        * After \c stop() is called, the pipeline doesn't own the device, thus, the pipeline selected device may change in subsequent activations.
+        * After \c stop() is called, the pipeline doesn't own the device, thus, the pipeline selected device may change in 
+        * subsequent activations.
         *
         * \return  The actual pipeline device and streams profile, which was successfully configured to the streaming device on start.
         */

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -384,7 +384,6 @@ namespace rs2
         * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
         * may lack memory resources to produce new frames, and the following call to this method shall fail to retrieve new frames, until resources
         * are retained.
-        * open: different FPS - where do the extras go???
         *
         * \param[in] timeout_ms   Max time in milliseconds to wait until an exception will be thrown
         * \return                 Set of time synchronized frames, one from each active stream
@@ -408,13 +407,16 @@ namespace rs2
         * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
         * may lack memory resources to produce new frames, and the following calls to this method shall return no new frames, until resources are
         * retained.
-        * open: different FPS - where do the extras go???
         *
         * \param[out] f     Frames set handle
         * \return           True if new set of time synchronized frames was stored to f, false if no new frames set is available
         */
         bool poll_for_frames(frameset* f) const
         {
+            if (!f)
+            {
+                throw std::invalid_argument("null frameset");
+            }
             rs2_error* e = nullptr;
             rs2_frame* frame_ref = nullptr;
             auto res = rs2_pipeline_poll_for_frames(_pipeline.get(), &frame_ref, &e);

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -126,26 +126,42 @@ namespace rs2
         * vision modules and processing blocks requirements, and fails if conflicts are found. Before \c resolve() is called, no conflict
         * check is done.
         *
-        * \param[in] stream    Stream type to be enabled
-        * \param[in] index     Stream index, used for multiple streams of the same type. -1 indicates any.
-        * \param[in] width     Stream image width - for images streams. 0 indicates any.
-        * \param[in] height    Stream image height - for images streams. 0 indicates any.
-        * \param[in] format    Stream data format - pixel format for images streams, of data type for other streams. RS2_FORMAT_ANY indicates any.
-        * \param[in] framerate Stream frames per second. 0 indicates any.
+        * \param[in] stream_type    Stream type to be enabled
+        * \param[in] stream_index   Stream index, used for multiple streams of the same type. -1 indicates any.
+        * \param[in] width          Stream image width - for images streams. 0 indicates any.
+        * \param[in] height         Stream image height - for images streams. 0 indicates any.
+        * \param[in] format         Stream data format - pixel format for images streams, of data type for other streams. RS2_FORMAT_ANY indicates any.
+        * \param[in] framerate      Stream frames per second. 0 indicates any.
         */
-        void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format = RS2_FORMAT_ANY, int framerate = 0)
+        void enable_stream(rs2_stream stream_type, int stream_index, int width, int height, rs2_format format = RS2_FORMAT_ANY, int framerate = 0)
         {
             rs2_error* e = nullptr;
-            rs2_config_enable_stream(_config.get(), stream, index, width, height, format, framerate, &e);
+            rs2_config_enable_stream(_config.get(), stream_type, stream_index, width, height, format, framerate, &e);
             error::handle(e);
         }
-        void enable_stream(rs2_stream stream, int index = -1)
+
+        //Stream type and possibly also stream index
+        void enable_stream(rs2_stream stream_type, int stream_index = -1)
         {
-            enable_stream(stream, index, 0, 0, RS2_FORMAT_ANY, 0);
+            enable_stream(stream_type, stream_index, 0, 0, RS2_FORMAT_ANY, 0);
         }
-        void enable_stream(rs2_stream stream, int width, int height)
+
+        //Stream type and resolution, and possibly format and frame rate
+        void enable_stream(rs2_stream stream_type, int width, int height, rs2_format format = RS2_FORMAT_ANY, int framerate = 0)
         {
-            enable_stream(stream, -1, width, height, RS2_FORMAT_ANY, 0);
+            enable_stream(stream_type, -1, 0, 0, RS2_FORMAT_ANY, 0);
+        }
+
+        //Stream type and format
+        void enable_stream(rs2_stream stream_type, rs2_format format, int framerate = 0)
+        {
+            enable_stream(stream_type, -1, 0, 0, format, framerate);
+        }
+
+        //Stream type and format
+        void enable_stream(rs2_stream stream_type, int stream_index, rs2_format format, int framerate = 0)
+        {
+            enable_stream(stream_type, stream_index, 0, 0, format, framerate);
         }
 
         /**

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -48,11 +48,6 @@ namespace rs2
             return device(dev);
         }
 
-        std::shared_ptr<rs2_pipeline_profile> get() const
-        {
-            return _pipeline_profile;
-        }
-
     private:
         pipeline_profile(std::shared_ptr<rs2_pipeline_profile> profile = nullptr) :
             _pipeline_profile(profile)
@@ -160,14 +155,11 @@ namespace rs2
             return pipeline_profile(p);
         }
 
-        std::shared_ptr<rs2_pipeline> get() const
-        {
-            return _pipeline;
-        }
     private:
         context _ctx;
         device _dev;
         std::shared_ptr<rs2_pipeline> _pipeline;
+        friend class configurator;
     };
 
     class configurator
@@ -228,7 +220,7 @@ namespace rs2
         {
             rs2_error* e = nullptr;
             auto profile = std::shared_ptr<rs2_pipeline_profile>(
-                rs2_configurator_resolve(_config.get(), p.get().get(), &e),
+                rs2_configurator_resolve(_config.get(), p._pipeline.get(), &e),
                 rs2_delete_pipeline_profile);
 
             error::handle(e);
@@ -238,14 +230,9 @@ namespace rs2
         bool can_resolve(const pipeline& p) const
         {
             rs2_error* e = nullptr;
-            int res = rs2_config_can_resolve(_config.get(), p.get().get(), &e);
+            int res = rs2_config_can_resolve(_config.get(), p._pipeline.get(), &e);
             error::handle(e);
             return res == 0 ? false : true;
-        }
-
-        std::shared_ptr<rs2_configurator> get() const
-        {
-            return _config;
         }
 
         operator std::shared_ptr<rs2_configurator>() const

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -55,11 +55,11 @@ namespace rs2
 
         }
         std::shared_ptr<rs2_pipeline_profile> _pipeline_profile;
-        friend class configurator;
+        friend class config;
         friend class pipeline;
     };
 
-    class configurator;
+    class config;
     class pipeline
     {
     public:
@@ -82,7 +82,7 @@ namespace rs2
         //    error::handle(e);
         //}
 
-        pipeline_profile start(std::shared_ptr<rs2_configurator> config = nullptr) 
+        pipeline_profile start(std::shared_ptr<rs2_config> config = nullptr)
         {
             rs2_error* e = nullptr;
             auto p = std::shared_ptr<rs2_pipeline_profile>(
@@ -93,7 +93,7 @@ namespace rs2
             return pipeline_profile(p);
         }
 
-        pipeline_profile start(const std::string& record_to_filename, std::shared_ptr<rs2_configurator> config = nullptr)
+        pipeline_profile start(const std::string& record_to_filename, std::shared_ptr<rs2_config> config = nullptr)
         {
             rs2_error* e = nullptr;
             auto p = std::shared_ptr<rs2_pipeline_profile>(
@@ -157,62 +157,61 @@ namespace rs2
 
     private:
         context _ctx;
-        device _dev;
         std::shared_ptr<rs2_pipeline> _pipeline;
-        friend class configurator;
+        friend class config;
     };
 
-    class configurator
+    class config
     {
     public:
-        configurator()
+        config()
         {
             rs2_error* e = nullptr;
-            _config = std::shared_ptr<rs2_configurator>(
-                rs2_create_configurator(&e),
-                rs2_delete_configurator);
+            _config = std::shared_ptr<rs2_config>(
+                rs2_create_config(&e),
+                rs2_delete_config);
             error::handle(e);
         }
 
         void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate)
         {
             rs2_error* e = nullptr;
-            rs2_configurator_enable_stream(_config.get(), stream, index, width, height, format, framerate, &e);
+            rs2_config_enable_stream(_config.get(), stream, index, width, height, format, framerate, &e);
             error::handle(e);
         }
 
         void enable_all_streams()
         {
             rs2_error* e = nullptr;
-            rs2_configurator_enable_all_stream(_config.get(), &e);
+            rs2_config_enable_all_stream(_config.get(), &e);
             error::handle(e);
         }
 
         void enable_device(const std::string& serial)
         {
             rs2_error* e = nullptr;
-            rs2_configurator_enable_device(_config.get(), serial.c_str(), &e);
+            rs2_config_enable_device(_config.get(), serial.c_str(), &e);
             error::handle(e);
         }
 
         void enable_device_from_file(const std::string& file_name)
         {
             rs2_error* e = nullptr;
-            rs2_configurator_enable_device_from_file(_config.get(), file_name.c_str(), &e);
+            rs2_config_enable_device_from_file(_config.get(), file_name.c_str(), &e);
             error::handle(e);
         }
 
         void disable_stream(rs2_stream stream)
         {
             rs2_error* e = nullptr;
-            rs2_configurator_disable_stream(_config.get(), stream, &e);
+            rs2_config_disable_stream(_config.get(), stream, &e);
             error::handle(e);
         }
 
         void disable_all_streams()
         {
             rs2_error* e = nullptr;
-            rs2_configurator_disable_all_streams(_config.get(), &e);
+            rs2_config_disable_all_streams(_config.get(), &e);
             error::handle(e);
         }
 
@@ -220,7 +219,7 @@ namespace rs2
         {
             rs2_error* e = nullptr;
             auto profile = std::shared_ptr<rs2_pipeline_profile>(
-                rs2_configurator_resolve(_config.get(), p._pipeline.get(), &e),
+                rs2_config_resolve(_config.get(), p._pipeline.get(), &e),
                 rs2_delete_pipeline_profile);
 
             error::handle(e);
@@ -232,18 +231,18 @@ namespace rs2
             rs2_error* e = nullptr;
             int res = rs2_config_can_resolve(_config.get(), p._pipeline.get(), &e);
             error::handle(e);
-            return res == 0 ? false : true;
+            return res != 0;
         }
 
-        operator std::shared_ptr<rs2_configurator>() const
+        operator std::shared_ptr<rs2_config>() const
         {
             return _config;
         }
     private:
-        configurator(std::shared_ptr<rs2_configurator> config) : _config(config)
+        config(std::shared_ptr<rs2_config> config) : _config(config)
         {
         }
-        std::shared_ptr<rs2_configurator> _config;
+        std::shared_ptr<rs2_config> _config;
 
     };
 }

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -123,8 +123,7 @@ namespace rs2
         * The application can configure any of the input stream parameters according to its requirement, or set to 0 for don't 
         * care value.
         * The config accumulates the application calls for enable configuration methods, until the configuration is applied. 
-        * Multiple enable stream calls for the same stream with conflicting parameters override each other, and the last call is
-        * maintained.
+        * Multiple enable stream calls for the same stream override each other, and the last call is maintained.
         * Upon calling \c resolve(), the config checks for conflicts between the application configuration requests and the 
         * attached computer vision modules and processing blocks requirements, and fails if conflicts are found. 
         * Before \c resolve() is called, no conflict check is done.

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -23,8 +23,8 @@ extern "C" {
 #include "h/rs_sensor.h"
 
 #define RS2_API_MAJOR_VERSION    2
-#define RS2_API_MINOR_VERSION    7
-#define RS2_API_PATCH_VERSION    10
+#define RS2_API_MINOR_VERSION    8
+#define RS2_API_PATCH_VERSION    0
 #define RS2_API_BUILD_VERSION    0
 
 #define STRINGIFY(arg) #arg

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
 <package format="2">
   <name>librealsense2</name>
   <!-- The version tag needs to be updated with each new release of librealsense -->
-  <version>2.7.9</version>
+  <version>2.8.0</version>
   <description>
   Library for capturing data from the Intel(R) RealSense(TM) SR300 and D400 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project, including multi-camera capture.
   </description>

--- a/src/config.h
+++ b/src/config.h
@@ -358,16 +358,21 @@ namespace librealsense
                 std::map<index_type, sensor_interface*> stream_to_dev;
                 std::map<index_type, std::shared_ptr<stream_profile_interface>> stream_to_profile;
 
+                std::map<int, sensor_interface*> sensors_map;
                 std::vector<sensor_interface*> sensors;
                 for(auto i = 0; i< dev->get_sensors_count(); i++)
                 {
-                    sensors.push_back(&dev->get_sensor(i));
+                    if (mapping.find(i) != mapping.end())
+                    {
+                        sensors_map[i] = &dev->get_sensor(i);
+                        sensors.push_back(&dev->get_sensor(i));
+                    }
                 }
 
                 for (auto && kvp : mapping) {
                     dev_to_profiles[kvp.first].push_back(kvp.second);
                     index_type idx{ kvp.second->get_stream_type(), kvp.second->get_stream_index() };
-                    stream_to_dev.emplace(idx, sensors[kvp.first]);
+                    stream_to_dev.emplace(idx, sensors_map.at(kvp.first));
                     stream_to_profile[idx] = kvp.second;
                 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -520,7 +520,7 @@ namespace librealsense
                             {
                                 if (match(p.get(), t))
                                 {
-                                    out.emplace(i, p);
+                                    out.emplace((int)i, p);
                                     break;
                                 }
                             }

--- a/src/config.h
+++ b/src/config.h
@@ -50,6 +50,18 @@ namespace librealsense
                 }
             };
 
+
+
+            static bool match_stream(const index_type& a, const index_type& b)
+            {
+                if (a.stream != RS2_STREAM_ANY && b.stream != RS2_STREAM_ANY && (a.stream != b.stream))
+                    return false;
+                if (a.index != -1 && b.index != -1 && (a.index != b.index))
+                    return false;
+
+                return true;
+            }
+
             template<class Stream_Profile>
             static bool match(const Stream_Profile& a, const Stream_Profile& b)
             {
@@ -323,6 +335,7 @@ namespace librealsense
                return false;
 
            }
+
             multistream resolve(device_interface* dev)
             {
                  auto mapping = map_streams(dev);
@@ -335,15 +348,7 @@ namespace librealsense
                     for (auto && kvp : mapping)
                         all_streams.insert({ kvp.second->get_stream_type(), kvp.second->get_stream_index() });
 
-                    auto match_stream = [](const index_type& a, const index_type& b) -> bool
-                    {
-                        if (a.stream != RS2_STREAM_ANY && b.stream != RS2_STREAM_ANY && (a.stream != b.stream))
-                            return false;
-                        if (a.index != -1 && b.index != -1 && (a.index != b.index))
-                            return false;
-
-                        return true;
-                    };
+                    
                     for (auto && kvp : _presets)
                     {
                         auto it = std::find_if(std::begin(all_streams), std::end(all_streams), [&](const index_type& i)
@@ -510,7 +515,9 @@ namespace librealsense
 
                             for (auto itr: profiles)
                             {
-                                if (itr->get_stream_type() == kvp.first.stream && itr->get_stream_index() == kvp.first.index) {
+                                auto stream = index_type{ itr->get_stream_type() ,itr->get_stream_index() };
+                                if (match_stream(stream, kvp.first))
+                                {
                                     return to_request(itr.get());
                                 }
                             }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -343,13 +343,29 @@ namespace librealsense
 
             for (auto& kvp : devices_changed_callbacks)
             {
-                kvp.second->on_devices_changed(new rs2_device_list({ shared_from_this(), rs2_devices_info_removed }),
-                                               new rs2_device_list({ shared_from_this(), rs2_devices_info_added }));
+                try
+                {
+                    kvp.second->on_devices_changed(new rs2_device_list({ shared_from_this(), rs2_devices_info_removed }),
+                                                   new rs2_device_list({ shared_from_this(), rs2_devices_info_added }));
+                }
+                catch (...)
+                {
+                    LOG_ERROR("Exception thrown from user callback handler");
+                }
             }
 
             if (_devices_changed_callback)
-                _devices_changed_callback->on_devices_changed(new rs2_device_list({ shared_from_this(), rs2_devices_info_removed }),
-                                                              new rs2_device_list({ shared_from_this(), rs2_devices_info_added }));
+            {
+                try
+                {
+                    _devices_changed_callback->on_devices_changed(new rs2_device_list({ shared_from_this(), rs2_devices_info_removed }),
+                        new rs2_device_list({ shared_from_this(), rs2_devices_info_added }));
+                }
+                catch (...)
+                {
+                    LOG_ERROR("Exception thrown from user callback handler");
+                }    
+            }
         }
     }
 

--- a/src/context.h
+++ b/src/context.h
@@ -146,6 +146,23 @@ namespace librealsense
         std::mutex _streams_mutex, _devices_changed_callbacks_mtx;
     };
 
+    class readonly_device_info : public device_info
+    {
+    public:
+        readonly_device_info(std::shared_ptr<device_interface> dev) : device_info(dev->get_context()), _dev(dev) {}
+        std::shared_ptr<device_interface> create(std::shared_ptr<context> /*backend*/) const override
+        {
+            return _dev;
+        }
+
+        platform::backend_device_group get_device_data() const override
+        {
+            return _dev->get_device_data();
+        }
+    private:
+        std::shared_ptr<device_interface> _dev;
+    };
+
     // Helper functions for device list manipulation:
     std::vector<platform::uvc_device_info> filter_by_product(const std::vector<platform::uvc_device_info>& devices, const std::set<uint16_t>& pid_list);
     std::vector<std::pair<std::vector<platform::uvc_device_info>, std::vector<platform::hid_device_info>>> group_devices_and_hids_by_unique_id(

--- a/src/context.h
+++ b/src/context.h
@@ -150,7 +150,7 @@ namespace librealsense
     {
     public:
         readonly_device_info(std::shared_ptr<device_interface> dev) : device_info(dev->get_context()), _dev(dev) {}
-        std::shared_ptr<device_interface> create(std::shared_ptr<context> /*backend*/) const override
+        std::shared_ptr<device_interface> create(std::shared_ptr<context> ctx, bool register_device_notifications) const override
         {
             return _dev;
         }

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -40,6 +40,7 @@ device::~device()
     {
         _context->unregister_internal_device_callback(_callback_id);
     }
+    _sensors.clear();
 }
 
 int device::add_sensor(std::shared_ptr<sensor_interface> sensor_base)

--- a/src/device.h
+++ b/src/device.h
@@ -23,7 +23,6 @@ namespace librealsense
     {
     public:
         virtual ~device();
-
         size_t get_sensors_count() const override;
 
         sensor_interface& get_sensor(size_t subdevice) override;

--- a/src/ds5/ds5-device.h
+++ b/src/ds5/ds5-device.h
@@ -51,7 +51,6 @@ namespace librealsense
         bool is_camera_in_advanced_mode() const;
 
         uint8_t _depth_device_idx;
-        std::shared_ptr<uvc_sensor> _depth_sensor;
 
         lazy<std::vector<uint8_t>> _coefficients_table_raw;
 

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -229,8 +229,23 @@ namespace librealsense
             if((devices[0].pid == ds::RS430_MM_PID || devices[0].pid == ds::RS420_MM_PID) &&  hids.size()==0)
                 continue;
 
-            if (!devices.empty() &&
-                mi_present(devices, 0))
+            bool all_sensors_present = mi_present(devices, 0);
+
+            constexpr std::array<int, 3> multi_sensors = { ds::RS415_PID, ds::RS430_MM_RGB_PID, ds::RS435_RGB_PID };
+            auto is_pid_of_multisensor_device = [&multi_sensors](int pid) { return std::find(std::begin(multi_sensors), std::end(multi_sensors), pid) != std::end(multi_sensors); };
+            bool is_device_multisensor = false;;
+            for (auto&& uvc : devices)
+            {
+                if (is_pid_of_multisensor_device(uvc.pid))
+                    is_device_multisensor = true;
+            }
+
+            if(is_device_multisensor)
+            {
+                all_sensors_present = all_sensors_present && mi_present(devices, 3);
+            }
+
+            if (!devices.empty() && all_sensors_present)
             {
                 platform::usb_device_info hwm;
 

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -310,7 +310,7 @@ bool playback_device::is_real_time() const
 
 platform::backend_device_group playback_device::get_device_data() const
 {
-    return {};
+    return platform::backend_device_group({ platform::playback_device_info{ m_reader->get_file_name() } });
 }
 
 std::pair<uint32_t, rs2_extrinsics> playback_device::get_extrinsics(const stream_interface& stream) const

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -387,7 +387,10 @@ void librealsense::record_device::resume_recording()
         LOG_INFO("Record resumed");
     });
 }
-
+platform::backend_device_group record_device::get_device_data() const
+{
+    return m_device->get_device_data();
+}
 std::shared_ptr<matcher> record_device::create_matcher(const frame_holder& frame) const
 {
     return m_device->create_matcher(frame);

--- a/src/media/record/record_device.h
+++ b/src/media/record/record_device.h
@@ -38,7 +38,7 @@ namespace librealsense
 
         void pause_recording();
         void resume_recording();
-        platform::backend_device_group get_device_data() const override {return {}; } //ZIV: what to do?
+        platform::backend_device_group get_device_data() const override;
         std::pair<uint32_t, rs2_extrinsics> get_extrinsics(const stream_interface& stream) const override;
         bool is_valid() const override;
 

--- a/src/media/ros/ros_file_format.h
+++ b/src/media/ros/ros_file_format.h
@@ -12,6 +12,7 @@
 #include "rosbag/structures.h"
 #include <regex>
 #include "stream.h"
+#include "types.h"
 
 namespace librealsense
 {

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -419,7 +419,7 @@ namespace librealsense
 
                 continue;
             }
-
+            assert(profile->_multistream.get_profiles().size() > 0);
             profile->_multistream.open();
             profile->_multistream.start(syncer_callback);
             break;

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -466,18 +466,15 @@ namespace librealsense
             return f;
         }
         
-        if (!_hub.is_connected(*_active_profile->get_device()))
+        try
         {
-            //_dev = _hub.wait_for_device(timeout_ms/*, _dev.get()*/);
-            //TODO: handle start() from here with playback devices (dont reload file to context)
             unsafe_start(_prev_conf);
             return frame_holder();
         }
-        else
+        catch(const std::exception& e)
         {
             throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
         }
-        
     }
 
     bool pipeline::poll_for_frames(frame_holder* frame)

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -1,14 +1,267 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
 
-#include <librealsense2/rs.hpp>
-
+#include <algorithm>
 #include "pipeline.h"
 #include "stream.h"
+#include "media/record/record_device.h"
+#include "media/ros/ros_writer.h"
 
 namespace librealsense
 {
-    const int VID = 0x8086;
+    /*
+
+      ______   ______   .__   __.  _______  __    _______  __    __  .______           ___   .___________.  ______   .______      
+     /      | /  __  \  |  \ |  | |   ____||  |  /  _____||  |  |  | |   _  \         /   \  |           | /  __  \  |   _  \     
+    |  ,----'|  |  |  | |   \|  | |  |__   |  | |  |  __  |  |  |  | |  |_)  |       /  ^  \ `---|  |----`|  |  |  | |  |_)  |    
+    |  |     |  |  |  | |  . `  | |   __|  |  | |  | |_ | |  |  |  | |      /       /  /_\  \    |  |     |  |  |  | |      /     
+    |  `----.|  `--'  | |  |\   | |  |     |  | |  |__| | |  `--'  | |  |\  \----. /  _____  \   |  |     |  `--'  | |  |\  \----.
+     \______| \______/  |__| \__| |__|     |__|  \______|  \______/  | _| `._____|/__/     \__\  |__|      \______/  | _| `._____|
+
+    */
+
+    void configurator::enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int fps)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        //TODO: Should we throw in case the request will result in an invalid resolution?
+        //_stream_requests[{stream, index}] = { stream, index, width, height, format, fps };
+    }
+
+    void configurator::enable_all_stream()
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        //_stream_requests.clear();
+        _enable_all_streams = true;
+    }
+
+    void configurator::enable_device(const std::string& serial)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        _device_request.serial = serial;
+    }
+
+    void configurator::enable_device_from_file(const std::string& file)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (!_device_request.record_output.empty())
+        {
+            throw std::runtime_error("Configuring both device from file, and record to file is unsupported");
+        }
+        _device_request.filename = file;
+    }
+
+    void configurator::enable_record_to_file(const std::string& file)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (!_device_request.filename.empty())
+        {
+            throw std::runtime_error("Configuring both device from file, and record to file is unsupported");
+        }
+        _device_request.record_output = file;
+    }
+
+    void configurator::disable_stream(rs2_stream stream)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        //std::remove_if(std::begin(_stream_requests), 
+        //    std::end(_stream_requests), 
+        //    [stream](const std::pair<std::pair<rs2_stream, int>, util::config::request_type>& r)
+        //    {
+        //        return r.first.first == stream;
+        //    }
+        //);
+    }
+
+    void configurator::disable_all_streams()
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        //_stream_requests.clear();
+        _enable_all_streams = false;
+    }
+
+    std::shared_ptr<pipeline_profile> configurator::resolve(std::shared_ptr<pipeline> pipe)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+
+        auto requested_device = resolve_device_requests(pipe);
+
+        std::vector<stream_profile> resolved_profiles;
+
+        if (_enable_all_streams)
+        {
+            if (!requested_device)
+            {
+                requested_device = get_first_or_default_device(pipe);
+            }
+
+            util::config config;
+            config.enable_all(util::best_quality);
+            auto multistream = config.resolve(requested_device.get());
+            return std::make_shared<pipeline_profile>(requested_device, multistream, _device_request.record_output);
+        }
+        else
+        {
+            util::config config;
+
+            //If the user did not request anything, give it the default
+            if (true/* _stream_requests.empty()*/)
+            {
+                if (!requested_device)
+                {
+                    requested_device = get_first_or_default_device(pipe);
+                }
+
+                auto default_profiles = get_default_configuration(requested_device);
+                for (auto prof : default_profiles)
+                {
+                    auto p = dynamic_cast<video_stream_profile*>(prof.get());
+                    if (!p)
+                    {
+                        throw std::runtime_error(to_string() << "stream_profile is not video_stream_profile");
+                    }
+                    config.enable_stream(p->get_stream_type(), p->get_stream_index(), p->get_width(), p->get_height(), p->get_format(), p->get_framerate());
+                }
+
+                auto multistream = config.resolve(requested_device.get());
+                return std::make_shared<pipeline_profile>(requested_device, multistream, _device_request.record_output);
+            }
+            else
+            {
+                //User enabled some stream, enable only them                
+                /*for(auto&& req : _stream_requests)
+                {
+                    auto r = req.second;
+                    config.enable_stream(r.stream, r.stream_index, r.width, r.height, r.format, r.fps);
+                }*/
+
+                for (auto dev_info : pipe->get_context()->query_devices())
+                {
+                    try
+                    {
+                        auto dev = dev_info->create_device();
+                        auto multistream = config.resolve(dev.get());
+                        return std::make_shared<pipeline_profile>(dev, multistream, _device_request.record_output);
+                    }
+                    catch (...) {}
+                }
+
+                throw std::runtime_error("Config couldn't configure pipeline");
+
+            }
+        }
+    }
+
+    bool configurator::can_resolve(std::shared_ptr<pipeline> pipe)
+    {
+        throw not_implemented_exception(__FUNCTION__);
+    }
+    std::shared_ptr<device_interface> configurator::get_first_or_default_device(std::shared_ptr<pipeline> pipe)
+    {
+        try
+        {
+            return pipe->wait_for_device(5000);
+        }
+        catch (const std::exception& e)
+        {
+            throw std::runtime_error(to_string() << "Failed to resolve request. " << e.what());
+        }
+    }
+    //TODO: add timeout parameter?
+    std::shared_ptr<device_interface> configurator::resolve_device_requests(std::shared_ptr<pipeline> pipe)
+    {
+        const auto timeout_ms = std::chrono::milliseconds(5000).count();
+
+        //Prefer filename over serial
+        if(!_device_request.filename.empty())
+        {
+            std::shared_ptr<device_interface> dev;
+            try
+            {
+                dev = pipe->get_context()->add_device(_device_request.filename);
+            }
+            catch(const std::exception& e)
+            {
+                throw std::runtime_error(to_string() << "Failed to resolve request. Request to enable_device_from_file(\"" << _device_request.filename << "\") was invalid, Reason: " << e.what());
+            }
+            //check if a serial number was also requested, and check again the device
+            if (!_device_request.serial.empty())
+            {
+                if (!dev->supports_info(RS2_CAMERA_INFO_SERIAL_NUMBER))
+                {
+                    throw std::runtime_error(to_string() << "Failed to resolve request. "
+                        "Conflic between enable_device_from_file(\"" << _device_request.filename
+                        << "\") and enable_device(\"" << _device_request.serial << "\"), "
+                        "File does not contain a device with such serial");
+                }
+                else
+                {
+                    std::string s = dev->get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+                    if (s != _device_request.serial)
+                    {
+                        throw std::runtime_error(to_string() << "Failed to resolve request. "
+                            "Conflic between enable_device_from_file(\"" << _device_request.filename 
+                             << "\") and enable_device(\"" << _device_request.serial << "\"), "
+                            "File contains device with different serial number (" << s << "\")");
+                    }
+                }
+            }
+            return dev;
+        }
+
+        if (!_device_request.serial.empty())
+        {
+            return pipe->wait_for_device(timeout_ms, _device_request.serial);
+        }
+
+        return nullptr;
+    }
+
+    stream_profiles configurator::get_default_configuration(std::shared_ptr<device_interface> dev)
+    {
+        stream_profiles default_profiles;
+
+        for (unsigned int i = 0; i < dev->get_sensors_count(); i++)
+        {
+            auto&& sensor = dev->get_sensor(i);
+            auto profiles = sensor.get_stream_profiles();
+
+            for (auto p : profiles)
+            {
+                if (p->is_default())
+                {
+                    default_profiles.push_back(p);
+                }
+            }
+        }
+
+        // Workaround - default profiles that holds color stream shouldn't supposed to provide infrared either
+        auto color_it = std::find_if(default_profiles.begin(), default_profiles.end(), [](std::shared_ptr<stream_profile_interface> p)
+                        {
+                            return p.get()->get_stream_type() == RS2_STREAM_COLOR;
+                        });
+
+        bool default_profiles_contains_color_stream = color_it != default_profiles.end();
+        if (default_profiles_contains_color_stream)
+        {
+            auto it = std::find_if(default_profiles.begin(), default_profiles.end(), [](std::shared_ptr<stream_profile_interface> p) {return p.get()->get_stream_type() == RS2_STREAM_INFRARED; });
+            if (it != default_profiles.end())
+            {
+                default_profiles.erase(it);
+            }
+        }
+
+        return default_profiles;
+    }
+
+    /*
+        .______    __  .______    _______  __       __  .__   __.  _______ 
+        |   _  \  |  | |   _  \  |   ____||  |     |  | |  \ |  | |   ____|
+        |  |_)  | |  | |  |_)  | |  |__   |  |     |  | |   \|  | |  |__   
+        |   ___/  |  | |   ___/  |   __|  |  |     |  | |  . `  | |   __|  
+        |  |      |  | |  |      |  |____ |  `----.|  | |  |\   | |  |____ 
+        | _|      |__| | _|      |_______||_______||__| |__| \__| |_______|                                                        
+    */
+
     template<class T>
     class internal_frame_callback : public rs2_frame_callback
     {
@@ -24,117 +277,9 @@ namespace librealsense
         void release() override { delete this; }
     };
 
-    void configurator::enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate)
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    void configurator::enable_all_stream()
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    void configurator::enable_device(const std::string& serial)
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    void configurator::enable_device_from_file(const std::string& file)
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    void configurator::disable_stream(rs2_stream stream)
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    void configurator::disable_all_streams()
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    std::shared_ptr<pipeline_profile> configurator::resolve(std::shared_ptr<pipeline> pipe) const
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    bool configurator::can_resolve(std::shared_ptr<pipeline> pipe) const
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-
     pipeline::pipeline(std::shared_ptr<librealsense::context> ctx)
-        :_ctx(ctx), _hub(ctx, VID)
+        :_ctx(ctx), _hub(ctx)
     {}
-
-    std::shared_ptr<pipeline_profile> pipeline::start(std::shared_ptr<configurator> conf)
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    std::shared_ptr<pipeline_profile> pipeline::start_with_record(std::shared_ptr<configurator> conf, const std::string& file)
-    {
-        throw not_implemented_exception(__FUNCTION__);
-    }
-
-    std::shared_ptr<pipeline_profile> pipeline::get_active_profile() const
-    {
-        return nullptr;
-    }
-
-    void pipeline::stop()
-    {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-
-        if (_streaming)
-        {
-            _multistream.stop();
-            _multistream.close();
-        }
-        _streaming = false;
-
-    }
-
-    frame_holder pipeline::wait_for_frames(unsigned int timeout_ms)
-    {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-
-        frame_holder f;
-        if (_queue.dequeue(&f, timeout_ms))
-        {
-            return f;
-        }
-
-        {
-            std::lock_guard<std::recursive_mutex> lock(_mtx);
-            if (!_hub.is_connected(*_dev))
-            {
-                _dev = _hub.wait_for_device(timeout_ms/*, _dev.get()*/);
-                _sensors.clear();
-                _queue.clear();
-                _queue.start();
-                start();
-                return frame_holder();
-            }
-            else
-            {
-                throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
-            }
-        }
-    }
-
-    bool pipeline::poll_for_frames(frame_holder* frame)
-    {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-
-        if (_queue.try_dequeue(frame))
-        {
-            return true;
-        }
-        return false;
-    }
 
     pipeline::~pipeline()
     {
@@ -144,121 +289,40 @@ namespace librealsense
         }
         catch (...) {}
     }
-    
 
-
-
-    std::shared_ptr<device_interface> pipeline::get_device()
+    std::shared_ptr<pipeline_profile> pipeline::start(std::shared_ptr<configurator> conf)
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-        if (!_commited)
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (_active_profile)
         {
-            throw std::runtime_error(to_string() << "get_device() failed. device is not available before commiting all requests");
+            throw librealsense::wrong_api_call_sequence_exception("start() cannnot be called before stop()");
         }
-
-        // Check if the current device is still connected. if not, wait for it by its serial number.
-        // in case device is not found, return another device from the list.
-        // if the list is empty, throw an exception.
-        if (!_hub.is_connected(*_dev))
-        {
-            if (_device_serial.empty())
-                _dev = _hub.wait_for_device();
-            else
-                _dev = _hub.wait_for_device(5000, _device_serial);
-
-            _sensors.clear();
-            _queue->clear();
-            _queue->start();
-            if (_streaming)
-                start();
-        }
-
-        return _dev;
+        unsafe_start(conf);
+        return get_active_profile();
     }
 
-    void pipeline::open()
+    std::shared_ptr<pipeline_profile> pipeline::start_with_record(std::shared_ptr<configurator> conf, const std::string& file)
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-
-        if (!_dev)
-            _dev = _hub.wait_for_device();
-
-        if (_config.get_requests().size() == 0 && _config.get_requests().size() == 0)
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (_active_profile)
         {
-            stream_profiles default_profiles;
-            for (unsigned int i = 0; i < _dev->get_sensors_count(); i++)
-            {
-                auto&& sensor = _dev->get_sensor(i);
-                auto profiles = sensor.get_stream_profiles();
-
-                for (auto p : profiles)
-                {
-                    if (p->is_default())
-                    {
-                        default_profiles.push_back(p);
-                    }
-                }
-
-                _sensors.push_back(&sensor);
-            }
-
-            // Workaround - default profiles that holds color stream shouldn't supposed to provide infrared either
-            if (default_profiles.end() != std::find_if(default_profiles.begin(),
-                                                       default_profiles.end(),
-                                                       [](std::shared_ptr<stream_profile_interface> p)
-                                                       {return p.get()->get_stream_type() == RS2_STREAM_COLOR; }))
-            {
-                auto it = std::find_if(default_profiles.begin(), default_profiles.end(), [](std::shared_ptr<stream_profile_interface> p){return p.get()->get_stream_type() == RS2_STREAM_INFRARED; });
-                if (it != default_profiles.end())
-                {
-                    default_profiles.erase(it);
-                }
-            }
-
-            for (auto prof : default_profiles)
-            {
-                auto p = dynamic_cast<video_stream_profile*>(prof.get());
-                if (!p)
-                {
-                    throw std::runtime_error(to_string() << "stream_profile is not video_stream_profile");
-                }
-                enable(p->get_stream_type(), p->get_stream_index(), p->get_width(), p->get_height(), p->get_format(), p->get_framerate());
-            }
+            throw librealsense::wrong_api_call_sequence_exception("start() cannnot be called before stop()");
         }
-
-        _commited = true;
+        conf->enable_record_to_file(file);
+        unsafe_start(conf);
+        return get_active_profile();
     }
 
-    void pipeline::start(frame_callback_ptr callback)
+    std::shared_ptr<pipeline_profile> pipeline::get_active_profile() const
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-
-        _syncer = std::unique_ptr<syncer_proccess_unit>(new syncer_proccess_unit());
-        _queue = std::unique_ptr<single_consumer_queue<frame_holder>>(new single_consumer_queue<frame_holder>());
-
-        if (!_commited)
-        {
-            open();
-        }
-        auto to_syncer = [&](frame_holder fref)
-        {
-            _syncer->invoke(std::move(fref));
-        };
-
-        frame_callback_ptr syncer_callback =
-        { new internal_frame_callback<decltype(to_syncer)>(to_syncer),
-         [](rs2_frame_callback* p) { p->release(); } };
-
-        _syncer->set_output_callback(callback);
-
-        _multistream = _config.open(_dev.get());
-        _multistream.start(syncer_callback);
-        _streaming = true;
+        return _active_profile;
     }
 
-    void pipeline::start()
+    void pipeline::unsafe_start(std::shared_ptr<configurator> conf)
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
+        auto syncer = std::unique_ptr<syncer_proccess_unit>(new syncer_proccess_unit());
+        auto queue = std::unique_ptr<single_consumer_queue<frame_holder>>(new single_consumer_queue<frame_holder>());
+
         auto to_user = [&](frame_holder fref)
         {
             _queue->enqueue(std::move(fref));
@@ -266,79 +330,175 @@ namespace librealsense
 
         frame_callback_ptr user_callback =
         { new internal_frame_callback<decltype(to_user)>(to_user),
-         [](rs2_frame_callback* p) { p->release(); } };
+            [](rs2_frame_callback* p) { p->release(); } };
 
-        start(user_callback);
-    }
-
-    void pipeline::enable(std::string device_serial)
-    {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-        if (_commited)
+        auto to_syncer = [&](frame_holder fref)
         {
-            throw std::runtime_error(to_string() << "enable() failed. pipeline already configured");
+            _syncer->invoke(std::move(fref));
+        };
+
+        frame_callback_ptr syncer_callback =
+        { new internal_frame_callback<decltype(to_syncer)>(to_syncer),
+            [](rs2_frame_callback* p) { p->release(); } };
+
+        syncer->set_output_callback(user_callback);
+
+        _queue = std::move(queue);
+        _syncer = std::move(syncer);
+
+        std::shared_ptr<pipeline_profile> profile = nullptr;
+        const int NUM_TIMES_TO_RETRY = 3;
+        for (int i = 1; i <= NUM_TIMES_TO_RETRY; i++)
+        {
+            profile = conf->resolve(shared_from_this());
+            try
+            {
+                profile->_multistream.open();
+                profile->_multistream.start(syncer_callback);
+            }
+            catch (...)
+            {
+                if (i == NUM_TIMES_TO_RETRY)
+                    throw std::runtime_error("Failed to start device too many time");
+
+                //TODO: reconfig()?
+            }
+            break;
         }
 
-        _device_serial = device_serial;
-        _dev = _hub.wait_for_device(5000, device_serial);
+        //On successfull start, update members:
+        _active_profile = profile;
+        _prev_conf = conf;
     }
 
-    void pipeline::enable(rs2_stream stream, int index, uint32_t width, uint32_t height, rs2_format format, uint32_t framerate)
+    void pipeline::stop()
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-        if (_commited)
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (!_active_profile)
         {
-            throw std::runtime_error(to_string() << "enable() failed. pipeline already configured");
+            throw librealsense::wrong_api_call_sequence_exception("stop() cannnot be called before start()");
         }
-        _config.enable_stream(stream, index, width, height, format, framerate);
+        _active_profile->_multistream.stop();
+        _active_profile->_multistream.close();
+        _syncer.reset();
+        _queue.reset();
+        _active_profile.reset();
     }
 
-    void pipeline::disable_stream(rs2_stream stream)
+    frame_holder pipeline::wait_for_frames(unsigned int timeout_ms)
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-
-        if (_streaming)
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (!_active_profile)
         {
-            _multistream.stop();
-            _multistream.close();
+            throw librealsense::wrong_api_call_sequence_exception("wait_for_frames cannnot be called before start()");
         }
 
-        _commited = false;
-        _streaming = false;
-        _config.disable_stream(stream);
+        frame_holder f;
+        if (_queue->dequeue(&f, timeout_ms))
+        {
+            return f;
+        }
+        
+        if (!_hub.is_connected(*_active_profile->get_device()))
+        {
+            //_dev = _hub.wait_for_device(timeout_ms/*, _dev.get()*/);
+            //TODO: shouw we use active_profile to start with a new config?
+            unsafe_start(_prev_conf);
+            return frame_holder();
+        }
+        else
+        {
+            throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
+        }
+        
     }
 
-    void pipeline::disable_all()
+    bool pipeline::poll_for_frames(frame_holder* frame)
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-        if (_streaming)
+        std::lock_guard<std::mutex> lock(_mtx);
+
+        if (!_active_profile)
         {
-            _multistream.stop();
-            _multistream.close();
+            throw librealsense::wrong_api_call_sequence_exception("poll_for_frames cannnot be called before start()");
         }
-        _commited = false;
-        _streaming = false;
-        _config.disable_all();
+
+        if (_queue->try_dequeue(frame))
+        {
+            return true;
+        }
+        return false;
     }
-    stream_profiles pipeline::get_active_streams() const
+
+    std::shared_ptr<device_interface> pipeline::wait_for_device(unsigned int timeout_ms, std::string serial)
     {
-        stream_profiles res;
-        auto profs = _multistream.get_profiles();
-        for (auto p : profs)
+        return _hub.wait_for_device(timeout_ms, serial);
+    }
+
+    std::shared_ptr<librealsense::context> pipeline::get_context() const
+    {
+        return _ctx;
+    }
+
+
+    /*
+    
+        .______    __  .______    _______  __       __  .__   __.  _______        
+        |   _  \  |  | |   _  \  |   ____||  |     |  | |  \ |  | |   ____|       
+        |  |_)  | |  | |  |_)  | |  |__   |  |     |  | |   \|  | |  |__          
+        |   ___/  |  | |   ___/  |   __|  |  |     |  | |  . `  | |   __|         
+        |  |      |  | |  |      |  |____ |  `----.|  | |  |\   | |  |____        
+        | _|      |__| | _|      |_______||_______||__| |__| \__| |_______|______ 
+                                                                          |______|
+
+        .______   .______        ______    _______  __   __       _______ 
+        |   _  \  |   _  \      /  __  \  |   ____||  | |  |     |   ____|
+        |  |_)  | |  |_)  |    |  |  |  | |  |__   |  | |  |     |  |__   
+        |   ___/  |      /     |  |  |  | |   __|  |  | |  |     |   __|  
+        |  |      |  |\  \----.|  `--'  | |  |     |  | |  `----.|  |____ 
+        | _|      | _| `._____| \______/  |__|     |__| |_______||_______|
+                                                                  
+
+    */
+    pipeline_profile::pipeline_profile(std::shared_ptr<device_interface> dev, 
+                                       util::config::multistream multistream, 
+                                       const std::string& to_file) :
+        _dev(dev), _multistream(multistream), _to_file(to_file)
+    {
+        if (!to_file.empty())
         {
-            res.push_back(p.second);
+            if (!dev)
+                throw librealsense::invalid_value_exception("Failed to create a pipeline_profile, device is null");
+
+            _dev = std::make_shared<record_device>(dev, std::make_shared<ros_writer>(to_file));
         }
-        return res;
     }
 
     std::shared_ptr<device_interface> pipeline_profile::get_device()
     {
-        throw not_implemented_exception(__FUNCTION__);
+        //pipeline_profile can be retrieved from a configurator and pipeline::start()
+        //either way, it is created by the pipeline
+        
+        //TODO: handle case where device has disconnected and reconnected
+        //TODO: remember to recreate the device as record device in case of to_file.empty() == false
+        if (!_dev)
+        {
+            throw std::runtime_error("Device is unavailable");
+        }
+        return _dev;
     }
 
     stream_profiles pipeline_profile::get_active_streams() const
     {
-        throw not_implemented_exception(__FUNCTION__);
+        auto profiles_per_sensor = _multistream.get_profiles_per_sensor();
+        stream_profiles profiles;
+        //std::transform(std::begin(profiles_per_sensor),
+        //    std::end(profiles_per_sensor),
+        //    std::back_inserter(profiles), 
+        //    [](const std::pair<int, stream_profiles>& kvp)
+        //    {
+        //        return kvp.second;
+        //    }
+        //);
+        return profiles;
     }
-
 }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -61,18 +61,31 @@ namespace librealsense
     class pipeline_config
     {
     public:
+        pipeline_config();
         void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate);
         void enable_all_stream();
         void enable_device(const std::string& serial);
         void enable_device_from_file(const std::string& file);
+        void enable_record_to_file(const std::string& file); //TODO: add to top level api
         void disable_stream(rs2_stream stream);
         void disable_all_streams();
         std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe);
         bool can_resolve(std::shared_ptr<pipeline> pipe);
 
         //Non top level API
-        void enable_record_to_file(const std::string& file);
+        std::shared_ptr<pipeline_profile> get_cached_resolved_profile();
 
+        pipeline_config(const pipeline_config& other)
+        {
+            if (this == &other)
+                return;
+
+            _device_request = other._device_request;
+            _stream_requests = other._stream_requests;
+            _enable_all_streams = other._enable_all_streams;
+            _stream_requests = other._stream_requests;
+            _resolved_profile = nullptr;
+        }
     private:
         struct device_request
         {
@@ -80,14 +93,16 @@ namespace librealsense
             std::string filename;
             std::string record_output;
         };
-
+        std::shared_ptr<device_interface> get_or_add_playback_device(std::shared_ptr<pipeline> pipe, const std::string& file);
         std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe);
         stream_profiles get_default_configuration(std::shared_ptr<device_interface> dev);
         std::shared_ptr<device_interface> get_first_or_default_device(std::shared_ptr<pipeline> pipe);
+        
         device_request _device_request;
         std::map<std::pair<rs2_stream, int>, util::config::request_type> _stream_requests;
         std::mutex _mtx;
         bool _enable_all_streams = false;
+        std::shared_ptr<pipeline_profile> _resolved_profile;
     };
 
 }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -45,7 +45,7 @@ namespace librealsense
 
      private:
          void unsafe_start(std::shared_ptr<pipeline_config> conf);
-
+         void unsafe_stop();
         std::shared_ptr<librealsense::context> _ctx;
         std::mutex _mtx;
         device_hub _hub;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -15,7 +15,7 @@ namespace librealsense
     class pipeline_profile
     {
     public:
-        pipeline_profile(std::shared_ptr<device_interface> dev, util::config::multistream multistream, const std::string& file);
+        pipeline_profile(std::shared_ptr<device_interface> dev, util::config config, const std::string& file = "");
         std::shared_ptr<device_interface> get_device();
         stream_profiles get_active_streams() const;
         util::config::multistream _multistream;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -9,14 +9,28 @@
 
 namespace librealsense
 {
+    class pipeline_profile
+    {
+    public:
+        std::shared_ptr<device_interface> get_device();
+        stream_profiles get_active_streams() const;
+    };
+
+    class configurator;
     class pipeline
     {
     public:
         pipeline(std::shared_ptr<librealsense::context> ctx);
+
+        std::shared_ptr<pipeline_profile> start(std::shared_ptr<configurator> conf);
+        std::shared_ptr<pipeline_profile> start_with_record(std::shared_ptr<configurator> conf, const std::string& file);
+        void stop();
+        std::shared_ptr<pipeline_profile> get_active_profile() const;
+
         std::shared_ptr<device_interface> get_device();
         void start(frame_callback_ptr callback);
         void start();
-        void stop();
+        
         void open();
         void enable(std::string device_serial);
         void enable(rs2_stream stream, int index, uint32_t width, uint32_t height, rs2_format format, uint32_t framerate);
@@ -44,6 +58,20 @@ namespace librealsense
         bool _commited = false;
         bool _streaming = false; 
         std::string _device_serial;
+    };
+
+
+    class configurator
+    {
+    public:
+        void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate);
+        void enable_all_stream();
+        void enable_device(const std::string& serial);
+        void enable_device_from_file(const std::string& file);
+        void disable_stream(rs2_stream stream);
+        void disable_all_streams();
+        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe) const;
+        bool can_resolve(std::shared_ptr<pipeline> pipe) const;
     };
 
 }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -24,15 +24,15 @@ namespace librealsense
         std::string _to_file;
     };
 
-    class configurator;
+    class pipeline_config;
     class pipeline : public std::enable_shared_from_this<pipeline>
     {
     public:
         //Top level API
-        pipeline(std::shared_ptr<librealsense::context> ctx);
+        explicit pipeline(std::shared_ptr<librealsense::context> ctx);
         ~pipeline();
-        std::shared_ptr<pipeline_profile> start(std::shared_ptr<configurator> conf);
-        std::shared_ptr<pipeline_profile> start_with_record(std::shared_ptr<configurator> conf, const std::string& file);
+        std::shared_ptr<pipeline_profile> start(std::shared_ptr<pipeline_config> conf);
+        std::shared_ptr<pipeline_profile> start_with_record(std::shared_ptr<pipeline_config> conf, const std::string& file);
         void stop();
         std::shared_ptr<pipeline_profile> get_active_profile() const;
         frame_holder wait_for_frames(unsigned int timeout_ms = 5000);
@@ -44,7 +44,7 @@ namespace librealsense
 
 
      private:
-         void unsafe_start(std::shared_ptr<configurator> conf);
+         void unsafe_start(std::shared_ptr<pipeline_config> conf);
 
         std::shared_ptr<librealsense::context> _ctx;
         std::mutex _mtx;
@@ -53,11 +53,12 @@ namespace librealsense
         frame_callback_ptr _callback;
         std::unique_ptr<syncer_proccess_unit> _syncer;
         std::unique_ptr<single_consumer_queue<frame_holder>> _queue;
-        std::shared_ptr<configurator> _prev_conf;
+
+        std::shared_ptr<pipeline_config> _prev_conf;
     };
 
 
-    class configurator
+    class pipeline_config
     {
     public:
         void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate);

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -6,58 +6,54 @@
 #include "device_hub.h"
 #include "sync.h"
 #include "config.h"
+#include <map>
+#include <utility>
 
 namespace librealsense
 {
+    class pipeline;
     class pipeline_profile
     {
     public:
+        pipeline_profile(std::shared_ptr<device_interface> dev, util::config::multistream multistream, const std::string& file);
         std::shared_ptr<device_interface> get_device();
         stream_profiles get_active_streams() const;
+        util::config::multistream _multistream;
+    private:
+        std::shared_ptr<device_interface> _dev;
+        std::string _to_file;
     };
 
     class configurator;
-    class pipeline
+    class pipeline : public std::enable_shared_from_this<pipeline>
     {
     public:
+        //Top level API
         pipeline(std::shared_ptr<librealsense::context> ctx);
-
+        ~pipeline();
         std::shared_ptr<pipeline_profile> start(std::shared_ptr<configurator> conf);
         std::shared_ptr<pipeline_profile> start_with_record(std::shared_ptr<configurator> conf, const std::string& file);
         void stop();
         std::shared_ptr<pipeline_profile> get_active_profile() const;
-
-        std::shared_ptr<device_interface> get_device();
-        void start(frame_callback_ptr callback);
-        void start();
-        
-        void open();
-        void enable(std::string device_serial);
-        void enable(rs2_stream stream, int index, uint32_t width, uint32_t height, rs2_format format, uint32_t framerate);
-        void disable_stream(rs2_stream stream);
-        void disable_all();
-
         frame_holder wait_for_frames(unsigned int timeout_ms = 5000);
         bool poll_for_frames(frame_holder* frame);
 
-        stream_profiles get_active_streams() const;
+        //Non top level API
+        std::shared_ptr<device_interface> wait_for_device(unsigned int timeout_ms = std::numeric_limits<unsigned int>::max(), std::string serial = "");
+        std::shared_ptr<librealsense::context> get_context() const;
 
-        ~pipeline();
 
      private:
+         void unsafe_start(std::shared_ptr<configurator> conf);
+
         std::shared_ptr<librealsense::context> _ctx;
-        std::recursive_mutex _mtx;
-        std::shared_ptr<device_interface> _dev;
+        std::mutex _mtx;
         device_hub _hub;
+        std::shared_ptr<pipeline_profile> _active_profile;
         frame_callback_ptr _callback;
         std::unique_ptr<syncer_proccess_unit> _syncer;
         std::unique_ptr<single_consumer_queue<frame_holder>> _queue;
-        std::vector<sensor_interface*> _sensors;
-        util::config _config;
-        util::config::multistream _multistream;
-        bool _commited = false;
-        bool _streaming = false; 
-        std::string _device_serial;
+        std::shared_ptr<configurator> _prev_conf;
     };
 
 
@@ -70,8 +66,24 @@ namespace librealsense
         void enable_device_from_file(const std::string& file);
         void disable_stream(rs2_stream stream);
         void disable_all_streams();
-        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe) const;
-        bool can_resolve(std::shared_ptr<pipeline> pipe) const;
+        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe);
+        bool can_resolve(std::shared_ptr<pipeline> pipe);
+
+        //Non top level API
+        void enable_record_to_file(const std::string& file);
+    private:
+        std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe);
+        stream_profiles get_default_configuration(std::shared_ptr<device_interface> dev);
+        std::shared_ptr<device_interface> get_first_or_default_device(std::shared_ptr<pipeline> pipe);
+        struct device_request
+        {
+            std::string serial;
+            std::string filename;
+            std::string record_output;
+        } _device_request;
+
+        std::mutex _mtx;
+        bool _enable_all_streams = false;
     };
 
 }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -71,17 +71,20 @@ namespace librealsense
 
         //Non top level API
         void enable_record_to_file(const std::string& file);
+
     private:
-        std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe);
-        stream_profiles get_default_configuration(std::shared_ptr<device_interface> dev);
-        std::shared_ptr<device_interface> get_first_or_default_device(std::shared_ptr<pipeline> pipe);
         struct device_request
         {
             std::string serial;
             std::string filename;
             std::string record_output;
-        } _device_request;
+        };
 
+        std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe);
+        stream_profiles get_default_configuration(std::shared_ptr<device_interface> dev);
+        std::shared_ptr<device_interface> get_first_or_default_device(std::shared_ptr<pipeline> pipe);
+        device_request _device_request;
+        std::map<std::pair<rs2_stream, int>, util::config::request_type> _stream_requests;
         std::mutex _mtx;
         bool _enable_all_streams = false;
     };

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -195,7 +195,8 @@ rs2_device* rs2_device_hub_wait_for_device(rs2_context* ctx, const rs2_device_hu
 {
     VALIDATE_NOT_NULL(hub);
     VALIDATE_NOT_NULL(ctx);
-    return new rs2_device{ ctx->ctx, /*TODO: how does this affect the new device*/ nullptr, hub->hub->wait_for_device() };
+    auto dev = hub->hub->wait_for_device();
+    return new rs2_device{ ctx->ctx, std::make_shared<readonly_device_info>(dev), dev };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, hub, ctx)
 
@@ -1418,8 +1419,8 @@ rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_e
     VALIDATE_NOT_NULL(profile);
 
     auto dev = profile->profile->get_device();
-    
-    return new rs2_device{ dev->get_context(), nullptr, dev };
+    auto dev_info = std::make_shared<librealsense::readonly_device_info>(dev);
+    return new rs2_device{ dev->get_context(), dev_info , dev };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, profile)
 
@@ -1442,7 +1443,7 @@ NOEXCEPT_RETURN(, profile)
 //config
 rs2_config* rs2_create_config(rs2_error** error) try
 {
-    return new rs2_config();
+    return new rs2_config{ std::make_shared<librealsense::pipeline_config>() };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, 0)
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -53,6 +53,16 @@ struct rs2_pipeline
     std::shared_ptr<librealsense::pipeline> pipe;
 };
 
+struct rs2_configurator
+{
+    std::shared_ptr<librealsense::configurator> config;
+};
+
+struct rs2_pipeline_profile
+{
+    std::shared_ptr<librealsense::pipeline_profile> profile;
+};
+
 //struct rs2_intrinsics
 //{
 //    std::shared_ptr<librealsense::rs2_intrinsics> intrinsics;
@@ -1343,96 +1353,13 @@ rs2_pipeline* rs2_create_pipeline(rs2_context* ctx, rs2_error ** error) try
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, ctx)
 
-rs2_device* rs2_pipeline_get_device(rs2_context* ctx, rs2_pipeline* pipe, rs2_error ** error)try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    return new rs2_device{ ctx->ctx, /*TODO: how does this affect the new device*/ nullptr, pipe->pipe->get_device()};
-}
-HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
-
-void rs2_start_pipeline_with_callback(rs2_pipeline* pipe, rs2_frame_callback* callback, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    pipe->pipe->start({ callback, [](rs2_frame_callback* p) { p->release(); } });
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
-void rs2_start_pipeline(rs2_pipeline* pipe, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    pipe->pipe->start();
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
-void rs2_open_pipeline(rs2_pipeline* pipe, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    pipe->pipe->open();
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
-void rs2_start_pipeline_with_callback_cpp( rs2_pipeline* pipe, rs2_frame_callback* callback, rs2_error** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-    VALIDATE_NOT_NULL(callback);
-    pipe->pipe->start({ callback, [](rs2_frame_callback* p) { p->release(); } });
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe, callback)
-
-void rs2_start_pipeline_with_callback( rs2_pipeline* pipe,  rs2_frame_callback_ptr on_frame, void* user, rs2_error** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-    VALIDATE_NOT_NULL(on_frame);
-    librealsense::frame_callback_ptr callback(
-        new librealsense::frame_callback(on_frame, user));
-    pipe->pipe->start(move(callback));
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe, on_frame, user)
-
-void rs2_stop_pipeline(rs2_pipeline* pipe, rs2_error ** error) try
+void rs2_pipeline_stop(rs2_pipeline* pipe, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(pipe);
 
     pipe->pipe->stop();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
-void rs2_enable_pipeline_stream(rs2_pipeline* pipe, rs2_stream stream, int index, int width, int height, rs2_format format, int framerate, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    pipe->pipe->enable(stream, index,  width,  height,  format, framerate);
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
-void rs2_enable_pipeline_device(rs2_pipeline* pipe, const char* serial, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    pipe->pipe->enable(serial);
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
-void rs2_disable_stream_pipeline(rs2_pipeline* pipe, rs2_stream stream, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    pipe->pipe->disable_stream(stream);
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
-void rs2_disable_all_streams_pipeline(rs2_pipeline* pipe, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-
-    pipe->pipe->disable_all();
-}
-HANDLE_EXCEPTIONS_AND_RETURN(, pipe)
-
 
 rs2_frame* rs2_pipeline_wait_for_frames(rs2_pipeline* pipe, unsigned int timeout_ms, rs2_error ** error) try
 {
@@ -1460,28 +1387,6 @@ int rs2_pipeline_poll_for_frames(rs2_pipeline * pipe, rs2_frame** output_frame, 
     return false;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, pipe, output_frame)
-
-rs2_stream_profile_list* rs2_pipeline_get_active_streams(rs2_pipeline * pipe, rs2_error** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-    return new rs2_stream_profile_list{ pipe->pipe->get_active_streams() };
-}
-HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
-
-const rs2_stream_profile* rs2_pipeline_get_stream_type_selection(const rs2_stream_profile_list* list, rs2_stream stream, int index, rs2_error** error) try
-{
-    VALIDATE_NOT_NULL(list);
-   
-    for (auto prof : list->list)
-    {
-        if(prof->get_stream_type() == stream && prof ->get_stream_index() == index)
-            return prof->get_c_wrapper();
-    }
-
-    throw librealsense::invalid_value_exception(librealsense::to_string() << "stream " << stream << " is not contained in list!");
-}
-HANDLE_EXCEPTIONS_AND_RETURN(nullptr, list, index)
-
 void rs2_delete_pipeline(rs2_pipeline* pipe) try
 {
     VALIDATE_NOT_NULL(pipe);
@@ -1490,6 +1395,142 @@ void rs2_delete_pipeline(rs2_pipeline* pipe) try
 }
 NOEXCEPT_RETURN(, pipe)
 
+rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_configurator* config, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(pipe);
+    VALIDATE_NOT_NULL(config);
+    if (config == nullptr)
+    {
+        config = new rs2_configurator{};
+    }
+    return new rs2_pipeline_profile{ pipe->pipe->start(config->config) };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe, config)
+
+
+rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_configurator* config, const char* file, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(pipe);
+    VALIDATE_NOT_NULL(file);
+    if (config == nullptr)
+    {
+        config = new rs2_configurator{};
+    }
+    return new rs2_pipeline_profile{ pipe->pipe->start_with_record(config->config, file) };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe, config, file)
+
+rs2_pipeline_profile* rs2_pipeline_get_active_profile(rs2_pipeline* pipe, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(pipe);
+
+    return new rs2_pipeline_profile{ pipe->pipe->get_active_profile() };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
+
+rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(profile);
+
+    auto dev = profile->profile->get_device();
+    
+    return new rs2_device{ dev->get_context(), nullptr, dev };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, profile)
+
+
+rs2_stream_profile_list* rs2_pipeline_profile_get_active_streams(rs2_pipeline_profile* profile, rs2_error** error) try
+{
+    VALIDATE_NOT_NULL(profile);
+    return new rs2_stream_profile_list{ profile->profile->get_active_streams() };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, profile)
+
+void rs2_delete_pipeline_profile(rs2_pipeline_profile* profile) try
+{
+    VALIDATE_NOT_NULL(profile);
+
+    delete profile;
+}
+NOEXCEPT_RETURN(, profile)
+
+//configurator
+rs2_configurator* rs2_create_configurator(rs2_error ** error) try
+{
+    return new rs2_configurator();
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, 0)
+
+void rs2_delete_configurator(rs2_configurator* config) try
+{
+    VALIDATE_NOT_NULL(config);
+
+    delete config;
+}
+NOEXCEPT_RETURN(, config)
+
+void rs2_configurator_enable_stream(rs2_configurator* config, rs2_stream stream, int index, int width, int height, rs2_format format, int framerate, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    config->config->enable_stream(stream, index, width, height, format, framerate);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config, stream, index, width, height, format, framerate)
+
+void rs2_configurator_enable_all_stream(rs2_configurator* config, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    config->config->enable_all_stream();
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config)
+
+void rs2_configurator_enable_device(rs2_configurator* config, const char* serial, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    VALIDATE_NOT_NULL(serial);
+
+    config->config->enable_device(serial);
+
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config, serial)
+
+void rs2_configurator_enable_device_from_file(rs2_configurator* config, const char* file, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    VALIDATE_NOT_NULL(file);
+
+    config->config->enable_device_from_file(file);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
+
+void rs2_configurator_disable_stream(rs2_configurator* config, rs2_stream stream, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    config->config->disable_stream(stream);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config, stream)
+
+void rs2_configurator_disable_all_streams(rs2_configurator* config, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    config->config->disable_all_streams();
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config)
+
+rs2_pipeline_profile* rs2_configurator_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    VALIDATE_NOT_NULL(pipe);
+    return new rs2_pipeline_profile{ config->config->resolve(pipe->pipe) };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, config, pipe)
+
+int rs2_config_can_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    VALIDATE_NOT_NULL(pipe);
+    return config->config->can_resolve(pipe->pipe) ? 1 : 0;
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, config, pipe)
 
 rs2_processing_block* rs2_create_processing_block(rs2_frame_processor_callback* proc, rs2_error** error) try
 {

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1382,29 +1382,20 @@ void rs2_delete_pipeline(rs2_pipeline* pipe) try
 }
 NOEXCEPT_RETURN(, pipe)
 
-rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_config* config, rs2_error ** error) try
+rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(pipe);
-    if (config == nullptr)
-    {
-        return new rs2_pipeline_profile{ pipe->pipe->start(std::make_shared<pipeline_config>()) };
-    }
+    return new rs2_pipeline_profile{ pipe->pipe->start(std::make_shared<pipeline_config>()) };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
+
+rs2_pipeline_profile* rs2_pipeline_start_with_config(rs2_pipeline* pipe, rs2_config* config, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(pipe);
+    VALIDATE_NOT_NULL(config);
     return new rs2_pipeline_profile{ pipe->pipe->start(config->config) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe, config)
-
-
-rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_config* config, const char* file, rs2_error ** error) try
-{
-    VALIDATE_NOT_NULL(pipe);
-    VALIDATE_NOT_NULL(file);
-    if (config == nullptr)
-    {
-        return new rs2_pipeline_profile{ pipe->pipe->start_with_record(std::make_shared<pipeline_config>(), file) };
-    }
-    return new rs2_pipeline_profile{ pipe->pipe->start_with_record(config->config, file) };
-}
-HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe, config, file)
 
 rs2_pipeline_profile* rs2_pipeline_get_active_profile(rs2_pipeline* pipe, rs2_error ** error) try
 {
@@ -1425,7 +1416,7 @@ rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_e
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, profile)
 
 
-rs2_stream_profile_list* rs2_pipeline_profile_get_active_streams(rs2_pipeline_profile* profile, rs2_error** error) try
+rs2_stream_profile_list* rs2_pipeline_profile_get_streams(rs2_pipeline_profile* profile, rs2_error** error) try
 {
     VALIDATE_NOT_NULL(profile);
     return new rs2_stream_profile_list{ profile->profile->get_active_streams() };
@@ -1492,6 +1483,16 @@ void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs
     VALIDATE_NOT_NULL(file);
 
     config->config->enable_device_from_file(file);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
+
+
+void rs2_config_enable_record_to_file(rs2_config* config, const char* file, rs2_error ** error) try
+{
+    VALIDATE_NOT_NULL(config);
+    VALIDATE_NOT_NULL(file);
+
+    config->config->enable_record_to_file(file);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1398,10 +1398,9 @@ NOEXCEPT_RETURN(, pipe)
 rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_configurator* config, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(pipe);
-    VALIDATE_NOT_NULL(config);
     if (config == nullptr)
     {
-        config = new rs2_configurator{};
+        return new rs2_pipeline_profile{ pipe->pipe->start(std::make_shared<configurator>()) };
     }
     return new rs2_pipeline_profile{ pipe->pipe->start(config->config) };
 }
@@ -1414,7 +1413,7 @@ rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_con
     VALIDATE_NOT_NULL(file);
     if (config == nullptr)
     {
-        config = new rs2_configurator{};
+        return new rs2_pipeline_profile{ pipe->pipe->start_with_record(std::make_shared<configurator>(), file) };
     }
     return new rs2_pipeline_profile{ pipe->pipe->start_with_record(config->config, file) };
 }

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -53,29 +53,15 @@ struct rs2_pipeline
     std::shared_ptr<librealsense::pipeline> pipe;
 };
 
-struct rs2_configurator
+struct rs2_config
 {
-    std::shared_ptr<librealsense::configurator> config;
+    std::shared_ptr<librealsense::pipeline_config> config;
 };
 
 struct rs2_pipeline_profile
 {
     std::shared_ptr<librealsense::pipeline_profile> profile;
 };
-
-//struct rs2_intrinsics
-//{
-//    std::shared_ptr<librealsense::rs2_intrinsics> intrinsics;
-//};
-//struct rs2_record_device
-//{
-//    std::shared_ptr<librealsense::record_device> record_device;
-//};
-
-//struct rs2_syncer
-//{
-//    std::shared_ptr<librealsense::sync_interface> syncer;
-//};
 
 struct rs2_frame_queue
 {
@@ -1395,25 +1381,25 @@ void rs2_delete_pipeline(rs2_pipeline* pipe) try
 }
 NOEXCEPT_RETURN(, pipe)
 
-rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_configurator* config, rs2_error ** error) try
+rs2_pipeline_profile* rs2_pipeline_start(rs2_pipeline* pipe, rs2_config* config, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(pipe);
     if (config == nullptr)
     {
-        return new rs2_pipeline_profile{ pipe->pipe->start(std::make_shared<configurator>()) };
+        return new rs2_pipeline_profile{ pipe->pipe->start(std::make_shared<pipeline_config>()) };
     }
     return new rs2_pipeline_profile{ pipe->pipe->start(config->config) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe, config)
 
 
-rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_configurator* config, const char* file, rs2_error ** error) try
+rs2_pipeline_profile* rs2_pipeline_start_with_record(rs2_pipeline* pipe, rs2_config* config, const char* file, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(pipe);
     VALIDATE_NOT_NULL(file);
     if (config == nullptr)
     {
-        return new rs2_pipeline_profile{ pipe->pipe->start_with_record(std::make_shared<configurator>(), file) };
+        return new rs2_pipeline_profile{ pipe->pipe->start_with_record(std::make_shared<pipeline_config>(), file) };
     }
     return new rs2_pipeline_profile{ pipe->pipe->start_with_record(config->config, file) };
 }
@@ -1453,14 +1439,14 @@ void rs2_delete_pipeline_profile(rs2_pipeline_profile* profile) try
 }
 NOEXCEPT_RETURN(, profile)
 
-//configurator
-rs2_configurator* rs2_create_configurator(rs2_error ** error) try
+//config
+rs2_config* rs2_create_config(rs2_error** error) try
 {
-    return new rs2_configurator();
+    return new rs2_config();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, 0)
 
-void rs2_delete_configurator(rs2_configurator* config) try
+void rs2_delete_config(rs2_config* config) try
 {
     VALIDATE_NOT_NULL(config);
 
@@ -1468,21 +1454,28 @@ void rs2_delete_configurator(rs2_configurator* config) try
 }
 NOEXCEPT_RETURN(, config)
 
-void rs2_configurator_enable_stream(rs2_configurator* config, rs2_stream stream, int index, int width, int height, rs2_format format, int framerate, rs2_error ** error) try
+void rs2_config_enable_stream(rs2_config* config,
+                              rs2_stream stream,
+                              int index,
+                              int width,
+                              int height,
+                              rs2_format format,
+                              int framerate,
+                              rs2_error** error) try
 {
     VALIDATE_NOT_NULL(config);
     config->config->enable_stream(stream, index, width, height, format, framerate);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, stream, index, width, height, format, framerate)
 
-void rs2_configurator_enable_all_stream(rs2_configurator* config, rs2_error ** error) try
+void rs2_config_enable_all_stream(rs2_config* config, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(config);
     config->config->enable_all_stream();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config)
 
-void rs2_configurator_enable_device(rs2_configurator* config, const char* serial, rs2_error ** error) try
+void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(serial);
@@ -1492,7 +1485,7 @@ void rs2_configurator_enable_device(rs2_configurator* config, const char* serial
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, serial)
 
-void rs2_configurator_enable_device_from_file(rs2_configurator* config, const char* file, rs2_error ** error) try
+void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(file);
@@ -1501,21 +1494,21 @@ void rs2_configurator_enable_device_from_file(rs2_configurator* config, const ch
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
 
-void rs2_configurator_disable_stream(rs2_configurator* config, rs2_stream stream, rs2_error ** error) try
+void rs2_config_disable_stream(rs2_config* config, rs2_stream stream, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(config);
     config->config->disable_stream(stream);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, stream)
 
-void rs2_configurator_disable_all_streams(rs2_configurator* config, rs2_error ** error) try
+void rs2_config_disable_all_streams(rs2_config* config, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(config);
     config->config->disable_all_streams();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config)
 
-rs2_pipeline_profile* rs2_configurator_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error) try
+rs2_pipeline_profile* rs2_config_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(pipe);
@@ -1523,7 +1516,7 @@ rs2_pipeline_profile* rs2_configurator_resolve(rs2_configurator* config, rs2_pip
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, config, pipe)
 
-int rs2_config_can_resolve(rs2_configurator* config, rs2_pipeline* pipe, rs2_error ** error) try
+int rs2_config_can_resolve(rs2_config* config, rs2_pipeline* pipe, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(pipe);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -124,8 +124,15 @@ namespace librealsense
         if (sensor)
         {
 
-            auto dev = sensor->get_device().shared_from_this().get();
-
+            const device_interface* dev = nullptr;
+            try
+            {
+                dev = sensor->get_device().shared_from_this().get();
+            }
+            catch (const std::bad_weak_ptr& e)
+            {
+                LOG_WARNING("Device destroyed");
+            }
             if (dev)
             {
                 dev_exist = true;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -117,15 +117,16 @@ namespace librealsense
         auto stream_id = frame.frame->get_stream()->get_unique_id();
         auto stream_type = frame.frame->get_stream()->get_stream_type();
 
-        auto sensor = frame.frame->get_sensor();
+        auto sensor = frame.frame->get_sensor().get(); //TODO: Potential deadlock if get_sensor() gets a hold of the last reference of that sensor
 
         auto dev_exist = false;
 
-        if(sensor)
+        if (sensor)
         {
-            auto dev = sensor->get_device().shared_from_this();
 
-            if(dev)
+            auto dev = sensor->get_device().shared_from_this().get();
+
+            if (dev)
             {
                 dev_exist = true;
                 matcher = _matchers[stream_id];
@@ -140,7 +141,7 @@ namespace librealsense
 
                     for (auto stream : matcher->get_streams())
                     {
-                        if(_matchers[stream])
+                        if (_matchers[stream])
                         {
                             _frames_queue.erase(_matchers[stream].get());
                         }
@@ -154,18 +155,20 @@ namespace librealsense
                     }
 
                     if (std::find(_streams_type.begin(), _streams_type.end(), stream_type) == _streams_type.end())
+                    {
                         LOG_ERROR("Stream matcher not found! stream=" << rs2_stream_to_string(stream_type));
+                    }
                 }
-
             }
         }
-        if(!dev_exist)
+
+        if(!dev_exist) 
         {
             matcher = _matchers[stream_id];
             // We don't know what device this frame came from, so just store it under device NULL with ID matcher
             if (!matcher)
             {
-                if(_matchers[stream_id])
+                if (_matchers[stream_id])
                 {
                     _frames_queue.erase(_matchers[stream_id].get());
                 }
@@ -180,10 +183,8 @@ namespace librealsense
                 });
             }
         }
-
         return matcher;
     }
-
 
     void composite_matcher::sync(frame_holder f, syncronization_environment env)
     {

--- a/tools/data-collect/rs-data-collect.cpp
+++ b/tools/data-collect/rs-data-collect.cpp
@@ -212,7 +212,7 @@ int main(int argc, char** argv) try
             }
 
             bool collected_enough_frames = true;
-            for (auto&& profile : pipe.get_active_profile().get_active_streams())
+            for (auto&& profile : pipe.get_active_profile().get_streams())
             {
                 if (buffer[(int)profile.stream_type()].size() < max_frames_number)
                 {

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -37,7 +37,7 @@ namespace rs2
             }
 
             // Toggle advanced mode
-            auto dev = _pipe.get_device();
+            auto dev = _pipe.get_active_profile().get_device();
             if (dev.is<rs400::advanced_mode>())
             {
                 auto advanced_mode = dev.as<rs400::advanced_mode>();
@@ -501,7 +501,7 @@ namespace rs2
                 << "\nFirmware Ver:," << _device_model->dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION)
                 << "\n\nStreaming profile:\nStream,Format,Resolution,FPS\n";
 
-            for (auto& stream : _pipe.get_active_streams())
+            for (auto& stream : _pipe.get_active_profile().get_streams())
             {
                 auto vs = stream.as<video_stream_profile>();
                 ss << vs.stream_name() << ","

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -19,20 +19,21 @@ namespace rs2
 
         void tool_model::start(ux_window& window)
         {
-            _pipe.enable_stream(RS2_STREAM_DEPTH, 0, 0, 0, RS2_FORMAT_Z16, 30);
-            _pipe.enable_stream(RS2_STREAM_INFRARED, 0, 0, 0, RS2_FORMAT_RGB8, 30);
+            rs2::config cfg;
+            cfg.enable_stream(RS2_STREAM_DEPTH, -1, 0, 0, RS2_FORMAT_Z16, 30);
+            cfg.enable_stream(RS2_STREAM_INFRARED, -1, 0, 0, RS2_FORMAT_RGB8, 30);
 
             // Wait till a valid device is found
             try {
-                _pipe.start();
+                _pipe.start(cfg);
             }
             catch (...)
             {
                 // Switch to infrared luminocity as a secondary in case synthetic chroma is not supported
-                _pipe.disable_all();
-                _pipe.enable_stream(RS2_STREAM_DEPTH, 0, 0, 0, RS2_FORMAT_Z16, 30);
-                _pipe.enable_stream(RS2_STREAM_INFRARED, 1, 0, 0, RS2_FORMAT_Y8, 30);
-                _pipe.start();
+                rs2::config cfg;
+                cfg.enable_stream(RS2_STREAM_DEPTH, 0, 0, 0, RS2_FORMAT_Z16, 30);
+                cfg.enable_stream(RS2_STREAM_INFRARED, 1, 0, 0, RS2_FORMAT_Y8, 30);
+                _pipe.start(cfg);
             }
 
             // Toggle advanced mode
@@ -153,16 +154,16 @@ namespace rs2
                             {
                                 // Preserve streams and ui selections
                                 auto primary = _depth_sensor_model->get_selected_profiles().front().as<video_stream_profile>();
-                                auto secondary = _pipe.get_active_streams().back().as<video_stream_profile>();
+                                auto secondary = _pipe.get_active_profile().get_streams().back().as<video_stream_profile>();
                                 _depth_sensor_model->store_ui_selection();
 
                                 _pipe.stop();
 
-                                _pipe.disable_all();
+                                rs2::config cfg;
 
-                                _pipe.enable_stream(primary.stream_type(), primary.stream_index(),
+                                cfg.enable_stream(primary.stream_type(), primary.stream_index(),
                                                     primary.width(), primary.height(), primary.format(), primary.fps());
-                                _pipe.enable_stream(secondary.stream_type(), secondary.stream_index(),
+                                cfg.enable_stream(secondary.stream_type(), secondary.stream_index(),
                                                     primary.width(), primary.height(), secondary.format(), primary.fps());
 
                                 // Wait till a valid device is found and responsive
@@ -171,7 +172,7 @@ namespace rs2
                                 {
                                     try // Retries are needed to cope with HW stability issues
                                     {
-                                        _pipe.start();
+                                        _pipe.start(cfg);
                                         success = true;
                                     }
                                     catch (...){}
@@ -281,7 +282,7 @@ namespace rs2
                 save = true;
             }
 
-            auto dev = _pipe.get_device();
+            auto dev = _pipe.get_active_profile().get_device();
             auto dpt_sensor = dev.first<depth_sensor>();
             _device_model = std::shared_ptr<rs2::device_model>(new device_model(dev, _error_message, _viewer_model));
             _device_model->allow_remove = false;
@@ -326,7 +327,7 @@ namespace rs2
                 if (!sub->s.is<depth_sensor>()) continue;
 
                 sub->show_algo_roi = true;
-                auto profiles = _pipe.get_active_streams();
+                auto profiles = _pipe.get_active_profile().get_streams();
                 sub->streaming = true;      // The streaming activated externally to the device_model
                 for (auto&& profile : profiles)
                 {

--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -2272,23 +2272,128 @@ class RSFrameSet : public Nan::ObjectWrap {
 
 Nan::Persistent<v8::Function> RSFrameSet::constructor;
 
-class RSPipeline : public Nan::ObjectWrap {
+
+
+class RSPipelineProfile : public Nan::ObjectWrap {
  public:
   static void Init(v8::Local<v8::Object> exports) {
     v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
-    tpl->SetClassName(Nan::New("RSPipeline").ToLocalChecked());
+    tpl->SetClassName(Nan::New("RSPipelineProfile").ToLocalChecked());
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+    Nan::SetPrototypeMethod(tpl, "getStreams", GetStreams);
+    Nan::SetPrototypeMethod(tpl, "getDevice", GetDevice);
+   
+    constructor.Reset(tpl->GetFunction());
+    exports->Set(Nan::New("RSPipelineProfile").ToLocalChecked(), tpl->GetFunction());
+  }
+
+  static v8::Local<v8::Object> NewInstance(rs2_pipeline_profile* profile) {
+    Nan::EscapableHandleScope scope;
+
+    v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
+    v8::Local<v8::Context> context =
+        v8::Isolate::GetCurrent()->GetCurrentContext();
+
+    v8::Local<v8::Object> instance =
+        cons->NewInstance(context, 0, nullptr).ToLocalChecked();
+
+    auto me = Nan::ObjectWrap::Unwrap<RSPipelineProfile>(instance);
+    me->pipelineProfile = profile;
+    return scope.Escape(instance);
+  }
+
+ private:
+ 
+  RSPipelineProfile() {
+    error = nullptr;
+    pipelineProfile = nullptr;
+  }
+
+  ~RSPipelineProfile() {
+    DestroyMe();
+  }
+
+  void DestroyMe() {
+   
+  }
+
+  static NAN_METHOD(Destroy) {
+    auto me = Nan::ObjectWrap::Unwrap<RSPipelineProfile>(info.Holder());
+    if (me) me->DestroyMe();
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    if (info.IsConstructCall()) {
+      RSPipelineProfile* obj = new RSPipelineProfile();
+      obj->Wrap(info.This());
+      info.GetReturnValue().Set(info.This());
+    }
+  }
+
+
+
+static NAN_METHOD(GetStreams) {
+    auto me = Nan::ObjectWrap::Unwrap<RSPipelineProfile>(info.Holder());
+    if (me) {
+      rs2_stream_profile_list* list = rs2_pipeline_profile_get_streams(me->pipelineProfile, &me->error);
+     
+      if (list) {
+        int32_t size = rs2_get_stream_profiles_count(list, &me->error);
+        v8::Local<v8::Array> array = Nan::New<v8::Array>(size);
+        for (int32_t i = 0; i < size; i++) {
+          rs2_stream_profile* profile = const_cast<rs2_stream_profile*>(
+              rs2_get_stream_profile(list, i, &me->error));
+          array->Set(i, RSStreamProfile::NewInstance(profile));
+        }
+        info.GetReturnValue().Set(array);
+        return;
+      }
+    }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+static NAN_METHOD(GetDevice) {
+     auto me = Nan::ObjectWrap::Unwrap<RSPipelineProfile>(info.Holder());
+    if (me) {
+      rs2_device* dev = rs2_pipeline_profile_get_device(me->pipelineProfile, &me->error);
+      if (dev) {
+        info.GetReturnValue().Set(RSDevice::NewInstance(dev));
+        return;
+      }
+    }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+ private:
+  static Nan::Persistent<v8::Function> constructor;
+
+  rs2_pipeline_profile* pipelineProfile;
+  rs2_error* error;
+};
+Nan::Persistent<v8::Function> RSPipelineProfile::constructor;
+
+class RSPipeline;
+class RSConfig :public Nan::ObjectWrap  {
+ public:
+  static void Init(v8::Local<v8::Object> exports) {
+    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+    tpl->SetClassName(Nan::New("RSConfig").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
     Nan::SetPrototypeMethod(tpl, "destroy", Destroy);
-    Nan::SetPrototypeMethod(tpl, "create", Create);
-    Nan::SetPrototypeMethod(tpl, "waitForFrames", WaitForFrames);
-    Nan::SetPrototypeMethod(tpl, "startWithAlign", StartWithAlign);
-    Nan::SetPrototypeMethod(tpl, "start", Start);
-    Nan::SetPrototypeMethod(tpl, "stop", Stop);
-    Nan::SetPrototypeMethod(tpl, "getDevice", GetDevice);
+    Nan::SetPrototypeMethod(tpl, "enableStream", EnableStream);
+    Nan::SetPrototypeMethod(tpl, "enableAllStreams", EnableAllStreams);
+    Nan::SetPrototypeMethod(tpl, "enableDevice", EnableDevice);
+    Nan::SetPrototypeMethod(tpl, "enableDeviceFromFile", EnableDeviceFromFile); 
+    Nan::SetPrototypeMethod(tpl, "enableRecordToFile", EnableRecordToFile);
+    Nan::SetPrototypeMethod(tpl, "disableStream", DisableStream);
+    Nan::SetPrototypeMethod(tpl, "disableAllStreams", DisableAllStreams);
+    Nan::SetPrototypeMethod(tpl, "resolve", Resolve);
+    Nan::SetPrototypeMethod(tpl, "canResolve", CanResolve);
 
     constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("RSPipeline").ToLocalChecked(), tpl->GetFunction());
+    exports->Set(Nan::New("RSConfig").ToLocalChecked(), tpl->GetFunction());
   }
 
   static v8::Local<v8::Object> NewInstance() {
@@ -2307,7 +2412,226 @@ class RSPipeline : public Nan::ObjectWrap {
   }
 
  private:
-  static NAN_METHOD(StartWithAlign);
+ 
+  RSConfig() {
+    error = nullptr;
+    config = nullptr;
+  }
+
+  ~RSConfig() {
+    DestroyMe();
+  }
+
+  void DestroyMe() {
+    if (error) rs2_free_error(error);
+    error = nullptr;
+    if (config) rs2_delete_config(config);
+    config = nullptr;
+  }
+
+  static NAN_METHOD(Destroy) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+    if (me) me->DestroyMe();
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+  static void New(const Nan::FunctionCallbackInfo<v8::Value>& info) {
+    if (info.IsConstructCall()) {
+      RSConfig* obj = new RSConfig();
+      obj->Wrap(info.This());
+      info.GetReturnValue().Set(info.This());
+    }
+  }
+
+  static NAN_METHOD(Create) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+   
+    if (me) {
+      me->config = rs2_create_config(&me->error);
+    }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+  //TODO: added all the overloads
+  static NAN_METHOD(EnableStream) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+
+    auto stream = info[0]->IntegerValue();
+    auto index = info[1]->IntegerValue();
+    auto width = info[2]->IntegerValue();
+    auto height = info[3]->IntegerValue();
+    auto format = info[4]->IntegerValue();
+    auto framerate = info[5]->IntegerValue();
+
+    if (me && me->config) {
+      rs2_config_enable_stream(me->config, (rs2_stream)stream, index, width, height, (rs2_format)format, framerate, &me->error);
+    }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+  static NAN_METHOD(EnableAllStreams) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+
+    if (me) {
+      rs2_config_enable_all_stream(
+          me->config, &me->error);
+      }
+    
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+  static NAN_METHOD(EnableDevice) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+
+   auto device = info[0]->ToString();
+   v8::String::Utf8Value value(device);
+
+    if (me) {
+      rs2_config_enable_device(me->config, *value,
+          &me->error);
+     
+      }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+   static NAN_METHOD(EnableDeviceFromFile) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+
+   auto device_file = info[0]->ToString();
+   v8::String::Utf8Value value(device_file);
+
+    if (me) {
+      rs2_config_enable_device_from_file(me->config, *value, 
+          &me->error);
+     
+      }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+static NAN_METHOD(EnableRecordToFile) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+
+   auto device_file = info[0]->ToString();
+   v8::String::Utf8Value value(device_file);
+
+    if (me) {
+      rs2_config_enable_record_to_file(me->config, *value, 
+          &me->error);
+     
+      }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+static NAN_METHOD(DisableStream) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+
+   auto stream = info[0]->IntegerValue();
+
+
+    if (me) {
+      rs2_config_disable_stream(me->config, (rs2_stream)stream, 
+          &me->error);
+     
+      }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+static NAN_METHOD(DisableAllStreams) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+
+  
+    if (me) {
+      rs2_config_disable_all_streams(me->config, 
+          &me->error);
+     
+      }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+static NAN_METHOD(Resolve) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+    RSPipeline* pipe = Nan::ObjectWrap::Unwrap<RSPipeline>(info[0]->ToObject());
+  
+    if (me) {
+      auto pipelineProfile = me->ResolveInternal( me->config,  pipe, &me->error);
+     
+    
+      info.GetReturnValue().Set(pipelineProfile);
+      return;
+      }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+static NAN_METHOD(CanResolve) {
+    auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
+    RSPipeline* pipe = Nan::ObjectWrap::Unwrap<RSPipeline>(info[0]->ToObject());
+  
+    if (me) {
+     if(me->CanResolveInternal(me->config, pipe, &me->error)){
+       info.GetReturnValue().Set(Nan::New(true));
+        return;
+      }
+      info.GetReturnValue().Set(Nan::New(false));
+      return;
+    }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+v8::Local<v8::Object> ResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error);
+bool CanResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error);
+
+
+
+
+
+ private:
+  static Nan::Persistent<v8::Function> constructor;
+  friend class RSPipeline;
+
+  rs2_config* config;
+  rs2_error* error;
+};
+
+Nan::Persistent<v8::Function> RSConfig::constructor;
+
+class RSPipeline : public Nan::ObjectWrap {
+ public:
+  static void Init(v8::Local<v8::Object> exports) {
+    v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+    tpl->SetClassName(Nan::New("RSPipeline").ToLocalChecked());
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+    Nan::SetPrototypeMethod(tpl, "start", Start);
+    Nan::SetPrototypeMethod(tpl, "startWithConfig", StartWithConfig);
+    Nan::SetPrototypeMethod(tpl, "stop", Stop);
+    Nan::SetPrototypeMethod(tpl, "waitForFrames", WaitForFrames);
+    Nan::SetPrototypeMethod(tpl, "pollForFrames", PollForFrames);		
+    Nan::SetPrototypeMethod(tpl, "getActiveProfile", GetActiveProfile);
+    Nan::SetPrototypeMethod(tpl, "create", Create);
+
+    
+    constructor.Reset(tpl->GetFunction());
+    exports->Set(Nan::New("RSPipeline").ToLocalChecked(), tpl->GetFunction());
+  }
+
+
+  static v8::Local<v8::Object> NewInstance() {
+    Nan::EscapableHandleScope scope;
+
+    v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
+    v8::Local<v8::Context> context =
+        v8::Isolate::GetCurrent()->GetCurrentContext();
+
+    v8::Local<v8::Object> instance =
+        cons->NewInstance(context, 0, nullptr).ToLocalChecked();
+
+    // auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(instance);
+
+    return scope.Escape(instance);
+  }
+
+ private:
+ friend class RSConfig;
   RSPipeline() {
     error = nullptr;
     pipeline = nullptr;
@@ -2350,10 +2674,23 @@ class RSPipeline : public Nan::ObjectWrap {
     info.GetReturnValue().Set(Nan::Undefined());
   }
 
+  static NAN_METHOD(StartWithConfig) {
+    auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
+
+    RSConfig* config = Nan::ObjectWrap::Unwrap<RSConfig>(info[0]->ToObject());
+    if (me && me->pipeline) {
+      rs2_pipeline_profile* prof = rs2_pipeline_start_with_config(me->pipeline, config->config, &me->error);
+      info.GetReturnValue().Set(RSPipelineProfile::NewInstance(prof));
+    }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
   static NAN_METHOD(Start) {
     auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
     if (me && me->pipeline) {
-      rs2_start_pipeline(me->pipeline, &me->error);
+      
+      rs2_pipeline_profile* prof = rs2_pipeline_start(me->pipeline, &me->error);
+      info.GetReturnValue().Set(RSPipelineProfile::NewInstance(prof));
     }
     info.GetReturnValue().Set(Nan::Undefined());
   }
@@ -2361,7 +2698,7 @@ class RSPipeline : public Nan::ObjectWrap {
   static NAN_METHOD(Stop) {
     auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
     if (me && me->pipeline) {
-      rs2_stop_pipeline(me->pipeline, &me->error);
+      rs2_pipeline_stop(me->pipeline, &me->error);
     }
     info.GetReturnValue().Set(Nan::Undefined());
   }
@@ -2380,13 +2717,26 @@ class RSPipeline : public Nan::ObjectWrap {
     info.GetReturnValue().Set(Nan::Undefined());
   }
 
-  static NAN_METHOD(GetDevice) {
+ static NAN_METHOD(PollForFrames) {
+       auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
+    if (me) {
+      rs2_frame* frame = nullptr;
+      auto res = rs2_pipeline_poll_for_frames(me->pipeline, &frame, &me->error);
+      if (res) {
+        info.GetReturnValue().Set(RSFrameSet::NewInstance(frame));
+        return;
+      }
+    }
+    info.GetReturnValue().Set(Nan::Undefined());
+  }
+
+  static NAN_METHOD(GetActiveProfile) {
     auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
     if (me) {
-      rs2_device* dev = rs2_pipeline_get_device(me->ctx, me->pipeline,
+      rs2_pipeline_profile* prof = rs2_pipeline_get_active_profile(me->pipeline,
           &me->error);
-      if (dev) {
-        info.GetReturnValue().Set(RSDevice::NewInstance(dev));
+      if (prof) {
+        info.GetReturnValue().Set(RSPipelineProfile::NewInstance(prof));
         return;
       }
     }
@@ -2402,6 +2752,19 @@ class RSPipeline : public Nan::ObjectWrap {
 };
 
 Nan::Persistent<v8::Function> RSPipeline::constructor;
+
+
+v8::Local<v8::Object> RSConfig::ResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error) {
+    auto pipelineProfile = rs2_config_resolve(config, pipe->pipeline, error);
+    auto profile = RSPipelineProfile::NewInstance(pipelineProfile);
+   
+    return profile;
+  }
+
+bool RSConfig::CanResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error) {
+
+     return rs2_config_can_resolve(config, pipe->pipeline, error);
+  }
 
 class RSColorizer : public Nan::ObjectWrap {
  public:
@@ -2584,16 +2947,6 @@ class RSAlign : public Nan::ObjectWrap {
 
 Nan::Persistent<v8::Function> RSAlign::constructor;
 
-NAN_METHOD(RSPipeline::StartWithAlign) {
-  auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
-  auto align = Nan::ObjectWrap::Unwrap<RSAlign>(info[0]->ToObject());
-  if (me && align && me->pipeline) {
-    rs2_start_pipeline_with_callback_cpp(me->pipeline,
-        new FrameCallbackForProcessingBlock(align->align), &me->error);
-  }
-  info.GetReturnValue().Set(Nan::Undefined());
-}
-
 
 ///////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -2633,6 +2986,8 @@ void InitModule(v8::Local<v8::Object> exports) {
 
   RSContext::Init(exports);
   RSPointcloud::Init(exports);
+  RSPipelineProfile::Init(exports);
+  RSConfig::Init(exports);
   RSPipeline::Init(exports);
   RSFrameSet::Init(exports);
   RSSensor::Init(exports);

--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -2283,6 +2283,7 @@ class RSPipelineProfile : public Nan::ObjectWrap {
 
     Nan::SetPrototypeMethod(tpl, "getStreams", GetStreams);
     Nan::SetPrototypeMethod(tpl, "getDevice", GetDevice);
+    Nan::SetPrototypeMethod(tpl, "destroy", Destroy);
    
     constructor.Reset(tpl->GetFunction());
     exports->Set(Nan::New("RSPipelineProfile").ToLocalChecked(), tpl->GetFunction());
@@ -2608,7 +2609,7 @@ class RSPipeline : public Nan::ObjectWrap {
     Nan::SetPrototypeMethod(tpl, "pollForFrames", PollForFrames);		
     Nan::SetPrototypeMethod(tpl, "getActiveProfile", GetActiveProfile);
     Nan::SetPrototypeMethod(tpl, "create", Create);
-
+    Nan::SetPrototypeMethod(tpl, "destroy", Destroy);
     
     constructor.Reset(tpl->GetFunction());
     exports->Set(Nan::New("RSPipeline").ToLocalChecked(), tpl->GetFunction());

--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -2284,9 +2284,9 @@ class RSPipelineProfile : public Nan::ObjectWrap {
     Nan::SetPrototypeMethod(tpl, "getStreams", GetStreams);
     Nan::SetPrototypeMethod(tpl, "getDevice", GetDevice);
     Nan::SetPrototypeMethod(tpl, "destroy", Destroy);
-   
     constructor.Reset(tpl->GetFunction());
-    exports->Set(Nan::New("RSPipelineProfile").ToLocalChecked(), tpl->GetFunction());
+    exports->Set(Nan::New("RSPipelineProfile").ToLocalChecked(),
+      tpl->GetFunction());
   }
 
   static v8::Local<v8::Object> NewInstance(rs2_pipeline_profile* profile) {
@@ -2305,7 +2305,6 @@ class RSPipelineProfile : public Nan::ObjectWrap {
   }
 
  private:
- 
   RSPipelineProfile() {
     error = nullptr;
     pipelineProfile = nullptr;
@@ -2316,7 +2315,6 @@ class RSPipelineProfile : public Nan::ObjectWrap {
   }
 
   void DestroyMe() {
-   
   }
 
   static NAN_METHOD(Destroy) {
@@ -2338,8 +2336,9 @@ class RSPipelineProfile : public Nan::ObjectWrap {
 static NAN_METHOD(GetStreams) {
     auto me = Nan::ObjectWrap::Unwrap<RSPipelineProfile>(info.Holder());
     if (me) {
-      rs2_stream_profile_list* list = rs2_pipeline_profile_get_streams(me->pipelineProfile, &me->error);
-     
+      rs2_stream_profile_list* list =
+              rs2_pipeline_profile_get_streams(me->pipelineProfile, &me->error);
+
       if (list) {
         int32_t size = rs2_get_stream_profiles_count(list, &me->error);
         v8::Local<v8::Array> array = Nan::New<v8::Array>(size);
@@ -2357,7 +2356,8 @@ static NAN_METHOD(GetStreams) {
 static NAN_METHOD(GetDevice) {
      auto me = Nan::ObjectWrap::Unwrap<RSPipelineProfile>(info.Holder());
     if (me) {
-      rs2_device* dev = rs2_pipeline_profile_get_device(me->pipelineProfile, &me->error);
+      rs2_device* dev =
+               rs2_pipeline_profile_get_device(me->pipelineProfile, &me->error);
       if (dev) {
         info.GetReturnValue().Set(RSDevice::NewInstance(dev));
         return;
@@ -2386,7 +2386,7 @@ class RSConfig :public Nan::ObjectWrap  {
     Nan::SetPrototypeMethod(tpl, "enableStream", EnableStream);
     Nan::SetPrototypeMethod(tpl, "enableAllStreams", EnableAllStreams);
     Nan::SetPrototypeMethod(tpl, "enableDevice", EnableDevice);
-    Nan::SetPrototypeMethod(tpl, "enableDeviceFromFile", EnableDeviceFromFile); 
+    Nan::SetPrototypeMethod(tpl, "enableDeviceFromFile", EnableDeviceFromFile);
     Nan::SetPrototypeMethod(tpl, "enableRecordToFile", EnableRecordToFile);
     Nan::SetPrototypeMethod(tpl, "disableStream", DisableStream);
     Nan::SetPrototypeMethod(tpl, "disableAllStreams", DisableAllStreams);
@@ -2413,7 +2413,6 @@ class RSConfig :public Nan::ObjectWrap  {
   }
 
  private:
- 
   RSConfig() {
     error = nullptr;
     config = nullptr;
@@ -2446,14 +2445,14 @@ class RSConfig :public Nan::ObjectWrap  {
 
   static NAN_METHOD(Create) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
-   
+
     if (me) {
       me->config = rs2_create_config(&me->error);
     }
     info.GetReturnValue().Set(Nan::Undefined());
   }
 
-  //TODO: added all the overloads
+  // TODO(halton): added all the overloads
   static NAN_METHOD(EnableStream) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
 
@@ -2465,7 +2464,14 @@ class RSConfig :public Nan::ObjectWrap  {
     auto framerate = info[5]->IntegerValue();
 
     if (me && me->config) {
-      rs2_config_enable_stream(me->config, (rs2_stream)stream, index, width, height, (rs2_format)format, framerate, &me->error);
+      rs2_config_enable_stream(me->config,
+        (rs2_stream)stream,
+        index,
+        width,
+        height,
+        (rs2_format)format,
+        framerate,
+        &me->error);
     }
     info.GetReturnValue().Set(Nan::Undefined());
   }
@@ -2477,34 +2483,31 @@ class RSConfig :public Nan::ObjectWrap  {
       rs2_config_enable_all_stream(
           me->config, &me->error);
       }
-    
+
     info.GetReturnValue().Set(Nan::Undefined());
   }
 
   static NAN_METHOD(EnableDevice) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
-
-   auto device = info[0]->ToString();
-   v8::String::Utf8Value value(device);
+    auto device = info[0]->ToString();
+    v8::String::Utf8Value value(device);
 
     if (me) {
       rs2_config_enable_device(me->config, *value,
           &me->error);
-     
       }
     info.GetReturnValue().Set(Nan::Undefined());
   }
 
-   static NAN_METHOD(EnableDeviceFromFile) {
+  static NAN_METHOD(EnableDeviceFromFile) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
 
-   auto device_file = info[0]->ToString();
-   v8::String::Utf8Value value(device_file);
+    auto device_file = info[0]->ToString();
+    v8::String::Utf8Value value(device_file);
 
     if (me) {
-      rs2_config_enable_device_from_file(me->config, *value, 
+      rs2_config_enable_device_from_file(me->config, *value,
           &me->error);
-     
       }
     info.GetReturnValue().Set(Nan::Undefined());
   }
@@ -2512,13 +2515,12 @@ class RSConfig :public Nan::ObjectWrap  {
 static NAN_METHOD(EnableRecordToFile) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
 
-   auto device_file = info[0]->ToString();
-   v8::String::Utf8Value value(device_file);
+    auto device_file = info[0]->ToString();
+    v8::String::Utf8Value value(device_file);
 
     if (me) {
-      rs2_config_enable_record_to_file(me->config, *value, 
+      rs2_config_enable_record_to_file(me->config, *value,
           &me->error);
-     
       }
     info.GetReturnValue().Set(Nan::Undefined());
   }
@@ -2526,13 +2528,12 @@ static NAN_METHOD(EnableRecordToFile) {
 static NAN_METHOD(DisableStream) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
 
-   auto stream = info[0]->IntegerValue();
+    auto stream = info[0]->IntegerValue();
 
 
     if (me) {
-      rs2_config_disable_stream(me->config, (rs2_stream)stream, 
+      rs2_config_disable_stream(me->config, (rs2_stream)stream,
           &me->error);
-     
       }
     info.GetReturnValue().Set(Nan::Undefined());
   }
@@ -2540,11 +2541,10 @@ static NAN_METHOD(DisableStream) {
 static NAN_METHOD(DisableAllStreams) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
 
-  
+
     if (me) {
-      rs2_config_disable_all_streams(me->config, 
+      rs2_config_disable_all_streams(me->config,
           &me->error);
-     
       }
     info.GetReturnValue().Set(Nan::Undefined());
   }
@@ -2552,11 +2552,13 @@ static NAN_METHOD(DisableAllStreams) {
 static NAN_METHOD(Resolve) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
     RSPipeline* pipe = Nan::ObjectWrap::Unwrap<RSPipeline>(info[0]->ToObject());
-  
+
     if (me) {
-      auto pipelineProfile = me->ResolveInternal( me->config,  pipe, &me->error);
-     
-    
+        auto pipelineProfile = me->ResolveInternal(me->config,
+                                                  pipe,
+                                                  &me->error);
+
+
       info.GetReturnValue().Set(pipelineProfile);
       return;
       }
@@ -2566,9 +2568,9 @@ static NAN_METHOD(Resolve) {
 static NAN_METHOD(CanResolve) {
     auto me = Nan::ObjectWrap::Unwrap<RSConfig>(info.Holder());
     RSPipeline* pipe = Nan::ObjectWrap::Unwrap<RSPipeline>(info[0]->ToObject());
-  
+
     if (me) {
-     if(me->CanResolveInternal(me->config, pipe, &me->error)){
+     if (me->CanResolveInternal(me->config, pipe, &me->error)) {
        info.GetReturnValue().Set(Nan::New(true));
         return;
       }
@@ -2578,8 +2580,10 @@ static NAN_METHOD(CanResolve) {
     info.GetReturnValue().Set(Nan::Undefined());
   }
 
-v8::Local<v8::Object> ResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error);
-bool CanResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error);
+v8::Local<v8::Object> ResolveInternal(rs2_config* config,
+  RSPipeline* pipe, rs2_error** error);
+bool CanResolveInternal(rs2_config* config,
+  RSPipeline* pipe, rs2_error** error);
 
 
 
@@ -2606,11 +2610,11 @@ class RSPipeline : public Nan::ObjectWrap {
     Nan::SetPrototypeMethod(tpl, "startWithConfig", StartWithConfig);
     Nan::SetPrototypeMethod(tpl, "stop", Stop);
     Nan::SetPrototypeMethod(tpl, "waitForFrames", WaitForFrames);
-    Nan::SetPrototypeMethod(tpl, "pollForFrames", PollForFrames);		
+    Nan::SetPrototypeMethod(tpl, "pollForFrames", PollForFrames);
     Nan::SetPrototypeMethod(tpl, "getActiveProfile", GetActiveProfile);
     Nan::SetPrototypeMethod(tpl, "create", Create);
     Nan::SetPrototypeMethod(tpl, "destroy", Destroy);
-    
+
     constructor.Reset(tpl->GetFunction());
     exports->Set(Nan::New("RSPipeline").ToLocalChecked(), tpl->GetFunction());
   }
@@ -2632,7 +2636,7 @@ class RSPipeline : public Nan::ObjectWrap {
   }
 
  private:
- friend class RSConfig;
+    friend class RSConfig;
   RSPipeline() {
     error = nullptr;
     pipeline = nullptr;
@@ -2680,7 +2684,8 @@ class RSPipeline : public Nan::ObjectWrap {
 
     RSConfig* config = Nan::ObjectWrap::Unwrap<RSConfig>(info[0]->ToObject());
     if (me && me->pipeline) {
-      rs2_pipeline_profile* prof = rs2_pipeline_start_with_config(me->pipeline, config->config, &me->error);
+      rs2_pipeline_profile* prof =
+       rs2_pipeline_start_with_config(me->pipeline, config->config, &me->error);
       info.GetReturnValue().Set(RSPipelineProfile::NewInstance(prof));
     }
     info.GetReturnValue().Set(Nan::Undefined());
@@ -2689,7 +2694,6 @@ class RSPipeline : public Nan::ObjectWrap {
   static NAN_METHOD(Start) {
     auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
     if (me && me->pipeline) {
-      
       rs2_pipeline_profile* prof = rs2_pipeline_start(me->pipeline, &me->error);
       info.GetReturnValue().Set(RSPipelineProfile::NewInstance(prof));
     }
@@ -2718,7 +2722,7 @@ class RSPipeline : public Nan::ObjectWrap {
     info.GetReturnValue().Set(Nan::Undefined());
   }
 
- static NAN_METHOD(PollForFrames) {
+  static NAN_METHOD(PollForFrames) {
        auto me = Nan::ObjectWrap::Unwrap<RSPipeline>(info.Holder());
     if (me) {
       rs2_frame* frame = nullptr;
@@ -2755,16 +2759,19 @@ class RSPipeline : public Nan::ObjectWrap {
 Nan::Persistent<v8::Function> RSPipeline::constructor;
 
 
-v8::Local<v8::Object> RSConfig::ResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error) {
+v8::Local<v8::Object> RSConfig::ResolveInternal(rs2_config* config,
+                                                RSPipeline* pipe,
+                                                rs2_error** error) {
     auto pipelineProfile = rs2_config_resolve(config, pipe->pipeline, error);
     auto profile = RSPipelineProfile::NewInstance(pipelineProfile);
-   
+
     return profile;
   }
 
-bool RSConfig::CanResolveInternal(rs2_config* config, RSPipeline* pipe, rs2_error** error) {
-
-     return rs2_config_can_resolve(config, pipe->pipeline, error);
+bool RSConfig::CanResolveInternal(rs2_config* config,
+                                  RSPipeline* pipe,
+                                  rs2_error** error) {
+    return rs2_config_can_resolve(config, pipe->pipeline, error);
   }
 
 class RSColorizer : public Nan::ObjectWrap {

--- a/wrappers/python/opencv_viewer_example.py
+++ b/wrappers/python/opencv_viewer_example.py
@@ -4,11 +4,12 @@ import cv2
 
 # Configure depth and color streams
 pipeline = rs.pipeline()
-pipeline.enable_stream(rs.stream.depth, 0, 640, 480, rs.format.z16, 30)
-pipeline.enable_stream(rs.stream.color, 0, 640, 480, rs.format.bgr8, 30)
+config = rs.config()
+config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
+config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)
 
 # Start streaming
-pipeline.start()
+pipeline.start(config)
 
 try:
     while True:

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -612,27 +612,47 @@ PYBIND11_PLUGIN(NAME) {
                 .def("__nonzero__", &rs2::depth_sensor::operator bool);
 
     /* rs2_pipeline.hpp */
+
+
     py::class_<rs2::pipeline> pipeline(m, "pipeline");
     pipeline.def(py::init<rs2::context>(), "ctx"_a = rs2::context())
-            .def("get_device", &rs2::pipeline::get_device)
-            .def("start", (void (rs2::pipeline::*)()const) &rs2::pipeline::start)
-            .def("stop", &rs2::pipeline::stop)
-            .def("enable_stream" , &rs2::pipeline::enable_stream, "stream"_a, "index"_a,
-                 "width"_a, "height"_a, "format"_a, "framerate"_a)
-            .def("disable_stream", &rs2::pipeline::disable_stream, "stream"_a)
-            .def("disable_all", &rs2::pipeline::disable_all)
-            .def("wait_for_frames", &rs2::pipeline::wait_for_frames, "timeout_ms"_a = 5000)
-            .def("poll_for_frames", &rs2::pipeline::poll_for_frames, "frameset*"_a)
-            .def("enable_device",  &rs2::pipeline::enable_device,  "std::string"_a)
-            .def("get_active_streams", (rs2::stream_profile (rs2::pipeline::*)(const rs2_stream, const int) const)
-                 &rs2::pipeline::get_active_streams, "stream"_a, "index"_a = 0)
-            .def("get_active_streams", (std::vector<rs2::stream_profile> (rs2::pipeline::*)() const)
-                 &rs2::pipeline::get_active_streams)
-            .def("open", &rs2::pipeline::open);
+    .def("start", (rs2::pipeline_profile (rs2::pipeline::*)(const rs2::config&)) &rs2::pipeline::start, "config")
+    .def("start", (rs2::pipeline_profile (rs2::pipeline::*)() ) &rs2::pipeline::start)
+    .def("stop", &rs2::pipeline::stop)
+    .def("wait_for_frames", &rs2::pipeline::wait_for_frames, "timeout_ms"_a = 5000)
+    .def("poll_for_frames", &rs2::pipeline::poll_for_frames, "frameset*"_a);
+
+
+    /* rs2_pipeline.hpp */
+    py::class_<rs2::pipeline_profile> pipeline_profile(m, "pipeline_profile");
+    pipeline_profile.def(py::init<>())
+            .def("get_streams", &rs2::pipeline_profile::get_streams)
+            .def("get_device", &rs2::pipeline_profile::get_device);
+
+
+    py::class_<rs2::config> config(m, "config");
+    config.def(py::init<>())
+            .def("enable_stream", (void (rs2::config::*)(rs2_stream, int, int, int, rs2_format, int)) &rs2::config::enable_stream, "stream_type"_a, "stream_index"_a, "width"_a, "height"_a, "format"_a = RS2_FORMAT_ANY, "framerate"_a = 0)
+            .def("enable_stream", (void (rs2::config::*)(rs2_stream, int)) &rs2::config::enable_stream, "stream_type"_a, "stream_index"_a = -1)
+            .def("enable_stream", (void (rs2::config::*)(rs2_stream, int, int, rs2_format, int)) &rs2::config::enable_stream, "stream_type"_a, "width"_a, "height"_a, "format"_a = RS2_FORMAT_ANY, "framerate"_a = 0)
+            .def("enable_stream", (void (rs2::config::*)(rs2_stream, rs2_format, int))&rs2::config::enable_stream, "stream_type"_a, "format"_a, "framerate"_a = 0)
+            .def("enable_stream", (void (rs2::config::*)(rs2_stream, int , rs2_format, int)) &rs2::config::enable_stream, "stream_type"_a, "stream_index"_a, "format"_a, "framerate"_a = 0)
+            .def("enable_all_streams", &rs2::config::enable_all_streams)
+            .def("enable_device",  &rs2::config::enable_device,  "serial"_a)
+            .def("enable_device_from_file", &rs2::config::enable_device_from_file, "file_name"_a)
+            .def("enable_record_to_file", &rs2::config::enable_record_to_file, "file_name"_a)
+            .def("disable_stream", &rs2::config::disable_stream, "stream"_a)
+            .def("disable_all_streams", &rs2::config::disable_all_streams)
+            .def("resolve", (rs2::pipeline_profile (rs2::config::*)(rs2::pipeline) const) &rs2::config::resolve, "pipeline"_a)
+            .def("can_resolve", (bool (rs2::config::*)(rs2::pipeline) const) &rs2::config::can_resolve, "pipeline"_a);
+
 
     /* rs2.hpp */
     m.def("log_to_console", &rs2::log_to_console, "min_severity"_a);
     m.def("log_to_file", &rs2::log_to_file, "min_severity"_a, "file_path"_a);
 
     return m.ptr();
+
+
+
 }


### PR DESCRIPTION
## Comprehensive API refactoring of pipeline.

Split pipeline functionality into 3 classes: config, profile, pipeline.
Updated all samples, tools and tests to new API.

Previous API had a single class that encapsulated all capabilities, of both configuring, selecting and streaming with `rs2::pipeline`. These capabilities have been split apart now for the simplest use, without any configuration requirements, the `pipeline` remains similar to before.

**`rs2::config`** - responsible for configuration constraints
**`rs2::pipeline_profile`** - stateless object representing the device and streams of the pipeline (or of the resolved configuration)
**`rs2::pipeline`** - facade for streaming over RealSense devices and in the future also managing computer vision modules.


#Pipeline API usage

#### Pipeline Creation

```cpp
rs2::pipeline pipe;
```

#### Starting streaming with default configuration:


```cpp
rs2::pipeline pipe;
pipe.start();
```
The `start` function now returns a `rs2::pipeline_profile` which represents the profile that the pipeline chose to start the device with:

```cpp
rs2::pipeline pipe;
rs2::pipeline_profile profile = pipe.start();
```

#### Getting the device and active streams

Using the `rs2::pipeline_profile` we can get the `rs2::device` and `rs2::stream_profile`s:

```cpp
rs2::pipeline pipe;
rs2::pipeline_profile profile = pipe.start();

rs2::device dev = profile.get_device();
std::vector<stream_profile> streams =  profile.get_streams()
```
The `rs2::pipeline_profile` can also be retrieved from an already started `pipeline` by calling the `get_active_profile` function:

```cpp
//pipe.start();

rs2::pipeline_profile profile = pipe.get_active_profile();
```

#### Getting Frames

In order to get frames from an active `rs2::pipeline` we have 2 methods:

##### Blocking
```cpp
rs2::pipeline pipe;
pipe.start();

rs2::frameset frames = pipe.wait_for_frames(); //Blocking call
```

##### Non Blocking

```cpp
rs2::pipeline pipe;
pipe.start();

rs2::frameset frames;
if(pipe.poll_for_frames(frames)) //Non blocking call
{
    //Use frames
}
```

#### Configuring the pipeline

The new API provides the `rs2::config` class that enables `pipeline` users to add constraints on which device and/or which streams that pipeline will use.

#### Creating a default configuration

```cpp
rs2::config cfg;
```

This will create a default configuration object that has no constraints.

The `pipeline` has an overload for the `start` function that takes a `rs2::config`:

```cpp
rs2::config cfg;
rs2::pipeline pipe;
pipe.start(cfg);
```

Passing this default configuration to the `pipeline::start` method is equivalent to calling the `pipeline::start` without any parameters.

#### Adding constraints to the configuraion


The `rs2::config` class has a number of functions that allow users to add constrains on the `pipeline`

##### Selecting a certain stream

To enable a specific stream, simply call the `rs2::config::enable_stream` function with the desired stream:

```cpp
rs2::config cfg;
cfg.enable_stream(RS2_STREAM_DEPTH);
rs2::pipeline pipe;
pipe.start(cfg);
```

The above will indicate that the user is requesting the `pipeline` to start with a device that provides a depth stream.

If a certain device has a sensor that provides more than one stream of the same type, it is possible by passing a stream type and a corresponding stream index:

```cpp
rs2::config cfg;
cfg.enable_stream(RS2_STREAM_INFRARED, 1);
rs2::pipeline pipe;
pipe.start(cfg);
```

This will indicate that the user wants IR #1 to be streaming, and not just any IR stream.

##### Selecting a certain resolution / FPS / Format

The `rs2::config::enable_stream`  has several overloads which allows users to easily specify a certain resolution, frame rate and/or format. In any case, the stream type is required to be specified.

```cpp
rs2::config cfg;
cfg.enable_stream(RS2_STREAM_COLOR, 1920, 1080);
rs2::pipeline pipe;
pipe.start(cfg);
```

This will indicate that the user wants a color stream with a FHD resolution.
#### Selecting a specific device

The `rs2::config` allows users to indicate which specific device they want to use.

##### Selecting device by serial number

If you know the serial number of the device you wish to use, you can specify it to `enable_device`:

```cpp
const std::string my_D400_camera_serial = "123456789";

rs2::config cfg;
cfg.enable_device(my_D400_camera_serial );
rs2::pipeline pipe;
pipe.start(cfg);
```

##### Selecting a device from file (playback)

```cpp
rs2::config cfg;
cfg.enable_device_from_file("my_recorded_file.bag");
rs2::pipeline pipe;
pipe.start(cfg);
```

#### Enabling recording to file

The configuration object can be used to indicate that the device which will be selected should be recorded to file. To allow this, simply call:


```cpp
rs2::config cfg;
cfg.enable_record_to_file("record_sequence1.bag");
rs2::pipeline pipe;
pipe.start(cfg); //Frames and changes to sensors will be saved to file
```


#### Testing a configuration

In order to allow users with means of testing whether the constraints on a configuration are valid the `rs2::config` provides two methods of resolution:

* `bool rs2::config::can_resolve(...)` - returns true if and only if a valid resolution can be made.
* `rs2::pipeline_profile rs2::config::resolve(...)` - Throws an exception on failure, returns the profile that will be chosen by the pipeline in case of successful resolution.


The first function simply indicates if the configuration is valid. This use case will be common if your application programmatically tries to create a valid `rs2::config`:

```cpp
rs2::config cfg;
cfg.enable_stream(RS2_STREAM_COLOR, 123, 456); //INVALID RESOLUTION

rs2::pipeline pipe;
if(cfg.can_resolve(pipe))
{
    pipe.start(cfg);
}
else
{
    pipe.start();
}
```

The second option is request the `rs2::config` to try to resolve and return the `rs2::pipeline_profile` that will be used if that configuration were to be passed to `pipeline::start`:

```cpp
rs2::config cfg;
cfg.enable_stream(RS2_STREAM_COLOR, 640, 480); //Valid resolution (for most cameras)

rs2::pipeline pipe;
try
{
    rs2::pipeline_profile profile = cfg.resolve(pipe);
    rs2::device dev = profile.get_device();
    //Use the device pre-streaming
}
catch(const std::exception& e)
{
    //recover, exit, or any other choice
}
```
