### PR TITLE
make legacy devices explicit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Linux | Windows |
 ## Overview
 **Intel® RealSense™ SDK 2.0** is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).
 
-> For other Intel® RealSense™ devices (F200, R200, LR200 and ZR300) please refer to the [latest legacy release](https://github.com/IntelRealSense/librealsense/tree/v1.12.1).
+> For other Intel® RealSense™ devices (F200, R200, LR200 and ZR300), please refer to the [latest legacy release](https://github.com/IntelRealSense/librealsense/tree/v1.12.1).
 
 The SDK allows depth and color streaming, and provides intrinsic and extrinsic calibration information.
 The library also offers synthetic streams (pointcloud, depth aligned to color and vise-versa), and a built-in support for [record and playback](./src/media/readme.md) of streaming sessions.

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Linux | Windows |
 ## Overview
 **Intel® RealSense™ SDK 2.0** is a cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300).
 
-> For other Intel® RealSense™ devices, please refer to the [latest legacy release](https://github.com/IntelRealSense/librealsense/tree/v1.12.1).
+> For other Intel® RealSense™ devices (F200, R200, LR200 and ZR300) please refer to the [latest legacy release](https://github.com/IntelRealSense/librealsense/tree/v1.12.1).
 
 The SDK allows depth and color streaming, and provides intrinsic and extrinsic calibration information.
 The library also offers synthetic streams (pointcloud, depth aligned to color and vise-versa), and a built-in support for [record and playback](./src/media/readme.md) of streaming sessions.


### PR DESCRIPTION
I spent way too much time trying to debug why my old-school F200 wasn't working, and finally realized it's because it's legacy.  I should have caught this way sooner, but the above change may potentially make it easier for users to determine which API they need *faceslap*.