### PR TITLE
Pipeline behavior change - returned framesets will contain frames from all active streams 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,11 @@ script:
 
       export LRS_LOG_LEVEL="DEBUG";
 
-      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_19_40_10_19_17;
-      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_18_01_10_19_17;
+      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_23_40_10_19_17;
+      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc_lrs_2.8.0_fw_5.8.9_ts_23_25_10_19_17;
 
-      ./unit-tests/live-test from awgc_lrs_2.8.0_fw_5.8.9_ts_19_40_10_19_17 -d yes;
-      ./unit-tests/live-test from asrc__lrs_2.8.0_fw_5.8.9_ts_18_01_10_19_17 -d yes;
+      ./unit-tests/live-test from awgc_lrs_2.8.0_fw_5.8.9_ts_23_40_10_19_17 -d yes;
+      ./unit-tests/live-test from asrc_lrs_2.8.0_fw_5.8.9_ts_23_25_10_19_17 -d yes;
 
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,11 @@ script:
 
       export LRS_LOG_LEVEL="DEBUG";
 
-      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_fw_5.8.9_lrs_2.8.0;
-      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc_fw_5.8.9_lrs_2.8.0;
+      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17;
+      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17;
 
-      ./unit-tests/live-test from awgc_fw_5.8.9_lrs_2.8.0 -d yes;
-      ./unit-tests/live-test from asrc_fw_5.8.9_lrs_2.8.0 -d yes;
+      ./unit-tests/live-test from awgc_lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17 -d yes;
+      ./unit-tests/live-test from asrc__lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17 -d yes;
 
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,11 +77,11 @@ script:
 
       export LRS_LOG_LEVEL="DEBUG";
 
-      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17;
-      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17;
+      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_19_40_10_19_17;
+      wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_18_01_10_19_17;
 
-      ./unit-tests/live-test from awgc_lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17 -d yes;
-      ./unit-tests/live-test from asrc__lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17 -d yes;
+      ./unit-tests/live-test from awgc_lrs_2.8.0_fw_5.8.9_ts_19_40_10_19_17 -d yes;
+      ./unit-tests/live-test from asrc__lrs_2.8.0_fw_5.8.9_ts_18_01_10_19_17 -d yes;
 
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,9 @@ build:
   verbosity: minimal
 test_script:
 - ps: >-
-    $url_awgc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17"
+    $url_awgc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_19_40_10_19_17"
 
-    $url_asrc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17"
+    $url_asrc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_18_01_10_19_17"
 
     $output_awgc = "C:/projects/librealsense/build/Debug/live_test_awgc"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,9 @@ build:
   verbosity: minimal
 test_script:
 - ps: >-
-    $url_awgc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_19_40_10_19_17"
+    $url_awgc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_23_40_10_19_17"
 
-    $url_asrc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_18_01_10_19_17"
+    $url_asrc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc_lrs_2.8.0_fw_5.8.9_ts_23_25_10_19_17"
 
     $output_awgc = "C:/projects/librealsense/build/Debug/live_test_awgc"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,9 +32,9 @@ build:
   verbosity: minimal
 test_script:
 - ps: >-
-    $url_awgc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_fw_5.8.9_lrs_2.8.0"
+    $url_awgc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/awgc_lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17"
 
-    $url_asrc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc_fw_5.8.9_lrs_2.8.0"
+    $url_asrc = "http://realsense-hw-public.s3.amazonaws.com/rs-tests/asrc__lrs_2.8.0_fw_5.8.9_ts_16_00_10_18_17"
 
     $output_awgc = "C:/projects/librealsense/build/Debug/live_test_awgc"
 

