### PR TITLE
[Node.js] Change FrameSet.at() to be based on FrameSet.getFrame()

### DIFF
--- a/wrappers/nodejs/index.js
+++ b/wrappers/nodejs/index.js
@@ -1676,24 +1676,11 @@ class FrameSet {
    * @return {DepthFrame|VideoFrame|Frame|undefined}
    */
   at(index) {
-    //
-    // TODO(ting): mapping index to stream and use this.cache[]
-    //   e.g. return getFrame(this.cxxFrameSet.indexToStream(index));
-    //
-
-    let cxxFrame = this.cxxFrameSet.at(index);
-
-    if (!cxxFrame) return undefined;
-
-    if (cxxFrame.isDepthFrame()) {
-      return new DepthFrame(cxxFrame);
+    if ((arguments.length !== 1) || (typeof index !== 'number') ||
+        (parseInt(index) >= this.size)) {
+      throw new TypeError('FrameSet.at(index) expects a valid integer argument');
     }
-
-    if (cxxFrame.isVideoFrame()) {
-      return new VideoFrame(cxxFrame);
-    }
-
-    return new Frame(cxxFrame);
+    return this.getFrame(this.cxxFrameSet.indexToStream(index));
   }
 
   __internalAssembleFrame(cxxFrame) {


### PR DESCRIPTION
@halton This could avoid creating a new Frame object each time at() is called,
thus using less memory. PTAL, thanks.