### PR TITLE
Depth Quality: Connect/disconnect events & improvements

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2823,7 +2823,7 @@ namespace rs2
         static bool icon_visible = false;
         if (every_sec) icon_visible = !icon_visible;
         float alpha = icon_visible ? 1.f : 0.2f;
-        
+
         glViewport(0, 0,
                    win.framebuf_width(), win.framebuf_height());
         glLoadIdentity();

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -478,6 +478,14 @@ namespace rs2
             return model;
         }
 
+        void reset(void)
+        {
+            rs2::frame f{};
+            model = f;
+            while (resulting_3d_models.poll_for_frame(&f));
+            while (depth_frames_to_render.poll_for_frame(&f));
+        }
+
     private:
         void render_loop();
 

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -102,10 +102,12 @@ namespace rs2
                 {
                     try
                     {
-                        on_load();
-                        _app_ready = true;
+                        _app_ready = on_load();
                     }
-                    catch (...) {}
+                    catch (...)
+                    {
+                        std::this_thread::sleep_for(std::chrono::seconds(1)); // Wait for connect event and retry
+                    }
                 } while (!_app_ready);
             });
             _first_frame = false;
@@ -220,7 +222,7 @@ namespace rs2
         glfwPollEvents();
         glfwGetWindowSize(_win, &_width, &_height);
         glfwGetFramebufferSize(_win, &_fb_width, &_fb_height);
-        
+
         // Update the scale factor each frame
         // based on resolution and physical display size
         _scale_factor = pick_scale_factor(_win);

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -13,7 +13,8 @@ namespace rs2
     ux_window::ux_window(const char* title) :
         _win(nullptr), _width(0), _height(0), _output_height(0),
         _font_14(nullptr), _font_18(nullptr), _app_ready(false),
-        _first_frame(true)
+        _first_frame(true), _query_devices(true), _missing_device(false),
+        _hourglass_index(0), _dev_stat_message{}
     {
         if (!glfwInit())
             exit(1);
@@ -73,6 +74,9 @@ namespace rs2
         auto r = stbi_load_from_memory(splash, splash_size, &x, &y, &comp, false);
         _splash_tex.upload_image(x, y, r);
 
+        // Apply initial UI state
+        reset();
+
     }
 
     void ux_window::add_on_load_message(const std::string& msg)
@@ -94,12 +98,18 @@ namespace rs2
         if (_first_frame)
         {
             std::thread first_load([&]() {
-                on_load();
-                _app_ready = true;
+                do
+                {
+                    try
+                    {
+                        on_load();
+                        _app_ready = true;
+                    }
+                    catch (...) {}
+                } while (!_app_ready);
             });
-            first_load.detach();
-
             _first_frame = false;
+            first_load.detach();
         }
 
         // If we are just getting started, render the Splash Screen instead of normal UI
@@ -109,7 +119,7 @@ namespace rs2
             glfwPollEvents();
 
             begin_frame();
-            
+
             glPushMatrix();
             glViewport(0.f, 0.f, _fb_width, _fb_height);
             glClearColor(0.036f, 0.044f, 0.051f, 1.f);
@@ -122,26 +132,22 @@ namespace rs2
             auto opacity = smoothstep(_splash_timer.elapsed_ms(), 100.f, 2000.f);
             _splash_tex.show({ 0.f,0.f,(float)_width,(float)_height }, opacity);
 
-            static bool query_devices = true;
-            static bool missing_device = false;
-            static int hourglass_index = 0;
-            static std::string message = u8"\uf287 Please connect Intel RealSense device!";
             std::string hourglass = u8"\uf250";
             static periodic_timer every_200ms(std::chrono::milliseconds(200));
             bool do_200ms = every_200ms;
