### PR TITLE
Pipeline Bug fix

### DIFF
--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -170,7 +170,7 @@ namespace rs2
         //Stream type and resolution, and possibly format and frame rate
         void enable_stream(rs2_stream stream_type, int width, int height, rs2_format format = RS2_FORMAT_ANY, int framerate = 0)
         {
-            enable_stream(stream_type, -1, width, height, RS2_FORMAT_ANY, framerate);
+            enable_stream(stream_type, -1, width, height, format, framerate);
         }
 
         //Stream type and format

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -460,8 +460,10 @@ namespace librealsense
             {
                 //first try to get the previously resolved profile (if exists)
                 profile = conf->get_cached_resolved_profile();
-                if(i > 1 || !profile)
-                    profile = conf->resolve(shared_from_this(), std::chrono::seconds(5));
+                if (profile && i <= 1) //If a cached profile exists and this is the first iteration, no need to resolve
+                    break;
+
+                profile = conf->resolve(shared_from_this(), std::chrono::seconds(5));
             }
             catch (...)
             {


### PR DESCRIPTION
In PR #727 a `break` statement was removed from the retry loop of the `unsafe_start` method of `librealsense::pipeline`.  
Without this `break` - a previously resolved profile (cached by `config` after the user called `resolve` or `can_resolve`) will be ignored.
This PR restores the desired behavior of using the same profile as the last `resolve`d one.