### PR TITLE
Viewer device changes

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -615,4 +615,15 @@ namespace rs2
     int save_to_png(const char* filename,
         size_t pixel_width, size_t pixels_height, size_t bytes_per_pixel,
         const void* raster_data, size_t stride_bytes);
+
+    class device_changes
+    {
+    public:
+        explicit device_changes(rs2::context& ctx);
+        bool try_get_next_changes(event_information& removed_and_connected);
+    private:
+        void add_changes(const event_information& c);
+        std::queue<event_information> _changes;
+        std::mutex _mtx;
+    };
 }

--- a/src/backend.h
+++ b/src/backend.h
@@ -548,7 +548,8 @@ namespace librealsense
             bool operator == (const backend_device_group& other)
             {
                 return !list_changed(uvc_devices, other.uvc_devices) &&
-                    !list_changed(hid_devices, other.hid_devices);
+                    !list_changed(hid_devices, other.hid_devices) &&
+                    !list_changed(playback_devices, other.playback_devices);
             }
 
             operator std::string()


### PR DESCRIPTION
Fixed bug in viewer [DSO-7015]: disable/enable advanced mode did not update the device list.
**Root Cause:** 
Connection events arrived one after the other and refresh_device_list was called after the device had reconnected thus it did not remove it from the list).

**Changes summary:**
Viewer used to rely on both main loop and context's device change callback in order to keep track on the connected devices, their names and which is device is viewed in the left panel. 
The context's callbacks are of course asynchronous while the main loop is iterating on a single thread. The separation of this logic between `devices_changed_callback` and `refresh_devices` is error prone and a bit confusing.

This change includes encapsulation of the logic of tracking after device changes (connection\disconnections) into a single class. This class is basically a queue of changes to connected devices so that each event of device connection change is pushed to the queue. This way allows the main loop and the `refresh_devices`  to simply check if the queue is not empty, and if it contains an event, handle that event one iteration at a time so that all changes will be view-able in the GUI.


In addition, this change revealed a bug in the `backend_device_group` class which did not compare all backend groups, in particular the playback group 