### PR TITLE
Fix for issue #890  Stream matcher not found! stream=Depth

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -123,9 +123,6 @@ namespace librealsense
 
         void dispatch(frame_holder f, syncronization_environment env) override;
 
-
-    private:
-        rs2_stream _streams_type;
     };
 
     class composite_matcher : public matcher


### PR DESCRIPTION
when there is no meta-data.

Remove the  _streams_type from the identity matcher due to redundancy with _streams_type on  his base class - matcher.