-            if (query_devices && do_200ms)
+            if (_query_devices && do_200ms)
             {
-                missing_device = rs2::context().query_devices().size() == 0;
-                hourglass_index = (hourglass_index + 1) % 5;
+                _missing_device = rs2::context().query_devices().size() == 0;
+                _hourglass_index = (_hourglass_index + 1) % 5;
 
-                if (!missing_device)
+                if (!_missing_device)
                 {
-                    message = u8"\uf287 RealSense device detected.";
-                    query_devices = false;
+                    _dev_stat_message = u8"\uf287 RealSense device detected.";
+                    _query_devices = false;
                 }
             }
 
-            hourglass[2] += hourglass_index;
+            hourglass[2] += _hourglass_index;
 
             bool blink = sin(_splash_timer.elapsed_ms() / 150.f) > -0.3f;
 
@@ -166,11 +172,11 @@ namespace rs2
                 std::lock_guard<std::mutex> lock(_on_load_message_mtx);
                 if (_on_load_message.empty() && blink)
                 {
-                    ImGui::Text("%s", message.c_str());
+                    ImGui::Text("%s", _dev_stat_message.c_str());
                 }
                 else if (!_on_load_message.empty())
                 {
-                    ImGui::Text("%s", message.c_str());
+                    ImGui::Text("%s", _dev_stat_message.c_str());
                     for (auto& msg : _on_load_message)
                     {
                         auto is_last_msg = (msg == _on_load_message.back());
@@ -189,7 +195,6 @@ namespace rs2
 
             end_frame();
 
-            //glfwSwapBuffers(_win);
             glPopMatrix();
 
             // Yield the CPU
@@ -251,5 +256,16 @@ namespace rs2
             glfwSwapBuffers(_win);
             _mouse.mouse_wheel = 0;
         }
+    }
+
+    void ux_window::reset()
+    {
+        _query_devices = true;
+        _missing_device = false;
+        _hourglass_index = 0;
+        _first_frame = true;
+        _app_ready = false;
+        _splash_timer.reset();
+        _dev_stat_message = u8"\uf287 Please connect Intel RealSense device!";
     }
 }

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -27,13 +27,13 @@ namespace rs2
     {
     public:
         std::function<void(std::string)> on_file_drop = [](std::string) {};
-        std::function<void()>            on_load = [](){};
+        std::function<bool()>            on_load = []() { return false; };
 
         ux_window(const char* title);
 
         float width() const { return float(_width); }
         float height() const { return float(_height); }
-        
+
         float framebuf_width() const { return float(_fb_width); }
         float framebuf_height() const { return float(_fb_height); }
 

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -50,6 +50,8 @@ namespace rs2
 
         void end_frame();
 
+        void reset();
+
         ImFont* get_large_font() const { return _font_18; }
         ImFont* get_font() const { return _font_14; }
 
@@ -76,5 +78,10 @@ namespace rs2
         std::string              _title_str;
         std::vector<std::string> _on_load_message;
         std::mutex               _on_load_message_mtx;
+
+        bool                     _query_devices = true;
+        bool                     _missing_device = false;
+        int                      _hourglass_index = 0;
+        std::string              _dev_stat_message;
     };
 }

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -3,7 +3,7 @@
 
 // This file converts the call to WinMain to a call to cross-platform main
 // We need WinMain on Windows to offer proper Windows application and not console application
-// Should not be used in CMake on Linux 
+// Should not be used in CMake on Linux
 
 #include <Windows.h>
 #include <memory>

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -241,7 +241,7 @@ extern "C" {
     * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     */
     void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error);
-    
+
     /**
     * Requires that the resolved device would be recorded to file
     * This request cannot be used if enable_device_from_file() is called for the current config, and vise versa
@@ -252,7 +252,7 @@ extern "C" {
     */
     void rs2_config_enable_record_to_file(rs2_config* config, const char* file, rs2_error ** error);
 
-    
+
     /**
     * Disable a device stream explicitly, to remove any requests on this stream type.
     * The stream can still be enabled due to pipeline computer vision module request. This call removes any filter on the
@@ -275,7 +275,7 @@ extern "C" {
     * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     */
     void rs2_config_disable_indexed_stream(rs2_config* config, rs2_stream stream, int index, rs2_error ** error);
