### PR TITLE
Fix rs-data-collect tool

### DIFF
--- a/tools/data-collect/rs-data-collect.cpp
+++ b/tools/data-collect/rs-data-collect.cpp
@@ -137,7 +137,7 @@ void save_data_to_file(std::array<list<frame_data>, NUM_OF_STREAMS> buffer, cons
         {
             ostringstream line;
             auto data = buffer[stream_index].front();
-            line << rs2_stream_to_string(data.stream_type) << "," << data.frame_number << "," << data.ts << "," << data.arrival_time << "\n";
+            line << rs2_stream_to_string(data.stream_type) << "," << data.frame_number << "," << std::fixed << std::setprecision(3) << data.ts << "," << data.arrival_time << "\n";
             buffer[stream_index].pop_front();
             csv << line.str();
         }
@@ -151,7 +151,7 @@ int main(int argc, char** argv) try
     log_to_file(RS2_LOG_SEVERITY_WARN);
 
     // Parse command line arguments
-    CmdLine cmd("librealsense cpp-data-collect example tool", ' ');
+    CmdLine cmd("librealsense rs-data-collect example tool", ' ');
     ValueArg<int>    timeout("t", "Timeout", "Max amount of time to receive frames (in seconds)", false, 10, "");
     ValueArg<int>    max_frames("m", "MaxFrames_Number", "Maximun number of frames data to receive", false, 100, "");
     ValueArg<string> filename("f", "FullFilePath", "the file which the data will be saved to", false, "", "");
@@ -238,7 +238,10 @@ int main(int argc, char** argv) try
             data.domain = f.get_frame_timestamp_domain();
             data.arrival_time = arrival_time.count();
 
-            buffer[(int)data.stream_type].push_back(data);
+            if (buffer[(int)data.stream_type].size() < max_frames_number)
+            {
+                buffer[(int)data.stream_type].push_back(data);
+            }
 
             if (need_to_reset)
             {

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -66,7 +66,7 @@ void print(rs2_intrinsics intrinsics)
 
 int main(int argc, char** argv) try
 {
-    CmdLine cmd("librealsense cpp-enumerate-devices example tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-enumerate-devices example tool", ' ', RS2_API_VERSION_STR);
 
     SwitchArg compact_view_arg("s", "short", "Provide short summary of the devices");
     SwitchArg show_options("o", "option", "Show all supported options per subdevice");

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -46,7 +46,7 @@ string datetime_string()
 
 int main(int argc, char* argv[])
 {
-    CmdLine cmd("librealsense cpp-fw-logger example tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-fw-logger example tool", ' ', RS2_API_VERSION_STR);
     ValueArg<string> xml_arg("l", "load", "Full file path of HW Logger Events XML file", false, "", "Load HW Logger Events XML file");
     cmd.add(xml_arg);
     cmd.parse(argc, argv);

--- a/tools/terminal/rs-terminal.cpp
+++ b/tools/terminal/rs-terminal.cpp
@@ -144,9 +144,9 @@ void read_script_file(const string& full_file_path, vector<string>& hex_lines)
 
 int main(int argc, char** argv)
 {
-    CmdLine cmd("librealsense cpp-terminal example tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-terminal example tool", ' ', RS2_API_VERSION_STR);
     ValueArg<string> xml_arg("l", "load", "Full file path of commands XML file", false, "", "Load commands XML file");
-    ValueArg<int> device_id_arg("d", "deviceId", "Device ID could be obtain from cpp-enumerate-devices example", false, 0, "Select a device to work with");
+    ValueArg<int> device_id_arg("d", "deviceId", "Device ID could be obtain from rs-enumerate-devices example", false, 0, "Select a device to work with");
     ValueArg<string> hex_cmd_arg("s", "send", "Hexadecimal raw data", false, "", "Send hexadecimal raw data to device");
     ValueArg<string> hex_script_arg("r", "raw", "Full file path of hexadecimal raw data script", false, "", "Send raw data line by line from script file");
     ValueArg<string> commands_script_arg("c", "cmd", "Full file path of commands script", false, "", "Send commands line by line from script file");


### PR DESCRIPTION
- Fixed bug when the requested frames to take is not as defined. This behavior changed to save exactly the requested amount of frames for each stream type.
- Added std::setprecision to save the accurate frame timestamp.