### PR TITLE
Support USB2 RealSense SKUs

### DIFF
--- a/config/99-realsense-libusb.rules
+++ b/config/99-realsense-libusb.rules
@@ -11,6 +11,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0ad2", MODE:="066
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0ad3", MODE:="0666", GROUP:="plugdev"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0ad4", MODE:="0666", GROUP:="plugdev"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0ad5", MODE:="0666", GROUP:="plugdev"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0ad6", MODE:="0666", GROUP:="plugdev"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0af6", MODE:="0666", GROUP:="plugdev"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0afe", MODE:="0666", GROUP:="plugdev"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="8086", ATTRS{idProduct}=="0aff", MODE:="0666", GROUP:="plugdev"

--- a/src/ds5/ds5-active.cpp
+++ b/src/ds5/ds5-active.cpp
@@ -25,22 +25,26 @@ namespace librealsense
     {
         using namespace ds;
 
-        auto& depth_ep = get_depth_sensor();
-        auto emitter_enabled = std::make_shared<emitter_option>(depth_ep);
-        depth_ep.register_option(RS2_OPTION_EMITTER_ENABLED, emitter_enabled);
+        auto pid = group.uvc_devices.front().pid;
+        if (pid != RS_USB2_PID)
+        {
+            auto& depth_ep = get_depth_sensor();
+            auto emitter_enabled = std::make_shared<emitter_option>(depth_ep);
+            depth_ep.register_option(RS2_OPTION_EMITTER_ENABLED, emitter_enabled);
 
-        auto laser_power = std::make_shared<uvc_xu_option<uint16_t>>(depth_ep,
-                                                                     depth_xu,
-                                                                     DS5_LASER_POWER,
-                                                                     "Manual laser power in mw. applicable only when laser power mode is set to Manual");
-        depth_ep.register_option(RS2_OPTION_LASER_POWER,
-                                 std::make_shared<auto_disabling_control>(
-                                 laser_power,
-                                 emitter_enabled,
-                                 std::vector<float>{0.f, 2.f}, 1.f));
+            auto laser_power = std::make_shared<uvc_xu_option<uint16_t>>(depth_ep,
+                                                                         depth_xu,
+                                                                         DS5_LASER_POWER,
+                                                                         "Manual laser power in mw. applicable only when laser power mode is set to Manual");
+            depth_ep.register_option(RS2_OPTION_LASER_POWER,
+                                     std::make_shared<auto_disabling_control>(
+                                     laser_power,
+                                     emitter_enabled,
+                                     std::vector<float>{0.f, 2.f}, 1.f));
 
-        depth_ep.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE,
-                std::make_shared<asic_and_projector_temperature_options>(depth_ep,
-                RS2_OPTION_PROJECTOR_TEMPERATURE));
+            depth_ep.register_option(RS2_OPTION_PROJECTOR_TEMPERATURE,
+                    std::make_shared<asic_and_projector_temperature_options>(depth_ep,
+                    RS2_OPTION_PROJECTOR_TEMPERATURE));
+        }
     }
 }

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -207,6 +207,8 @@ namespace librealsense
             return std::make_shared<rs430_rgb_mm_device>(ctx, group, register_device_notifications);
         case RS435_RGB_PID:
             return std::make_shared<rs435_device>(ctx, group, register_device_notifications);
+        case RS_USB2_PID:
+            return std::make_shared<rs410_device>(ctx, group, register_device_notifications);
         default:
             throw std::runtime_error("Unsupported RS400 model!");
         }

--- a/src/ds5/ds5-private.cpp
+++ b/src/ds5/ds5-private.cpp
@@ -166,16 +166,17 @@ namespace librealsense
                     result = *it;
                     switch (info.pid)
                     {
+                    case RS_USB2_PID:
                     case RS400_PID:
                     case RS410_PID:
                     case RS460_PID:
                     case RS430_PID:
                     case RS420_PID:
-                        found = result.mi == 3;
+                        found = (result.mi == 3);
                         break;
                     case RS430_MM_PID:
                     case RS420_MM_PID:
-                        found = result.mi == 6;
+                        found = (result.mi == 6);
                         break;
                     case RS415_PID:
                     case RS435_RGB_PID:

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -27,7 +27,8 @@ namespace librealsense
         const uint16_t RS430_MM_PID     = 0x0ad5; // AWGT
         const uint16_t RS430_MM_RGB_PID = 0x0b01; // AWGCT
         const uint16_t RS435_RGB_PID    = 0x0b07; // AWGC
-        const uint16_t RS460_PID       = 0x0b03; // DS5U
+        const uint16_t RS460_PID        = 0x0b03; // DS5U
+        const uint16_t RS_USB2_PID      = 0x0ad6; // USB2
 
         // DS5 depth XU identifiers
         const uint8_t DS5_HWMONITOR                       = 1;
@@ -52,7 +53,8 @@ namespace librealsense
             ds::RS430_MM_PID,
             ds::RS430_MM_RGB_PID,
             ds::RS435_RGB_PID,
-            ds::RS460_PID
+            ds::RS460_PID,
+            ds::RS_USB2_PID
         };
 
         static const std::map<std::uint16_t, std::string> rs400_sku_names = {
@@ -68,6 +70,7 @@ namespace librealsense
             { RS430_MM_PID, "Intel RealSense 430 with Tracking Module and RGB Module"},
             { RS435_RGB_PID,"Intel RealSense 435"},
             { RS460_PID,    "Intel RealSense 460" },
+            { RS_USB2_PID,  "Intel RealSense USB2" }
         };
 
         // DS5 fisheye XU identifiers

--- a/src/ds5/ds5-rolling-shutter.cpp
+++ b/src/ds5/ds5-rolling-shutter.cpp
@@ -25,7 +25,8 @@ namespace librealsense
     {
         using namespace ds;
 
-        if (_fw_version >= firmware_version("5.5.8.0"))
+        auto pid = group.uvc_devices.front().pid;
+        if ((_fw_version >= firmware_version("5.5.8.0")) && (pid != RS_USB2_PID))
         {
             get_depth_sensor().register_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE,
                 std::make_shared<uvc_xu_option<uint8_t>>(get_depth_sensor(),


### PR DESCRIPTION
Allow D400 SKUs streaming depth and IR over USB 2 interface using RealSense SDK.
Currently the available resolutions are 480x270 and 424x240 with 30, 15 and 6 FPS configuration.