### PR TITLE
Rectify device selection for the pipeline

### DIFF
--- a/examples/example.hpp
+++ b/examples/example.hpp
@@ -116,7 +116,7 @@ public:
         glDisable(GL_TEXTURE_2D);
         glBindTexture(GL_TEXTURE_2D, 0);
 
-        draw_text(r.x + 15, r.y + 20, rs2_stream_to_string(stream));
+        draw_text((int)r.x + 15, (int)r.y + 20, rs2_stream_to_string(stream));
     }
 private:
     GLuint gl_handle = 0;

--- a/examples/multicam/rs-multicam.cpp
+++ b/examples/multicam/rs-multicam.cpp
@@ -70,7 +70,8 @@ public:
             }
         }
     }
-    int device_count()
+
+    size_t device_count()
     {
         std::lock_guard<std::mutex> lock(_mutex);
         return _devices.size();
@@ -174,15 +175,16 @@ int main(int argc, char * argv[]) try
         auto total_number_of_streams = connected_devices.stream_count();
         if (total_number_of_streams == 0)
         {
-            draw_text(std::max(0.f, (app.width() / 2) - no_camera_message.length() * 3), app.height() / 2, no_camera_message.c_str());
+            draw_text(int(std::max(0.f, (app.width() / 2) - no_camera_message.length() * 3)),
+                      int(app.height() / 2), no_camera_message.c_str());
             continue;
         }
         if (connected_devices.device_count() == 1)
         {
             draw_text(0, 10, "Please connect another camera");
         }
-        int cols = std::ceil(std::sqrt(total_number_of_streams));
-        int rows = std::ceil(total_number_of_streams / static_cast<float>(cols));
+        int cols = int(std::ceil(std::sqrt(total_number_of_streams)));
+        int rows = int(std::ceil(total_number_of_streams / static_cast<float>(cols)));
 
         float view_width = (app.width() / cols);
         float view_height = (app.height() / rows);

--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -280,6 +280,5 @@ namespace rs2
     private:
         std::shared_ptr<rs2_device_list> _list;
     };
-   
 }
 #endif // LIBREALSENSE_RS2_DEVICE_HPP

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -276,7 +276,7 @@ namespace rs2
         * In the absence of any request, the rs2::config selects the first available device and the first color and depth
         * streams configuration.
         * The pipeline profile selection during \c start() follows the same method. Thus, the selected profile is the same, if no
-        * change occurs to the available devices occurs.
+        * change occurs to the available devices.
         * Resolving the pipeline configuration provides the application access to the pipeline selected device for advanced
         * control.
         * The returned configuration is not applied to the device, so the application doesn't own the device sensors. However,

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -364,7 +364,7 @@ namespace librealsense
                 catch (...)
                 {
                     LOG_ERROR("Exception thrown from user callback handler");
-                }    
+                }
             }
         }
     }

--- a/src/core/serialization.h
+++ b/src/core/serialization.h
@@ -57,8 +57,8 @@ namespace librealsense
                 max
             };
         public:
-            explicit serialized_data(const device_serializer::nanoseconds& timestamp = device_serializer::nanoseconds::max()) : 
-                _timestamp(timestamp) 
+            explicit serialized_data(const device_serializer::nanoseconds& timestamp = device_serializer::nanoseconds::max()) :
+                _timestamp(timestamp)
             {
             }
             virtual ~serialized_data() = default;
@@ -78,9 +78,9 @@ namespace librealsense
 
                 switch (T::get_type())
                 {
-                    case end_of_file: 
-                    case frame:       
-                    case option:      
+                    case end_of_file:
+                    case frame:
+                    case option:
                         return std::static_pointer_cast<T>(std::const_pointer_cast<serialized_data>(shared_from_this()));
                 }
                 return nullptr;

--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -57,9 +57,7 @@ namespace librealsense
         std::shared_ptr<device_interface> res = nullptr;
         for(auto i = 0; ((i< _device_list.size()) && (nullptr == res)); i++)
         {
-            // user can switch the devices by calling to wait_for_device until he get the desire device
-            // _camera_index is the curr device that user want to work with
-
+            // _camera_index is the curr device that the hub will expose
             auto d = _device_list[ (_camera_index + i) % _device_list.size()];
             auto dev = d->create_device(_register_device_notifications);
 
@@ -70,6 +68,7 @@ namespace librealsense
                 if(serial == new_serial)
                 {
                     res = dev;
+                    cycle_devices = false;  // Requesting a device by its serial shall not invoke internal cycling
                 }
             }
             else

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -20,17 +20,17 @@ namespace librealsense
         /**
          * The function implements both blocking and non-blocking device generation functionality based on the input parameters:
          * Calling the function with zero timeout results in searching and fetching the device specified by the `serial` parameter
-         * from a list of connected devices. The call will return nullptr if none is found.
+         * from a list of connected devices.
          * Calling the function with a valid timeout will block till the resulted device is found or the timeout expires.
-         *
          * \param[in] timeout_ms  The waiting period for the requested device to be reconnected (milliseconds).
-         * Set it to zero to avoid blocking the thread execution
-         *\param[in] loop_through_devices  - promote internal index to the next available device that will be retrieved on successive call
-         * \param[in] serial  The serial number of the requested device. Use empty pattern ("") to request for "any suitable" device.
-         * \return       a shared pointer to the device_interface that satisfies the search criteria. In case of failure the function will
-         * return nullptr for the non-blocking call The function will throw and throw exception when a blocking wait is timed out
+         *.\param[in] loop_through_devices  - promote internal index to the next available device that will be retrieved on successive call
+         *  Note that selection of the next device is deterministic but not predictable, and therefore is recommended for
+         * specific use-cases only , such as tutorials or unit-tests where no assumptions as for the device order are made.
+         * \param[in] serial  The serial number of the requested device. Use empty pattern ("") to request for "any RealSense" device.
+         * \return       a shared pointer to the device_interface that satisfies the search criteria. In case the request was not
+         * satisfied  the call will throw an exception
          */
