### PR TITLE
Allow removal of EasyLogging++ from the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,14 @@ if(BUILD_WITH_OPENMP)
     endif()
 endif()
 
+option(BUILD_EASYLOGGINGPP "Build EasyLogging++ as a part of the build" ON)
+
+if (BUILD_EASYLOGGINGPP)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_EASYLOGGINGPP=1")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_EASYLOGGINGPP=0")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 
 set(REALSENSE_CPP
@@ -118,7 +126,6 @@ set(REALSENSE_CPP
     src/ds5/advanced_mode/presets.cpp
     src/ds5/advanced_mode/advanced_mode.cpp
 
-    third-party/easyloggingpp/src/easylogging++.cc
     third-party/sqlite/sqlite3.c
 
     src/mock/sql.cpp
@@ -129,6 +136,10 @@ set(REALSENSE_CPP
     src/media/playback/playback_device.cpp
     src/media/playback/playback_sensor.cpp
     )
+
+if(BUILD_EASYLOGGINGPP)
+    list(APPEND REALSENSE_CPP third-party/easyloggingpp/src/easylogging++.cc)
+endif()
 
 set(REALSENSE_HPP
     include/librealsense2/rs.hpp
@@ -234,13 +245,16 @@ set(REALSENSE_HPP
     src/ds5/advanced_mode/json_loader.hpp
     src/ds5/advanced_mode/presets.h
 
-    third-party/easyloggingpp/src/easylogging++.h
     third-party/sqlite/sqlite3.h
     src/mock/sql.h
     src/mock/recorder.h
 
     src/media/ros/ros_file_format.h
 )
+
+if(BUILD_EASYLOGGINGPP)
+    list(APPEND REALSENSE_HPP third-party/easyloggingpp/src/easylogging++.h)
+endif()
 
 if(WIN32)
     source_group("Source Files\\Backend" FILES

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -4350,14 +4350,14 @@ namespace rs2
 
                                 ImGui::PushStyleColor(ImGuiCol_Text, redish);
                                 ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, redish + 0.1f);
-                                ImGui::TextDisabled(label.c_str());
+                                ImGui::TextDisabled("%s", label.c_str());
                             }
                             else
                             {
                                 std::string label = to_string() << u8"\uf205";
                                 ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
                                 ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue + 0.1f);
-                                ImGui::TextDisabled(label.c_str());
+                                ImGui::TextDisabled("%s", label.c_str());
                             }
                         }
                         else
@@ -4426,14 +4426,14 @@ namespace rs2
 
                                         ImGui::PushStyleColor(ImGuiCol_Text, redish);
                                         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, redish + 0.1f);
-                                        ImGui::TextDisabled(label.c_str());
+                                        ImGui::TextDisabled("%s", label.c_str());
                                     }
                                     else
                                     {
                                         std::string label = to_string() << u8"\uf205";
                                         ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
                                         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue + 0.1f);
-                                        ImGui::TextDisabled(label.c_str());
+                                        ImGui::TextDisabled("%s", label.c_str());
                                     }
                                 }
                                 else
@@ -4452,7 +4452,7 @@ namespace rs2
                                         if (ImGui::IsItemHovered())
                                         {
                                             label = to_string() << "Enable " << pb->get_name() << " post-processing filter";
-                                            ImGui::SetTooltip(label.c_str());
+                                            ImGui::SetTooltip("%s", label.c_str());
                                         }
                                     }
                                     else
@@ -4468,7 +4468,7 @@ namespace rs2
                                         if (ImGui::IsItemHovered())
                                         {
                                             label = to_string() << "Disable " << pb->get_name() << " post-processing filter";
-                                            ImGui::SetTooltip(label.c_str());
+                                            ImGui::SetTooltip("%s", label.c_str());
                                         }
                                     }
                                 }

--- a/doc/RaspberryPi3.md
+++ b/doc/RaspberryPi3.md
@@ -2,7 +2,7 @@
 
 This document describes how to use the Intel RealSense D400 cameras on Raspberry PI 3 Model B (which offers only USB2 interface).
 
