### PR TITLE
Fixed dropped frame issue of color streaming on Linux

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -22,12 +22,12 @@
 #include <sstream>
 
 
-const uint16_t MAX_RETRIES           = 100;
-const uint16_t VID_INTEL_CAMERA      = 0x8086;
-const uint8_t  DEFAULT_FRAME_BUFFERS = 4;
-const uint16_t DELAY_FOR_RETRIES     = 50;
+const uint16_t MAX_RETRIES                = 100;
+const uint16_t VID_INTEL_CAMERA           = 0x8086;
+const uint8_t  DEFAULT_V4L2_FRAME_BUFFERS = 4;
+const uint16_t DELAY_FOR_RETRIES          = 50;
 
-const uint8_t MAX_META_DATA_SIZE      = 0xff; // UVC Metadata total length
+const uint8_t MAX_META_DATA_SIZE          = 0xff; // UVC Metadata total length
                                             // is limited by (UVC Bulk) design to 255 bytes
 
 namespace librealsense
@@ -362,7 +362,7 @@ namespace librealsense
         class uvc_device
         {
         public:
-            virtual void probe_and_commit(stream_profile profile, frame_callback callback, int buffers = DEFAULT_FRAME_BUFFERS) = 0;
+            virtual void probe_and_commit(stream_profile profile, frame_callback callback, int buffers = DEFAULT_V4L2_FRAME_BUFFERS) = 0;
             virtual void stream_on(std::function<void(const notification& n)> error_handler = [](const notification& n){}) = 0;
             virtual void start_callbacks() = 0;
             virtual void stop_callbacks() = 0;

--- a/src/backend.h
+++ b/src/backend.h
@@ -362,7 +362,7 @@ namespace librealsense
         class uvc_device
         {
         public:
-            virtual void probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers = DEFAULT_FRAME_BUFFERS) = 0;
+            virtual void probe_and_commit(stream_profile profile, frame_callback callback, int buffers = DEFAULT_FRAME_BUFFERS) = 0;
             virtual void stream_on(std::function<void(const notification& n)> error_handler = [](const notification& n){}) = 0;
             virtual void start_callbacks() = 0;
             virtual void stop_callbacks() = 0;
@@ -400,9 +400,9 @@ namespace librealsense
             explicit retry_controls_work_around(std::shared_ptr<uvc_device> dev)
                 : _dev(dev) {}
 
-            void probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers) override
+            void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override
             {
-                _dev->probe_and_commit(profile, zero_copy, callback, buffers);
+                _dev->probe_and_commit(profile, callback, buffers);
             }
 
             void stream_on(std::function<void(const notification& n)> error_handler = [](const notification& n){}) override
@@ -661,11 +661,11 @@ namespace librealsense
                 : _dev(dev)
             {}
 
-            void probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers) override
+            void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override
             {
                 auto dev_index = get_dev_index_by_profiles(profile);
                 _configured_indexes.insert(dev_index);
-                _dev[dev_index]->probe_and_commit(profile, zero_copy, callback, buffers);
+                _dev[dev_index]->probe_and_commit(profile, callback, buffers);
             }
 
 

--- a/src/libuvc/libuvc.cpp
+++ b/src/libuvc/libuvc.cpp
@@ -294,7 +294,7 @@ namespace librealsense
             }
 
             /* request to set up a streaming profile and its calback */
-            void probe_and_commit(stream_profile profile, bool zero_copy, frame_callback callback, int buffers) override
+            void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override
             {
                 uvc_error_t res;
                 uvc_stream_ctrl_t ctrl;

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -517,11 +517,8 @@ namespace librealsense
             if (_thread) _thread->join();
         }
 
