### PR TITLE
[Node.js] Fix npm install error on node v9.2.0

### DIFF
--- a/wrappers/nodejs/examples/package-lock.json
+++ b/wrappers/nodejs/examples/package-lock.json
@@ -593,9 +593,9 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "2.3.0",
@@ -719,7 +719,6 @@
         "json-stringify-safe": "5.0.1",
         "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
         "qs": "6.4.0",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",

--- a/wrappers/nodejs/package-lock.json
+++ b/wrappers/nodejs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-librealsense",
-  "version": "0.281.0",
+  "version": "0.282.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -116,9 +116,9 @@
       }
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "pngjs": {
       "version": "3.3.0",

--- a/wrappers/nodejs/package.json
+++ b/wrappers/nodejs/package.json
@@ -27,7 +27,7 @@
     "bindings": "^1.2.1",
     "fs-compare": "0.0.4",
     "jsonfile": "^3.0.1",
-    "nan": "^2.7.0",
+    "nan": "^2.8.0",
     "pngjs": "^3.3.0"
   },
   "devDependencies": {

--- a/wrappers/nodejs/scripts/generate-dist-package.js
+++ b/wrappers/nodejs/scripts/generate-dist-package.js
@@ -5,7 +5,6 @@
 // Purpose: pack librealsense dir & wrappers/nodejs dir into npm package
 
 const {exec} = require('child_process');
-const package = require('../package.json');
 const jf = require('jsonfile');
 
 function genDistPackage() {
@@ -32,8 +31,7 @@ function genPackageJson() {
 }
 
 function callDistScript() {
-  const fileName = 'librealsense.' + package.version + '.tar.gz';
-  exec('./scripts/npm_dist/gen-dist.sh ' + fileName, (error, stdout, stderr) => {
+  exec('./scripts/npm_dist/gen-dist.sh ', (error, stdout, stderr) => {
     if (error) {
       console.log('fail to generate dist package, error:', error);
       throw error;

--- a/wrappers/nodejs/scripts/npm_dist/build-librealsense.js
+++ b/wrappers/nodejs/scripts/npm_dist/build-librealsense.js
@@ -41,17 +41,17 @@ function buildNativeLibWindows() {
 
   exec('cmd /c .\\scripts\\npm_dist\\build-dist.bat ' + cmakeGenPlatform + ' ' + msBuildPlatform,
        (error, stdout, stderr) => {
-    if (error) {
-      console.log('Failed to build librealsense, error:', error);
-      throw error;
-    }
-
     if (stdout) {
       process.stdout.write(stdout);
     }
 
     if (stderr) {
       process.stderr.write(stderr);
+    }
+
+    if (error) {
+      console.log('Failed to build librealsense, error:', error);
+      throw error;
     }
   });
 }

--- a/wrappers/nodejs/scripts/npm_dist/gen-dist.sh
+++ b/wrappers/nodejs/scripts/npm_dist/gen-dist.sh
@@ -7,10 +7,9 @@
 #Usage: gen-dist.sh xxxx.tar.gz
 
 WORKDIR=`mktemp -d`
-RAWMODULEDIR="node-librealsense"
+RAWMODULEDIR="node-librealsense/"
 MODULEDIR="$WORKDIR/$RAWMODULEDIR"
 RSDIR="$MODULEDIR/librealsense"
-TARFILENAME="$WORKDIR/$1"
 
 mkdir -p $RSDIR
 rsync -a ../.. $RSDIR --exclude wrappers --exclude doc --exclude unit-tests --exclude build --exclude .git
@@ -22,16 +21,17 @@ cp -f scripts/npm_dist/README.md $MODULEDIR
 
 pushd . > /dev/null
 cd $WORKDIR
-tar -czf $1 $RAWMODULEDIR
+FILENAME=`npm pack $RAWMODULEDIR`
+TARFILENAME="$WORKDIR/$FILENAME"
 
 popd > /dev/null
 mkdir -p dist
 cp -f $TARFILENAME ./dist/
 rm -rf $WORKDIR
 
+echo "Generated ./dist/$FILENAME"
 # SHOW INFO & DIR
-if [ "$RS_SHOW_DIST_PACKAGE" -eq 1 ]
+if [ "$RS_SHOW_DIST_PACKAGE" == "1" ];
 then
-	echo "Generated ./dist/$1"
 	gnome-open ./dist
 fi

--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -3431,15 +3431,10 @@ NAN_METHOD(GetTime) {
 }
 
 #define _FORCE_SET_ENUM(name) \
-  exports->ForceSet(Nan::New(#name).ToLocalChecked(), \
-  Nan::New(static_cast<int>((name))), \
-  static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
-
-// TODO(tingshao): try DefineOwnProperty or CreateDataProperty
-// e.g.
-// exports->DefineOwnProperty(env->context(),
-//                            OneByteString(env->isolate(), str),
-//                            True(env->isolate()), ReadOnly).FromJust();
+  Nan::DefineOwnProperty(exports, \
+      Nan::New(#name).ToLocalChecked(), \
+      Nan::New(static_cast<int>((name))), \
+      static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete));
 
 void InitModule(v8::Local<v8::Object> exports) {
   exports->Set(Nan::New("globalCleanup").ToLocalChecked(),


### PR DESCRIPTION
1. Use 'npm pack' to generate tarball instead of tar which has compatibility
issue on new npm versions.
2. Use Nan::DefineOwnProperty instead of v8::Object::ForceSet which has compile
issue on latest node

@halton PTAL, thanks