### PR TITLE
Python binding for RS400 Advanced Mode

### DIFF
--- a/include/librealsense2/rs_advanced_mode.h
+++ b/include/librealsense2/rs_advanced_mode.h
@@ -21,70 +21,70 @@ void rs2_toggle_advanced_mode(rs2_device* dev, int enable, rs2_error** error);
 void rs2_is_enabled(rs2_device* dev, int* enabled, rs2_error** error);
 
 /* Sets new values for Depth Control Group, returns 0 if success */
-void rs2_set_depth_control(rs2_device* dev, STDepthControlGroup* group, rs2_error** error);
+void rs2_set_depth_control(rs2_device* dev, const STDepthControlGroup* group, rs2_error** error);
 
 /* Gets new values for Depth Control Group, returns 0 if success */
 void rs2_get_depth_control(rs2_device* dev, STDepthControlGroup* group, int mode, rs2_error** error);
 
 /* Sets new values for RSM Group, returns 0 if success */
-void rs2_set_rsm(rs2_device* dev, STRsm* group, rs2_error** error);
+void rs2_set_rsm(rs2_device* dev, const STRsm* group, rs2_error** error);
 
 /* Gets new values for RSM Group, returns 0 if success */
 void rs2_get_rsm(rs2_device* dev, STRsm* group, int mode, rs2_error** error);
 
 /* Sets new values for STRauSupportVectorControl, returns 0 if success */
-void rs2_set_rau_support_vector_control(rs2_device* dev, STRauSupportVectorControl* group, rs2_error** error);
+void rs2_set_rau_support_vector_control(rs2_device* dev, const STRauSupportVectorControl* group, rs2_error** error);
 
 /* Gets new values for STRauSupportVectorControl, returns 0 if success */
 void rs2_get_rau_support_vector_control(rs2_device* dev, STRauSupportVectorControl* group, int mode, rs2_error** error);
 
 /* Sets new values for STColorControl, returns 0 if success */
-void rs2_set_color_control(rs2_device* dev, STColorControl* group, rs2_error** error);
+void rs2_set_color_control(rs2_device* dev, const STColorControl* group, rs2_error** error);
 
 /* Gets new values for STColorControl, returns 0 if success */
 void rs2_get_color_control(rs2_device* dev, STColorControl* group, int mode, rs2_error** error);
 
 /* Sets new values for STRauColorThresholdsControl, returns 0 if success */
-void rs2_set_rau_thresholds_control(rs2_device* dev, STRauColorThresholdsControl* group, rs2_error** error);
+void rs2_set_rau_thresholds_control(rs2_device* dev, const STRauColorThresholdsControl* group, rs2_error** error);
 
 /* Gets new values for STRauColorThresholdsControl, returns 0 if success */
 void rs2_get_rau_thresholds_control(rs2_device* dev, STRauColorThresholdsControl* group, int mode, rs2_error** error);
 
 /* Sets new values for STSloColorThresholdsControl, returns 0 if success */
-void rs2_set_slo_color_thresholds_control(rs2_device* dev, STSloColorThresholdsControl* group, rs2_error** error);
+void rs2_set_slo_color_thresholds_control(rs2_device* dev, const STSloColorThresholdsControl* group, rs2_error** error);
 
 /* Gets new values for STRauColorThresholdsControl, returns 0 if success */
 void rs2_get_slo_color_thresholds_control(rs2_device* dev, STSloColorThresholdsControl* group, int mode, rs2_error** error);
 
 /* Sets new values for STSloPenaltyControl, returns 0 if success */
-void rs2_set_slo_penalty_control(rs2_device* dev, STSloPenaltyControl* group, rs2_error** error);
+void rs2_set_slo_penalty_control(rs2_device* dev, const STSloPenaltyControl* group, rs2_error** error);
 
 /* Gets new values for STSloPenaltyControl, returns 0 if success */
 void rs2_get_slo_penalty_control(rs2_device* dev, STSloPenaltyControl* group, int mode, rs2_error** error);
 
 /* Sets new values for STHdad, returns 0 if success */
-void rs2_set_hdad(rs2_device* dev, STHdad* group, rs2_error** error);
+void rs2_set_hdad(rs2_device* dev, const STHdad* group, rs2_error** error);
 
 /* Gets new values for STHdad, returns 0 if success */
 void rs2_get_hdad(rs2_device* dev, STHdad* group, int mode, rs2_error** error);
 
 /* Sets new values for STColorCorrection, returns 0 if success */
-void rs2_set_color_correction(rs2_device* dev, STColorCorrection* group, rs2_error** error);
+void rs2_set_color_correction(rs2_device* dev, const  STColorCorrection* group, rs2_error** error);
 
 /* Gets new values for STColorCorrection, returns 0 if success */
 void rs2_get_color_correction(rs2_device* dev, STColorCorrection* group, int mode, rs2_error** error);
 
 /* Sets new values for STDepthTableControl, returns 0 if success */
-void rs2_set_depth_table(rs2_device* dev, STDepthTableControl* group, rs2_error** error);
+void rs2_set_depth_table(rs2_device* dev, const  STDepthTableControl* group, rs2_error** error);
 
 /* Gets new values for STDepthTableControl, returns 0 if success */
 void rs2_get_depth_table(rs2_device* dev, STDepthTableControl* group, int mode, rs2_error** error);
 
-void rs2_set_ae_control(rs2_device* dev, STAEControl* group, rs2_error** error);
+void rs2_set_ae_control(rs2_device* dev, const  STAEControl* group, rs2_error** error);
 
 void rs2_get_ae_control(rs2_device* dev, STAEControl* group, int mode, rs2_error** error);
 
-void rs2_set_census(rs2_device* dev, STCensusRadius* group, rs2_error** error);
+void rs2_set_census(rs2_device* dev, const  STCensusRadius* group, rs2_error** error);
 
 void rs2_get_census(rs2_device* dev, STCensusRadius* group, int mode, rs2_error** error);
 

--- a/include/librealsense2/rs_advanced_mode.hpp
+++ b/include/librealsense2/rs_advanced_mode.hpp
@@ -40,7 +40,7 @@ namespace rs400
             return !!enabled;
         }
 
-        void set_depth_control(STDepthControlGroup& group)
+        void set_depth_control(const STDepthControlGroup& group)
         {
             rs2_error* e = nullptr;
             rs2_set_depth_control(_dev.get(), &group, &e);
@@ -57,7 +57,7 @@ namespace rs400
             return group;
         }
 
-        void set_rsm(STRsm& group)
+        void set_rsm(const STRsm& group)
         {
             rs2_error* e = nullptr;
             rs2_set_rsm(_dev.get(), &group, &e);
@@ -74,7 +74,7 @@ namespace rs400
             return group;
         }
 
-        void set_rau_support_vector_control(STRauSupportVectorControl& group)
+        void set_rau_support_vector_control(const STRauSupportVectorControl& group)
         {
             rs2_error* e = nullptr;
             rs2_set_rau_support_vector_control(_dev.get(), &group, &e);
@@ -91,7 +91,7 @@ namespace rs400
             return group;
         }
 
-        void set_color_control(STColorControl& group)
+        void set_color_control(const STColorControl& group)
         {
             rs2_error* e = nullptr;
             rs2_set_color_control(_dev.get(),  &group, &e);
@@ -108,7 +108,7 @@ namespace rs400
             return group;
         }
 
-        void set_rau_thresholds_control(STRauColorThresholdsControl& group)
+        void set_rau_thresholds_control(const STRauColorThresholdsControl& group)
         {
             rs2_error* e = nullptr;
             rs2_set_rau_thresholds_control(_dev.get(), &group, &e);
@@ -125,7 +125,7 @@ namespace rs400
             return group;
         }
 
-        void set_slo_color_thresholds_control(STSloColorThresholdsControl& group)
+        void set_slo_color_thresholds_control(const STSloColorThresholdsControl& group)
         {
             rs2_error* e = nullptr;
             rs2_set_slo_color_thresholds_control(_dev.get(), &group, &e);
@@ -142,7 +142,7 @@ namespace rs400
             return group;
         }
 
-        void set_slo_penalty_control(STSloPenaltyControl& group)
+        void set_slo_penalty_control(const STSloPenaltyControl& group)
         {
             rs2_error* e = nullptr;
             rs2_set_slo_penalty_control(_dev.get(), &group, &e);
@@ -159,7 +159,7 @@ namespace rs400
             return group;
         }
 
-        void set_hdad(STHdad& group)
+        void set_hdad(const STHdad& group)
         {
             rs2_error* e = nullptr;
             rs2_set_hdad(_dev.get(), &group, &e);
@@ -176,7 +176,7 @@ namespace rs400
             return group;
         }
 
