### PR TITLE
Pybind support for options

### DIFF
--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -107,13 +107,8 @@ namespace rs2
     class options
     {
     public:
-        options(rs2_options* options = nullptr)
-        {
-            _options = options;
-        }
-
         /**
-        * check if particular option is supported by a subdevice
+        * check if particular option is supported
         * \param[in] option     option id to be checked
         * \return true if option is supported
         */
@@ -153,7 +148,7 @@ namespace rs2
         }
 
         /**
-        * read option value from the device
+        * read option's value
         * \param[in] option   option id to be queried
         * \return value of the option
         */
@@ -180,7 +175,7 @@ namespace rs2
         }
 
         /**
-        * write new value to device option
+        * write new value to the option
         * \param[in] option     option id to be queried
         * \param[in] value      new value for the option
         */
@@ -211,6 +206,8 @@ namespace rs2
         }
 
    protected:
+       explicit options(rs2_options* o = nullptr) : _options(o) {}
+
        template<class T>
        options& operator=(const T& dev)
        {
@@ -230,8 +227,8 @@ namespace rs2
 
         using options::supports;
         /**
-        * open subdevice for exclusive access, by committing to a configuration
-        * \param[in] profile    configuration committed by the device
+        * open sensor for exclusive access, by committing to a configuration
+        * \param[in] profile    configuration committed by the sensor
         */
         void open(const stream_profile& profile) const
         {
@@ -245,7 +242,7 @@ namespace rs2
         /**
         * check if specific camera info is supported
         * \param[in] info    the parameter to check for support
-        * \return                true if the parameter both exist and well-defined for the specific device
+        * \return                true if the parameter both exist and well-defined for the specific sensor
         */
         bool supports(rs2_camera_info info) const
         {
@@ -258,7 +255,7 @@ namespace rs2
         /**
         * retrieve camera specific information, like versions of various internal components
         * \param[in] info     camera info type to retrieve
-        * \return             the requested camera info string, in a format specific to the device model
+        * \return             the requested camera info string, in a format specific to the sensor model
         */
         const char* get_info(rs2_camera_info info) const
         {
@@ -269,9 +266,9 @@ namespace rs2
         }
 
         /**
-        * open subdevice for exclusive access, by committing to composite configuration, specifying one or more stream profiles
+        * open sensor for exclusive access, by committing to composite configuration, specifying one or more stream profiles
         * this method should be used for interdependent  streams, such as depth and infrared, that have to be configured together
-        * \param[in] profiles   vector of configurations to be commited by the device
+        * \param[in] profiles   vector of configurations to be commited by the sensor
         */
         void open(const std::vector<stream_profile>& profiles) const
         {
@@ -292,8 +289,8 @@ namespace rs2
         }
 
         /**
-        * close subdevice for exclusive access
-        * this method should be used for releasing device resource
+        * close sensor for exclusive access
+        * this method should be used for releasing sensor resource
         */
         void close() const
         {
@@ -339,8 +336,8 @@ namespace rs2
 
 
         /**
-        * check if physical subdevice is supported
-        * \return   list of stream profiles that given subdevice can provide, should be released by rs2_delete_profiles_list
+        * check if physical sensor is supported
+        * \return   list of stream profiles that given sensor can provide, should be released by rs2_delete_profiles_list
         */
         std::vector<stream_profile> get_stream_profiles() const
         {
@@ -377,19 +374,19 @@ namespace rs2
             return intrin;
         }
 
-        sensor& operator=(const std::shared_ptr<rs2_sensor> dev)
+        sensor& operator=(const std::shared_ptr<rs2_sensor> other)
         {  
-            options::operator=(dev);
+            options::operator=(other);
             _sensor.reset();
-            _sensor = dev;
+            _sensor = other;
             return *this;
         }
 
-        sensor& operator=(const sensor& dev)
+        sensor& operator=(const sensor& other)
         {
             *this = nullptr;
-             options::operator=(dev._sensor);
-            _sensor = dev._sensor;
+             options::operator=(other._sensor);
+            _sensor = other._sensor;
             return *this;
         }
         sensor() : _sensor(nullptr) {}

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -187,6 +187,10 @@ PYBIND11_PLUGIN(NAME) {
           .value("depth_units", RS2_OPTION_DEPTH_UNITS)
           .value("enable_motion_correction", RS2_OPTION_ENABLE_MOTION_CORRECTION)
           .value("auto_exposure_priority", RS2_OPTION_AUTO_EXPOSURE_PRIORITY)
+          .value("color_scheme", RS2_OPTION_COLOR_SCHEME)
+          .value("histogram_equalization_enabled", RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED)
+          .value("min_distance", RS2_OPTION_MIN_DISTANCE)
+          .value("max_distance", RS2_OPTION_MAX_DISTANCE)
           .value("count", RS2_OPTION_COUNT);
 
     // Multi-dimensional c-array rs2_motion_device_instrinc::data causing trouble
@@ -462,6 +466,20 @@ PYBIND11_PLUGIN(NAME) {
                     }, "Poll if a new frame is available and dequeue it if it is")
                .def("__call__", &rs2::frame_queue::operator());
 
+    // Base class for options interface. Should be used via sensor
+    py::class_<rs2::options> options(m, "options");
+    options.def("is_option_read_only", &rs2::options::is_option_read_only, "Check if particular option "
+        "is read only.", "option"_a)
+        .def("get_option", &rs2::options::get_option, "Read option value from the device.", "option"_a)
+        .def("get_option_range", &rs2::options::get_option_range, "Retrieve the available range of values "
+            "of a supported option", "option"_a)
+        .def("set_option", &rs2::options::set_option, "Write new value to device option", "option"_a, "value"_a)
+        .def("supports", (bool (rs2::options::*)(rs2_option option) const) &rs2::options::supports, "Check if particular "
+            "option is supported by a subdevice", "option"_a)
+        .def("get_option_description", &rs2::options::get_option_description, "Get option description.", "option"_a)
+        .def("get_option_value_description", &rs2::options::get_option_value_description, "Get option value description "
+            "(In case a specific option value holds special meaning)", "option"_a, "value"_a);
+
     py::class_<rs2::pointcloud> pointcloud(m, "pointcloud");
     pointcloud.def(py::init<>())
         .def("calculate", &rs2::pointcloud::calculate, "depth"_a)
@@ -479,7 +497,7 @@ PYBIND11_PLUGIN(NAME) {
                }, "Check if a coherent set of frames is available");
           /*.def("__call__", &rs2::syncer::operator(), "frame"_a)*/;
 
-    py::class_<rs2::colorizer> colorizer(m, "colorizer");
+    py::class_<rs2::colorizer, rs2::options> colorizer(m, "colorizer");
     colorizer.def(py::init<>())
              .def("colorize", &rs2::colorizer::colorize, "depth"_a)
              /*.def("__call__", &rs2::colorizer::operator())*/;
@@ -567,36 +585,26 @@ PYBIND11_PLUGIN(NAME) {
             "Retrieve the notification's severity.");
 
     // not binding notifications_callback, templated
-
-    py::class_<rs2::sensor> sensor(m, "sensor");
+    py::class_<rs2::sensor, rs2::options> sensor(m, "sensor");
     sensor.def("open", (void (rs2::sensor::*)(const rs2::stream_profile&) const) &rs2::sensor::open,
-               "Open subdevice for exclusive access, by committing to a configuration", "profile"_a)
-          .def("supports", (bool (rs2::sensor::*)(rs2_camera_info) const) &rs2::device::supports,
+               "Open sensor for exclusive access, by commiting to a configuration", "profile"_a)
+          .def("supports", (bool (rs2::sensor::*)(rs2_camera_info) const) &rs2::sensor::supports,
                "Check if speific camera info is supported.", "info")
+          .def("supports", (bool (rs2::sensor::*)(rs2_option) const) &rs2::options::supports,
+            "Check if speific camera info is supported.", "info")
           .def("get_info", &rs2::sensor::get_info, "Retrieve camera specific information, "
                "like versions of various internal components.", "info"_a)
+           .def("set_notifications_callback", [](const rs2::sensor& self, std::function<void(rs2::notification)> callback)
+               { self.set_notifications_callback(callback); }, "Register Notifications callback", "callback"_a)
           .def("open", (void (rs2::sensor::*)(const std::vector<rs2::stream_profile>&) const) &rs2::sensor::open,
-               "Open subdevice for exclusive access, by committing to a composite configuration, specifying one or "
+               "Open sensor for exclusive access, by committing to a composite configuration, specifying one or "
                "more stream profiles.", "profiles"_a)
-          .def("close", [](const rs2::sensor& self){ py::gil_scoped_release lock; self.close(); }, "Close subdevice for exclusive access.")
+          .def("close", [](const rs2::sensor& self){ py::gil_scoped_release lock; self.close(); }, "Close sensor for exclusive access.")
           .def("start", [](const rs2::sensor& self, std::function<void(rs2::frame)> callback)
                { self.start(callback); }, "Start passing frames into user provided callback.", "callback"_a)
           .def("start", [](const rs2::sensor& self, rs2::frame_queue& queue) { self.start(queue); })
           .def("stop", &rs2::sensor::stop, "Stop streaming.")
-          .def("is_option_read_only", &rs2::sensor::is_option_read_only, "Check if particular option "
-               "is read only.", "option"_a)
-          .def("set_notifications_callback", [](const rs2::sensor& self, std::function<void(rs2::notification)> callback)
-               { self.set_notifications_callback(callback); }, "Register Notifications callback", "callback"_a)
-          .def("get_option", &rs2::sensor::get_option, "Read option value from the device.", "option"_a)
-          .def("get_option_range", &rs2::sensor::get_option_range, "Retrieve the available range of values "
-               "of a supported option", "option"_a)
-          .def("set_option", &rs2::sensor::set_option, "Write new value to device option", "option"_a, "value"_a)
-          .def("supports", (bool (rs2::sensor::*)(rs2_option option) const) &rs2::sensor::supports, "Check if particular "
-               "option is supported by a subdevice", "option"_a)
-          .def("get_option_description", &rs2::sensor::get_option_description, "Get option description.", "option"_a)
-          .def("get_option_value_description", &rs2::sensor::get_option_value_description, "Get option value description "
-               "(In case a specific option value holds special meaning)", "option"_a, "value"_a)
-          .def("get_stream_profiles", &rs2::sensor::get_stream_profiles, "Check if physical subdevice is supported.")
+          .def("get_stream_profiles", &rs2::sensor::get_stream_profiles, "Check if physical sensor is supported.")
           .def("get_motion_intrisics", &rs2::sensor::get_motion_intrinsics, "Returns scale and bias of a motion stream.",
                "stream"_a)
           .def(py::init<>())

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -589,9 +589,9 @@ PYBIND11_PLUGIN(NAME) {
     sensor.def("open", (void (rs2::sensor::*)(const rs2::stream_profile&) const) &rs2::sensor::open,
                "Open sensor for exclusive access, by commiting to a configuration", "profile"_a)
           .def("supports", (bool (rs2::sensor::*)(rs2_camera_info) const) &rs2::sensor::supports,
-               "Check if speific camera info is supported.", "info")
+               "Check if specific camera info is supported.", "info")
           .def("supports", (bool (rs2::sensor::*)(rs2_option) const) &rs2::options::supports,
-            "Check if speific camera info is supported.", "info")
+            "Check if specific camera info is supported.", "info")
           .def("get_info", &rs2::sensor::get_info, "Retrieve camera specific information, "
                "like versions of various internal components.", "info"_a)
            .def("set_notifications_callback", [](const rs2::sensor& self, std::function<void(rs2::notification)> callback)


### PR DESCRIPTION
1. Adding 4 missing `rs2_options` enums: `RS2_OPTION_COLOR_SCHEME`, `RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED`, `RS2_OPTION_MIN_DISTANCE`, `RS2_OPTION_MAX_DISTANCE`
2. Fixing issue #799 - Sensor object fails to access Options Base Class
3. Minor refactor to PR #772 - `rs2::options` now has only `protected` constructor

Thanks to Carl Allendorph for reporting the issue and for PR #801 👏 