-        std::shared_ptr<device_interface> wait_for_device( unsigned int timeout_ms = std::numeric_limits<unsigned int>::max(),
+        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::milliseconds(std::numeric_limits<unsigned int>::max()),
                                                             bool loop_through_devices = true,
                                                             const std::string& serial = "");
 

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -21,8 +21,7 @@ namespace librealsense
          * The function implements both blocking and non-blocking device generation functionality based on the input parameters:
          * Calling the function with zero timeout results in searching and fetching the device specified by the `serial` parameter
          * from a list of connected devices. The call will return nullptr if none is found.
-         * Calling the function with a valid timeout will establish block the thread execution till the resulted device is found or the timeout expires.
-         * Additionally, Calling this method multiple times will cycle through the connected devices
+         * Calling the function with a valid timeout will block till the resulted device is found or the timeout expires.
          *
          * \param[in] timeout_ms  The waiting period for the requested device to be reconnected (milliseconds).
          * Set it to zero to avoid blocking the thread execution

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -23,14 +23,14 @@ namespace librealsense
          * from a list of connected devices.
          * Calling the function with a valid timeout will block till the resulted device is found or the timeout expires.
          * \param[in] timeout_ms  The waiting period for the requested device to be reconnected (milliseconds).
-         * Due to aimplementation issue both in MSVC and GCC the timeout duration shall be initialized with hours::max() to avoid generation of
+         * Due to an implementation issue both in MSVC and GCC the timeout duration is initialized with hours::max() to avoid generation of
          * negative durations.
          *.\param[in] loop_through_devices  - promote internal index to the next available device that will be retrieved on successive call
          *  Note that selection of the next device is deterministic but not predictable, and therefore is recommended for
-         * specific use-cases only , such as tutorials or unit-tests where no assumptions as for the device order are made.
+         * specific use-cases only , such as tutorials or unit-tests where no assumptions as to the device ordering are made.
          * \param[in] serial  The serial number of the requested device. Use empty pattern ("") to request for "any RealSense" device.
          * \return       a shared pointer to the device_interface that satisfies the search criteria. In case the request was not
-         * satisfied  the call will throw an exception
+         * resloved the call will throw an exception
          */
         std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::hours::max(),
                                                             bool loop_through_devices = true,

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -23,6 +23,8 @@ namespace librealsense
          * from a list of connected devices.
          * Calling the function with a valid timeout will block till the resulted device is found or the timeout expires.
          * \param[in] timeout_ms  The waiting period for the requested device to be reconnected (milliseconds).
+         * Due to aimplementation issue both in MSVC and GCC the timeout duration shall be initialized with hours::max() to avoid generation of
+         * negative durations.
          *.\param[in] loop_through_devices  - promote internal index to the next available device that will be retrieved on successive call
          *  Note that selection of the next device is deterministic but not predictable, and therefore is recommended for
          * specific use-cases only , such as tutorials or unit-tests where no assumptions as for the device order are made.
@@ -30,7 +32,7 @@ namespace librealsense
          * \return       a shared pointer to the device_interface that satisfies the search criteria. In case the request was not
          * satisfied  the call will throw an exception
          */
-        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::milliseconds(std::numeric_limits<unsigned int>::max()),
+        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::hours::max(),
                                                             bool loop_through_devices = true,
                                                             const std::string& serial = "");
 

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -18,10 +18,22 @@ namespace librealsense
         explicit device_hub(std::shared_ptr<librealsense::context> ctx, int vid = 0, bool register_device_notifications = true);
 
         /**
-         * If any device is connected return it, otherwise wait until next RealSense device connects.
-         * Calling this method multiple times will cycle through connected devices
+         * The function implements both blocking and non-blocking device generation functionality based on the input parameters:
+         * Calling the function with zero timeout results in searching and fetching the device specified by the `serial` parameter
+         * from a list of connected devices. The call will return nullptr if none is found.
+         * Calling the function with a valid timeout will establish block the thread execution till the resulted device is found or the timeout expires.
+         * Additionally, Calling this method multiple times will cycle through the connected devices
+         *
+         * \param[in] timeout_ms  The waiting period for the requested device to be reconnected (milliseconds).
+         * Set it to zero to avoid blocking the thread execution
+         *\param[in] loop_through_devices  - promote internal index to the next available device that will be retrieved on successive call
+         * \param[in] serial  The serial number of the requested device. Use empty pattern ("") to request for "any suitable" device.
+         * \return       a shared pointer to the device_interface that satisfies the search criteria. In case of failure the function will
+         * return nullptr for the non-blocking call The function will throw and throw exception when a blocking wait is timed out
          */