-        void v4l_uvc_device::probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers)
+        void v4l_uvc_device::probe_and_commit(stream_profile profile, frame_callback callback, int buffers)
         {
-            if(!zero_copy)
-                buffers = 1;
-
             if(!_is_capturing && !_callback)
             {
                 v4l2_fmtdesc pixel_format = {};
@@ -538,7 +535,7 @@ namespace librealsense
                         // Microsoft Depth GUIDs for R400 series are not yet recognized
                         // by the Linux kernel, but they do not require a patch, since there
                         // are "backup" Z16 and Y8 formats in place
-                        std::set<std::string> known_problematic_formats = {
+                        static const std::set<std::string> known_problematic_formats = {
                             "00000050-0000-0010-8000-00aa003",
                             "00000032-0000-0010-8000-00aa003",
                         };

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -535,15 +535,15 @@ namespace librealsense
                         // Microsoft Depth GUIDs for R400 series are not yet recognized
                         // by the Linux kernel, but they do not require a patch, since there
                         // are "backup" Z16 and Y8 formats in place
-                        static const std::set<std::string> known_problematic_formats = {
+                        static const std::set<std::string> pending_formats = {
                             "00000050-0000-0010-8000-00aa003",
                             "00000032-0000-0010-8000-00aa003",
                         };
 
-                        if (std::find(known_problematic_formats.begin(),
-                                      known_problematic_formats.end(),
+                        if (std::find(pending_formats.begin(),
+                                      pending_formats.end(),
                                       (const char*)pixel_format.description) ==
-                            known_problematic_formats.end())
+                            pending_formats.end())
                         {
                             const std::string s(to_string() << "!" << pixel_format.description);
                             std::regex rgx("!([0-9a-f]+)-.*");

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -141,7 +141,7 @@ namespace librealsense
 
             ~v4l_uvc_device();
 
-            void probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers) override;
+            void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override;
 
             void stream_on(std::function<void(const notification& n)> error_handler) override;
 

--- a/src/mock/recorder.cpp
+++ b/src/mock/recorder.cpp
@@ -628,11 +628,11 @@ namespace librealsense
         }
 
 
-        void record_uvc_device::probe_and_commit( stream_profile profile, bool zero_copy,   frame_callback callback, int buffers)
+        void record_uvc_device::probe_and_commit(stream_profile profile, frame_callback callback, int buffers)
         {
-            _owner->try_record([this, zero_copy, callback, profile](recording* rec, lookup_key k)
+            _owner->try_record([this, callback, profile](recording* rec, lookup_key k)
             {
-                _source->probe_and_commit(profile, zero_copy, [this, callback](stream_profile p, frame_object f, std::function<void()> continuation)
+                _source->probe_and_commit(profile, [this, callback](stream_profile p, frame_object f, std::function<void()> continuation)
                 {
                     _owner->try_record([this, callback, p, &f, continuation](recording* rec1, lookup_key key1)
                     {
@@ -1179,7 +1179,7 @@ namespace librealsense
             });
         }
 
-        void playback_uvc_device::probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers)
+        void playback_uvc_device::probe_and_commit(stream_profile profile, frame_callback callback, int buffers)
         {
             auto stored = _rec->load_stream_profiles(_entity_id, call_type::uvc_probe_commit);
             vector<stream_profile> input{ profile };

--- a/src/mock/recorder.h
+++ b/src/mock/recorder.h
@@ -324,7 +324,7 @@ namespace librealsense
         class record_uvc_device : public uvc_device
         {
         public:
-            void probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers) override;
+            void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override;
             void stream_on(std::function<void(const notification& n)> error_handler = [](const notification& n) {}) override;
             void start_callbacks() override;
             void stop_callbacks() override;
@@ -502,7 +502,7 @@ namespace librealsense
         class playback_uvc_device : public uvc_device
         {
         public:
-            void probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers) override;
+            void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override;
             void stream_on(std::function<void(const notification& n)> error_handler = [](const notification& n) {}) override;
             void start_callbacks() override;
             void stop_callbacks() override;

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -318,7 +318,7 @@ namespace librealsense
         {
             try
             {
-                _device->probe_and_commit(mode.profile, !mode.requires_processing(),
+                _device->probe_and_commit(mode.profile,
                 [this, mode, timestamp_reader, requests](platform::stream_profile p, platform::frame_object f, std::function<void()> continuation) mutable
                 {
                     auto system_time = environment::get_instance().get_time_service()->get_time();
@@ -420,7 +420,7 @@ namespace librealsense
                             _source.invoke_callback(std::move(pref));
                     }
                 },
-                static_cast<int>(_source.get_published_size_option()->query()));
+                DEFAULT_FRAME_BUFFERS);
             }
             catch(...)
             {

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -419,8 +419,7 @@ namespace librealsense
                         if (pref->get_stream().get())
                             _source.invoke_callback(std::move(pref));
                     }
-                },
-                DEFAULT_FRAME_BUFFERS);
+                });
             }
             catch(...)
             {

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -38,7 +38,7 @@ namespace librealsense
 
     std::shared_ptr<option> frame_source::get_published_size_option()
     {
-        return std::make_shared<frame_queue_size>(&_max_publish_list_size, option_range{ 0, 32, 1, 16 });
+        return std::make_shared<frame_queue_size>(&_max_publish_list_size, option_range{ 1, 32, 1, 16 });
     }
 
     frame_source::frame_source()

--- a/src/win/win-uvc.cpp
+++ b/src/win/win-uvc.cpp
@@ -986,7 +986,7 @@ namespace librealsense
             }
         }
 
-        void wmf_uvc_device::probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int /*buffers*/)
+        void wmf_uvc_device::probe_and_commit(stream_profile profile, frame_callback callback, int /*buffers*/)
         {
             if (_streaming)
                 throw std::runtime_error("Device is already streaming!");

--- a/src/win/win-uvc.h
+++ b/src/win/win-uvc.h
@@ -53,7 +53,7 @@ namespace librealsense
             wmf_uvc_device(const uvc_device_info& info, std::shared_ptr<const wmf_backend> backend);
             ~wmf_uvc_device();
 
-            void probe_and_commit( stream_profile profile, bool zero_copy,  frame_callback callback, int buffers) override;
+            void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override;
             void stream_on(std::function<void(const notification& n)> error_handler = [](const notification& n){}) override;
             void start_callbacks() override;
             void stop_callbacks() override;

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -230,7 +230,7 @@ PYBIND11_PLUGIN(NAME) {
         .def("probe_and_commit",
             [](platform::retry_controls_work_around& dev, const platform::stream_profile& profile,
                 std::function<void(const platform::stream_profile&, const platform::frame_object&)> callback) {
-        dev.probe_and_commit(profile, false, [=](const platform::stream_profile& p,
+        dev.probe_and_commit(profile, [=](const platform::stream_profile& p,
             const platform::frame_object& fo, std::function<void()> next)
         {
             callback(p, fo);


### PR DESCRIPTION
- Fixing DSO-7183 - FPS dropped to half than expected on color streaming with processing formats (RGB8, BGR8...) on Linux.
This issue was fixed by changing the number of v4l2 buffers to 4.