### PR TITLE
Support for alignment of any stream to depth

### DIFF
--- a/examples/align/readme.md
+++ b/examples/align/readme.md
@@ -8,7 +8,7 @@ In this example, we align depth frames to their corresponding color frames. Then
 
 Using this information, we "remove" the background of the color frame that is further (away from the camera) than some user-define distance.
 
-The example display a GUI for controlling the max distance to show from the original color image.
+The example displays a GUI for controlling the maximum distance to show from the original color image.
 
 ## Expected Output
 
@@ -117,8 +117,9 @@ rs2_stream align_to = find_stream_to_align(profile.get_streams());
 rs2::align align(align_to);
 ```
 
-`rs2::align` is a utility class that performs image alignment (registration) of 2 frames. Basically, each pixel from the first image will be transformed so that it matches its corresponding pixel in the second image.
-A `rs2::align` object always transforms depth images to some target image which, in this example, is specified with the `RS2_STREAM_COLOR` parameter.
+`rs2::align` is a utility class that performs image alignment (registration) of 2 frames. 
+Basically, each pixel from the first image will be transformed so that it matches its corresponding pixel in the second image.
+A `rs2::align` object transforms between two input images, from a source image to some target image which is specified with the `align_to` parameter.
 
 Now comes the interesting part of the application. We start our main loop, which breaks only when the window is closed:
 

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -296,9 +296,21 @@ namespace rs2
         frame_queue _results;
     };
 
+    /**
+        Auxiliary processing block that performs image alignment using depth data and camera calibration
+    */
     class align
     {
     public:
+        /**
+            Create align processing block 
+            Alignment is performed between a depth image and another image. 
+            To perform alignment of a depth image to the other, set the align_to parameter with the other stream type.
+            To perform alignment of a non depth image to a depth image, set the align_to parameter to RS2_STREAM_DEPTH
+            Camera calibration and frame's stream type are determined on the fly, according to the first valid frameset passed to proccess()
+
+            * \param[in] align_to      The stream type to which alignment should be made.
+        */
         align(rs2_stream align_to) :_queue(1)
         {
             rs2_error* e = nullptr;
@@ -311,6 +323,12 @@ namespace rs2
             _block->start(_queue);
         }
 
+        /**
+        * Run the alignment process on the given frames to get an aligned set of frames
+        *
+        * \param[in] frame      A pair of images, where at least one of which is a depth frame
+        * \return Input frames aligned to one another
+        */
         frameset proccess(frameset frame)
         {
             (*_block)(frame);

--- a/src/align.cpp
+++ b/src/align.cpp
@@ -482,44 +482,47 @@ namespace librealsense
     //}
 
     template<class GET_DEPTH, class TRANSFER_PIXEL>
-    void align_images(const rs2_intrinsics & depth_intrin, const rs2_extrinsics & depth_to_other,
-        const rs2_intrinsics & other_intrin, GET_DEPTH get_depth, TRANSFER_PIXEL transfer_pixel)
+    void align_images(const rs2_intrinsics & from_intrin, const rs2_extrinsics & extrinsic,
+        const rs2_intrinsics & to_intrin, GET_DEPTH get_depth, TRANSFER_PIXEL transfer_pixel)
     {
         // Iterate over the pixels of the depth image
-#pragma omp parallel for schedule(dynamic)
-        for (int depth_y = 0; depth_y < depth_intrin.height; ++depth_y)
+        #pragma omp parallel for schedule(dynamic)
+        for (int y = 0; y < from_intrin.height; ++y)
         {
-            int depth_pixel_index = depth_y * depth_intrin.width;
-            for (int depth_x = 0; depth_x < depth_intrin.width; ++depth_x, ++depth_pixel_index)
+            int pixel_index = y * from_intrin.width;
+            for (int x = 0; x < from_intrin.width; ++x, ++pixel_index)
             {
                 // Skip over depth pixels with the value of zero, we have no depth data so we will not write anything into our aligned images
-                if (float depth = get_depth(depth_pixel_index))
+                if (float depth = get_depth(pixel_index))
                 {
                     // Map the top-left corner of the depth pixel onto the other image
-                    float depth_pixel[2] = { depth_x - 0.5f, depth_y - 0.5f }, depth_point[3], other_point[3], other_pixel[2];
-                    rs2_deproject_pixel_to_point(depth_point, &depth_intrin, depth_pixel, depth);
-                    rs2_transform_point_to_point(other_point, &depth_to_other, depth_point);
-                    rs2_project_point_to_pixel(other_pixel, &other_intrin, other_point);
-                    const int other_x0 = static_cast<int>(other_pixel[0] + 0.5f);
-                    const int other_y0 = static_cast<int>(other_pixel[1] + 0.5f);
+                    float from_pixel[2] = { x - 0.5f, y - 0.5f };
+                    float from_point[3];
+                    float to_point[3];
+                    float to_pixel[2];
+                    rs2_deproject_pixel_to_point(from_point, &from_intrin, from_pixel, depth);
+                    rs2_transform_point_to_point(to_point, &extrinsic, from_point);
+                    rs2_project_point_to_pixel(to_pixel, &to_intrin, to_point);
+                    const int to_x0 = static_cast<int>(to_pixel[0] + 0.5f);
+                    const int to_y0 = static_cast<int>(to_pixel[1] + 0.5f);
 
-                    // Map the bottom-right corner of the depth pixel onto the other image
-                    depth_pixel[0] = depth_x + 0.5f; depth_pixel[1] = depth_y + 0.5f;
-                    rs2_deproject_pixel_to_point(depth_point, &depth_intrin, depth_pixel, depth);
-                    rs2_transform_point_to_point(other_point, &depth_to_other, depth_point);
-                    rs2_project_point_to_pixel(other_pixel, &other_intrin, other_point);
-                    const int other_x1 = static_cast<int>(other_pixel[0] + 0.5f);
-                    const int other_y1 = static_cast<int>(other_pixel[1] + 0.5f);
+                    // Map the bottom-right corner of the pixel onto the other image
+                    from_pixel[0] = x + 0.5f; from_pixel[1] = y + 0.5f;
+                    rs2_deproject_pixel_to_point(from_point, &from_intrin, from_pixel, depth);
+                    rs2_transform_point_to_point(to_point, &extrinsic, from_point);
+                    rs2_project_point_to_pixel(to_pixel, &to_intrin, to_point);
+                    const int to_x1 = static_cast<int>(to_pixel[0] + 0.5f);
+                    const int to_y1 = static_cast<int>(to_pixel[1] + 0.5f);
 
-                    if (other_x0 < 0 || other_y0 < 0 || other_x1 >= other_intrin.width || other_y1 >= other_intrin.height)
+                    if (to_x0 < 0 || to_y0 < 0 || to_x1 >= to_intrin.width || to_y1 >= to_intrin.height)
                         continue;
 
-                    // Transfer between the depth pixels and the pixels inside the rectangle on the other image
-                    for (int y = other_y0; y <= other_y1; ++y)
+                    // Transfer between the pixels and the pixels inside the rectangle on the other image
+                    for (int y = to_y0; y <= to_y1; ++y)
                     {
-                        for (int x = other_x0; x <= other_x1; ++x)
+                        for (int x = to_x0; x <= to_x1; ++x)
                         {
-                            transfer_pixel(depth_pixel_index, y * other_intrin.width + x);
+                            transfer_pixel(pixel_index, y * to_intrin.width + x);
                         }
                     }
                 }
@@ -527,138 +530,140 @@ namespace librealsense
         }
     }
 
-    align::align(rs2_stream to_stream)
-       : _depth_intrinsics_ptr(nullptr),
-        _depth_units_ptr(nullptr),
-        _other_intrinsics_ptr(nullptr),
-        _depth_to_other_extrinsics_ptr(nullptr),
-        _other_bytes_per_pixel_ptr(nullptr),
-        _other_stream_type(to_stream)
+    void align::update_frame_info(const frame_interface* frame, optional_value<rs2_intrinsics>& intrin,
+        std::shared_ptr<stream_profile_interface>& profile, bool register_extrin)
     {
-        auto on_frame = [this](rs2::frame f, const rs2::frame_source& source)
+        if (!frame)
+            return;
+
+        // Get profile
+        if (!profile)
         {
-            auto inspect_depth_frame = [this, &source](const rs2::frame& depth, const rs2::frame& other)
+            profile = frame->get_stream();
+            if(register_extrin)
+                environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*profile, *profile);
+        }
+
+        // Get intrinsics
+        if (!intrin)
+        {
+            if (auto video = As<video_stream_profile_interface>(profile))
             {
-                auto depth_frame = (frame_interface*)depth.get();
-                std::lock_guard<std::mutex> lock(_mutex);
+                intrin = video->get_intrinsics();
+            }
+        }
+    }
+    void align::update_align_info(const frame_interface* depth_frame)
+    {
+        // Get depth units
+        if (!_depth_units)
+        {
+            auto sensor = depth_frame->get_sensor();
+            _depth_units = sensor->get_option(RS2_OPTION_DEPTH_UNITS).query();
+        }
 
-                bool found_depth_intrinsics = false;
-                bool found_depth_units = false;
+        // Get extrinsics
+        if (!_extrinsics && _from_stream_profile && _to_stream_profile)
+        {
+            rs2_extrinsics ex;
+            if (environment::get_instance().get_extrinsics_graph().try_fetch_extrinsics(*_from_stream_profile, *_to_stream_profile, &ex))
+            {
+                _extrinsics = ex;
+            }
+        }
+    }
+    
 
-                if (!_depth_intrinsics_ptr)
+    align::align(rs2_stream to_stream)
+    {
+        auto on_frame = [this, to_stream](rs2::frame f, const rs2::frame_source& source)
+        {
+            auto composite = f.as<rs2::frameset>();
+            if (!composite)
+                return;
+
+            std::unique_lock<std::mutex> lock(_mutex);
+
+            assert(composite.size() >= 2);
+            if (!_from_stream_type)
+            {
+                _from_stream_type = RS2_STREAM_DEPTH;
+                _to_stream_type = to_stream;
+                if (to_stream == RS2_STREAM_DEPTH) //Align other to depth
                 {
-                    auto stream_profile = depth_frame->get_stream();
-                    if (auto video = dynamic_cast<video_stream_profile_interface*>(stream_profile.get()))
+                    for (auto&& f : composite)
                     {
-                        _depth_intrinsics = video->get_intrinsics();
-                        _depth_intrinsics_ptr = &_depth_intrinsics;
-                        found_depth_intrinsics = true;
+                        rs2_stream other_stream_type = f.get_profile().stream_type();
+                        if (other_stream_type != RS2_STREAM_DEPTH)
+                        {
+                            _from_stream_type = other_stream_type;
+                            break; //Take first matching stream type that is not depth
+                        }
                     }
+                    if (!_from_stream_type)
+                        _from_stream_type = RS2_STREAM_DEPTH; //If we only have depth frames, align them to one another
                 }
+            }
 
-                if (!_depth_units_ptr)
-                {
-                    auto sensor = depth_frame->get_sensor();
-                    _depth_units = sensor->get_option(RS2_OPTION_DEPTH_UNITS).query();
-                    _depth_units_ptr = &_depth_units;
-                    found_depth_units = true;
-                }
+            rs2::frame from = composite.first_or_default(*_from_stream_type);
+            rs2::depth_frame depth_frame = composite.get_depth_frame();
+            rs2::frame to = composite.first_or_default(_to_stream_type);
 
-                if (found_depth_units != found_depth_intrinsics)
-                {
-                    throw wrong_api_call_sequence_exception("Received depth frame that doesn't provide either intrinsics or depth units!");
-                }
+            // align_frames(source, from, to)
+            update_frame_info((frame_interface*)from.get(), _from_intrinsics, _from_stream_profile, false);
+            update_frame_info((frame_interface*)to.get(), _to_intrinsics, _to_stream_profile, true);
+            update_align_info((frame_interface*)depth_frame.get());
 
-                if (!_depth_stream_profile.get())
-                {
-                    _depth_stream_profile = depth_frame->get_stream();
-                     environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_depth_stream_profile, *depth_frame->get_stream());
-                    auto vid_frame = depth.as<rs2::video_frame>();
-                    _width = vid_frame.get_width();
-                    _height = vid_frame.get_height();
-                }
-
-                if (!_depth_to_other_extrinsics_ptr && _depth_stream_profile && _other_stream_profile)
-                {
-                     environment::get_instance().get_extrinsics_graph().try_fetch_extrinsics(*_depth_stream_profile, *_other_stream_profile, &_depth_to_other_extrinsics);
-                    _depth_to_other_extrinsics_ptr = &_depth_to_other_extrinsics;
-                }
-
-                if (_depth_intrinsics_ptr && _depth_units_ptr && _depth_stream_profile && _other_bytes_per_pixel_ptr &&
-                    _depth_to_other_extrinsics_ptr && _other_intrinsics_ptr && _other_stream_profile && other)
-                {
-                    std::vector<frame_holder> frames(2);
-
-                    auto other_frame = (frame_interface*)other.get();
-                    other_frame->acquire();
-                    frames[0] = frame_holder{ other_frame };
-
-                    frame_holder out_frame = get_source().allocate_video_frame(_depth_stream_profile, depth_frame,
-                        _other_bytes_per_pixel / 8, _other_intrinsics.width, _other_intrinsics.height, 0, RS2_EXTENSION_DEPTH_FRAME);
-                    auto p_out_frame = reinterpret_cast<uint16_t*>(((frame*)(out_frame.frame))->data.data());
-                    memset(p_out_frame, _depth_stream_profile->get_format() == RS2_FORMAT_DISPARITY16 ? 0xFF : 0x00, _other_intrinsics.height * _other_intrinsics.width * sizeof(uint16_t));
-                    auto p_depth_frame = reinterpret_cast<const uint16_t*>(((frame*)(depth_frame))->get_frame_data());
-
-                    align_images(*_depth_intrinsics_ptr, *_depth_to_other_extrinsics_ptr, *_other_intrinsics_ptr,
-                        [p_depth_frame, this](int z_pixel_index)
-                    {
-                        return _depth_units * p_depth_frame[z_pixel_index];
-                    },
-                        [p_out_frame, p_depth_frame/*, p_out_other_frame, other_bytes_per_pixel*/](int z_pixel_index, int other_pixel_index)
-                    {
-                        p_out_frame[other_pixel_index] = p_out_frame[other_pixel_index] ?
-                                                            std::min( (int)(p_out_frame[other_pixel_index]), (int)(p_depth_frame[z_pixel_index]) )
-                                                          : p_depth_frame[z_pixel_index];
-                    });
-                    frames[1] = std::move(out_frame);
-                    auto composite = get_source().allocate_composite_frame(std::move(frames));
-                    get_source().frame_ready(std::move(composite));
-                }
-            };
-
-            auto inspect_other_frame = [this, &source](const rs2::frame& other)
+            if (!_to_bytes_per_pixel)
             {
-                auto other_frame = (frame_interface*)other.get();
-                std::lock_guard<std::mutex> lock(_mutex);
+                auto vid_frame = to.as<rs2::video_frame>();
+                _to_bytes_per_pixel = vid_frame.get_bytes_per_pixel();
+            }
 
-                if (_other_stream_type != other_frame->get_stream()->get_stream_type())
-                    return;
+            if (_from_intrinsics && _to_intrinsics && _extrinsics && _depth_units && _from_stream_profile && _to_stream_profile)
+            {
+                std::vector<frame_holder> frames(2);
+                bool from_depth = (*_from_stream_type == RS2_STREAM_DEPTH);
 
-                if (!_other_stream_profile.get())
+                // Save the target ("to") frame as is
+                auto to_frame = (frame_interface*)to.get();
+                to_frame->acquire();
+                frames[0] = frame_holder{ to_frame };
+                
+                auto from_frame = (frame_interface*)from.get();
+
+                // Create a new frame which will transform the "from" frame
+                frame_holder out_frame = get_source().allocate_video_frame(_from_stream_profile, from_frame,
+                    _to_bytes_per_pixel.value(), _to_intrinsics->width, _to_intrinsics->height, 0, from_depth ? RS2_EXTENSION_DEPTH_FRAME : RS2_EXTENSION_VIDEO_FRAME);
+
+                //Clear the new image buffer
+                auto p_out_frame = reinterpret_cast<uint16_t*>(((frame*)(out_frame.frame))->data.data());
+                int blank_color = (_from_stream_profile->get_format() == RS2_FORMAT_DISPARITY16) ? 0xFF : 0x00;
+                memset(p_out_frame, blank_color, _to_intrinsics->height * _to_intrinsics->width * _to_bytes_per_pixel.value());
+
+                auto p_depth_frame = reinterpret_cast<const uint16_t*>(depth_frame.get_data());
+                auto p_from_frame = reinterpret_cast<const uint16_t*>(from.get_data());
+                
+                lock.unlock();
+                float depth_units = _depth_units.value();
+                align_images(*_from_intrinsics, *_extrinsics, *_to_intrinsics, 
+                    [p_depth_frame, depth_units, from_depth](int z_pixel_index) -> float
                 {
-                    _other_stream_profile = other_frame->get_stream();
-                }
-
-                if (!_other_bytes_per_pixel_ptr)
-                {
-                    auto vid_frame = other.as<rs2::video_frame>();
-                    _other_bytes_per_pixel = vid_frame.get_bytes_per_pixel();
-                    _other_bytes_per_pixel_ptr = &_other_bytes_per_pixel;
-                }
-
-                if (!_other_intrinsics_ptr)
-                {
-                    if (auto video = dynamic_cast<video_stream_profile_interface*>(_other_stream_profile.get()))
+                    if (from_depth)
                     {
-                        _other_intrinsics = video->get_intrinsics();
-                        _other_intrinsics_ptr = &_other_intrinsics;
+                        return depth_units * p_depth_frame[z_pixel_index];
                     }
-                }
-                //source.frame_ready(other);
-            };
-
-            if (auto composite = f.as<rs2::frameset>())
-            {
-                auto depth = composite.first_or_default(RS2_STREAM_DEPTH);
-                auto other = composite.first_or_default(_other_stream_type);
-                if (other)
+                    return 1;
+                },
+                    [p_out_frame, p_from_frame](int from_pixel_index, int out_pixel_index)
                 {
-                    inspect_other_frame(other);
-                }
-                if (depth)
-                {
-                    inspect_depth_frame(depth, other);
-                }
+                    p_out_frame[out_pixel_index] = p_out_frame[out_pixel_index] ?
+                        std::min((int)(p_out_frame[out_pixel_index]), (int)(p_from_frame[from_pixel_index]))
+                        : p_from_frame[from_pixel_index];
+                });
+                frames[1] = std::move(out_frame);
+                auto composite = get_source().allocate_composite_frame(std::move(frames));
+                get_source().frame_ready(std::move(composite));
             }
         };
         auto callback = new rs2::frame_processor_callback<decltype(on_frame)>(on_frame);

--- a/src/align.h
+++ b/src/align.h
@@ -80,66 +80,6 @@ namespace librealsense
         stream_profile_interface* _depth_stream = nullptr;
     };
 
-    template <typename T>
-    class optional_value
-    {
-    public:
-        optional_value() : _valid(false) {}
-        explicit optional_value(const T& v) : _valid(true), _value(v) {}
-
-        operator bool() const
-        {
-            return has_value();
-        }
-        bool has_value() const
-        {
-            return _valid;
-        }
-        
-        T& operator=(const T& v)
-        {
-            _valid = true;
-            _value = v;
-            return _value;
-        }
-        
-        T& value() &
-        {
-            if (!_valid) throw std::runtime_error("bad optional access");
-            return _value;
-        }
-
-        T&& value() &&
-        {
-            if (!_valid) throw std::runtime_error("bad optional access");
-            return std::move(_value);
-        }
-
-        const T* operator->() const
-        {
-            return &_value;
-        }
-        T* operator->()
-        {
-            return &_value;
-        }
-        const T& operator*() const&
-        {
-            return _value;
-        }
-        T& operator*() &
-        {
-            return _value;
-        }
-        T&& operator*() &&
-        {
-            return std::move(_value);
-        }
-    private:
-        bool _valid;
-        T _value;
-    };
-
     class align : public processing_block
     {
     public:

--- a/src/align.h
+++ b/src/align.h
@@ -94,7 +94,7 @@ namespace librealsense
         optional_value<rs2_intrinsics> _to_intrinsics;
         optional_value<rs2_extrinsics> _extrinsics;
         optional_value<float> _depth_units;
-        optional_value<int> _to_bytes_per_pixel;
+        optional_value<int> _from_bytes_per_pixel;
         optional_value<rs2_stream> _from_stream_type;
         rs2_stream _to_stream_type;
         std::shared_ptr<stream_profile_interface> _from_stream_profile;

--- a/src/types.h
+++ b/src/types.h
@@ -1380,6 +1380,66 @@ namespace librealsense
         std::mutex m_mutex;
         std::map<int, std::function<void(Args...)>> m_subscribers;
     };
+
+    template <typename T>
+    class optional_value
+    {
+    public:
+        optional_value() : _valid(false) {}
+        explicit optional_value(const T& v) : _valid(true), _value(v) {}
+
+        operator bool() const
+        {
+            return has_value();
+        }
+        bool has_value() const
+        {
+            return _valid;
+        }
+
+        T& operator=(const T& v)
+        {
+            _valid = true;
+            _value = v;
+            return _value;
+        }
+
+        T& value() &
+        {
+            if (!_valid) throw std::runtime_error("bad optional access");
+            return _value;
+        }
+
+        T&& value() &&
+        {
+            if (!_valid) throw std::runtime_error("bad optional access");
+            return std::move(_value);
+        }
+
+        const T* operator->() const
+        {
+            return &_value;
+        }
+        T* operator->()
+        {
+            return &_value;
+        }
+        const T& operator*() const&
+        {
+            return _value;
+        }
+        T& operator*() &
+        {
+            return _value;
+        }
+        T&& operator*() &&
+        {
+            return std::move(_value);
+        }
+    private:
+        bool _valid;
+        T _value;
+    };
 }
 
 namespace std {


### PR DESCRIPTION
This PR addresses Issue #858 and fixes the missing feature of aligning color (or other streams) **to** depth.

The previous implementation assumed only depth to other stream alignment.
This PR make the align processing block the generic stream alignment it should have been, such that given a depth stream and another stream, the object will align (according to the user's configuration) either the depth stream to the other, or the other stream to the depth one.

Some code refactoring was added to make the code cleaner and clearer.