### PR TITLE
Allow removal of EasyLogging++ from the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,12 @@ if(BUILD_WITH_OPENMP)
     endif()
 endif()
 
+option(BUILD_EASYLOGGINGPP "Build EasyLogging++ as a part of the build" ON)
+
+if (BUILD_EASYLOGGINGPP)
+    add_definitions(-DBUILD_EASYLOGGINGPP)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
 
 set(REALSENSE_CPP
@@ -118,7 +124,6 @@ set(REALSENSE_CPP
     src/ds5/advanced_mode/presets.cpp
     src/ds5/advanced_mode/advanced_mode.cpp
 
-    third-party/easyloggingpp/src/easylogging++.cc
     third-party/sqlite/sqlite3.c
 
     src/mock/sql.cpp
@@ -234,13 +239,17 @@ set(REALSENSE_HPP
     src/ds5/advanced_mode/json_loader.hpp
     src/ds5/advanced_mode/presets.h
 
-    third-party/easyloggingpp/src/easylogging++.h
     third-party/sqlite/sqlite3.h
     src/mock/sql.h
     src/mock/recorder.h
 
     src/media/ros/ros_file_format.h
 )
+
+if(BUILD_EASYLOGGINGPP)
+    list(APPEND REALSENSE_CPP third-party/easyloggingpp/src/easylogging++.cc)
+    list(APPEND REALSENSE_HPP third-party/easyloggingpp/src/easylogging++.h)
+endif()
 
 if(WIN32)
     source_group("Source Files\\Backend" FILES

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,8 +1,8 @@
 #include "types.h"
 
 #include <fstream>
-#include <iostream>
 
+#if BUILD_EASYLOGGINGPP
 INITIALIZE_EASYLOGGINGPP
 
 namespace librealsense
@@ -147,3 +147,16 @@ void librealsense::log_to_file(rs2_log_severity min_severity, const char * file_
 {
     logger.log_to_file(min_severity, file_path);
 }
+
+#else // BUILD_EASYLOGGINGPP
+
+void librealsense::log_to_console(rs2_log_severity min_severity)
+{
+}
+
+void librealsense::log_to_file(rs2_log_severity min_severity, const char * file_path)
+{
+}
+
+#endif // BUILD_EASYLOGGINGPP
+

--- a/src/types.h
+++ b/src/types.h
@@ -18,6 +18,7 @@
 #include <sstream>                          // For ostringstream
 #include <mutex>                            // For mutex, unique_lock
 #include <memory>                           // For unique_ptr
+#include <iostream>
 #include <map>
 #include <limits>
 #include <algorithm>
@@ -27,7 +28,9 @@
 
 #include "concurrency.h"
 
+#if BUILD_EASYLOGGINGPP
 #include "../third-party/easyloggingpp/src/easylogging++.h"
+#endif // BUILD_EASYLOGGINGPP
 
 typedef unsigned char byte;
 
@@ -64,12 +67,23 @@ namespace librealsense
     void log_to_console(rs2_log_severity min_severity);
     void log_to_file(rs2_log_severity min_severity, const char * file_path);
 
+#if BUILD_EASYLOGGINGPP
+
 #define LOG_DEBUG(...)   do { CLOG(DEBUG   ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_INFO(...)    do { CLOG(INFO    ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_WARNING(...) do { CLOG(WARNING ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_ERROR(...)   do { CLOG(ERROR   ,"librealsense") << __VA_ARGS__; } while(false)
 #define LOG_FATAL(...)   do { CLOG(FATAL   ,"librealsense") << __VA_ARGS__; } while(false)
 
+#else // BUILD_EASYLOGGINGPP
+
+#define LOG_DEBUG(...)   do { ; } while(false)
+#define LOG_INFO(...)    do { ; } while(false)
+#define LOG_WARNING(...) do { ; } while(false)
+#define LOG_ERROR(...)   do { ; } while(false)
+#define LOG_FATAL(...)   do { ; } while(false)
+
+#endif // BUILD_EASYLOGGINGPP
 
     //////////////////////////
     // Exceptions mechanism //


### PR DESCRIPTION
On some implementations, it is desired not to have
EasyLogging++ included in the build of Librealsense.
E.g. if EasyLogging++ is used in some other project
that is linked to Librealsense.

This is due to the global initialization macro that
EasyLogging++ rely on.

To disable, run cmake with:
cmake -DBUILD_EASYLOGGINGPP=false ../

Signed-off-by: Soren Friis <soren.friis@intel.com>