### PR TITLE
Fixed bug on viewer - streams got stuck when playing all streams.

### DIFF
--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -667,7 +667,7 @@ namespace rs2
                 frameset f;
                 if (_pipe.poll_for_frames(&f))
                 {
-                    _viewer_model.ppf.frames_queue.enqueue(f);
+                    _viewer_model.ppf.frames_queue[f.get_profile().unique_id()].enqueue(f);
                 }
                 frame dpt = _viewer_model.handle_ready_frames(viewer_rect, win, 1, _error_message);
                 if (dpt)
@@ -751,7 +751,7 @@ namespace rs2
 
                 for (auto&& profile : profiles)
                 {
-                    _viewer_model.streams[profile.unique_id()].begin_stream(sub, profile);
+                    _viewer_model.begin_stream(sub, profile);
                     _viewer_model.streams[profile.unique_id()].texture->colorize = sub->depth_colorizer;
 
                     if (profile.stream_type() == RS2_STREAM_DEPTH)


### PR DESCRIPTION
1. Viewer model will enqueue the frames to separated queues  for each stream instead of one queue for all the stream together.
2. In sync mode it will enqueue to syncer_queue.
2. In 2D mode the default mode will be synchronize.
3.  Small refactor to begin_stream.
4. handle ready queue poll for frames in loop until no frames - to avoid drops. 
