### PR TITLE
Fix pyenv error in travis to avoid blocking pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ script:
   # Exit immediately if a command exits with a non-zero status
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       set -e;
+      pyenv install 3.6.1;
       pyenv local `pyenv versions|sed 's/ //g'|grep "^3"|tail -1`;
       mkdir build && cd build;
       cmake .. -DBUILD_EXAMPLES:BOOL=true -DBUILD_PYTHON_BINDINGS:BOOL=true -DBUILD_NODEJS_BINDINGS:BOOL=true;


### PR DESCRIPTION
In latest travis, 'pyenv versions' command just output '*system ...'
And the default system python is 2.7. This temp solution is to manually
install 3.6.1 to avoid failure.

@halton @dorodnic PTAL, thanks.