-        std::shared_ptr<device_interface> wait_for_device( unsigned int timeout_ms = std::numeric_limits<unsigned int>::max(), std::string serial = "");
+        std::shared_ptr<device_interface> wait_for_device( unsigned int timeout_ms = std::numeric_limits<unsigned int>::max(),
+                                                            bool loop_through_devices = true,
+                                                            const std::string& serial = "");
 
         /**
         * Checks if device is still connected
@@ -34,7 +46,7 @@ namespace librealsense
         }
 
     private:
-        std::shared_ptr<device_interface> create_device(std::string serial = "");
+        std::shared_ptr<device_interface> create_device(const std::string& serial, bool cycle_devices = true);
         std::shared_ptr<librealsense::context> _ctx;
         std::mutex _mutex;
         std::condition_variable _cv;

--- a/src/ds5/advanced_mode/json_loader.hpp
+++ b/src/ds5/advanced_mode/json_loader.hpp
@@ -193,8 +193,8 @@ namespace librealsense
 
         void load(const std::string& str) override
         {
-            float value = ::atof(str.c_str());
-            (strct->vals[0].*field) = (value > 0) ? 0 : 1.f;
+            auto value = ::atof(str.c_str());
+            (strct->vals[0].*field) = (value > 0) ? 0 : 1;
             strct->update = true;
         }
 

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -221,7 +221,7 @@ namespace librealsense
         auto gain_option =  std::make_shared<uvc_pu_option>(*uvc_ep, RS2_OPTION_GAIN);
 
         auto exposure_option =  std::make_shared<uvc_xu_option<uint16_t>>(*uvc_ep,
-                *fisheye_xu,                          
+                *fisheye_xu,
                 librealsense::ds::FISHEYE_EXPOSURE, "Exposure time of Fisheye camera");
 
         auto ae_state = std::make_shared<auto_exposure_state>();

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -342,7 +342,7 @@ device_serializer::nanoseconds playback_device::calc_sleep_time(device_serialize
     }
     auto time_diff = timestamp - m_base_timestamp;
     auto recorded_time = std::chrono::duration_cast<device_serializer::nanoseconds>(time_diff / m_sample_rate.load());
-    
+
     LOG_DEBUG("Time Now  : " << now.time_since_epoch().count() << " ,    Time When Started: " << m_base_sys_time.time_since_epoch().count() << " , Diff: " << play_time.count() << " == " << (play_time.count()/1000)/1000 << "ms");
     LOG_DEBUG("Original Recording Delta: " << time_diff.count() << " == " << (time_diff.count() / 1000) / 1000 << "ms");
     LOG_DEBUG("Frame Time: " << timestamp.count() << "  , First Frame: " << m_base_timestamp.count() << " ,  Diff: " << recorded_time.count() << " == " << (recorded_time.count() / 1000) / 1000 << "ms");

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -46,7 +46,7 @@ stream_profiles playback_sensor::get_stream_profiles() const
 
 void playback_sensor::open(const stream_profiles& requests)
 {
-    //Playback can only play the streams that were recorded. 
+    //Playback can only play the streams that were recorded.
     //Go over the requested profiles and see if they are available
     LOG_DEBUG("Open Sensor " << m_sensor_id);
 
@@ -151,7 +151,7 @@ void playback_sensor::handle_frame(frame_holder frame, bool is_real_time)
         frame->set_stream(m_streams[std::make_pair(type, index)]);
         frame->set_sensor(shared_from_this());
         auto stream_id = frame.frame->get_stream()->get_unique_id();
-        //TODO: remove this once filter is implemented (which will only read streams that were 'open'ed 
+        //TODO: remove this once filter is implemented (which will only read streams that were 'open'ed
         if(m_dispatchers.find(stream_id) == m_dispatchers.end())
         {
             return;

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -63,8 +63,8 @@ librealsense::record_device::~record_device()
 }
 
 std::shared_ptr<context> librealsense::record_device::get_context() const
-{ 
-    return m_device->get_context(); 
+{
+    return m_device->get_context();
 }
 
 librealsense::sensor_interface& librealsense::record_device::get_sensor(size_t i)
@@ -79,7 +79,7 @@ size_t librealsense::record_device::get_sensors_count() const
 
 void librealsense::record_device::write_header()
 {
-    
+
     auto device_extensions_md = get_extensions_snapshots(m_device.get());
     LOG_DEBUG("Created device snapshot with " << device_extensions_md.get_snapshots().size() << " snapshots");
 
@@ -91,7 +91,7 @@ void librealsense::record_device::write_header()
         sensors_snapshot.emplace_back(static_cast<uint32_t>(j), sensor_extensions_snapshots);
         LOG_DEBUG("Created sensor " << j << " snapshot with " << device_extensions_md.get_snapshots().size() << " snapshots");
     }
-    
+
     m_ros_writer->write_device_description({ device_extensions_md, sensors_snapshot, {/*extrinsics are written by ros_writer*/} });
 }
 
@@ -109,7 +109,7 @@ std::chrono::nanoseconds librealsense::record_device::get_capture_time() const
 void librealsense::record_device::write_data(size_t sensor_index, librealsense::frame_holder frame, std::function<void(std::string const&)> on_error)
 {
     //write_data is called from the sensors, when the live sensor raises a frame
-    
+
     LOG_DEBUG("write frame " << (frame ? std::to_string(frame.frame->get_frame_number()) : "") <<  " from sensor " << sensor_index);
 
     std::call_once(m_first_call_flag, [this]()
@@ -298,7 +298,7 @@ void record_device::write_sensor_extension_snapshot(size_t sensor_index,
     });
 }
 
