### PR TITLE
[Node.js] Create build jobs according to processor count

### DIFF
--- a/wrappers/nodejs/scripts/npm_dist/build-dist.sh
+++ b/wrappers/nodejs/scripts/npm_dist/build-dist.sh
@@ -23,7 +23,8 @@ then
 fi
 
 # Step 2
-make -j 8
+CPU_NUM=`grep -c ^processor /proc/cpuinfo`
+make -j $CPU_NUM
 if [ "$?" -gt 0 ]
 then
 	echo 'Failed to build librealsense'


### PR DESCRIPTION
This is to avoid eating up resources on low end machines

@halton PTAL, thanks.