### PR TITLE
Fixed issues in device_hub

### DIFF
--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -96,6 +96,7 @@ namespace librealsense
         std::shared_ptr<device_interface> res = nullptr;
 
         // check if there is at least one device connected
+        _device_list = filter_by_vid(_ctx->query_devices(), _vid);
         if (_device_list.size() > 0)
         {
             res = create_device(serial, loop_through_devices);

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -23,7 +23,7 @@ namespace librealsense
          * from a list of connected devices.
          * Calling the function with a valid timeout will block till the resulted device is found or the timeout expires.
          * \param[in] timeout_ms  The waiting period for the requested device to be reconnected (milliseconds).
-         * Due to an implementation issue both in MSVC and GCC the timeout duration is initialized with hours::max() to avoid generation of
+         * Due to an implementation issue both in MSVC and GCC the timeout equals to 1 hour to avoid generation of
          * negative durations.
          *.\param[in] loop_through_devices  - promote internal index to the next available device that will be retrieved on successive call
          *  Note that selection of the next device is deterministic but not predictable, and therefore is recommended for
@@ -32,9 +32,9 @@ namespace librealsense
          * \return       a shared pointer to the device_interface that satisfies the search criteria. In case the request was not
          * resloved the call will throw an exception
          */
-        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::hours::max(),
-                                                            bool loop_through_devices = true,
-                                                            const std::string& serial = "");
+        std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::milliseconds(std::chrono::hours(1)),
+                                                          bool loop_through_devices = true,
+                                                          const std::string& serial = "");
 
         /**
         * Checks if device is still connected
@@ -57,5 +57,3 @@ namespace librealsense
         bool _register_device_notifications;
     };
 }
-
-

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -54,9 +54,6 @@ int main(int argc, char* argv[])
     log_to_file(RS2_LOG_SEVERITY_WARN, "librealsense.log");
     // Obtain a list of devices currently present on the system
 
-
-
-
     unique_ptr<fw_logs_parser> fw_log_parser;
     auto use_xml_file = false;
     auto xml_full_file_path = xml_arg.getValue();
@@ -70,17 +67,18 @@ int main(int argc, char* argv[])
         }
     }
 
-
     context ctx;
     device_hub hub(ctx);
 
-    while (true) {
-
+    while (true)
+    {
+        cout << "\nWaiting for RealSense device to connect...\n";
         auto dev = hub.wait_for_device();
-        vector<uint8_t> input;
-
+        cout << "RealSense device has connected...\n";
         try
         {
+            vector<uint8_t> input;
+
             auto str_op_code = dev.get_info(RS2_CAMERA_INFO_DEBUG_OP_CODE);
             auto op_code = static_cast<uint8_t>(stoi(str_op_code));
             input = {0x14, 0x00, 0xab, 0xcd, op_code, 0x00, 0x00, 0x00,
@@ -91,14 +89,8 @@ int main(int argc, char* argv[])
                     "Device Location: " << dev.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT) << endl << endl;
 
             setvbuf(stdout, NULL, _IONBF, 0); // unbuffering stdout
-        }
-        catch (const error & e)
-        {
-            cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << endl;
-        }
 
-        while (hub.is_connected(dev)) {
-            try
+            while (hub.is_connected(dev))
             {
                 this_thread::sleep_for(chrono::milliseconds(100));
 
@@ -112,7 +104,7 @@ int main(int argc, char* argv[])
                     fw_logs_binary_data fw_logs_binary_data = {raw_data};
                     fw_logs_binary_data.logs_buffer.erase(fw_logs_binary_data.logs_buffer.begin(),fw_logs_binary_data.logs_buffer.begin()+4);
                     fw_log_lines = fw_log_parser->get_fw_log_lines(fw_logs_binary_data);
-                    for (auto & elem : fw_log_lines)
+                    for (auto& elem : fw_log_lines)
                         elem = datetime_string() + "  " + elem;
                 }
                 else
@@ -128,13 +120,12 @@ int main(int argc, char* argv[])
                 for (auto& line : fw_log_lines)
                     cout << line << endl;
             }
-            catch (const error & e)
-            {
-                cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << endl;
-            }
         }
-
+        catch (const error & e)
+        {
+            cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << endl;
+        }
     }
-    return EXIT_SUCCESS;
 
+    return EXIT_SUCCESS;
 }

--- a/tools/terminal/rs-terminal.cpp
+++ b/tools/terminal/rs-terminal.cpp
@@ -141,6 +141,13 @@ void read_script_file(const string& full_file_path, vector<string>& hex_lines)
     throw runtime_error("Script file not found!");
 }
 
+device wait_for_device(const device_hub& hub)
+{
+    cout << "\nWaiting for RealSense device to connect...\n";
+    auto dev = hub.wait_for_device();
+    cout << "RealSense device has connected...\n";
+    return dev;
+}
 
 int main(int argc, char** argv)
 {
@@ -190,7 +197,7 @@ int main(int argc, char** argv)
 
     while (true)
     {
-        auto dev = hub.wait_for_device();
+        auto dev = wait_for_device(hub);
         fflush(nullptr);
 
         if (hex_cmd_arg.isSet())
@@ -275,7 +282,7 @@ int main(int argc, char** argv)
 
                 if (line == "next")
                 {
-                    dev = hub.wait_for_device();
+                    dev = wait_for_device(hub);
                     continue;
                 }
                 if (line == "exit")


### PR DESCRIPTION
- Fixed an issue when a device has disconnected and wait_for_device() was called before an event has handled by 'device_hub'. In this case '_device_list' variable will contain an invalid device and will transfer to create_device(...) function. This issue was fixed by calling to query_devices() in wait_for_device() function.
- Default timeout changed to 1 hour due to negative time duration. 
- Added prints to console before and after wait_for_device() function in rs_terminal and rs_fw_logger.