-    
+
     /**
     * Disable all device stream explicitly, to remove any requests on the streams profiles.
     * The streams can still be enabled due to pipeline computer vision module request. This call removes any filter on the

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -556,7 +556,7 @@ namespace rs2
     private:
         size_t _size;
     };
-   
+
 
 }
 #endif // LIBREALSENSE_RS2_FRAME_HPP

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -11,8 +11,8 @@
 namespace rs2
 {
     /**
-    * The pipeline profile includes a device and a selection of active streams, with specific profile. 
-    * The profile is a selection of the above under filters and conditions defined by the pipeline. 
+    * The pipeline profile includes a device and a selection of active streams, with specific profile.
+    * The profile is a selection of the above under filters and conditions defined by the pipeline.
     * Streams may belong to more than one sensor of the device.
     */
     class pipeline_profile
@@ -137,14 +137,14 @@ namespace rs2
         /**
         * Enable a device stream explicitly, with selected stream parameters.
         * The method allows the application to request a stream with specific configuration. If no stream is explicitly enabled,
-        * the pipeline configures the device and its streams according to the attached computer vision modules and processing 
+        * the pipeline configures the device and its streams according to the attached computer vision modules and processing
         * blocks requirements, or default configuration for the first available device.
-        * The application can configure any of the input stream parameters according to its requirement, or set to 0 for don't 
+        * The application can configure any of the input stream parameters according to its requirement, or set to 0 for don't
         * care value.
-        * The config accumulates the application calls for enable configuration methods, until the configuration is applied. 
+        * The config accumulates the application calls for enable configuration methods, until the configuration is applied.
         * Multiple enable stream calls for the same stream override each other, and the last call is maintained.
-        * Upon calling \c resolve(), the config checks for conflicts between the application configuration requests and the 
-        * attached computer vision modules and processing blocks requirements, and fails if conflicts are found. 
+        * Upon calling \c resolve(), the config checks for conflicts between the application configuration requests and the
+        * attached computer vision modules and processing blocks requirements, and fails if conflicts are found.
         * Before \c resolve() is called, no conflict check is done.
         *
         * \param[in] stream_type    Stream type to be enabled
@@ -188,7 +188,7 @@ namespace rs2
         /**
         * Enable all device streams explicitly.
         * The conditions and behavior of this method are similar to those of \c enable_stream().
-        * This filter enables all raw streams of the selected device. The device is either selected explicitly by the 
+        * This filter enables all raw streams of the selected device. The device is either selected explicitly by the
         * application, or by the pipeline requirements or default. The list of streams is device dependent.
         */
         void enable_all_streams()