-template <rs2_extension E, typename P> 
+template <rs2_extension E, typename P>
 bool librealsense::record_device::extend_to_aux(std::shared_ptr<P> p, void** ext)
 {
     using EXT_TYPE = typename ExtensionToType<E>::type;
@@ -312,7 +312,7 @@ bool librealsense::record_device::extend_to_aux(std::shared_ptr<P> p, void** ext
             write_device_extension_changes(ext);
         });
     }
-    
+
     *ext = &ptr;
     return true;
 }
@@ -322,10 +322,10 @@ bool librealsense::record_device::extend_to(rs2_extension extension_type, void**
     /**************************************************************************************
      A record device wraps the live device, and should have the same functionalities.
      To do that, the record device implements the extendable_interface and when the user tries to
-     treat the device as some extension, this function is called, and we return a pointer to the 
+     treat the device as some extension, this function is called, and we return a pointer to the
      live device's extension. If that extension is a recordable one, we also enable_recording for it.
     **************************************************************************************/
-    
+
     switch (extension_type)
     {
     case RS2_EXTENSION_INFO:    // [[fallthrough]]

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -42,7 +42,7 @@ librealsense::option_range librealsense::uvc_pu_option::get_range() const
         {
             return dev.get_pu_range(_id);
         });
-    
+
     if (uvc_range.min.size() < sizeof(int32_t)) return option_range{0,0,1,0};
 
     auto min = *(reinterpret_cast<int32_t*>(uvc_range.min.data()));

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -19,7 +19,7 @@ namespace librealsense
      \______| \______/  |__| \__| |__|     |__|  \______|
 
     */
-    pipeline_config::pipeline_config() 
+    pipeline_config::pipeline_config()
     {
         //empty
     }
@@ -100,11 +100,11 @@ namespace librealsense
         _resolved_profile.reset();
     }
 
