### PR TITLE
Fix Python depth Tutorial

### DIFF
--- a/wrappers/python/examples/python-tutorial-1-depth.py
+++ b/wrappers/python/examples/python-tutorial-1-depth.py
@@ -22,16 +22,16 @@ try:
 
         # Print a simple text-based representation of the image, by breaking it into 10x20 pixel regions and approximating the coverage of pixels within one meter
         coverage = [0]*64
-        for y in xrange(480):
-            for x in xrange(640):
+        for y in range(480):
+            for x in range(640):
                 dist = depth.get_distance(x, y)
                 if 0 < dist and dist < 1:
-                    coverage[x/10] += 1
+                    coverage[x//10] += 1
             
             if y%20 is 19:
                 line = ""
                 for c in coverage:
-                    line += " .:nhBXWW"[c/25]
+                    line += " .:nhBXWW"[c//25]
                 coverage = [0]*64
                 print(line)
     exit(0)

--- a/wrappers/python/readme.md
+++ b/wrappers/python/readme.md
@@ -14,6 +14,8 @@
   * `sudo apt-get install python python-dev` or `sudo apt-get install python3 python3-dev`
   * **Note:** The project will only use Python2 if it can't use Python3
 3. run the toplevel cmake command with the following additional flag: `-DBUILD_PYTHON_BINDINGS=bool:true`
+4. update your PYTHONPATH environment variable to add the path to the pyrealsense library
+  * `export PYTHONPATH=$PYTHONPATH:/usr/local/lib`
 
 **Note**: To force compilation with a specific version on a system with both Python 2 and Python 3 installed, add the following flag to CMake command:
 `-DPYTHON_EXECUTABLE=[full path to the exact python executable]`
@@ -73,4 +75,3 @@ depth = frames.get_depth_frame()
 depth_data = depth.as_frame().get_data()
 np_image = np.asanyarray(depth_data)
 ```
-


### PR DESCRIPTION
This PR is to fix 2 issues with the python-tutorial-depth-1.py
1) change syntax to work with python3 by using range instead of xrange and x//10, x//25 as array indices
2) update the readme to include setting the PYTHONPATH

I'm happy to make changes if you need me to, let me know.