@@ -201,7 +201,7 @@ namespace rs2
         /**
         * Select a specific device explicitly by its serial number, to be used by the pipeline.
         * The conditions and behavior of this method are similar to those of \c enable_stream().
-        * This method is required if the application needs to set device or sensor settings prior to pipeline streaming, 
+        * This method is required if the application needs to set device or sensor settings prior to pipeline streaming,
         * to enforce the pipeline to use the configured device.
         *
         * \param[in] Serial device serial number, as returned by RS2_CAMERA_INFO_SERIAL_NUMBER
@@ -215,7 +215,7 @@ namespace rs2
 
         /**
         * Select a recorded device from a file, to be used by the pipeline through playback.
-        * The device available streams are as recorded to the file, and \c resolve() considers only this device and 
+        * The device available streams are as recorded to the file, and \c resolve() considers only this device and
         * configuration as available.
         * This request cannot be used if enable_record_to_file() is called for the current config, and vise versa
         *
@@ -273,14 +273,14 @@ namespace rs2
         * The method resolves the user configuration filters for the device and streams, and combines them with the requirements
         * of the computer vision modules and processing blocks attached to the pipeline. If there are no conflicts of requests,
         * it looks for an available device, which can satisfy all requests, and selects the first matching streams configuration.
-        * In the absence of any request, the rs2::config selects the first available device and the first color and depth 
+        * In the absence of any request, the rs2::config selects the first available device and the first color and depth
         * streams configuration.
         * The pipeline profile selection during \c start() follows the same method. Thus, the selected profile is the same, if no
         * change occurs to the available devices occurs.
-        * Resolving the pipeline configuration provides the application access to the pipeline selected device for advanced 
+        * Resolving the pipeline configuration provides the application access to the pipeline selected device for advanced
         * control.
-        * The returned configuration is not applied to the device, so the application doesn't own the device sensors. However, 
-        * the application can call \c enable_device(), to enforce the device returned by this method is selected by pipeline \c 
+        * The returned configuration is not applied to the device, so the application doesn't own the device sensors. However,
+        * the application can call \c enable_device(), to enforce the device returned by this method is selected by pipeline \c
         * start(), and configure the device and sensors options or extensions before streaming starts.
         *
         * \param[in] p  The pipeline for which the selected filters are applied
@@ -354,9 +354,9 @@ namespace rs2
 
         /**
         * Start the pipeline streaming with its default configuration.
-        * The pipeline streaming loop captures samples from the device, and delivers them to the attached computer vision 
+        * The pipeline streaming loop captures samples from the device, and delivers them to the attached computer vision
         * modules and processing blocks, according to each module requirements and threading model.
-        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or 
+        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or
         * \c poll_for_frames().
         * The streaming loop runs until the pipeline is stopped.
         * Starting the pipeline is possible only when it is not started. If the pipeline was started, an exception is raised.
@@ -378,15 +378,15 @@ namespace rs2
         * Start the pipeline streaming according to the configuraion.
         * The pipeline streaming loop captures samples from the device, and delivers them to the attached computer vision modules
         * and processing blocks, according to each module requirements and threading model.
-        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or 
+        * During the loop execution, the application can access the camera streams by calling \c wait_for_frames() or
         * \c poll_for_frames().
         * The streaming loop runs until the pipeline is stopped.
         * Starting the pipeline is possible only when it is not started. If the pipeline was started, an exception is raised.
         * The pipeline selects and activates the device upon start, according to configuration or a default configuration.
-        * When the rs2::config is provided to the method, the pipeline tries to activate the config \c resolve() result. 
+        * When the rs2::config is provided to the method, the pipeline tries to activate the config \c resolve() result.
         * If the application requests are conflicting with pipeline computer vision modules or no matching device is available on
         * the platform, the method fails.
-        * Available configurations and devices may change between config \c resolve() call and pipeline start, in case devices 
+        * Available configurations and devices may change between config \c resolve() call and pipeline start, in case devices
         * are connected or disconnected, or another application acquires ownership of a device.
         *
         * \param[in] config   A rs2::config with requested filters on the pipeline configuration. By default no filters are applied.
@@ -406,7 +406,7 @@ namespace rs2
 
         /**
         * Stop the pipeline streaming.
-        * The pipeline stops delivering samples to the attached computer vision modules and processing blocks, stops the device 
+        * The pipeline stops delivering samples to the attached computer vision modules and processing blocks, stops the device
         * streaming and releases the device resources used by the pipeline. It is the application's responsibility to release any
         * frame reference it owns.
         * The method takes effect only after \c start() was called, otherwise an exception is raised.
@@ -422,10 +422,10 @@ namespace rs2
         * Wait until a new set of frames becomes available.
         * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
         * The method blocks the calling thread, and fetches the latest unread frames set.
-        * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method 
+        * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method
         * should be called as fast as the device frame rate.
-        * The application can maintain the frames handles to defer processing. However, if the application maintains too long 
-        * history, the device may lack memory resources to produce new frames, and the following call to this method shall fail 
+        * The application can maintain the frames handles to defer processing. However, if the application maintains too long
+        * history, the device may lack memory resources to produce new frames, and the following call to this method shall fail
         * to retrieve new frames, until resources are retained.
         *
         * \param[in] timeout_ms   Max time in milliseconds to wait until an exception will be thrown
@@ -443,12 +443,12 @@ namespace rs2
         /**
         * Check if a new set of frames is available and retrieve the latest undelivered set.
         * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
-        * The method returns without blocking the calling thread, with status of new frames available or not. 
+        * The method returns without blocking the calling thread, with status of new frames available or not.
         * If available, it fetches the latest frames set.
-        * Device frames, which were produced while the function wasn't called, are dropped. 
+        * Device frames, which were produced while the function wasn't called, are dropped.
         * To avoid frame drops, this method should be called as fast as the device frame rate.
         * The application can maintain the frames handles to defer processing. However, if the application maintains too long
-        * history, the device may lack memory resources to produce new frames, and the following calls to this method shall 
+        * history, the device may lack memory resources to produce new frames, and the following calls to this method shall
         * return no new frames, until resources are retained.
         *
         * \param[out] f     Frames set handle
@@ -473,7 +473,7 @@ namespace rs2
         * Return the active device and streams profiles, used by the pipeline.
         * The pipeline streams profiles are selected during \c start(). The method returns a valid result only when the pipeline is active -
         * between calls to \c start() and \c stop().
-        * After \c stop() is called, the pipeline doesn't own the device, thus, the pipeline selected device may change in 
+        * After \c stop() is called, the pipeline doesn't own the device, thus, the pipeline selected device may change in
         * subsequent activations.
         *
         * \return  The actual pipeline device and streams profile, which was successfully configured to the streaming device on start.

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -59,7 +59,7 @@ namespace rs2
         frame_source(const frame_source&) = delete;
 
     };
-    
+
     template<class T>
     class frame_processor_callback : public rs2_frame_processor_callback
     {

--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -88,19 +88,19 @@ namespace rs2
 
         void release() override { delete this; }
     };
-    
+
     template<class T>
     class frame_callback : public rs2_frame_callback
     {
         T on_frame_function;
     public:
         explicit frame_callback(T on_frame) : on_frame_function(on_frame) {}
-        
+
         void on_frame(rs2_frame* fref) override
         {
             on_frame_function(frame{ fref });
         }
-        
+
         void release() override { delete this; }
     };
 

--- a/src/config.h
+++ b/src/config.h
@@ -321,7 +321,7 @@ namespace librealsense
                         return true;
                 return false;
             }*/
