### PR TITLE
Fix src/concurrency.h by adding #include <functional> so that compiler errors no longer occur

### DIFF
--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -7,6 +7,7 @@
 #include <condition_variable>
 #include <thread>
 #include <atomic>
+#include <functional>
 
 const int QUEUE_MAX_SIZE = 10;
 // Simplest implementation of a blocking concurrent queue for thread messaging


### PR DESCRIPTION
When compiling the current master with g++ 7.2.0, compiler errors would result. This change adds #include <functional> to src/concurrency.h so that no more compiler errors result, and it can build completely. The exact output when attempting to compile without the patch is: 




[ 17%] Built target realsense-file
[ 18%] Building CXX object CMakeFiles/realsense2.dir/src/error-handling.cpp.o
In file included from /home/genericuser/Desktop/librealsense/src/error-handling.h:3:0,
                 from /home/genericuser/Desktop/librealsense/src/error-handling.cpp:1:
/home/genericuser/Desktop/librealsense/src/concurrency.h:243:32: error: ‘function’ is not a member of ‘std’
     single_consumer_queue<std::function<void(cancellable_timer)>> _queue;
                                ^~~~~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h:243:32: note: suggested alternative: ‘is_function’
     single_consumer_queue<std::function<void(cancellable_timer)>> _queue;
                                ^~~~~~~~
                                is_function
/home/genericuser/Desktop/librealsense/src/concurrency.h:243:32: error: ‘function’ is not a member of ‘std’
/home/genericuser/Desktop/librealsense/src/concurrency.h:243:32: note: suggested alternative: ‘is_function’
     single_consumer_queue<std::function<void(cancellable_timer)>> _queue;
                                ^~~~~~~~
                                is_function
/home/genericuser/Desktop/librealsense/src/concurrency.h:243:64: error: template argument 1 is invalid
     single_consumer_queue<std::function<void(cancellable_timer)>> _queue;
                                                                ^~
/home/genericuser/Desktop/librealsense/src/concurrency.h: In lambda function:
/home/genericuser/Desktop/librealsense/src/concurrency.h:157:22: error: ‘function’ is not a member of ‘std’
                 std::function<void(cancellable_timer)> item;
                      ^~~~~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h:157:22: note: suggested alternative: ‘is_function’
                 std::function<void(cancellable_timer)> item;
                      ^~~~~~~~
                      is_function
/home/genericuser/Desktop/librealsense/src/concurrency.h:157:31: error: expected primary-expression before ‘void’
                 std::function<void(cancellable_timer)> item;
                               ^~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h:159:28: error: request for member ‘dequeue’ in ‘this->dispatcher::_queue’, which is of non-class type ‘int’
                 if (_queue.dequeue(&item))
                            ^~~~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h:159:37: error: ‘item’ was not declared in this scope
                 if (_queue.dequeue(&item))
                                     ^~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h:159:37: note: suggested alternative: ‘tm’
                 if (_queue.dequeue(&item))
                                     ^~~~
                                     tm
/home/genericuser/Desktop/librealsense/src/concurrency.h: In member function ‘void dispatcher::invoke(T)’:
/home/genericuser/Desktop/librealsense/src/concurrency.h:178:20: error: request for member ‘enqueue’ in ‘((dispatcher*)this)->dispatcher::_queue’, which is of non-class type ‘int’
             _queue.enqueue(std::move(item));
                    ^~~~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h: In member function ‘void dispatcher::start()’:
/home/genericuser/Desktop/librealsense/src/concurrency.h:187:16: error: request for member ‘start’ in ‘((dispatcher*)this)->dispatcher::_queue’, which is of non-class type ‘int’
         _queue.start();
                ^~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h: In member function ‘void dispatcher::stop()’:
/home/genericuser/Desktop/librealsense/src/concurrency.h:198:16: error: request for member ‘clear’ in ‘((dispatcher*)this)->dispatcher::_queue’, which is of non-class type ‘int’
         _queue.clear();
                ^~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h:208:16: error: request for member ‘start’ in ‘((dispatcher*)this)->dispatcher::_queue’, which is of non-class type ‘int’
         _queue.start();
                ^~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h: In destructor ‘dispatcher::~dispatcher()’:
/home/genericuser/Desktop/librealsense/src/concurrency.h:214:16: error: request for member ‘clear’ in ‘((dispatcher*)this)->dispatcher::_queue’, which is of non-class type ‘int’
         _queue.clear();
                ^~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h: At global scope:
/home/genericuser/Desktop/librealsense/src/concurrency.h:257:25: error: ‘function’ in namespace ‘std’ does not name a template type
 template<class T = std::function<void(dispatcher::cancellable_timer)>>
                         ^~~~~~~~