--- a/examples/align/readme.md
+++ b/examples/align/readme.md
@@ -121,11 +121,11 @@ while (app) // Application still alive?
 Inside the loop, the first thing we do is block the program until the `align` object returns a `rs2::frameset`. A `rs2::frameset` is an object that holds a set of frames and provides an interface for easily accessing them.
 
 ```cpp
-    // Using the align object, we block the application until a frameset is available
-    rs2::frameset frameset = align.wait_for_frames();
-```
+    // Using the pipeline object, we block the application until a frameset is available
+    frameset = pipe.wait_for_frames();
+``` auto proccessed = align.proccess(frameset);	
 
-The `frameset` returned from `wait_for_frames` should contain a set of aligned frames, but we should check that the frames it contains are indeed valid:
+The `proccessed` returned from `proccess` should contain a set of aligned frames
 
 
 ```cpp

--- a/examples/align/readme.md
+++ b/examples/align/readme.md
@@ -134,7 +134,7 @@ The `frameset` returned from `wait_for_frames` should contain a set of aligned f
     rs2::depth_frame aligned_depth_frame = frameset.get_depth_frame();
 
     //If one of them is unavailable, try to obtain another frameset
-    if (!aligned_depth_frame || !color_frame)
+    if (!aligned_depth_frame)
     {
         continue;
     }

--- a/examples/align/rs-align.cpp
+++ b/examples/align/rs-align.cpp
@@ -52,10 +52,7 @@ int main(int argc, char * argv[]) try
         // Using the align object, we block the application until a frameset is available
         rs2::frameset frameset;
 
-        while (!frameset.first_or_default(RS2_STREAM_DEPTH) || !frameset.first_or_default(align_to))
-        {
-            frameset = pipe.wait_for_frames();
-        }
+        frameset = pipe.wait_for_frames();
 
         auto proccessed = align.proccess(frameset);
 
@@ -64,7 +61,7 @@ int main(int argc, char * argv[]) try
         rs2::depth_frame aligned_depth_frame = proccessed.get_depth_frame();
 
         //If one of them is unavailable, continue iteration
-        if (!aligned_depth_frame || !color_frame)
+        if (!aligned_depth_frame)
         {
             continue;
         }

--- a/examples/pointcloud/readme.md
+++ b/examples/pointcloud/readme.md
@@ -74,7 +74,7 @@ Using helper functions on the `frameset` object we check for new depth and color
 	auto frames = pipe.wait_for_frames();
 	auto depth = frames.get_depth_frame();
 
-    // If we got a depth frame, generate the pointcloud and texture mappings
+    // Generate the pointcloud and texture mappings
     points = pc.calculate(depth);
 
 	auto color = frames.get_color_frame();

--- a/examples/pointcloud/readme.md
+++ b/examples/pointcloud/readme.md
@@ -68,23 +68,23 @@ Next, we wait in a loop unit for the next set of frames:
 auto data = pipe.wait_for_frames(); // Wait for next set of frames from the camera
 ```
 
-Using helper functions on the `frameset` object we check for new depth and color frames. If we get a color frame, we pass it to the `pointcloud` object to use as the texture, and also give it to OpenGL with the help of the `texture` class. If we get a depth frame, we generate a new pointcloud.
+Using helper functions on the `frameset` object we check for new depth and color frames. We pass it to the `pointcloud` object to use as the texture, and also give it to OpenGL with the help of the `texture` class. We generate a new pointcloud.
 ```cpp
 // Wait for the next set of frames from the camera