-          
+
            bool can_enable_stream(device_interface* dev, rs2_stream stream, int index, int width, int height, rs2_format format, int fps)
            {
                config c(*this);
@@ -333,7 +333,6 @@ namespace librealsense
 
                auto it = _requests.erase({stream, index});
                return false;
-
            }
 
             multistream resolve(device_interface* dev)
@@ -342,13 +341,13 @@ namespace librealsense
 
                 // If required, make sure we've succeeded at opening
                 // all the requested streams
-                if (require_all) 
+                if (require_all)
                 {
                     std::set<index_type> all_streams;
                     for (auto && kvp : mapping)
                         all_streams.insert({ kvp.second->get_stream_type(), kvp.second->get_stream_index() });
 
-                    
+
                     for (auto && kvp : _presets)
                     {
                         auto it = std::find_if(std::begin(all_streams), std::end(all_streams), [&](const index_type& i)
@@ -395,7 +394,7 @@ namespace librealsense
                 // TODO: make sure it works
                 return multistream(std::move(sensors), std::move(stream_to_profile), std::move(dev_to_profiles));
             }
-        
+
         private:
             static bool sort_highest_framerate(const std::shared_ptr<stream_profile_interface> lhs, const std::shared_ptr<stream_profile_interface> rhs) {
                 return lhs->get_framerate() < rhs->get_framerate();

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -199,6 +199,7 @@ namespace librealsense
 
         auto fw_version = _hw_monitor->get_firmware_version_string(GVD, fw_version_offset);
         auto serial = _hw_monitor->get_module_serial_string(GVD, module_serial_offset);
+        _camer_calib_params = [this]() { return get_calibration(); };
         enable_timestamp(true, true);
 
         auto pid_hex_str = hexify(color.pid>>8) + hexify(static_cast<uint8_t>(color.pid));
@@ -214,7 +215,7 @@ namespace librealsense
 
         _depth_to_color_extrinsics = std::make_shared<lazy<rs2_extrinsics>>([this]()
         {
-            auto c = get_calibration();
+            auto c = *_camer_calib_params;
             pose depth_to_color = {
                 transpose(reinterpret_cast<const float3x3 &>(c.Rt)),
                 reinterpret_cast<const float3 &>(c.Tt) * 0.001f
@@ -233,7 +234,7 @@ namespace librealsense
         get_depth_sensor().register_option(RS2_OPTION_DEPTH_UNITS,
                                            std::make_shared<const_value_option>("Number of meters represented by a single depth unit",
                                             lazy<float>([this]() {
-                                                auto c = get_calibration();
+                                                auto c = *_camer_calib_params;
                                                 return (c.Rmax / 1000 / 0xFFFF);
                                             })));
 

--- a/src/ivcam/sr300.h
+++ b/src/ivcam/sr300.h
@@ -155,7 +155,7 @@ namespace librealsense
         platform::usb_device_info _hwm;
     };
 
-    class sr300_camera final : public device, public debug_interface
+    class sr300_camera final : public virtual device, public debug_interface
     {
     public:
         class preset_option : public option_base
@@ -208,7 +208,7 @@ namespace librealsense
 
             rs2_intrinsics get_intrinsics(const stream_profile& profile) const override
             {
-                return make_color_intrinsics(_owner->get_calibration(), { int(profile.width), int(profile.height) });
+                return make_color_intrinsics(*_owner->_camer_calib_params, { int(profile.width), int(profile.height) });
             }
 
             stream_profiles init_stream_profiles() override
@@ -256,7 +256,7 @@ namespace librealsense
 
             rs2_intrinsics get_intrinsics(const stream_profile& profile) const override
             {
-                return make_depth_intrinsics(_owner->get_calibration(), { int(profile.width), int(profile.height) });
+                return make_depth_intrinsics(*_owner->_camer_calib_params, { int(profile.width), int(profile.height) });
             }
 
             stream_profiles init_stream_profiles() override
@@ -538,5 +538,7 @@ namespace librealsense
         std::shared_ptr<stream_interface> _ir_stream;
         std::shared_ptr<stream_interface> _color_stream;
         std::shared_ptr<lazy<rs2_extrinsics>> _depth_to_color_extrinsics;
+
+        lazy<ivcam::camera_calib_params> _camer_calib_params;
     };
 }

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -462,8 +462,11 @@ namespace librealsense
     {
         if (_active_profile)
         {
-            _active_profile->_multistream.stop();
-            _active_profile->_multistream.close();
+            try {
+                _active_profile->_multistream.stop();
+                _active_profile->_multistream.close();
+            }
+            catch(...){ } // Stop will throw if device was disconnected. TODO - refactoring anticipated
         }
         _syncer.reset();
         _queue.reset();
@@ -489,7 +492,7 @@ namespace librealsense
             unsafe_start(_prev_conf);
             return frame_holder();
         }
-        catch(const std::exception& e)
+        catch(const std::exception&)
         {
             throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
         }

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1408,7 +1408,6 @@ HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
 rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(profile);
-    VALIDATE_NOT_NULL(profile->profile); // TODO
 
     auto dev = profile->profile->get_device();
     auto dev_info = std::make_shared<librealsense::readonly_device_info>(dev);

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1408,6 +1408,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
 rs2_device* rs2_pipeline_profile_get_device(rs2_pipeline_profile* profile, rs2_error ** error) try
 {
     VALIDATE_NOT_NULL(profile);
+    VALIDATE_NOT_NULL(profile->profile); // TODO
 
     auto dev = profile->profile->get_device();
     auto dev_info = std::make_shared<librealsense::readonly_device_info>(dev);

--- a/src/win/win-backend.cpp
+++ b/src/win/win-backend.cpp
@@ -202,6 +202,8 @@ namespace librealsense
                             TranslateMessage(&msg);
                             DispatchMessage(&msg);
                     }
+                    else  // Yield CPU resources, as this is required for connect/disconnect events only
+                        std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 }
 
                 UnregisterDeviceNotification(_data.hdevnotifyHW);

--- a/tools/depth-quality/depth-quality-model.h
+++ b/tools/depth-quality/depth-quality-model.h
@@ -160,7 +160,7 @@ namespace rs2
         public:
             tool_model();
 
-            void start(ux_window& win);
+            bool start(ux_window& win);
 
             void render(ux_window& win);
 

--- a/tools/depth-quality/depth-quality-model.h
+++ b/tools/depth-quality/depth-quality-model.h
@@ -166,6 +166,8 @@ namespace rs2
 
             void update_configuration();
 
+            void reset(ux_window& win);
+
             void snapshot_metrics();
 
             void draw_instructions(ux_window& win, const rect& viewer_rect);
@@ -177,6 +179,7 @@ namespace rs2
 
             void on_frame(callback_type callback) { _metrics_model.callback = callback; }
 
+            rs2::device get_active_device(void) const;
         private:
 
             std::string capture_description();
@@ -190,7 +193,7 @@ namespace rs2
             bool                            _first_frame = true;
             periodic_timer                  _update_readonly_options_timer;
 
-            float                           _roi_percent = 0.33f;
+            float                           _roi_percent = 0.4f;
             int                             _roi_combo_index = 1;
             temporal_event                  _roi_located;
         };

--- a/tools/depth-quality/rs-depth-quality.cpp
+++ b/tools/depth-quality/rs-depth-quality.cpp
@@ -83,7 +83,7 @@ int main(int argc, const char * argv[]) try
                  set(metric_plot::RED_RANGE,     -100, 100);
 
     // ===============================
-    //       Metrics Calculation      
+    //       Metrics Calculation
     // ===============================
 
     model.on_frame([&](const std::vector<rs2::float3>& points, rs2::plane p, rs2::region_of_interest roi,
@@ -145,7 +145,7 @@ int main(int argc, const char * argv[]) try
     });
 
     // ===============================
-    //      Device plug-out handler
+    //      Device plug-in/out handler
     // ===============================
     rs2::context ctx;
     std::mutex m;
@@ -160,12 +160,12 @@ int main(int argc, const char * argv[]) try
     });
 
     // ===============================