-> **Note:** Both Raspberry Pi platform and USB2 support in general are experimental features and are **not** officially supported by Intel RealSense group at this point. Camera capabilities are severely reduced when connected to USB2 port due to lack of bandwidth.
+> **Note:** Both Raspberry Pi platform and USB2 support in general are experimental features and are **not** officially supported by Intel RealSense group at this point. Camera capabilities are severely reduced when connected to USB2 port due to lack of bandwidth.<br />USB2 interface over D400 cameras is supported from FW 5.08.14.0 and on.
 
 <p align="center"><img src="https://raw.githubusercontent.com/wiki/IntelRealSense/librealsense/res/RaspberryPi3Model-B.png" /></p>
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,8 +1,8 @@
 #include "types.h"
 
 #include <fstream>
-#include <iostream>
 
+#if BUILD_EASYLOGGINGPP
 INITIALIZE_EASYLOGGINGPP
 
 namespace librealsense
@@ -147,3 +147,16 @@ void librealsense::log_to_file(rs2_log_severity min_severity, const char * file_
 {
     logger.log_to_file(min_severity, file_path);
 }
+
+#else // BUILD_EASYLOGGINGPP
+
+void librealsense::log_to_console(rs2_log_severity min_severity)
+{
+}
+
+void librealsense::log_to_file(rs2_log_severity min_severity, const char * file_path)
+{
+}
+
+#endif // BUILD_EASYLOGGINGPP
+

--- a/src/sync.h
+++ b/src/sync.h
@@ -123,9 +123,6 @@ namespace librealsense
 
         void dispatch(frame_holder f, syncronization_environment env) override;
 
-
-    private:
-        rs2_stream _streams_type;
     };
 
     class composite_matcher : public matcher

--- a/src/types.h
+++ b/src/types.h
@@ -18,6 +18,7 @@
 #include <sstream>                          // For ostringstream
 #include <mutex>                            // For mutex, unique_lock
 #include <memory>                           // For unique_ptr
+#include <iostream>
 #include <map>
 #include <limits>
 #include <algorithm>
@@ -27,7 +28,9 @@
 
 #include "concurrency.h"
 
+#if BUILD_EASYLOGGINGPP
 #include "../third-party/easyloggingpp/src/easylogging++.h"
+#endif // BUILD_EASYLOGGINGPP
 
 typedef unsigned char byte;
 
@@ -64,12 +67,23 @@ namespace librealsense
     void log_to_console(rs2_log_severity min_severity);
     void log_to_file(rs2_log_severity min_severity, const char * file_path);
 
+#if BUILD_EASYLOGGINGPP
+
 #define LOG_DEBUG(...)   do { CLOG(DEBUG   ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_INFO(...)    do { CLOG(INFO    ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_WARNING(...) do { CLOG(WARNING ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_ERROR(...)   do { CLOG(ERROR   ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_FATAL(...)   do { CLOG(FATAL   ,"librealsense") << __VA_ARGS__; } while(false)
 
+#else // BUILD_EASYLOGGINGPP
+
+#define LOG_DEBUG(...)   do { ; } while(false)
+#define LOG_INFO(...)    do { ; } while(false)
+#define LOG_WARNING(...) do { ; } while(false)
+#define LOG_ERROR(...)   do { ; } while(false)
+#define LOG_FATAL(...)   do { ; } while(false)
+
+#endif // BUILD_EASYLOGGINGPP
 
     //////////////////////////
     // Exceptions mechanism //

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -667,7 +667,7 @@ namespace rs2
                 frameset f;
                 if (_pipe.poll_for_frames(&f))
                 {
-                    _viewer_model.ppf.frames_queue.enqueue(f);
+                    _viewer_model.ppf.frames_queue[f.get_profile().unique_id()].enqueue(f);
                 }
                 frame dpt = _viewer_model.handle_ready_frames(viewer_rect, win, 1, _error_message);
                 if (dpt)
@@ -751,7 +751,7 @@ namespace rs2
 
                 for (auto&& profile : profiles)
                 {
-                    _viewer_model.streams[profile.unique_id()].begin_stream(sub, profile);
+                    _viewer_model.begin_stream(sub, profile);
                     _viewer_model.streams[profile.unique_id()].texture->colorize = sub->depth_colorizer;
 
                     if (profile.stream_type() == RS2_STREAM_DEPTH)


### PR DESCRIPTION
On some implementations it is desired not to have
EasyLogging++ included in the build of Librealsense.
E.g. if EasyLogging++ is used in some other project
that is linked to Librealsense.

This is due to the global initialization macro that
EasyLogging++ rely on.

To disable, run cmake with:
cmake ../ -DDISABLE_EASYLOGGINGPP=true

Signed-off-by: Soren Friis <soren.friis@intel.com>