-auto frames = pipe.wait_for_frames();
-if (rs2::frame depth = frames.get_depth_frame())
-{
+	auto frames = pipe.wait_for_frames();
+	auto depth = frames.get_depth_frame();
+
     // If we got a depth frame, generate the pointcloud and texture mappings
     points = pc.calculate(depth);
-}
-if (rs2::frame color = frames.get_color_frame())
-{
+
+	auto color = frames.get_color_frame();
+
     // Tell pointcloud object to map to this color frame
     pc.map_to(color);
 
     // Upload the color frame to OpenGL
     app_state.tex.upload(color);
-}
+
 ```
 
 Finally we call `draw_pointcloud` to draw the pointcloud.

--- a/examples/pointcloud/rs-pointcloud.cpp
+++ b/examples/pointcloud/rs-pointcloud.cpp
@@ -41,20 +41,19 @@ int main(int argc, char * argv[]) try
         // Wait for the next set of frames from the camera
         auto frames = pipe.wait_for_frames();
 
-        if (rs2::frame depth = frames.get_depth_frame())
-        {
-            // If we got a depth frame, generate the pointcloud and texture mappings
-            points = pc.calculate(depth);
-        }
-        if (rs2::frame color = frames.get_color_frame())
-        {
-            // Tell pointcloud object to map to this color frame
-            pc.map_to(color);
+        auto depth = frames.get_depth_frame();
+        
+        // If we got a depth frame, generate the pointcloud and texture mappings
+        points = pc.calculate(depth);
+        
+        auto color = frames.get_color_frame();
+        
+        // Tell pointcloud object to map to this color frame
+        pc.map_to(color);
 
-            // Upload the color frame to OpenGL
-            app_state.tex.upload(color);
-        }
-
+        // Upload the color frame to OpenGL
+        app_state.tex.upload(color);
+        
         // Draw the pointcloud
         draw_pointcloud(app, app_state, points);
     }

--- a/examples/pointcloud/rs-pointcloud.cpp
+++ b/examples/pointcloud/rs-pointcloud.cpp
@@ -43,7 +43,7 @@ int main(int argc, char * argv[]) try
 
         auto depth = frames.get_depth_frame();
         
-        // If we got a depth frame, generate the pointcloud and texture mappings
+        // Generate the pointcloud and texture mappings
         points = pc.calculate(depth);
         
         auto color = frames.get_color_frame();

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -421,6 +421,8 @@ namespace rs2
         /**
         * Wait until a new set of frames becomes available.
         * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
+        * In case of different frame rates of the streams, the frames set include a matching frame of the slow stream,
+        * which may have been included in previous frames set.
         * The method blocks the calling thread, and fetches the latest unread frames set.
         * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method
         * should be called as fast as the device frame rate.

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #define RS2_API_MAJOR_VERSION    2
 #define RS2_API_MINOR_VERSION    8
-#define RS2_API_PATCH_VERSION    0
+#define RS2_API_PATCH_VERSION    1
 #define RS2_API_BUILD_VERSION    0
 
 #define STRINGIFY(arg) #arg

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
 <package format="2">
   <name>librealsense2</name>
   <!-- The version tag needs to be updated with each new release of librealsense -->
-  <version>2.8.0</version>
+  <version>2.8.1</version>
   <description>
   Library for capturing data from the Intel(R) RealSense(TM) SR300 and D400 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project, including multi-camera capture.
   </description>

--- a/src/core/processing.h
+++ b/src/core/processing.h
@@ -43,7 +43,6 @@ namespace librealsense
         virtual void set_processing_callback(frame_processor_callback_ptr callback) = 0;
         virtual void set_output_callback(frame_callback_ptr callback) = 0;
         virtual void invoke(frame_holder frame) = 0;
-
         virtual synthetic_source_interface& get_source() = 0;
 
         virtual ~processing_block_interface() = default;

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -409,6 +409,7 @@ namespace librealsense
         else
         {
             LOG_ERROR("Non composite frame arrived to pipeline::handle_frame");
+            assert(false);
         }
     }
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -513,6 +513,7 @@ namespace librealsense
             return f;
         }
 
+        //hub returns true even if device already reconnected
         if (!_hub.is_connected(*_active_profile->get_device()))
         {
             try
@@ -527,9 +528,9 @@ namespace librealsense
                 }
 
             }
-            catch (const std::exception&)
+            catch (const std::exception& e)
             {
-                throw std::runtime_error(to_string() << "Device disconnected. Failed to recconect" << timeout_ms);
+                throw std::runtime_error(to_string() << "Device disconnected. Failed to recconect: "<<e.what() << timeout_ms);
             }
         }
         throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -401,7 +401,6 @@ namespace librealsense
             {
                 set.push_back(s.second.clone());
             }
-            //frame_holder f(comp);
             auto fref = source->allocate_composite_frame(std::move(set));
 
             _queue->enqueue(fref);

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -451,7 +451,7 @@ namespace librealsense
                 //first try to get the previously resolved profile (if exists)
                 profile = conf->get_cached_resolved_profile();
                 if(i > 1 || !profile)
-                    profile = conf->resolve(shared_from_this());
+                    profile = conf->resolve(shared_from_this(), std::chrono::seconds(5));
             }
             catch (...)
             {
@@ -520,11 +520,16 @@ namespace librealsense
                 auto prev_conf = _prev_conf;
                 unsafe_stop();
                 unsafe_start(prev_conf);
-                return frame_holder();
+
+                if (_queue->dequeue(&f, timeout_ms))
+                {
+                    return f;
+                }
+
             }
             catch (const std::exception&)
             {
-                throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
+                throw std::runtime_error(to_string() << "Device disconnected. Failed to recconect" << timeout_ms);
             }
         }
         throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -513,7 +513,9 @@ namespace librealsense
         {
             try
             {
-                unsafe_start(_prev_conf);
+                auto prev_conf = _prev_conf;
+                unsafe_stop();
+                unsafe_start(prev_conf);
                 return frame_holder();
             }
             catch (const std::exception&)

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -492,10 +492,10 @@ namespace librealsense
             catch(...){ } // Stop will throw if device was disconnected. TODO - refactoring anticipated
         }
         _syncer.reset();
+        _pipeline_proccess.reset();
         _queue.reset();
         _active_profile.reset();
         _prev_conf.reset();
-        _pipeline_proccess.reset();
         _last_set.clear();
 
     }

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -391,18 +391,53 @@ namespace librealsense
 
         return _active_profile;
     }
+    void pipeline::handle_frame(frame_holder frame, synthetic_source_interface* source)
+    {
+        auto comp = dynamic_cast<composite_frame*>(frame.frame);
+        if (comp)
+        {
+            for (auto i = 0; i< comp->get_embedded_frames_count(); i++)
+            {
+                auto f = comp->get_frame(i);
+                f->acquire();
+                _last_set[f->get_stream()->get_unique_id()] = f;
+            }
+
+            for (auto&& s : _active_profile->get_active_streams())
+            {
+                if (!_last_set[s->get_unique_id()])
+                    return;
+            }
+
+            std::vector<frame_holder> set;
+            for (auto&& s : _last_set)
+            {
+                set.push_back(s.second.clone());
+            }
+            //frame_holder f(comp);
+            auto fref = source->allocate_composite_frame(std::move(set));
+
+            _queue->enqueue(fref);
+        }
+
+    }
+
     void pipeline::unsafe_start(std::shared_ptr<pipeline_config> conf)
     {
-        auto syncer = std::unique_ptr<syncer_proccess_unit>(new syncer_proccess_unit());
-        auto queue = std::unique_ptr<single_consumer_queue<frame_holder>>(new single_consumer_queue<frame_holder>());
-
-        auto to_user = [&](frame_holder fref)
+        _syncer = std::unique_ptr<syncer_proccess_unit>(new syncer_proccess_unit());
+        _queue = std::unique_ptr<single_consumer_queue<frame_holder>>(new single_consumer_queue<frame_holder>());
+        _pipeline_proccess = std::unique_ptr<processing_block>(new processing_block());
+        auto f = [&](frame_holder frame, synthetic_source_interface* source)
         {
-            _queue->enqueue(std::move(fref));
+            handle_frame(std::move(frame), source);
         };
 
+        _pipeline_proccess->set_processing_callback(std::shared_ptr<rs2_frame_processor_callback>(
+            new internal_frame_processor_callback<decltype(f)>(f)));
+
+        auto t = [&](frame_holder fref){_pipeline_proccess->invoke(std::move(fref));};
         frame_callback_ptr user_callback =
-        { new internal_frame_callback<decltype(to_user)>(to_user),
+        { new internal_frame_callback<decltype(t)>(t),
             [](rs2_frame_callback* p) { p->release(); } };
 
         auto to_syncer = [&](frame_holder fref)
@@ -414,10 +449,7 @@ namespace librealsense
         { new internal_frame_callback<decltype(to_syncer)>(to_syncer),
             [](rs2_frame_callback* p) { p->release(); } };
 
-        syncer->set_output_callback(user_callback);
-
-        _queue = std::move(queue);
-        _syncer = std::move(syncer);
+        _syncer->set_output_callback(user_callback);
 
         std::shared_ptr<pipeline_profile> profile = nullptr;
         const int NUM_TIMES_TO_RETRY = 3;
@@ -472,6 +504,9 @@ namespace librealsense
         _queue.reset();
         _active_profile.reset();
         _prev_conf.reset();
+        _pipeline_proccess.reset();
+        _last_set.clear();
+
     }
     frame_holder pipeline::wait_for_frames(unsigned int timeout_ms)
     {
@@ -487,15 +522,19 @@ namespace librealsense
             return f;
         }
         
-        try
+        if (!_hub.is_connected(*_active_profile->get_device()))
         {
-            unsafe_start(_prev_conf);
-            return frame_holder();
+            try
+            {
+                unsafe_start(_prev_conf);
+                return frame_holder();
+            }
+            catch (const std::exception&)
+            {
+                throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
+            }
         }
-        catch(const std::exception&)
-        {
-            throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
-        }
+        throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
     }
 
     bool pipeline::poll_for_frames(frame_holder* frame)

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -44,9 +44,10 @@ namespace librealsense
 
 
      private:
-         void unsafe_start(std::shared_ptr<pipeline_config> conf);
-         void unsafe_stop();
-         std::shared_ptr<pipeline_profile> unsafe_get_active_profile() const;
+        void unsafe_start(std::shared_ptr<pipeline_config> conf);
+        void unsafe_stop();
+        std::shared_ptr<pipeline_profile> unsafe_get_active_profile() const;
+        void handle_frame(frame_holder frame, synthetic_source_interface* source);
 
         std::shared_ptr<librealsense::context> _ctx;
         mutable std::mutex _mtx;
@@ -54,9 +55,12 @@ namespace librealsense
         std::shared_ptr<pipeline_profile> _active_profile;
         frame_callback_ptr _callback;
         std::unique_ptr<syncer_proccess_unit> _syncer;
+        std::unique_ptr<processing_block> _pipeline_proccess;
         std::unique_ptr<single_consumer_queue<frame_holder>> _queue;
 
         std::shared_ptr<pipeline_config> _prev_conf;
+
+        std::map<stream_id, frame_holder> _last_set;
     };
 
 

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -11,6 +11,18 @@
 
 namespace librealsense
 {
+    class pipeline_processing_block : public processing_block
+    {
+        std::map<stream_id, frame_holder> _last_set;
+        std::unique_ptr<single_consumer_queue<frame_holder>> _queue;
+        std::vector<int> _streams_ids;
+        void handle_frame(frame_holder frame, synthetic_source_interface* source);
+    public:
+        pipeline_processing_block(const std::vector<int>& streams_to_aggragate);
+        bool dequeue(frame_holder* item, unsigned int timeout_ms = 5000);
+        bool try_dequeue(frame_holder* item);
+    };
+
     class pipeline;
     class pipeline_profile
     {
@@ -55,74 +67,9 @@ namespace librealsense
         std::shared_ptr<pipeline_profile> _active_profile;
         frame_callback_ptr _callback;
         std::unique_ptr<syncer_proccess_unit> _syncer;
-
-        class pipeline_processing_block : public processing_block
-        {
-            std::map<stream_id, frame_holder> _last_set;
-            std::unique_ptr<single_consumer_queue<frame_holder>> _queue;
-            std::vector<int> _streams_ids;
-            void handle_frame(frame_holder frame, synthetic_source_interface* source)
-            {
-                auto comp = dynamic_cast<composite_frame*>(frame.frame);
-                if (comp)
-                {
-                    for (auto i = 0; i< comp->get_embedded_frames_count(); i++)
-                    {
-                        auto f = comp->get_frame(i);
-                        f->acquire();
-                        _last_set[f->get_stream()->get_unique_id()] = f;
-                    }
-
-                    for (int s : _streams_ids)
-                    {
-                        if (!_last_set[s])
-                            return;
-                    }
-
-                    std::vector<frame_holder> set;
-                    for (auto&& s : _last_set)
-                    {
-                        set.push_back(s.second.clone());
-                    }
-                    auto fref = source->allocate_composite_frame(std::move(set));
-
-                    _queue->enqueue(fref);
-                }
-                else
-                {
-                    LOG_ERROR("Non composite frame arrived to pipeline::handle_frame");
-                    assert(false);
-                }
-            }
-        public:
-            pipeline_processing_block(const std::vector<int>& streams_to_aggragate) :
-                _queue(new single_consumer_queue<frame_holder>()),
-                _streams_ids(streams_to_aggragate)
-            {
-                auto processing_callback = [&](frame_holder frame, synthetic_source_interface* source)
-                {
-                    handle_frame(std::move(frame), source);
-                };
-
-                set_processing_callback(std::shared_ptr<rs2_frame_processor_callback>(
-                    new internal_frame_processor_callback<decltype(processing_callback)>(processing_callback)));
-            }
-            
-            bool dequeue(frame_holder* item, unsigned int timeout_ms = 5000)
-            {
-                return _queue->dequeue(item, timeout_ms);
-            }
-            bool try_dequeue(frame_holder* item)
-            {
-                return _queue->try_dequeue(item);
-            }
-
-        } ;
         std::unique_ptr<pipeline_processing_block> _pipeline_proccess;
         std::shared_ptr<pipeline_config> _prev_conf;
-
     };
-
 
     class pipeline_config
     {

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -6,26 +6,12 @@
 
 namespace librealsense
 {
-    template<class T>
-    class internal_frame_processor_callback : public rs2_frame_processor_callback
-    {
-        T on_frame_function;
-    public:
-        explicit internal_frame_processor_callback(T on_frame) : on_frame_function(on_frame) {}
 
-        void on_frame(rs2_frame * f, rs2_source * source) override
-        {
-            frame_holder front((frame_interface*)f);
-            on_frame_function(std::move(front), source->source);
-        }
-
-        void release() override { delete this; }
-    };
 
     syncer_proccess_unit::syncer_proccess_unit()
-        : _matcher({})
+        : _matcher((new timestamp_composite_matcher({})))
     {
-        _matcher.set_callback([this](frame_holder f, syncronization_environment env)
+        _matcher->set_callback([this](frame_holder f, syncronization_environment env)
         {
 
             std::stringstream ss;
@@ -37,7 +23,7 @@ namespace librealsense
                 ss << matched->get_stream()->get_stream_type() << " " << matched->get_frame_number() << ", "<<std::fixed<< matched->get_frame_timestamp()<<" ";
             }
 
-            LOG_WARNING(ss.str());
+            LOG_DEBUG(ss.str());
             env.matches.enqueue(std::move(f));
         });
 
@@ -47,7 +33,7 @@ namespace librealsense
 
             {
                 std::lock_guard<std::mutex> lock(_mutex);
-                _matcher.dispatch(std::move(frame), { source, matches });
+                _matcher->dispatch(std::move(frame), { source, matches });
             }
 
             frame_holder f;
@@ -68,6 +54,7 @@ namespace librealsense
 
     void  matcher::sync(frame_holder f, syncronization_environment env)
     {
+        auto cb = begin_callback();
         _callback(std::move(f), env);
     }
 
@@ -95,7 +82,8 @@ namespace librealsense
     {
         for (auto&& matcher : matchers)
         {
-            for (auto&& stream : matcher->get_streams())
+            auto s = matcher->get_streams();
+            for (auto&& stream : s)
             {
                 matcher->set_callback([&](frame_holder f, syncronization_environment env)
                 {
@@ -195,6 +183,7 @@ namespace librealsense
 
     void composite_matcher::sync(frame_holder f, syncronization_environment env)
     {
+        update_next_expected(f);
         auto matcher = find_matcher(f);
         _frames_queue[matcher.get()].enqueue(std::move(f));
 
@@ -202,7 +191,7 @@ namespace librealsense
         std::vector<librealsense::matcher*> frames_arrived_matchers;
         std::vector<librealsense::matcher*> synced_frames;
         std::vector<librealsense::matcher*> missing_streams;
-
+        
         do
         {
             auto old_frames = false;
@@ -278,7 +267,7 @@ namespace librealsense
                     frame_holder frame;
                     _frames_queue[index].dequeue(&frame);
 
-                    update_next_expected(frame);
+                    
 
                     match.push_back(std::move(frame));
                 }
@@ -309,11 +298,11 @@ namespace librealsense
 
                 }
                 s<<"\n";
-                //std::cout<<s.str();
-                LOG_DEBUG(s.str());
+                //LOG_DEBUG(s.str());
                 frame_holder composite = env.source->allocate_composite_frame(std::move(match));
                 if (composite.frame)
                 {
+                    auto cb = begin_callback();
                     _callback(std::move(composite), env);
                 }
             }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -82,8 +82,7 @@ namespace librealsense
     {
         for (auto&& matcher : matchers)
         {
-            auto s = matcher->get_streams();
-            for (auto&& stream : s)
+            for (auto&& stream : matcher->get_streams())
             {
                 matcher->set_callback([&](frame_holder f, syncronization_environment env)
                 {

--- a/src/sync.h
+++ b/src/sync.h
@@ -90,24 +90,24 @@ namespace librealsense
 
         callback_invocation_holder begin_callback()
         {
-            return{ callback_inflight.allocate(), &callback_inflight };
+            return{ _callback_inflight.allocate(), &_callback_inflight };
         }
 
         virtual ~matcher()
         {
-            callback_inflight.stop_allocation();
+            _callback_inflight.stop_allocation();
 
-            auto callbacks_inflight = callback_inflight.get_size();
+            auto callbacks_inflight = _callback_inflight.get_size();
             if (callbacks_inflight > 0)
             {
                 LOG_WARNING(callbacks_inflight << " callbacks are still running on some other threads. Waiting until all callbacks return...");
             }
             // wait until user is done with all the stuff he chose to borrow
-            callback_inflight.wait_until_empty();
+            _callback_inflight.wait_until_empty();
         }
     protected:
         sync_callback _callback;
-        callbacks_heap callback_inflight;
+        callbacks_heap _callback_inflight;
     };
 
     class identity_matcher : public matcher


### PR DESCRIPTION
## Pipeline behavior change

### Was: 
On successful return from `wait_for_frames()` or `poll_for_frames()`, the returned `rs2::frameset` **could have contained less** frames than the number of active streams
### Now: 
On successful return from `wait_for_frames()` or `poll_for_frames()`, the returned `rs2::frameset` **will contain exactly** the number of active streams

### Required Change:
Previous checks of a returned `rs2::frameset`s for null frames inside the set are redundant.

## PR Summary:

- Updated pipeline to raise only full sets of frames.
- Updated examples to new behavior
- Updated CI (new recordings)
- Bumped version to 2.8.1
- Added frames flush to `librealsense::matcher`