-    //         Rendering Loop         
+    //         Rendering Loop
     // ===============================
 
     window.on_load = [&]()
     {
-        model.start(window);
+        return model.start(window);
     };
 
     while(window)

--- a/tools/depth-quality/rs-depth-quality.cpp
+++ b/tools/depth-quality/rs-depth-quality.cpp
@@ -145,6 +145,21 @@ int main(int argc, const char * argv[]) try
     });
 
     // ===============================
+    //      Device plug-out handler
+    // ===============================
+    rs2::context ctx;
+    std::mutex m;
+    ctx.set_devices_changed_callback([&model, &window, &m](rs2::event_information info) mutable
+    {
+        auto dev = model.get_active_device();
+        if (dev && info.was_removed(dev))
+        {
+            std::unique_lock<std::mutex> lock(m);
+            model.reset(window);
+        }
+    });
+
+    // ===============================
     //         Rendering Loop         
     // ===============================
 

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -276,6 +276,7 @@ int main(int argv, const char** argc) try
     window.on_load = [&]()
     {
         refresh_devices(m, ctx, refresh_device_list, list, device_names, device_models, viewer_model, devs, error_message);
+        return true;
     };
 
     // Closing the window


### PR DESCRIPTION
- Support device disconnect/reconnect
- Clear invalid viewports when changing configuration
- Provide patch for SR300 lack of intrinsic cache

Reduce CPU utilization for Windows backend - messages handling thread.
SR300 to use cached intrinsic for performance

Change-Id: I32b2c06c9866c6b12db29e0aa720f7a43774e4f5
Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>