### PR TITLE
Fixing the issue where Advanced Mode controls were not showing in the…

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3612,8 +3612,9 @@ namespace rs2
                             {
                                 ImGui::SetTooltip("Disabling advanced mode will reset depth generation to factory settings\nThis will not affect calibration");
                             }
-                            draw_advanced_mode_controls(advanced, amc, get_curr_advanced_controls);
                         }
+
+                        draw_advanced_mode_controls(advanced, amc, get_curr_advanced_controls);
                     }
                     else
                     {


### PR DESCRIPTION
In version 2.8.0 the Depth Quality tool was not showing the list of Advanced Mode controls in the UX due to a small bug in the rendering flow. 