-        void set_color_correction(STColorCorrection& group)
+        void set_color_correction(const STColorCorrection& group)
         {
             rs2_error* e = nullptr;
             rs2_set_color_correction(_dev.get(), &group, &e);
@@ -193,7 +193,7 @@ namespace rs400
             return group;
         }
 
-        void set_depth_table(STDepthTableControl& group)
+        void set_depth_table(const STDepthTableControl& group)
         {
             rs2_error* e = nullptr;
             rs2_set_depth_table(_dev.get(), &group, &e);
@@ -210,7 +210,7 @@ namespace rs400
             return group;
         }
 
-        void set_ae_control(STAEControl& group)
+        void set_ae_control(const STAEControl& group)
         {
             rs2_error* e = nullptr;
             rs2_set_ae_control(_dev.get(), &group, &e);
@@ -227,7 +227,7 @@ namespace rs400
             return group;
         }
 
-        void set_census(STCensusRadius& group)
+        void set_census(const STCensusRadius& group)
         {
             rs2_error* e = nullptr;
             rs2_set_census(_dev.get(), &group, &e);

--- a/src/ds5/advanced_mode/rs_advanced_mode.cpp
+++ b/src/ds5/advanced_mode/rs_advanced_mode.cpp
@@ -53,7 +53,7 @@ void rs2_is_enabled(rs2_device* dev, int* enabled, rs2_error** error) BEGIN_API_
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, enabled)
 
