### PR TITLE
Modify project setting for MSVC:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,7 +462,8 @@ if(FORCE_LIBUVC)
 endif()
 
 if (MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /wd4819")
+    add_definitions(-D_UNICODE)
 endif()
 
 add_definitions(-D${BACKEND} -DUNICODE)


### PR DESCRIPTION
1. disable C4819 warning
2. default to use Unicode instead of MBCS