-    std::shared_ptr<pipeline_profile> pipeline_config::resolve(std::shared_ptr<pipeline> pipe)
+    std::shared_ptr<pipeline_profile> pipeline_config::resolve(std::shared_ptr<pipeline> pipe, unsigned int timeout_ms)
     {
         std::lock_guard<std::mutex> lock(_mtx);
         _resolved_profile.reset();
-        auto requested_device = resolve_device_requests(pipe);
+        auto requested_device = resolve_device_requests(pipe, timeout_ms);
 
         std::vector<stream_profile> resolved_profiles;
 
@@ -113,7 +113,7 @@ namespace librealsense
         {
             if (!requested_device)
             {
-                requested_device = get_first_or_default_device(pipe);
+                requested_device = pipe->wait_for_device(timeout_ms,false);
             }
 
             util::config config;
@@ -130,7 +130,7 @@ namespace librealsense
             {
                 if (!requested_device)
                 {
-                    requested_device = get_first_or_default_device(pipe);
+                    requested_device = pipe->wait_for_device(timeout_ms,false);
                 }
 
                 auto default_profiles = get_default_configuration(requested_device);
@@ -150,7 +150,7 @@ namespace librealsense
             }
             else
             {
-                //User enabled some stream, enable only them   
+                //User enabled some stream, enable only them
                 for(auto&& req : _stream_requests)
                 {
                     auto r = req.second;
@@ -160,7 +160,7 @@ namespace librealsense
                 auto devs = pipe->get_context()->query_devices();
                 if (devs.empty())
                 {
-                    auto dev = get_first_or_default_device(pipe);
+                    auto dev = pipe->wait_for_device(timeout_ms,false);
                     _resolved_profile = std::make_shared<pipeline_profile>(dev, config, _device_request.record_output);
                     return _resolved_profile;
                 }
@@ -189,7 +189,9 @@ namespace librealsense
     {
         try
         {
-            resolve(pipe);
+            // Try to resolve from connected devices. Non-blocking call
+            const unsigned int immediately = 0u;
+            resolve(pipe, immediately);
             _resolved_profile.reset();
         }
         catch (const std::exception& e)
@@ -217,25 +219,12 @@ namespace librealsense
                 }
             }
         }
-        
+
         return pipe->get_context()->add_device(file);
     }
-    std::shared_ptr<device_interface> pipeline_config::get_first_or_default_device(std::shared_ptr<pipeline> pipe)
-    {
-        try
-        {
-            return pipe->wait_for_device(5000);
-        }
-        catch (const std::exception& e)
-        {
-            throw std::runtime_error(to_string() << "Failed to resolve request. " << e.what());
-        }
-    }
-    //TODO: add timeout parameter?
-    std::shared_ptr<device_interface> pipeline_config::resolve_device_requests(std::shared_ptr<pipeline> pipe)
-    {
-        const auto timeout_ms = std::chrono::milliseconds(5000).count();
 
+    std::shared_ptr<device_interface> pipeline_config::resolve_device_requests(std::shared_ptr<pipeline> pipe, unsigned int timeout_ms)
+    {
         //Prefer filename over serial
         if(!_device_request.filename.empty())
         {
@@ -264,7 +253,7 @@ namespace librealsense
                     if (s != _device_request.serial)
                     {
                         throw std::runtime_error(to_string() << "Failed to resolve request. "
-                            "Conflic between enable_device_from_file(\"" << _device_request.filename 
+                            "Conflic between enable_device_from_file(\"" << _device_request.filename
                              << "\") and enable_device(\"" << _device_request.serial << "\"), "
                             "File contains device with different serial number (" << s << "\")");
                     }
@@ -275,7 +264,7 @@ namespace librealsense
 
         if (!_device_request.serial.empty())
         {
-            return pipe->wait_for_device(timeout_ms, _device_request.serial);
+            return pipe->wait_for_device(timeout_ms, false, _device_request.serial);
         }
 
         return nullptr;
@@ -324,7 +313,7 @@ namespace librealsense
         |  |_)  | |  | |  |_)  | |  |__   |  |     |  | |   \|  | |  |__   
         |   ___/  |  | |   ___/  |   __|  |  |     |  | |  . `  | |   __|  
         |  |      |  | |  |      |  |____ |  `----.|  | |  |\   | |  |____ 
-        | _|      |__| | _|      |_______||_______||__| |__| \__| |_______|                                                        
+        | _|      |__| | _|      |_______||_______||__| |__| \__| |_______|
     */
 
     template<class T>
@@ -360,7 +349,7 @@ namespace librealsense
         std::lock_guard<std::mutex> lock(_mtx);
         if (_active_profile)
         {
-            throw librealsense::wrong_api_call_sequence_exception("start() cannnot be called before stop()");
+            throw librealsense::wrong_api_call_sequence_exception("start() cannot be called before stop()");
         }
         unsafe_start(conf);
         return unsafe_get_active_profile();
@@ -371,7 +360,7 @@ namespace librealsense
         std::lock_guard<std::mutex> lock(_mtx);
         if (_active_profile)
         {
-            throw librealsense::wrong_api_call_sequence_exception("start() cannnot be called before stop()");
+            throw librealsense::wrong_api_call_sequence_exception("start() cannot be called before stop()");
         }
         conf->enable_record_to_file(file);
         unsafe_start(conf);
@@ -453,7 +442,7 @@ namespace librealsense
         std::lock_guard<std::mutex> lock(_mtx);
         if (!_active_profile)
         {
-            throw librealsense::wrong_api_call_sequence_exception("stop() cannnot be called before start()");
+            throw librealsense::wrong_api_call_sequence_exception("stop() cannot be called before start()");
         }
         unsafe_stop();
     }
@@ -478,7 +467,7 @@ namespace librealsense
         std::lock_guard<std::mutex> lock(_mtx);
         if (!_active_profile)
         {
-            throw librealsense::wrong_api_call_sequence_exception("wait_for_frames cannnot be called before start()");
+            throw librealsense::wrong_api_call_sequence_exception("wait_for_frames cannot be called before start()");
         }
 
         frame_holder f;
@@ -486,7 +475,7 @@ namespace librealsense
         {
             return f;
         }
-        
+
         try
         {
             unsafe_start(_prev_conf);
@@ -504,7 +493,7 @@ namespace librealsense
 
         if (!_active_profile)
         {
-            throw librealsense::wrong_api_call_sequence_exception("poll_for_frames cannnot be called before start()");
+            throw librealsense::wrong_api_call_sequence_exception("poll_for_frames cannot be called before start()");
         }
 
         if (_queue->try_dequeue(frame))
@@ -514,9 +503,9 @@ namespace librealsense
         return false;
     }
 
-    std::shared_ptr<device_interface> pipeline::wait_for_device(unsigned int timeout_ms, std::string serial)
+    std::shared_ptr<device_interface> pipeline::wait_for_device(unsigned int timeout_ms, bool loop_devices, const std::string& serial)
     {
-        return _hub.wait_for_device(timeout_ms, serial);
+        return _hub.wait_for_device(timeout_ms, loop_devices, serial);
     }
 
     std::shared_ptr<librealsense::context> pipeline::get_context() const
@@ -534,7 +523,7 @@ namespace librealsense
         | _|      | _| `._____| \______/  |__|     |__| |_______||_______|
     */
 
-    pipeline_profile::pipeline_profile(std::shared_ptr<device_interface> dev, 
+    pipeline_profile::pipeline_profile(std::shared_ptr<device_interface> dev,
                                        util::config config,
                                        const std::string& to_file) :
         _dev(dev), _to_file(to_file)
@@ -553,7 +542,7 @@ namespace librealsense
     {
         //pipeline_profile can be retrieved from a pipeline_config and pipeline::start()
         //either way, it is created by the pipeline
-        
+
         //TODO: handle case where device has disconnected and reconnected
         //TODO: remember to recreate the device as record device in case of to_file.empty() == false
         if (!_dev)

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -39,7 +39,7 @@ namespace librealsense
         bool poll_for_frames(frame_holder* frame);
 
         //Non top level API
-        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::milliseconds(std::numeric_limits<unsigned int>::max()),
+        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::hours::max(),
                                                             const std::string& serial = "");
         std::shared_ptr<librealsense::context> get_context() const;
 

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -39,8 +39,8 @@ namespace librealsense
         bool poll_for_frames(frame_holder* frame);
 
         //Non top level API
-        std::shared_ptr<device_interface> wait_for_device(unsigned int timeout_ms = std::numeric_limits<unsigned int>::max(),
-                                                            bool loop_devices = true, const std::string& serial = "");
+        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::milliseconds(std::numeric_limits<unsigned int>::max()),
+                                                            const std::string& serial = "");
         std::shared_ptr<librealsense::context> get_context() const;
 
 
@@ -72,7 +72,7 @@ namespace librealsense
         void enable_record_to_file(const std::string& file);
         void disable_stream(rs2_stream stream, int index = -1);
         void disable_all_streams();
-        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe, unsigned int timeout_ms = 0);
+        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout = std::chrono::milliseconds(0));
         bool can_resolve(std::shared_ptr<pipeline> pipe);
 
         //Non top level API
@@ -97,7 +97,7 @@ namespace librealsense
             std::string record_output;
         };
         std::shared_ptr<device_interface> get_or_add_playback_device(std::shared_ptr<pipeline> pipe, const std::string& file);
-        std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe, unsigned int timeout_ms);
+        std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout);
         stream_profiles get_default_configuration(std::shared_ptr<device_interface> dev);
 
         device_request _device_request;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -39,7 +39,8 @@ namespace librealsense
         bool poll_for_frames(frame_holder* frame);
 
         //Non top level API
-        std::shared_ptr<device_interface> wait_for_device(unsigned int timeout_ms = std::numeric_limits<unsigned int>::max(), std::string serial = "");
+        std::shared_ptr<device_interface> wait_for_device(unsigned int timeout_ms = std::numeric_limits<unsigned int>::max(),
+                                                            bool loop_devices = true, const std::string& serial = "");
         std::shared_ptr<librealsense::context> get_context() const;
 
 
@@ -71,7 +72,7 @@ namespace librealsense
         void enable_record_to_file(const std::string& file);
         void disable_stream(rs2_stream stream, int index = -1);
         void disable_all_streams();
-        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe);
+        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe, unsigned int timeout_ms = 0);
         bool can_resolve(std::shared_ptr<pipeline> pipe);
 
         //Non top level API
@@ -96,10 +97,9 @@ namespace librealsense
             std::string record_output;
         };
         std::shared_ptr<device_interface> get_or_add_playback_device(std::shared_ptr<pipeline> pipe, const std::string& file);
-        std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe);
+        std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe, unsigned int timeout_ms);
         stream_profiles get_default_configuration(std::shared_ptr<device_interface> dev);
-        std::shared_ptr<device_interface> get_first_or_default_device(std::shared_ptr<pipeline> pipe);
-        
+
         device_request _device_request;
         std::map<std::pair<rs2_stream, int>, util::config::request_type> _stream_requests;
         std::mutex _mtx;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -129,7 +129,7 @@ namespace librealsense
             {
                 dev = sensor->get_device().shared_from_this().get();
             }
-            catch (const std::bad_weak_ptr& e)
+            catch (const std::bad_weak_ptr&)
             {
                 LOG_WARNING("Device destroyed");
             }
@@ -169,7 +169,7 @@ namespace librealsense
             }
         }
 
-        if(!dev_exist) 
+        if(!dev_exist)
         {
             matcher = _matchers[stream_id];
             // We don't know what device this frame came from, so just store it under device NULL with ID matcher
@@ -398,8 +398,8 @@ namespace librealsense
             return{ a->get_frame_timestamp(), b->get_frame_timestamp() };
         else
         {
-            return{ a->get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL),
-                    b->get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL) };
+            return{ (double)a->get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL),
+                    (double)b->get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL) };
         }
     }
 

--- a/tools/data-collect/rs-data-collect.cpp
+++ b/tools/data-collect/rs-data-collect.cpp
@@ -132,8 +132,8 @@ void save_data_to_file(std::array<list<frame_data>, NUM_OF_STREAMS> buffer, cons
 
     for (int stream_index = 0; stream_index < NUM_OF_STREAMS; stream_index++)
     {
-        unsigned int buffer_size = buffer[stream_index].size();
-        for (unsigned int i = 0; i < buffer_size; i++)
+        auto buffer_size = buffer[stream_index].size();
+        for (auto i = 0; i < buffer_size; i++)
         {
             ostringstream line;
             auto data = buffer[stream_index].front();
@@ -180,7 +180,7 @@ int main(int argc, char** argv) try
         {
             configure_stream(config, config_file.getValue());
         }
-        
+
         rs2::pipeline_profile profile = pipe.start(config);
         auto dev = profile.get_device();
 

--- a/tools/depth-quality/depth-metrics.h
+++ b/tools/depth-quality/depth-metrics.h
@@ -169,7 +169,7 @@ namespace rs2
             result.plane_corners[3] = approximate_intersection(p, intrin, roi.min_x, roi.max_y);
 
             // Distance of origin (the camera) from the plane is encoded in parameter D of the plane
-            result.distance = static_cast<float>(-p.d * 1000); 
+            result.distance = static_cast<float>(-p.d * 1000);
             // Angle can be calculated from param C
             result.angle = static_cast<float>(std::acos(std::abs(p.c)) / M_PI * 180.);
 

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -72,7 +72,7 @@ namespace rs2
             return valid_config;
         }
 
-        void draw_notification(ux_window& win, const rect& viewer_rect, int w, 
+        void draw_notification(ux_window& win, const rect& viewer_rect, int w,
             const std::string& msg, const std::string& second_line)
         {
             auto flags = ImGuiWindowFlags_NoResize |
@@ -96,11 +96,11 @@ namespace rs2
                 ImGui::SetCursorPosY(pos.y - 10);
             }
             ImGui::PushFont(win.get_large_font());
-            ImGui::Text(msg.c_str());
+            ImGui::Text("%s", msg.c_str());
             ImGui::PopFont();
 
             ImGui::PushFont(win.get_font());
-            ImGui::Text(second_line.c_str());
+            ImGui::Text("%s", second_line.c_str());
             ImGui::PopFont();
 
             ImGui::End();
@@ -114,7 +114,7 @@ namespace rs2
             if (!_roi_located.eval())
             {
                 draw_notification(win, viewer_rect, 450,
-                    u8"\n   \uf1b2  Please point the camera to a flat Wall / Surface!", 
+                    u8"\n   \uf1b2  Please point the camera to a flat Wall / Surface!",
                     "");
                 return false;
             }
@@ -146,7 +146,7 @@ namespace rs2
             if (_sku_right.eval())
             {
                 draw_notification(win, viewer_rect, 400,
-                    u8"\n          \uf061  Rotate the camera slightly Right", 
+                    u8"\n          \uf061  Rotate the camera slightly Right",
                     orientation_instruction);
                 return false;
             }
@@ -527,7 +527,7 @@ namespace rs2
                         ImGui::Text("Angle:");
                         ImGui::SameLine(); ImGui::SetCursorPosX(col1);
                         ImGui::Text("%.2f deg", _metrics_model.get_last_metrics().angle);
-                        
+
                         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
                         ImGui::TreePop();
                     }

--- a/tools/terminal/auto-complete.cpp
+++ b/tools/terminal/auto-complete.cpp
@@ -285,4 +285,5 @@ string auto_complete::get_line(std::function <bool()> to_stop)
     cout.clear();
     cin.clear();
     fflush(nullptr);
+    return std::string{};
 }

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -3662,7 +3662,6 @@ TEST_CASE("Pipeline config enable resolve start flow", "[live]") {
         REQUIRE_NOTHROW(dev = profile.get_device());
         REQUIRE(dev);
 
-        // Specifying RS2_FORMAT_ANY results in RS2_FORMAT_DISPARITY16 which subsequently fails on start
         REQUIRE_NOTHROW(cfg.enable_stream(RS2_STREAM_DEPTH, -1, 0, 0, RS2_FORMAT_Z16, 0));
         REQUIRE_NOTHROW(pipe.start(cfg));
 
@@ -3676,15 +3675,14 @@ TEST_CASE("Pipeline config enable resolve start flow", "[live]") {
         CAPTURE(depth_profile.height());
         std::vector<device_profiles> frames;
 
-        for (auto i = 0; i < 10; i++)
-            REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
-
+        for (auto i = 0; i < 5; i++)
+            REQUIRE_NOTHROW(pipe.wait_for_frames(500));
 
         REQUIRE_NOTHROW(pipe.stop());
         REQUIRE_NOTHROW(pipe.start(cfg));
 
-        for (auto i = 0; i < 20; i++)
-            REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
+        for (auto i = 0; i < 5; i++)
+            REQUIRE_NOTHROW(pipe.wait_for_frames(500));
 
         REQUIRE_NOTHROW(cfg.disable_all_streams());
 

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -1291,6 +1291,8 @@ TEST_CASE("Check width and height of stream intrinsics", "[live][AdvMd]")
             disable_sensitive_options_for(dev);
             std::string serial;
             REQUIRE_NOTHROW(serial = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+            std::string PID;
+            REQUIRE_NOTHROW(PID = dev.get_info(RS2_CAMERA_INFO_PRODUCT_ID));
             if (shared_dev->is<rs400::advanced_mode>())
             {
                 auto advanced = shared_dev->as<rs400::advanced_mode>();
@@ -1335,8 +1337,8 @@ TEST_CASE("Check width and height of stream intrinsics", "[live][AdvMd]")
                         CAPTURE(video.width());
                         CAPTURE(video.height());
 
-                        // Calibration format does not provide intrinsic data
-                        if ((RS2_FORMAT_Y16 != video.format()) || (RS2_STREAM_INFRARED !=video.stream_type()))
+                        // Calibration format does not provide intrinsic data, except for SR300
+                        if ((PID == "0AA5") || (RS2_FORMAT_Y16 != video.format()))
                             REQUIRE_NOTHROW(intrin = video.get_intrinsics());
                         else
                             REQUIRE_THROWS(intrin = video.get_intrinsics());
@@ -2690,7 +2692,7 @@ void validate(std::vector<std::vector<stream_profile>> frames, std::vector<std::
     CAPTURE(requests.sync);
 
     ss.str("");
-    ss << "Received profiles : " << std::endl;
+    ss << "\n\nReceived profiles : " << std::endl;
     std::sort(actual_streams_arrived.begin(), actual_streams_arrived.end());
     auto last = std::unique(actual_streams_arrived.begin(), actual_streams_arrived.end());
     actual_streams_arrived.erase(last, actual_streams_arrived.end());
@@ -2847,17 +2849,17 @@ TEST_CASE("Pipeline poll_for_frames", "[live]")
 }
 
 static const std::map<std::string, device_profiles> pipeline_custom_configurations = {
-    /* RS400/PSR*/      { "0AD1",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
-    /* RS410/ASR*/      { "0AD2",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 640, 1 } }, 30, true } },
+    /* RS400/PSR*/      { "0AD1",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
+    /* RS410/ASR*/      { "0AD2",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS415/ASRC*/     { "0AD3",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
     /* RS430/AWG*/      { "0AD4",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 640, 480, 1 } }, 30, true } },
-    /* RS430_MM/AWGT*/  { "0AD5",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+    /* RS430_MM/AWGT*/  { "0AD5",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS420/PWG*/      { "0AF6",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
-    /* RS420_MM/PWGT*/  { "0AFE",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
-    /* RS410_MM/ASRT*/  { "0AFF",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
-    /* RS400_MM/PSR*/   { "0B00",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+    /* RS420_MM/PWGT*/  { "0AFE",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
+    /* RS410_MM/ASRT*/  { "0AFF",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
+    /* RS400_MM/PSR*/   { "0B00",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS430_MC/AWGTC*/ { "0B01",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
-    /* RS405/DS5U*/     { "0B03",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+    /* RS405/DS5U*/     { "0B03",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS435_RGB/AWGC*/ { "0B07",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
 
     /* SR300*/          { "0AA5",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16,  640, 240, 0 },
@@ -2938,9 +2940,9 @@ static const std::map<std::string, device_profiles> pipeline_autocomplete_config
     /* RS430/AWG*/      { "0AD4",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_ANY, 0, 0, 0 } }, 30, true } },
     /* RS430_MM/AWGT*/  { "0AD5",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_ANY, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_ANY, 0, 0, 1 } }, 30, true } },
     /* RS420/PWG*/      { "0AF6",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_ANY, 0, 0, 0 } }, 30, true } },
-    /* RS420_MM/PWGT*/  { "0AFE",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 0, 0, 1 } }, 30, true } },
-    /* RS410_MM/ASRT*/  { "0AFF",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 0, 0, 1 } }, 30, true } },
-    /* RS400_MM/PSR*/   { "0B00",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 0, 0, 1 } }, 30, true } },
+    /* RS420_MM/PWGT*/  { "0AFE",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 0, 0, 0 } }, 30, true } },
+    /* RS410_MM/ASRT*/  { "0AFF",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 0, 0, 0 } }, 30, true } },
+    /* RS400_MM/PSR*/   { "0B00",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 0, 0, 0 } }, 30, true } },
     /* RS430_MM_RGB/AWGTC*/{ "0B01",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 0, 0, 0 } }, 30, true } },
     /* RS405/DS5U*/     { "0B03",{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 0, 0, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_ANY, 0, 0, 1 } }, 30, true } },
     /* RS435_RGB/AWGC*/ { "0B07",{ { /*{ RS2_STREAM_DEPTH, RS2_FORMAT_ANY, 0, 0, 0 },*/{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 0, 0, 0 } }, 30, true } },
@@ -3327,9 +3329,9 @@ bool compare(const rs2_extrinsics& first, const rs2_extrinsics& second, double d
 
 static const std::map<std::string, device_profiles> pipeline_configurations_for_extrinsic = {
     /* RS400/PSR*/      { "0AD1",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16,  640, 480, 0 },
-                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS410/ASR*/      { "0AD2",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16,  640, 480, 0 },
-                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS415/ASRC*/     { "0AD3",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16, 640, 480, 0 },
                                      { RS2_STREAM_INFRARED, RS2_FORMAT_Y8,  640, 480, 1 } ,
                                      { RS2_STREAM_COLOR,    RS2_FORMAT_RGB8, 1920, 1080, 0 } }, 30, true } },
@@ -3343,14 +3345,14 @@ static const std::map<std::string, device_profiles> pipeline_configurations_for_
     /* RS420_MM/PWGT*/  { "0AFE",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16, 640, 480, 0 },
                                      { RS2_STREAM_INFRARED, RS2_FORMAT_Y8,  640, 480, 1 } }, 30, true } },
     /* RS410_MM/ASRT*/  { "0AFF",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16,  640, 480, 0 },
-                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS400_MM/PSR*/   { "0B00",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16,  640, 480, 0 },
-                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS430_MM_RGB/AWGTC*/{"0B01",{ { { RS2_STREAM_DEPTH,  RS2_FORMAT_Z16, 640, 480, 0 },
                                      { RS2_STREAM_INFRARED, RS2_FORMAT_Y8,  640, 480, 1 } ,
                                      { RS2_STREAM_COLOR,    RS2_FORMAT_RGB8, 1920, 1080, 0 } }, 30, true } },
     /* RS405/DS5U*/     { "0B03",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16,  640, 480, 0 },
-                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+                                     { RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS435_RGB/AWGC*/ { "0B07",{ { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16, 640, 480, 0 },
                                      { RS2_STREAM_INFRARED, RS2_FORMAT_Y8,  640, 480, 1 } ,
                                      { RS2_STREAM_COLOR,    RS2_FORMAT_RGB8, 1920, 1080, 0 } }, 30, true } },


### PR DESCRIPTION
In multi-cam scenario the pipeline shall stick to the device selection as long as the streams configuration and the hw setup remain unchanged.
The pipeline relies on device hub that incorporates a subtle functionality to cycle through the available devices in certain scenarios. The feature was refactored to co-exist with an additional requirement for a predictable (i.e. persistent) device selection behavior in case the environment and the configuration have not been changed.

Fixes to pipeline unit-tests for ASR/PSR modules