/home/genericuser/Desktop/librealsense/src/concurrency.h:257:33: error: expected ‘>’ before ‘<’ token
 template<class T = std::function<void(dispatcher::cancellable_timer)>>
                                 ^
In file included from /home/genericuser/Desktop/librealsense/src/archive.h:6:0,
                 from /home/genericuser/Desktop/librealsense/src/option.h:7,
                 from /home/genericuser/Desktop/librealsense/src/error-handling.h:4,
                 from /home/genericuser/Desktop/librealsense/src/error-handling.cpp:1:
/home/genericuser/Desktop/librealsense/src/types.h:1257:23: error: template argument 1 is invalid
         active_object<> _active_object;
                       ^
/home/genericuser/Desktop/librealsense/src/types.h: In constructor ‘librealsense::polling_device_watcher::polling_device_watcher(const librealsense::platform::backend*)’:
/home/genericuser/Desktop/librealsense/src/types.h:1209:27: error: cannot convert ‘librealsense::polling_device_watcher::polling_device_watcher(const librealsense::platform::backend*)::<lambda(dispatcher::cancellable_timer)>’ to ‘int’ in initialization
         }), _devices_data()
                           ^
/home/genericuser/Desktop/librealsense/src/types.h: In member function ‘virtual void librealsense::polling_device_watcher::start(librealsense::platform::device_changed_callback)’:
/home/genericuser/Desktop/librealsense/src/types.h:1246:28: error: request for member ‘start’ in ‘((librealsense::polling_device_watcher*)this)->librealsense::polling_device_watcher::_active_object’, which is of non-class type ‘int’
             _active_object.start();
                            ^~~~~
/home/genericuser/Desktop/librealsense/src/types.h: In member function ‘virtual void librealsense::polling_device_watcher::stop()’:
/home/genericuser/Desktop/librealsense/src/types.h:1251:28: error: request for member ‘stop’ in ‘((librealsense::polling_device_watcher*)this)->librealsense::polling_device_watcher::_active_object’, which is of non-class type ‘int’
             _active_object.stop();
                            ^~~~
In file included from /home/genericuser/Desktop/librealsense/src/error-handling.cpp:1:0:
/home/genericuser/Desktop/librealsense/src/error-handling.h: At global scope:
/home/genericuser/Desktop/librealsense/src/error-handling.h:25:23: error: template argument 1 is invalid
         active_object<> _active_object;
                       ^
/home/genericuser/Desktop/librealsense/src/error-handling.cpp: In constructor ‘librealsense::polling_error_handler::polling_error_handler(unsigned int, std::unique_ptr<librealsense::option>, std::shared_ptr<librealsense::notifications_proccessor>, std::unique_ptr<librealsense::notification_decoder>)’:
/home/genericuser/Desktop/librealsense/src/error-handling.cpp:17:36: error: cannot convert ‘librealsense::polling_error_handler::polling_error_handler(unsigned int, std::unique_ptr<librealsense::option>, std::shared_ptr<librealsense::notifications_proccessor>, std::unique_ptr<librealsense::notification_decoder>)::<lambda(dispatcher::cancellable_timer)>’ to ‘int’ in initialization
         _decoder(std::move(decoder))
                                    ^
/home/genericuser/Desktop/librealsense/src/error-handling.cpp: In member function ‘void librealsense::polling_error_handler::start()’:
/home/genericuser/Desktop/librealsense/src/error-handling.cpp:28:24: error: request for member ‘start’ in ‘((librealsense::polling_error_handler*)this)->librealsense::polling_error_handler::_active_object’, which is of non-class type ‘int’
         _active_object.start();
                        ^~~~~
/home/genericuser/Desktop/librealsense/src/error-handling.cpp: In member function ‘void librealsense::polling_error_handler::stop()’:
/home/genericuser/Desktop/librealsense/src/error-handling.cpp:32:24: error: request for member ‘stop’ in ‘((librealsense::polling_error_handler*)this)->librealsense::polling_error_handler::_active_object’, which is of non-class type ‘int’
         _active_object.stop();
                        ^~~~
CMakeFiles/realsense2.dir/build.make:326: recipe for target 'CMakeFiles/realsense2.dir/src/error-handling.cpp.o' failed
make[2]: *** [CMakeFiles/realsense2.dir/src/error-handling.cpp.o] Error 1
CMakeFiles/Makefile2:99: recipe for target 'CMakeFiles/realsense2.dir/all' failed
make[1]: *** [CMakeFiles/realsense2.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2