-void rs2_set_depth_control(rs2_device* dev, STDepthControlGroup* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_depth_control(rs2_device* dev, const STDepthControlGroup* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -71,7 +71,7 @@ void rs2_get_depth_control(rs2_device* dev, STDepthControlGroup* group, int mode
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_rsm(rs2_device* dev, STRsm* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_rsm(rs2_device* dev, const STRsm* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -89,7 +89,7 @@ void rs2_get_rsm(rs2_device* dev, STRsm* group, int mode, rs2_error** error) BEG
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_rau_support_vector_control(rs2_device* dev, STRauSupportVectorControl* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_rau_support_vector_control(rs2_device* dev, const STRauSupportVectorControl* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -107,7 +107,7 @@ void rs2_get_rau_support_vector_control(rs2_device* dev, STRauSupportVectorContr
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_color_control(rs2_device* dev, STColorControl* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_color_control(rs2_device* dev, const STColorControl* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -125,7 +125,7 @@ void rs2_get_color_control(rs2_device* dev, STColorControl* group, int mode, rs2
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_rau_thresholds_control(rs2_device* dev, STRauColorThresholdsControl* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_rau_thresholds_control(rs2_device* dev, const STRauColorThresholdsControl* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -143,7 +143,7 @@ void rs2_get_rau_thresholds_control(rs2_device* dev, STRauColorThresholdsControl
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_slo_color_thresholds_control(rs2_device* dev, STSloColorThresholdsControl* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_slo_color_thresholds_control(rs2_device* dev, const STSloColorThresholdsControl* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -161,7 +161,7 @@ void rs2_get_slo_color_thresholds_control(rs2_device* dev, STSloColorThresholdsC
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_slo_penalty_control(rs2_device* dev, STSloPenaltyControl* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_slo_penalty_control(rs2_device* dev, const STSloPenaltyControl* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -179,7 +179,7 @@ void rs2_get_slo_penalty_control(rs2_device* dev, STSloPenaltyControl* group, in
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_hdad(rs2_device* dev, STHdad* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_hdad(rs2_device* dev, const STHdad* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -197,7 +197,7 @@ void rs2_get_hdad(rs2_device* dev, STHdad* group, int mode, rs2_error** error) B
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_color_correction(rs2_device* dev, STColorCorrection* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_color_correction(rs2_device* dev, const STColorCorrection* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -215,7 +215,7 @@ void rs2_get_color_correction(rs2_device* dev, STColorCorrection* group, int mod
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_depth_table(rs2_device* dev, STDepthTableControl* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_depth_table(rs2_device* dev, const STDepthTableControl* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -233,7 +233,7 @@ void rs2_get_depth_table(rs2_device* dev, STDepthTableControl* group, int mode, 
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_ae_control(rs2_device* dev, STAEControl* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_ae_control(rs2_device* dev, const STAEControl* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);
@@ -251,7 +251,7 @@ void rs2_get_ae_control(rs2_device* dev, STAEControl* group, int mode, rs2_error
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, group, mode)
 
-void rs2_set_census(rs2_device* dev, STCensusRadius* group, rs2_error** error) BEGIN_API_CALL
+void rs2_set_census(rs2_device* dev, const STCensusRadius* group, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(group);

--- a/wrappers/python/python-rs400-advanced-mode-example.py
+++ b/wrappers/python/python-rs400-advanced-mode-example.py
@@ -1,0 +1,88 @@
+## License: Apache 2.0. See LICENSE file in root directory.
+## Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#####################################################
+##          rs400 advanced mode tutorial           ##
+#####################################################
+
+# First import the library
+import pyrealsense2 as rs
+import time
+import json
+
+DS5_product_ids = ["0AD1", "0AD2", "0AD3", "0AD4", "0AD5", "0AF6", "0AFE", "0AFF", "0B00", "0B01", "0B03", "0B07"]
+
+def find_device_that_supports_advanced_mode() :
+    ctx = rs.context()
+    ds5_dev = rs.device()
+    devices = ctx.query_devices();
+    for dev in devices:
+        if dev.supports(rs.camera_info.product_id) and str(dev.get_info(rs.camera_info.product_id)) in DS5_product_ids:
+            if dev.supports(rs.camera_info.name):
+                print("Foudn device that supports advanced mode:", dev.get_info(rs.camera_info.name))
+            return dev
+    raise Exception("No device that supports advanced mode was found")
+
+try:
+    dev = find_device_that_supports_advanced_mode()
+    advnc_mode = rs.rs400_advanced_mode(dev)
+    print("Advanced mode is", "enabled" if advnc_mode.is_enabled() else "disabled")
+
+    # Loop until we successfully enable advanced mode
+    while not advnc_mode.is_enabled():
+        print("Trying to enable advanced mode...")
+        advnc_mode.toggle_advanced_mode(True)
+        # At this point the device will disconnect and re-connect.
+        print("Sleeping for 5 seconds...")
+        time.sleep(5)
+        # The 'dev' object will become invalid and we need to initialize it again
+        dev = find_device_that_supports_advanced_mode()
+        advnc_mode = rs.rs400_advanced_mode(dev)
+        print("Advanced mode is", "enabled" if advnc_mode.is_enabled() else "disabled")
+
+    # Get each control's current value
+    print("Depth Control: \n", advnc_mode.get_depth_control())
+    print("RSM: \n", advnc_mode.get_rsm())
+    print("RAU Support Vertial Control: \n", advnc_mode.get_rau_support_vector_control())
+    print("Color Control: \n", advnc_mode.get_color_control())
+    print("RAU Thresholds Control: \n", advnc_mode.get_rau_thresholds_control())
+    print("SLO Color Thresholds Control: \n", advnc_mode.get_slo_color_thresholds_control())
+    print("SLO Penalty Control: \n", advnc_mode.get_slo_penalty_control())
+    print("HDAD: \n", advnc_mode.get_hdad())
+    print("Color Correction: \n", advnc_mode.get_color_correction())
+    print("Depth Table: \n", advnc_mode.get_depth_table())
+    print("Auto Exposure Control: \n", advnc_mode.get_ae_control())
+    print("Census: \n", advnc_mode.get_census())
+
+    #To get the minimum and maximum value of each control use the mode value:
+    query_min_values_mode = 1
+    query_max_values_mode = 2
+    current_std_depth_control_group = advnc_mode.get_depth_control()
+    min_std_depth_control_group = advnc_mode.get_depth_control(query_min_values_mode)
+    max_std_depth_control_group = advnc_mode.get_depth_control(query_max_values_mode)
+    print("Depth Control Min Values: \n ", min_std_depth_control_group)
+    print("Depth Control Max Values: \n ", max_std_depth_control_group)
+
+    # Set some control with a new (median) value
+    current_std_depth_control_group.scoreThreshA = int((max_std_depth_control_group.scoreThreshA - min_std_depth_control_group.scoreThreshA) / 2)
+    advnc_mode.set_depth_control(current_std_depth_control_group)
+    print("After Setting new value, Depth Control: \n", advnc_mode.get_depth_control())
+
+    # Serialize all controls to a Json string
+    serialized_string = advnc_mode.serialize_json()
+    print("Controls as JSON: \n", serialized_string)
+    as_json_object = json.loads(serialized_string)
+
+    # We can also load controls from a json string
+    # The C++ JSON parser requires double-quotes for the json object so we need
+    #  to replace the single quote of the pythonic json to double-quotes
+    json_string = str(as_json_object).replace("'", '\"')
+    advnc_mode.load_json(json_string)
+#except rs.error as e:
+#    # Method calls agaisnt librealsense objects may throw exceptions of type pylibrs.error
+#    print("pylibrs.error was thrown when calling %s(%s):\n", % (e.get_failed_function(), e.get_failed_args()))
+#    print("    %s\n", e.what())
+#    exit(1)
+except Exception as e:
+    print(e)
+    pass

--- a/wrappers/python/python-rs400-advanced-mode-example.py
+++ b/wrappers/python/python-rs400-advanced-mode-example.py
@@ -19,7 +19,7 @@ def find_device_that_supports_advanced_mode() :
     for dev in devices:
         if dev.supports(rs.camera_info.product_id) and str(dev.get_info(rs.camera_info.product_id)) in DS5_product_ids:
             if dev.supports(rs.camera_info.name):
-                print("Foudn device that supports advanced mode:", dev.get_info(rs.camera_info.name))
+                print("Found device that supports advanced mode:", dev.get_info(rs.camera_info.name))
             return dev
     raise Exception("No device that supports advanced mode was found")
 
@@ -43,7 +43,7 @@ try:
     # Get each control's current value
     print("Depth Control: \n", advnc_mode.get_depth_control())
     print("RSM: \n", advnc_mode.get_rsm())
-    print("RAU Support Vertial Control: \n", advnc_mode.get_rau_support_vector_control())
+    print("RAU Support Vector Control: \n", advnc_mode.get_rau_support_vector_control())
     print("Color Control: \n", advnc_mode.get_color_control())
     print("RAU Thresholds Control: \n", advnc_mode.get_rau_thresholds_control())
     print("SLO Color Thresholds Control: \n", advnc_mode.get_slo_color_thresholds_control())
@@ -78,11 +78,7 @@ try:
     #  to replace the single quote of the pythonic json to double-quotes
     json_string = str(as_json_object).replace("'", '\"')
     advnc_mode.load_json(json_string)
-#except rs.error as e:
-#    # Method calls agaisnt librealsense objects may throw exceptions of type pylibrs.error
-#    print("pylibrs.error was thrown when calling %s(%s):\n", % (e.get_failed_function(), e.get_failed_args()))
-#    print("    %s\n", e.what())
-#    exit(1)
+
 except Exception as e:
     print(e)
     pass

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -675,14 +675,14 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("lrAgreeThreshold", &STDepthControlGroup::lrAgreeThreshold)
         .def("__repr__", [](const STDepthControlGroup &e) {
             std::stringstream ss;
-            ss << "minusDecrement: " << e.minusDecrement << " ";
-            ss << "deepSeaMedianThreshold: " << e.deepSeaMedianThreshold << " ";
-            ss << "scoreThreshA: " << e.scoreThreshA << " ";
-            ss << "scoreThreshB: " << e.scoreThreshB << " ";
-            ss << "textureDifferenceThreshold: " << e.textureDifferenceThreshold << " ";
-            ss << "textureCountThreshold: " << e.textureCountThreshold << " ";
-            ss << "deepSeaSecondPeakThreshold: " << e.deepSeaSecondPeakThreshold << " ";
-            ss << "deepSeaNeighborThreshold: " << e.deepSeaNeighborThreshold << " ";
+            ss << "minusDecrement: " << e.minusDecrement << ", ";
+            ss << "deepSeaMedianThreshold: " << e.deepSeaMedianThreshold << ", ";
+            ss << "scoreThreshA: " << e.scoreThreshA << ", ";
+            ss << "scoreThreshB: " << e.scoreThreshB << ", ";
+            ss << "textureDifferenceThreshold: " << e.textureDifferenceThreshold << ", ";
+            ss << "textureCountThreshold: " << e.textureCountThreshold << ", ";
+            ss << "deepSeaSecondPeakThreshold: " << e.deepSeaSecondPeakThreshold << ", ";
+            ss << "deepSeaNeighborThreshold: " << e.deepSeaNeighborThreshold << ", ";
             ss << "lrAgreeThreshold: " << e.lrAgreeThreshold;
             return ss.str();
         });
@@ -695,9 +695,9 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("removeThresh", &STRsm::removeThresh)
         .def("__repr__", [](const STRsm &e) {
             std::stringstream ss;
-            ss << "rsmBypass: " << e.rsmBypass << " ";
-            ss << "diffThresh: " << e.diffThresh << " ";
-            ss << "sloRauDiffThresh: " << e.sloRauDiffThresh << " ";
+            ss << "rsmBypass: " << e.rsmBypass << ", ";
+            ss << "diffThresh: " << e.diffThresh << ", ";
+            ss << "sloRauDiffThresh: " << e.sloRauDiffThresh << ", ";
             ss << "removeThresh: " << e.removeThresh;
             return ss.str();
         });
@@ -714,13 +714,13 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("vShrink", &STRauSupportVectorControl::vShrink)
         .def("__repr__", [](const STRauSupportVectorControl &e) {
             std::stringstream ss;
-            ss << "minWest: " << e.minWest << " ";
-            ss << "minEast: " << e.minEast << " ";
-            ss << "minWEsum: " << e.minWEsum << " ";
-            ss << "minNorth: " << e.minNorth << " ";
-            ss << "minSouth: " << e.minSouth << " ";
-            ss << "minNSsum: " << e.minNSsum << " ";
-            ss << "uShrink: " << e.uShrink << " ";
+            ss << "minWest: " << e.minWest << ", ";
+            ss << "minEast: " << e.minEast << ", ";
+            ss << "minWEsum: " << e.minWEsum << ", ";
+            ss << "minNorth: " << e.minNorth << ", ";
+            ss << "minSouth: " << e.minSouth << ", ";
+            ss << "minNSsum: " << e.minNSsum << ", ";
+            ss << "uShrink: " << e.uShrink << ", ";
             ss << "vShrink: " << e.vShrink;
             return ss.str();
         });
@@ -733,10 +733,10 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("disableSADNormalize", &STColorControl::disableSADNormalize)
         .def("__repr__", [](const STColorControl &e) {
             std::stringstream ss;
-            ss << "disableSADColor: " << e.disableSADColor << " ";
-            ss << "disableRAUColor: " << e.disableRAUColor << " ";
-            ss << "disableSLORightColor: " << e.disableSLORightColor << " ";
-            ss << "disableSLOLeftColor: " << e.disableSLOLeftColor << " ";
+            ss << "disableSADColor: " << e.disableSADColor << ", ";
+            ss << "disableRAUColor: " << e.disableRAUColor << ", ";
+            ss << "disableSLORightColor: " << e.disableSLORightColor << ", ";
+            ss << "disableSLOLeftColor: " << e.disableSLOLeftColor << ", ";
             ss << "disableSADNormalize: " << e.disableSADNormalize;
             return ss.str();
         });
@@ -748,8 +748,8 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("rauDiffThresholdBlue", &STRauColorThresholdsControl::rauDiffThresholdBlue)
         .def("__repr__", [](const STRauColorThresholdsControl &e) {
             std::stringstream ss;
-            ss << "rauDiffThresholdRed: " << e.rauDiffThresholdRed << " ";
-            ss << "rauDiffThresholdGreen: " << e.rauDiffThresholdGreen << " ";
+            ss << "rauDiffThresholdRed: " << e.rauDiffThresholdRed << ", ";
+            ss << "rauDiffThresholdGreen: " << e.rauDiffThresholdGreen << ", ";
             ss << "rauDiffThresholdBlue: " << e.rauDiffThresholdBlue;
             return ss.str();
         });
@@ -761,8 +761,8 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("diffThresholdBlue", &STSloColorThresholdsControl::diffThresholdBlue)
         .def("__repr__", [](const STSloColorThresholdsControl &e) {
             std::stringstream ss;
-            ss << "diffThresholdRed: " << e.diffThresholdRed << " ";
-            ss << "diffThresholdGreen: " << e.diffThresholdGreen << " ";
+            ss << "diffThresholdRed: " << e.diffThresholdRed << ", ";
+            ss << "diffThresholdGreen: " << e.diffThresholdGreen << ", ";
             ss << "diffThresholdBlue: " << e.diffThresholdBlue;
             return ss.str();
         });
@@ -776,11 +776,11 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("sloK2PenaltyMod2", &STSloPenaltyControl::sloK2PenaltyMod2)
         .def("__repr__", [](const STSloPenaltyControl &e) {
             std::stringstream ss;
-            ss << "sloK1Penalty: " << e.sloK1Penalty << " ";
-            ss << "sloK2Penalty: " << e.sloK2Penalty << " ";
-            ss << "sloK1PenaltyMod1: " << e.sloK1PenaltyMod1 << " ";
-            ss << "sloK2PenaltyMod1: " << e.sloK2PenaltyMod1 << " ";
-            ss << "sloK1PenaltyMod2: " << e.sloK1PenaltyMod2 << " ";
+            ss << "sloK1Penalty: " << e.sloK1Penalty << ", ";
+            ss << "sloK2Penalty: " << e.sloK2Penalty << ", ";
+            ss << "sloK1PenaltyMod1: " << e.sloK1PenaltyMod1 << ", ";
+            ss << "sloK2PenaltyMod1: " << e.sloK2PenaltyMod1 << ", ";
+            ss << "sloK1PenaltyMod2: " << e.sloK1PenaltyMod2 << ", ";
             ss << "sloK2PenaltyMod2: " << e.sloK2PenaltyMod2;
             return ss.str();
         });
@@ -791,8 +791,8 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("ignoreSAD", &STHdad::ignoreSAD)
         .def("__repr__", [](const STHdad &e) {
             std::stringstream ss;
-            ss << "lambdaCensus: " << e.lambdaCensus << " ";
-            ss << "lambdaAD: " << e.lambdaAD << " ";
+            ss << "lambdaCensus: " << e.lambdaCensus << ", ";
+            ss << "lambdaAD: " << e.lambdaAD << ", ";
             ss << "ignoreSAD: " << e.ignoreSAD;
             return ss.str();
         });
@@ -813,17 +813,17 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("colorCorrection12", &STColorCorrection::colorCorrection12)
         .def("__repr__", [](const STColorCorrection &e) {
             std::stringstream ss;
-            ss << "colorCorrection1: "  << e.colorCorrection1 << " ";
-            ss << "colorCorrection2: " << e.colorCorrection2 << " ";
-            ss << "colorCorrection3: " << e.colorCorrection3 << " ";
-            ss << "colorCorrection4: " << e.colorCorrection4 << " ";
-            ss << "colorCorrection5: " << e.colorCorrection5 << " ";
-            ss << "colorCorrection6: " << e.colorCorrection6 << " ";
-            ss << "colorCorrection7: " << e.colorCorrection7 << " ";
-            ss << "colorCorrection8: " << e.colorCorrection8 << " ";
-            ss << "colorCorrection9: " << e.colorCorrection9 << " ";
-            ss << "colorCorrection10: " << e.colorCorrection10 << " ";
-            ss << "colorCorrection11: " << e.colorCorrection11 << " ";
+            ss << "colorCorrection1: "  << e.colorCorrection1 << ", ";
+            ss << "colorCorrection2: " << e.colorCorrection2 << ", ";
+            ss << "colorCorrection3: " << e.colorCorrection3 << ", ";
+            ss << "colorCorrection4: " << e.colorCorrection4 << ", ";
+            ss << "colorCorrection5: " << e.colorCorrection5 << ", ";
+            ss << "colorCorrection6: " << e.colorCorrection6 << ", ";
+            ss << "colorCorrection7: " << e.colorCorrection7 << ", ";
+            ss << "colorCorrection8: " << e.colorCorrection8 << ", ";
+            ss << "colorCorrection9: " << e.colorCorrection9 << ", ";
+            ss << "colorCorrection10: " << e.colorCorrection10 << ", ";
+            ss << "colorCorrection11: " << e.colorCorrection11 << ", ";
             ss << "colorCorrection12: " << e.colorCorrection12;
             return ss.str();
         });
@@ -846,10 +846,10 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("disparityShift", &STDepthTableControl::disparityShift)
         .def("__repr__", [](const STDepthTableControl &e) {
             std::stringstream ss;
-            ss << "depthUnits: " << e.depthUnits << " ";
-            ss << "depthClampMin: " << e.depthClampMin << " ";
-            ss << "depthClampMax: " << e.depthClampMax << " ";
-            ss << "disparityMode: " << e.disparityMode << " ";
+            ss << "depthUnits: " << e.depthUnits << ", ";
+            ss << "depthClampMin: " << e.depthClampMin << ", ";
+            ss << "depthClampMax: " << e.depthClampMax << ", ";
+            ss << "disparityMode: " << e.disparityMode << ", ";
             ss << "disparityShift: " << e.disparityShift;
             return ss.str();
         });
@@ -860,7 +860,7 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("vDiameter", &STCensusRadius::vDiameter)
         .def("__repr__", [](const STCensusRadius &e) {
             std::stringstream ss;
-            ss << "uDiameter: " << e.uDiameter << " ";
+            ss << "uDiameter: " << e.uDiameter << ", ";
             ss << "vDiameter: " << e.vDiameter;
             return ss.str();
         });

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -14,7 +14,7 @@
 
 #include "../include/librealsense2/rs.h"
 #include "../include/librealsense2/rs.hpp"
-
+#include "../include/librealsense2/rs_advanced_mode.hpp"
 #define NAME pyrealsense2
 #define SNAME "pyrealsense2"
 #define BIND_RAW_ARRAY(class, name, type, size) #name, [](const class &c) -> const std::array<type, size>& { return reinterpret_cast<const std::array<type, size>&>(c.name); }
@@ -656,6 +656,127 @@ PYBIND11_PLUGIN(NAME) {
             .def("resolve", [](rs2::config* c, pipeline_wrapper pw) -> rs2::pipeline_profile { return c->resolve(pw._ptr); })
             .def("can_resolve", [](rs2::config* c, pipeline_wrapper pw) -> bool { return c->can_resolve(pw._ptr); });
 
+    /**
+        RS400 Advanced Mode commands
+    */
+
+    py::class_<STDepthControlGroup> STDepthControlGroup(m, "STDepthControlGroup");
+    STDepthControlGroup.def_readwrite("plusIncrement", &STDepthControlGroup::plusIncrement)
+        .def_readwrite("minusDecrement", &STDepthControlGroup::minusDecrement)
+        .def_readwrite("deepSeaMedianThreshold", &STDepthControlGroup::deepSeaMedianThreshold)
+        .def_readwrite("scoreThreshA", &STDepthControlGroup::scoreThreshA)
+        .def_readwrite("scoreThreshB", &STDepthControlGroup::scoreThreshB)
+        .def_readwrite("textureDifferenceThreshold", &STDepthControlGroup::textureDifferenceThreshold)
+        .def_readwrite("textureCountThreshold", &STDepthControlGroup::textureCountThreshold)
+        .def_readwrite("deepSeaSecondPeakThreshold", &STDepthControlGroup::deepSeaSecondPeakThreshold)
+        .def_readwrite("deepSeaNeighborThreshold", &STDepthControlGroup::deepSeaNeighborThreshold)
+        .def_readwrite("lrAgreeThreshold", &STDepthControlGroup::lrAgreeThreshold);
+
+    py::class_<STRsm> STRsm(m, "STRsm");
+    STRsm.def_readwrite("rsmBypass", &STRsm::rsmBypass)
+        .def_readwrite("diffThresh", &STRsm::diffThresh)
+        .def_readwrite("sloRauDiffThresh", &STRsm::sloRauDiffThresh)
+        .def_readwrite("removeThresh", &STRsm::removeThresh);
+
+    py::class_<STRauSupportVectorControl> STRauSupportVectorControl(m, "STRauSupportVectorControl");
+        STRauSupportVectorControl.def_readwrite("minWest", &STRauSupportVectorControl::minWest)
+        .def_readwrite("minEast", &STRauSupportVectorControl::minEast)
+        .def_readwrite("minWEsum", &STRauSupportVectorControl::minWEsum)
+        .def_readwrite("minNorth", &STRauSupportVectorControl::minNorth)
+        .def_readwrite("minSouth", &STRauSupportVectorControl::minSouth)
+        .def_readwrite("minNSsum", &STRauSupportVectorControl::minNSsum)
+        .def_readwrite("uShrink", &STRauSupportVectorControl::uShrink)
+        .def_readwrite("vShrink", &STRauSupportVectorControl::vShrink);
+
+    py::class_<STColorControl> STColorControl(m, "STColorControl");
+        STColorControl.def_readwrite("disableSADColor", &STColorControl::disableSADColor)
+        .def_readwrite("disableRAUColor", &STColorControl::disableRAUColor)
+        .def_readwrite("disableSLORightColor", &STColorControl::disableSLORightColor)
+        .def_readwrite("disableSLOLeftColor", &STColorControl::disableSLOLeftColor)
+        .def_readwrite("disableSADNormalize", &STColorControl::disableSADNormalize);
+
+    py::class_<STRauColorThresholdsControl> STRauColorThresholdsControl(m, "STRauColorThresholdsControl");
+        STRauColorThresholdsControl.def_readwrite("rauDiffThresholdRed", &STRauColorThresholdsControl::rauDiffThresholdRed)
+        .def_readwrite("rauDiffThresholdGreen", &STRauColorThresholdsControl::rauDiffThresholdGreen)
+        .def_readwrite("rauDiffThresholdBlue", &STRauColorThresholdsControl::rauDiffThresholdBlue);
+
+    py::class_<STSloColorThresholdsControl> STSloColorThresholdsControl(m, "STSloColorThresholdsControl");
+    STSloColorThresholdsControl.def_readwrite("diffThresholdRed", &STSloColorThresholdsControl::diffThresholdRed)
+        .def_readwrite("diffThresholdGreen", &STSloColorThresholdsControl::diffThresholdGreen)
+        .def_readwrite("diffThresholdBlue", &STSloColorThresholdsControl::diffThresholdBlue);
+
+    py::class_<STSloPenaltyControl> STSloPenaltyControl(m, "STSloPenaltyControl");
+    STSloPenaltyControl.def_readwrite("sloK1Penalty", &STSloPenaltyControl::sloK1Penalty)
+        .def_readwrite("sloK2Penalty", &STSloPenaltyControl::sloK2Penalty)
+        .def_readwrite("sloK1PenaltyMod1", &STSloPenaltyControl::sloK1PenaltyMod1)
+        .def_readwrite("sloK2PenaltyMod1", &STSloPenaltyControl::sloK2PenaltyMod1)
+        .def_readwrite("sloK1PenaltyMod2", &STSloPenaltyControl::sloK1PenaltyMod2)
+        .def_readwrite("sloK2PenaltyMod2", &STSloPenaltyControl::sloK2PenaltyMod2);
+
+    py::class_<STHdad> STHdad(m, "STHdad");
+        STHdad.def_readwrite("lambdaCensus", &STHdad::lambdaCensus)
+        .def_readwrite("lambdaAD", &STHdad::lambdaAD)
+        .def_readwrite("ignoreSAD", &STHdad::ignoreSAD);
+
+
+    py::class_<STColorCorrection> STColorCorrection(m, "STColorCorrection");
+    STColorCorrection.def_readwrite("colorCorrection1", &STColorCorrection::colorCorrection1)
+        .def_readwrite("colorCorrection2", &STColorCorrection::colorCorrection2)
+        .def_readwrite("colorCorrection3", &STColorCorrection::colorCorrection3)
+        .def_readwrite("colorCorrection4", &STColorCorrection::colorCorrection4)
+        .def_readwrite("colorCorrection5", &STColorCorrection::colorCorrection5)
+        .def_readwrite("colorCorrection6", &STColorCorrection::colorCorrection6)
+        .def_readwrite("colorCorrection7", &STColorCorrection::colorCorrection7)
+        .def_readwrite("colorCorrection8", &STColorCorrection::colorCorrection8)
+        .def_readwrite("colorCorrection9", &STColorCorrection::colorCorrection9)
+        .def_readwrite("colorCorrection10", &STColorCorrection::colorCorrection10)
+        .def_readwrite("colorCorrection11", &STColorCorrection::colorCorrection11)
+        .def_readwrite("colorCorrection12", &STColorCorrection::colorCorrection12);
+
+    py::class_<STAEControl> STAEControl(m, "STAEControl");
+    STAEControl.def_readwrite("meanIntensitySetPoint", &STAEControl::meanIntensitySetPoint);
+
+    py::class_<STDepthTableControl> STDepthTableControl(m, "STDepthTableControl");
+    STDepthTableControl.def_readwrite("depthUnits", &STDepthTableControl::depthUnits)
+        .def_readwrite("depthClampMin", &STDepthTableControl::depthClampMin)
+        .def_readwrite("depthClampMax", &STDepthTableControl::depthClampMax)
+        .def_readwrite("disparityMode", &STDepthTableControl::disparityMode)
+        .def_readwrite("disparityShift", &STDepthTableControl::disparityShift);
+
+    py::class_<STCensusRadius> STCensusRadius(m, "STCensusRadius");
+    STCensusRadius.def_readwrite("uDiameter", &STCensusRadius::uDiameter)
+        .def_readwrite("vDiameter", &STCensusRadius::vDiameter);
+
+    py::class_<rs400::advanced_mode> rs400_advanced_mode(m, "rs400_advanced_mode");
+    rs400_advanced_mode.def(py::init<rs2::device>(), "device"_a)
+        .def("toggle_advanced_mode", &rs400::advanced_mode::toggle_advanced_mode, "enable"_a)
+        .def("is_enabled", &rs400::advanced_mode::is_enabled)
+        .def("set_depth_control", &rs400::advanced_mode::set_depth_control, "group"_a) //STDepthControlGroup
+        .def("get_depth_control", &rs400::advanced_mode::get_depth_control, "mode"_a = 0)
+        .def("set_rsm", &rs400::advanced_mode::set_rsm, "group") //STRsm
+        .def("get_rsm", &rs400::advanced_mode::get_rsm, "mode"_a = 0)
+        .def("set_rau_support_vector_control", &rs400::advanced_mode::set_rau_support_vector_control, "group"_a)//STRauSupportVectorControl
+        .def("get_rau_support_vector_control", &rs400::advanced_mode::get_rau_support_vector_control, "mode"_a = 0)
+        .def("set_color_control", &rs400::advanced_mode::set_color_control, "group"_a) //STColorControl
+        .def("get_color_control", &rs400::advanced_mode::get_color_control, "mode"_a = 0)//STColorControl 
+        .def("set_rau_thresholds_control", &rs400::advanced_mode::set_rau_thresholds_control, "group"_a)//STRauColorThresholdsControl
+        .def("get_rau_thresholds_control", &rs400::advanced_mode::get_rau_thresholds_control, "mode"_a = 0)
+        .def("set_slo_color_thresholds_control", &rs400::advanced_mode::set_slo_color_thresholds_control, "group"_a)//STSloColorThresholdsControl
+        .def("get_slo_color_thresholds_control", &rs400::advanced_mode::get_slo_color_thresholds_control, "mode"_a = 0)//STSloColorThresholdsControl 
+        .def("set_slo_penalty_control", &rs400::advanced_mode::set_slo_penalty_control, "group"_a) //STSloPenaltyControl
+        .def("get_slo_penalty_control", &rs400::advanced_mode::get_slo_penalty_control, "mode"_a = 0)//STSloPenaltyControl 
+        .def("set_hdad", &rs400::advanced_mode::set_hdad, "group"_a) //STHdad
+        .def("get_hdad", &rs400::advanced_mode::get_hdad, "mode"_a = 0)
+        .def("set_color_correction", &rs400::advanced_mode::set_color_correction, "group"_a)
+        .def("get_color_correction", &rs400::advanced_mode::get_color_correction, "mode"_a = 0) //STColorCorrection 
+        .def("set_depth_table", &rs400::advanced_mode::set_depth_table, "group"_a)
+        .def("get_depth_table", &rs400::advanced_mode::get_depth_table, "mode"_a = 0) //STDepthTableControl 
+        .def("set_ae_control", &rs400::advanced_mode::set_ae_control, "group"_a)
+        .def("get_ae_control", &rs400::advanced_mode::get_ae_control, "mode"_a = 0) //STAEControl 
+        .def("set_census", &rs400::advanced_mode::set_census, "group"_a)    //STCensusRadius
+        .def("get_census", &rs400::advanced_mode::get_census, "mode"_a = 0) //STCensusRadius 
+        .def("serialize_json", &rs400::advanced_mode::serialize_json)
+        .def("load_json", &rs400::advanced_mode::load_json, "json_content"_a);
 
     /* rs2.hpp */
     m.def("log_to_console", &rs2::log_to_console, "min_severity"_a);

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -620,7 +620,8 @@ PYBIND11_PLUGIN(NAME) {
     .def("start", (rs2::pipeline_profile (rs2::pipeline::*)() ) &rs2::pipeline::start)
     .def("stop", &rs2::pipeline::stop)
     .def("wait_for_frames", &rs2::pipeline::wait_for_frames, "timeout_ms"_a = 5000)
-    .def("poll_for_frames", &rs2::pipeline::poll_for_frames, "frameset*"_a);
+    .def("poll_for_frames", &rs2::pipeline::poll_for_frames, "frameset*"_a)
+    .def("get_active_profile", &rs2::pipeline::get_active_profile);
 
     struct pipeline_wrapper //Workaround to allow python implicit conversion of pipeline to std::shared_ptr<rs2_pipeline>
     {
@@ -660,8 +661,8 @@ PYBIND11_PLUGIN(NAME) {
         RS400 Advanced Mode commands
     */
 
-    py::class_<STDepthControlGroup> STDepthControlGroup(m, "STDepthControlGroup");
-    STDepthControlGroup.def_readwrite("plusIncrement", &STDepthControlGroup::plusIncrement)
+    py::class_<STDepthControlGroup> _STDepthControlGroup(m, "STDepthControlGroup");
+    _STDepthControlGroup.def_readwrite("plusIncrement", &STDepthControlGroup::plusIncrement)
         .def_readwrite("minusDecrement", &STDepthControlGroup::minusDecrement)
         .def_readwrite("deepSeaMedianThreshold", &STDepthControlGroup::deepSeaMedianThreshold)
         .def_readwrite("scoreThreshA", &STDepthControlGroup::scoreThreshA)
@@ -670,57 +671,127 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("textureCountThreshold", &STDepthControlGroup::textureCountThreshold)
         .def_readwrite("deepSeaSecondPeakThreshold", &STDepthControlGroup::deepSeaSecondPeakThreshold)
         .def_readwrite("deepSeaNeighborThreshold", &STDepthControlGroup::deepSeaNeighborThreshold)
-        .def_readwrite("lrAgreeThreshold", &STDepthControlGroup::lrAgreeThreshold);
+        .def_readwrite("lrAgreeThreshold", &STDepthControlGroup::lrAgreeThreshold)
+        .def("__repr__", [](const STDepthControlGroup &e) {
+            std::stringstream ss;
+            ss << "minusDecrement: " << e.minusDecrement << " ";
+            ss << "deepSeaMedianThreshold: " << e.deepSeaMedianThreshold << " ";
+            ss << "scoreThreshA: " << e.scoreThreshA << " ";
+            ss << "scoreThreshB: " << e.scoreThreshB << " ";
+            ss << "textureDifferenceThreshold: " << e.textureDifferenceThreshold << " ";
+            ss << "textureCountThreshold: " << e.textureCountThreshold << " ";
+            ss << "deepSeaSecondPeakThreshold: " << e.deepSeaSecondPeakThreshold << " ";
+            ss << "deepSeaNeighborThreshold: " << e.deepSeaNeighborThreshold << " ";
+            ss << "lrAgreeThreshold: " << e.lrAgreeThreshold;
+            return ss.str();
+        });
 
-    py::class_<STRsm> STRsm(m, "STRsm");
-    STRsm.def_readwrite("rsmBypass", &STRsm::rsmBypass)
+    py::class_<STRsm> _STRsm(m, "STRsm");
+    _STRsm.def_readwrite("rsmBypass", &STRsm::rsmBypass)
         .def_readwrite("diffThresh", &STRsm::diffThresh)
         .def_readwrite("sloRauDiffThresh", &STRsm::sloRauDiffThresh)
-        .def_readwrite("removeThresh", &STRsm::removeThresh);
+        .def_readwrite("removeThresh", &STRsm::removeThresh)
+        .def("__repr__", [](const STRsm &e) {
+            std::stringstream ss;
+            ss << "rsmBypass: " << e.rsmBypass << " ";
+            ss << "diffThresh: " << e.diffThresh << " ";
+            ss << "sloRauDiffThresh: " << e.sloRauDiffThresh << " ";
+            ss << "removeThresh: " << e.removeThresh;
+            return ss.str();
+        });
 
-    py::class_<STRauSupportVectorControl> STRauSupportVectorControl(m, "STRauSupportVectorControl");
-        STRauSupportVectorControl.def_readwrite("minWest", &STRauSupportVectorControl::minWest)
+    py::class_<STRauSupportVectorControl> _STRauSupportVectorControl(m, "STRauSupportVectorControl");
+        _STRauSupportVectorControl.def_readwrite("minWest", &STRauSupportVectorControl::minWest)
         .def_readwrite("minEast", &STRauSupportVectorControl::minEast)
         .def_readwrite("minWEsum", &STRauSupportVectorControl::minWEsum)
         .def_readwrite("minNorth", &STRauSupportVectorControl::minNorth)
         .def_readwrite("minSouth", &STRauSupportVectorControl::minSouth)
         .def_readwrite("minNSsum", &STRauSupportVectorControl::minNSsum)
         .def_readwrite("uShrink", &STRauSupportVectorControl::uShrink)
-        .def_readwrite("vShrink", &STRauSupportVectorControl::vShrink);
-
-    py::class_<STColorControl> STColorControl(m, "STColorControl");
-        STColorControl.def_readwrite("disableSADColor", &STColorControl::disableSADColor)
+        .def_readwrite("vShrink", &STRauSupportVectorControl::vShrink)
+        .def("__repr__", [](const STRauSupportVectorControl &e) {
+            std::stringstream ss;
+            ss << "minWest: " << e.minWest << " ";
+            ss << "minEast: " << e.minEast << " ";
+            ss << "minWEsum: " << e.minWEsum << " ";
+            ss << "minNorth: " << e.minNorth << " ";
+            ss << "minSouth: " << e.minSouth << " ";
+            ss << "minNSsum: " << e.minNSsum << " ";
+            ss << "uShrink: " << e.uShrink << " ";
+            ss << "vShrink: " << e.vShrink;
+            return ss.str();
+        });
+    py::class_<STColorControl> _STColorControl(m, "STColorControl");
+        _STColorControl.def_readwrite("disableSADColor", &STColorControl::disableSADColor)
         .def_readwrite("disableRAUColor", &STColorControl::disableRAUColor)
         .def_readwrite("disableSLORightColor", &STColorControl::disableSLORightColor)
         .def_readwrite("disableSLOLeftColor", &STColorControl::disableSLOLeftColor)
-        .def_readwrite("disableSADNormalize", &STColorControl::disableSADNormalize);
+        .def_readwrite("disableSADNormalize", &STColorControl::disableSADNormalize)
+        .def("__repr__", [](const STColorControl &e) {
+            std::stringstream ss;
+            ss << "disableSADColor: " << e.disableSADColor << " ";
+            ss << "disableRAUColor: " << e.disableRAUColor << " ";
+            ss << "disableSLORightColor: " << e.disableSLORightColor << " ";
+            ss << "disableSLOLeftColor: " << e.disableSLOLeftColor << " ";
+            ss << "disableSADNormalize: " << e.disableSADNormalize;
+            return ss.str();
+        });
 
-    py::class_<STRauColorThresholdsControl> STRauColorThresholdsControl(m, "STRauColorThresholdsControl");
-        STRauColorThresholdsControl.def_readwrite("rauDiffThresholdRed", &STRauColorThresholdsControl::rauDiffThresholdRed)
+    py::class_<STRauColorThresholdsControl> _STRauColorThresholdsControl(m, "STRauColorThresholdsControl");
+        _STRauColorThresholdsControl.def_readwrite("rauDiffThresholdRed", &STRauColorThresholdsControl::rauDiffThresholdRed)
         .def_readwrite("rauDiffThresholdGreen", &STRauColorThresholdsControl::rauDiffThresholdGreen)
-        .def_readwrite("rauDiffThresholdBlue", &STRauColorThresholdsControl::rauDiffThresholdBlue);
+        .def_readwrite("rauDiffThresholdBlue", &STRauColorThresholdsControl::rauDiffThresholdBlue)
+        .def("__repr__", [](const STRauColorThresholdsControl &e) {
+            std::stringstream ss;
+            ss << "rauDiffThresholdRed: " << e.rauDiffThresholdRed << " ";
+            ss << "rauDiffThresholdGreen: " << e.rauDiffThresholdGreen << " ";
+            ss << "rauDiffThresholdBlue: " << e.rauDiffThresholdBlue;
+            return ss.str();
+        });
 
-    py::class_<STSloColorThresholdsControl> STSloColorThresholdsControl(m, "STSloColorThresholdsControl");
-    STSloColorThresholdsControl.def_readwrite("diffThresholdRed", &STSloColorThresholdsControl::diffThresholdRed)
+    py::class_<STSloColorThresholdsControl> _STSloColorThresholdsControl(m, "STSloColorThresholdsControl");
+    _STSloColorThresholdsControl.def_readwrite("diffThresholdRed", &STSloColorThresholdsControl::diffThresholdRed)
         .def_readwrite("diffThresholdGreen", &STSloColorThresholdsControl::diffThresholdGreen)
-        .def_readwrite("diffThresholdBlue", &STSloColorThresholdsControl::diffThresholdBlue);
-
-    py::class_<STSloPenaltyControl> STSloPenaltyControl(m, "STSloPenaltyControl");
-    STSloPenaltyControl.def_readwrite("sloK1Penalty", &STSloPenaltyControl::sloK1Penalty)
+        .def_readwrite("diffThresholdBlue", &STSloColorThresholdsControl::diffThresholdBlue)
+        .def("__repr__", [](const STSloColorThresholdsControl &e) {
+            std::stringstream ss;
+            ss << "diffThresholdRed: " << e.diffThresholdRed << " ";
+            ss << "diffThresholdGreen: " << e.diffThresholdGreen << " ";
+            ss << "diffThresholdBlue: " << e.diffThresholdBlue;
+            return ss.str();
+        });
+    py::class_<STSloPenaltyControl> _STSloPenaltyControl(m, "STSloPenaltyControl");
+    _STSloPenaltyControl.def_readwrite("sloK1Penalty", &STSloPenaltyControl::sloK1Penalty)
         .def_readwrite("sloK2Penalty", &STSloPenaltyControl::sloK2Penalty)
         .def_readwrite("sloK1PenaltyMod1", &STSloPenaltyControl::sloK1PenaltyMod1)
         .def_readwrite("sloK2PenaltyMod1", &STSloPenaltyControl::sloK2PenaltyMod1)
         .def_readwrite("sloK1PenaltyMod2", &STSloPenaltyControl::sloK1PenaltyMod2)
-        .def_readwrite("sloK2PenaltyMod2", &STSloPenaltyControl::sloK2PenaltyMod2);
-
-    py::class_<STHdad> STHdad(m, "STHdad");
-        STHdad.def_readwrite("lambdaCensus", &STHdad::lambdaCensus)
+        .def_readwrite("sloK2PenaltyMod2", &STSloPenaltyControl::sloK2PenaltyMod2)
+        .def("__repr__", [](const STSloPenaltyControl &e) {
+            std::stringstream ss;
+            ss << "sloK1Penalty: " << e.sloK1Penalty << " ";
+            ss << "sloK2Penalty: " << e.sloK2Penalty << " ";
+            ss << "sloK1PenaltyMod1: " << e.sloK1PenaltyMod1 << " ";
+            ss << "sloK2PenaltyMod1: " << e.sloK2PenaltyMod1 << " ";
+            ss << "sloK1PenaltyMod2: " << e.sloK1PenaltyMod2 << " ";
+            ss << "sloK2PenaltyMod2: " << e.sloK2PenaltyMod2;
+            return ss.str();
+        });
+    py::class_<STHdad> _STHdad(m, "STHdad");
+        _STHdad.def_readwrite("lambdaCensus", &STHdad::lambdaCensus)
         .def_readwrite("lambdaAD", &STHdad::lambdaAD)
-        .def_readwrite("ignoreSAD", &STHdad::ignoreSAD);
+        .def_readwrite("ignoreSAD", &STHdad::ignoreSAD)
+        .def("__repr__", [](const STHdad &e) {
+            std::stringstream ss;
+            ss << "lambdaCensus: " << e.lambdaCensus << " ";
+            ss << "lambdaAD: " << e.lambdaAD << " ";
+            ss << "ignoreSAD: " << e.ignoreSAD;
+            return ss.str();
+        });
 
-
-    py::class_<STColorCorrection> STColorCorrection(m, "STColorCorrection");
-    STColorCorrection.def_readwrite("colorCorrection1", &STColorCorrection::colorCorrection1)
+    py::class_<STColorCorrection> _STColorCorrection(m, "STColorCorrection");
+    _STColorCorrection
+        .def_readwrite("colorCorrection1", &STColorCorrection::colorCorrection1)
         .def_readwrite("colorCorrection2", &STColorCorrection::colorCorrection2)
         .def_readwrite("colorCorrection3", &STColorCorrection::colorCorrection3)
         .def_readwrite("colorCorrection4", &STColorCorrection::colorCorrection4)
@@ -731,21 +802,57 @@ PYBIND11_PLUGIN(NAME) {
         .def_readwrite("colorCorrection9", &STColorCorrection::colorCorrection9)
         .def_readwrite("colorCorrection10", &STColorCorrection::colorCorrection10)
         .def_readwrite("colorCorrection11", &STColorCorrection::colorCorrection11)
-        .def_readwrite("colorCorrection12", &STColorCorrection::colorCorrection12);
+        .def_readwrite("colorCorrection12", &STColorCorrection::colorCorrection12)
+        .def("__repr__", [](const STColorCorrection &e) {
+            std::stringstream ss;
+            ss << "colorCorrection1: "  << e.colorCorrection1 << " ";
+            ss << "colorCorrection2: " << e.colorCorrection2 << " ";
+            ss << "colorCorrection3: " << e.colorCorrection3 << " ";
+            ss << "colorCorrection4: " << e.colorCorrection4 << " ";
+            ss << "colorCorrection5: " << e.colorCorrection5 << " ";
+            ss << "colorCorrection6: " << e.colorCorrection6 << " ";
+            ss << "colorCorrection7: " << e.colorCorrection7 << " ";
+            ss << "colorCorrection8: " << e.colorCorrection8 << " ";
+            ss << "colorCorrection9: " << e.colorCorrection9 << " ";
+            ss << "colorCorrection10: " << e.colorCorrection10 << " ";
+            ss << "colorCorrection11: " << e.colorCorrection11 << " ";
+            ss << "colorCorrection12: " << e.colorCorrection12;
+            return ss.str();
+        });
 
-    py::class_<STAEControl> STAEControl(m, "STAEControl");
-    STAEControl.def_readwrite("meanIntensitySetPoint", &STAEControl::meanIntensitySetPoint);
+    py::class_<STAEControl> _STAEControl(m, "STAEControl");
+    _STAEControl.def_readwrite("meanIntensitySetPoint", &STAEControl::meanIntensitySetPoint)
+    .def("__repr__", [](const STAEControl &e) {
+        std::stringstream ss;
+        ss << "Mean Intensity Set Point: " << e.meanIntensitySetPoint;
+        return ss.str();
+    });
 
-    py::class_<STDepthTableControl> STDepthTableControl(m, "STDepthTableControl");
-    STDepthTableControl.def_readwrite("depthUnits", &STDepthTableControl::depthUnits)
+    py::class_<STDepthTableControl> _STDepthTableControl(m, "STDepthTableControl");
+    _STDepthTableControl.def_readwrite("depthUnits", &STDepthTableControl::depthUnits)
         .def_readwrite("depthClampMin", &STDepthTableControl::depthClampMin)
         .def_readwrite("depthClampMax", &STDepthTableControl::depthClampMax)
         .def_readwrite("disparityMode", &STDepthTableControl::disparityMode)
-        .def_readwrite("disparityShift", &STDepthTableControl::disparityShift);
+        .def_readwrite("disparityShift", &STDepthTableControl::disparityShift)
+        .def("__repr__", [](const STDepthTableControl &e) {
+            std::stringstream ss;
+            ss << "depthUnits: " << e.depthUnits << " ";
+            ss << "depthClampMin: " << e.depthClampMin << " ";
+            ss << "depthClampMax: " << e.depthClampMax << " ";
+            ss << "disparityMode: " << e.disparityMode << " ";
+            ss << "disparityShift: " << e.disparityShift;
+            return ss.str();
+        });
 
-    py::class_<STCensusRadius> STCensusRadius(m, "STCensusRadius");
-    STCensusRadius.def_readwrite("uDiameter", &STCensusRadius::uDiameter)
-        .def_readwrite("vDiameter", &STCensusRadius::vDiameter);
+    py::class_<STCensusRadius> _STCensusRadius(m, "STCensusRadius");
+    _STCensusRadius.def_readwrite("uDiameter", &STCensusRadius::uDiameter)
+        .def_readwrite("vDiameter", &STCensusRadius::vDiameter)
+        .def("__repr__", [](const STCensusRadius &e) {
+            std::stringstream ss;
+            ss << "uDiameter: " << e.uDiameter << " ";
+            ss << "vDiameter: " << e.vDiameter;
+            return ss.str();
+        });
 
     py::class_<rs400::advanced_mode> rs400_advanced_mode(m, "rs400_advanced_mode");
     rs400_advanced_mode.def(py::init<rs2::device>(), "device"_a)

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -662,7 +662,8 @@ PYBIND11_PLUGIN(NAME) {
     */
 
     py::class_<STDepthControlGroup> _STDepthControlGroup(m, "STDepthControlGroup");
-    _STDepthControlGroup.def_readwrite("plusIncrement", &STDepthControlGroup::plusIncrement)
+    _STDepthControlGroup.def(py::init<>())
+        .def_readwrite("plusIncrement", &STDepthControlGroup::plusIncrement)
         .def_readwrite("minusDecrement", &STDepthControlGroup::minusDecrement)
         .def_readwrite("deepSeaMedianThreshold", &STDepthControlGroup::deepSeaMedianThreshold)
         .def_readwrite("scoreThreshA", &STDepthControlGroup::scoreThreshA)
@@ -687,7 +688,8 @@ PYBIND11_PLUGIN(NAME) {
         });
 
     py::class_<STRsm> _STRsm(m, "STRsm");
-    _STRsm.def_readwrite("rsmBypass", &STRsm::rsmBypass)
+    _STRsm.def(py::init<>())
+        .def_readwrite("rsmBypass", &STRsm::rsmBypass)
         .def_readwrite("diffThresh", &STRsm::diffThresh)
         .def_readwrite("sloRauDiffThresh", &STRsm::sloRauDiffThresh)
         .def_readwrite("removeThresh", &STRsm::removeThresh)
@@ -701,7 +703,8 @@ PYBIND11_PLUGIN(NAME) {
         });
 
     py::class_<STRauSupportVectorControl> _STRauSupportVectorControl(m, "STRauSupportVectorControl");
-        _STRauSupportVectorControl.def_readwrite("minWest", &STRauSupportVectorControl::minWest)
+        _STRauSupportVectorControl.def(py::init<>())
+        .def_readwrite("minWest", &STRauSupportVectorControl::minWest)
         .def_readwrite("minEast", &STRauSupportVectorControl::minEast)
         .def_readwrite("minWEsum", &STRauSupportVectorControl::minWEsum)
         .def_readwrite("minNorth", &STRauSupportVectorControl::minNorth)
@@ -722,7 +725,8 @@ PYBIND11_PLUGIN(NAME) {
             return ss.str();
         });
     py::class_<STColorControl> _STColorControl(m, "STColorControl");
-        _STColorControl.def_readwrite("disableSADColor", &STColorControl::disableSADColor)
+        _STColorControl.def(py::init<>())
+        .def_readwrite("disableSADColor", &STColorControl::disableSADColor)
         .def_readwrite("disableRAUColor", &STColorControl::disableRAUColor)
         .def_readwrite("disableSLORightColor", &STColorControl::disableSLORightColor)
         .def_readwrite("disableSLOLeftColor", &STColorControl::disableSLOLeftColor)
@@ -738,7 +742,8 @@ PYBIND11_PLUGIN(NAME) {
         });
 
     py::class_<STRauColorThresholdsControl> _STRauColorThresholdsControl(m, "STRauColorThresholdsControl");
-        _STRauColorThresholdsControl.def_readwrite("rauDiffThresholdRed", &STRauColorThresholdsControl::rauDiffThresholdRed)
+        _STRauColorThresholdsControl.def(py::init<>())
+        .def_readwrite("rauDiffThresholdRed", &STRauColorThresholdsControl::rauDiffThresholdRed)
         .def_readwrite("rauDiffThresholdGreen", &STRauColorThresholdsControl::rauDiffThresholdGreen)
         .def_readwrite("rauDiffThresholdBlue", &STRauColorThresholdsControl::rauDiffThresholdBlue)
         .def("__repr__", [](const STRauColorThresholdsControl &e) {
@@ -750,7 +755,8 @@ PYBIND11_PLUGIN(NAME) {
         });
 
     py::class_<STSloColorThresholdsControl> _STSloColorThresholdsControl(m, "STSloColorThresholdsControl");
-    _STSloColorThresholdsControl.def_readwrite("diffThresholdRed", &STSloColorThresholdsControl::diffThresholdRed)
+    _STSloColorThresholdsControl.def(py::init<>())
+        .def_readwrite("diffThresholdRed", &STSloColorThresholdsControl::diffThresholdRed)
         .def_readwrite("diffThresholdGreen", &STSloColorThresholdsControl::diffThresholdGreen)
         .def_readwrite("diffThresholdBlue", &STSloColorThresholdsControl::diffThresholdBlue)
         .def("__repr__", [](const STSloColorThresholdsControl &e) {
@@ -761,7 +767,8 @@ PYBIND11_PLUGIN(NAME) {
             return ss.str();
         });
     py::class_<STSloPenaltyControl> _STSloPenaltyControl(m, "STSloPenaltyControl");
-    _STSloPenaltyControl.def_readwrite("sloK1Penalty", &STSloPenaltyControl::sloK1Penalty)
+    _STSloPenaltyControl.def(py::init<>())
+        .def_readwrite("sloK1Penalty", &STSloPenaltyControl::sloK1Penalty)
         .def_readwrite("sloK2Penalty", &STSloPenaltyControl::sloK2Penalty)
         .def_readwrite("sloK1PenaltyMod1", &STSloPenaltyControl::sloK1PenaltyMod1)
         .def_readwrite("sloK2PenaltyMod1", &STSloPenaltyControl::sloK2PenaltyMod1)
@@ -778,7 +785,8 @@ PYBIND11_PLUGIN(NAME) {
             return ss.str();
         });
     py::class_<STHdad> _STHdad(m, "STHdad");
-        _STHdad.def_readwrite("lambdaCensus", &STHdad::lambdaCensus)
+        _STHdad.def(py::init<>())
+        .def_readwrite("lambdaCensus", &STHdad::lambdaCensus)
         .def_readwrite("lambdaAD", &STHdad::lambdaAD)
         .def_readwrite("ignoreSAD", &STHdad::ignoreSAD)
         .def("__repr__", [](const STHdad &e) {
@@ -790,7 +798,7 @@ PYBIND11_PLUGIN(NAME) {
         });
 
     py::class_<STColorCorrection> _STColorCorrection(m, "STColorCorrection");
-    _STColorCorrection
+    _STColorCorrection.def(py::init<>())
         .def_readwrite("colorCorrection1", &STColorCorrection::colorCorrection1)
         .def_readwrite("colorCorrection2", &STColorCorrection::colorCorrection2)
         .def_readwrite("colorCorrection3", &STColorCorrection::colorCorrection3)
@@ -821,15 +829,17 @@ PYBIND11_PLUGIN(NAME) {
         });
 
     py::class_<STAEControl> _STAEControl(m, "STAEControl");
-    _STAEControl.def_readwrite("meanIntensitySetPoint", &STAEControl::meanIntensitySetPoint)
-    .def("__repr__", [](const STAEControl &e) {
-        std::stringstream ss;
-        ss << "Mean Intensity Set Point: " << e.meanIntensitySetPoint;
-        return ss.str();
-    });
+    _STAEControl.def(py::init<>())
+        .def_readwrite("meanIntensitySetPoint", &STAEControl::meanIntensitySetPoint)
+        .def("__repr__", [](const STAEControl &e) {
+            std::stringstream ss;
+            ss << "Mean Intensity Set Point: " << e.meanIntensitySetPoint;
+            return ss.str();
+        });
 
     py::class_<STDepthTableControl> _STDepthTableControl(m, "STDepthTableControl");
-    _STDepthTableControl.def_readwrite("depthUnits", &STDepthTableControl::depthUnits)
+    _STDepthTableControl.def(py::init<>())
+        .def_readwrite("depthUnits", &STDepthTableControl::depthUnits)
         .def_readwrite("depthClampMin", &STDepthTableControl::depthClampMin)
         .def_readwrite("depthClampMax", &STDepthTableControl::depthClampMax)
         .def_readwrite("disparityMode", &STDepthTableControl::disparityMode)
@@ -845,7 +855,8 @@ PYBIND11_PLUGIN(NAME) {
         });
 
     py::class_<STCensusRadius> _STCensusRadius(m, "STCensusRadius");
-    _STCensusRadius.def_readwrite("uDiameter", &STCensusRadius::uDiameter)
+    _STCensusRadius.def(py::init<>())
+        .def_readwrite("uDiameter", &STCensusRadius::uDiameter)
         .def_readwrite("vDiameter", &STCensusRadius::vDiameter)
         .def("__repr__", [](const STCensusRadius &e) {
             std::stringstream ss;

--- a/wrappers/python/readme.md
+++ b/wrappers/python/readme.md
@@ -55,7 +55,11 @@ try:
                 coverage = [0]*64
                 print(line)
 ```
-A longer example can be found [here](./python-tutorial-1-depth.py)
+
+Additionally the following examples are available:
+ - [Tutorial 1](./python-tutorial-1-depth.py)
+ - [RS400 Advanced Mode](./python-rs400-advanced-mode-example.py)
+ - [Backend Example](./pybackend_example_1_general.py)
 
 ### NumPy Integration
 Librealsense frames support the buffer protocol. A numpy array can be constructed using this protocol with no data marshalling overhead:


### PR DESCRIPTION
Updated `C` and `C++` APIs to take a `const` ref/pointer in `set_*` functions of advanced mode.
Added python binding for existing C++ API of `rs400::advanced_mode`.
Added python example for using the new python wrapper API.
