### PR TITLE
Adding Export to PLY to API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,6 @@ librealsense-log.txt
 *.check_cache
 *.dll
 *.list
-*.txt
-!CMakeLists.txt
 *.json
 *.ini
 *.cxx

--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -235,3 +235,5 @@ EXPORTS
     rs2_device_hub_is_device_connected
     rs2_device_hub_wait_for_device
     rs2_delete_device_hub
+
+    rs2_export_to_ply

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -199,8 +199,6 @@ namespace rs2
     void export_to_ply(const std::string& fname, notifications_model& ns, frameset frames, video_frame texture)
     {
         std::thread([&ns, frames, texture, fname]() mutable {
-            std::string texfname(fname);
-            texfname += ".png";
 
             points p;
 
@@ -214,72 +212,7 @@ namespace rs2
 
             if (p)
             {
-                const auto vertices = p.get_vertices();
-                const auto texcoords = p.get_texture_coordinates();
-                const auto tex = reinterpret_cast<const uint8_t*>(texture.get_data());
-                std::vector<vertex> new_vertices;
-                //std::vector<texture_coordinate> new_texcoords;
-                std::vector<std::tuple<uint8_t, uint8_t, uint8_t>> new_tex;
-                new_vertices.reserve(p.size());
-                //new_texcoords.reserve(points.size());
-                new_tex.reserve(p.size());
-                assert(p.size());
-                for (size_t i = 0; i < p.size(); ++i)
-                    if (std::abs(vertices[i].x) >= 1e-6 || std::abs(vertices[i].y) >= 1e-6 || std::abs(vertices[i].z) >= 1e-6)
-                    {
-                        new_vertices.push_back(vertices[i]);
-                        if (texture)
-                        {
-                            //new_texcoords.push_back(texcoords[i]);
-                            auto color = get_texcolor(texture, texcoords[i]);
-                            new_tex.push_back(color);
-                        }
-
-                    }
-
-                std::ofstream out(fname);
-                out << "ply\n";
-                out << "format binary_little_endian 1.0\n" /*"format ascii 1.0\n"*/;
-                out << "comment pointcloud saved from Realsense Viewer\n";
-                //if (texture) out << "comment TextureFile " << get_file_name(texfname) << "\n";
-                out << "element vertex " << new_vertices.size() << "\n";
-                out << "property float" << sizeof(float) * 8 << " x\n";
-                out << "property float" << sizeof(float) * 8 << " y\n";
-                out << "property float" << sizeof(float) * 8 << " z\n";
-                if (texture)
-                {
-                    //out << "property float" << sizeof(float) * 8 << " u\n";
-                    //out << "property float" << sizeof(float) * 8 << " v\n";
-                    out << "property uchar red\n";
-                    out << "property uchar green\n";
-                    out << "property uchar blue\n";
-                }
-                out << "end_header\n";
-                out.close();
-
-                out.open(fname, std::ios_base::app | std::ios_base::binary);
-                for (int i = 0; i < new_vertices.size(); ++i)
-                {
-                    // we assume little endian architecture on your device
-                    out.write(reinterpret_cast<const char*>(&(new_vertices[i].x)), sizeof(float));
-                    out.write(reinterpret_cast<const char*>(&(new_vertices[i].y)), sizeof(float));
-                    out.write(reinterpret_cast<const char*>(&(new_vertices[i].z)), sizeof(float));
-                    //                out << new_vertices[i].x << ' ' << new_vertices[i].y << ' ' << new_vertices[i].z;
-                    if (texture)
-                    {
-                        //out.write(reinterpret_cast<const char*>(&(new_texcoords[i].u)), sizeof(float));
-                        //out.write(reinterpret_cast<const char*>(&(new_texcoords[i].v)), sizeof(float));
-                        out.write(reinterpret_cast<const char*>(&(std::get<0>(new_tex[i]))), sizeof(uint8_t));
-                        out.write(reinterpret_cast<const char*>(&(std::get<1>(new_tex[i]))), sizeof(uint8_t));
-                        out.write(reinterpret_cast<const char*>(&(std::get<2>(new_tex[i]))), sizeof(uint8_t));
-                        //                    out << std::hex << ' ' << std::get<0>(new_tex[i]) << ' ' << std::get<1>(new_tex[i]) << ' ' << std::get<2>(new_tex[i]);
-                    }
-                    //                out << '\n';
-                }
-
-                /* save texture to texfname */
-                //if (texture) stbi_write_png(texfname.data(), texture.get_width(), texture.get_height(), texture.get_bytes_per_pixel(), texture.get_data(), texture.get_width() * texture.get_bytes_per_pixel());
-
+                p.export_to_ply(fname, texture);
                 ns.add_notification({ to_string() << "Finished saving 3D view " << (texture ? "to " : "without texture to ") << fname,
                     std::chrono::duration_cast<std::chrono::duration<double,std::micro>>(std::chrono::high_resolution_clock::now().time_since_epoch()).count(),
                     RS2_LOG_SEVERITY_INFO,

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -162,6 +162,14 @@ void rs2_release_frame(rs2_frame* frame);
 rs2_vertex* rs2_get_frame_vertices(const rs2_frame* frame, rs2_error** error);
 
 /**
+* When called on Points frame type, this method creates a ply file of the model with the given file name.
+* \param[in] frame       Points frame
+* \param[out] error      If non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \param[in] fname       The name for the ply file
+*/
+void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_error** error);
+
+/**
 * When called on Points frame type, this method returns a pointer to an array of texture coordinates per vertex
 * Each coordinate represent a (u,v) pair within [0,1] range, to be mapped to texture image
 * \param[in] frame       Points frame

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -164,8 +164,9 @@ rs2_vertex* rs2_get_frame_vertices(const rs2_frame* frame, rs2_error** error);
 /**
 * When called on Points frame type, this method creates a ply file of the model with the given file name.
 * \param[in] frame       Points frame
-* \param[out] error      If non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \param[in] fname       The name for the ply file
+* \param[in] texture     Texture frame
+* \param[out] error      If non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
 void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_frame* texture, rs2_error** error); 
 

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -167,7 +167,7 @@ rs2_vertex* rs2_get_frame_vertices(const rs2_frame* frame, rs2_error** error);
 * \param[out] error      If non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \param[in] fname       The name for the ply file
 */
-void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_error** error);
+void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_frame* texture, rs2_error** error); 
 
 /**
 * When called on Points frame type, this method returns a pointer to an array of texture coordinates per vertex

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -16,6 +16,7 @@ namespace rs2
     class sensor;
     class frame;
     class pipeline_profile;
+    class points;
 
     class stream_profile
     {
@@ -307,6 +308,7 @@ namespace rs2
         friend class rs2::syncer;
         friend class rs2::processing_block;
         friend class rs2::pointcloud;
+        friend class rs2::points;
 
         rs2_frame* frame_ref;
     };
@@ -324,6 +326,7 @@ namespace rs2
             }
             error::handle(e);
         }
+
 
         /**
         * returns image width in pixels
@@ -416,10 +419,12 @@ namespace rs2
             return (const vertex*)res;
         }
 
-		void export_to_ply(const std::string& fname) 
+		void export_to_ply(const std::string& fname, video_frame texture) 
 		{
+            rs2_frame* ptr = nullptr;
+            std::swap(texture.frame_ref, ptr);
 		    rs2_error* e = nullptr;
-		    rs2_export_to_ply(get(), fname.c_str(), &e);
+		    rs2_export_to_ply(get(), fname.c_str(), ptr, &e);
 		    error::handle(e);
 		}
 

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -416,6 +416,13 @@ namespace rs2
             return (const vertex*)res;
         }
 
+		void export_to_ply(const std::string& fname) 
+		{
+		    rs2_error* e = nullptr;
+		    rs2_export_to_ply(get(), fname.c_str(), &e);
+		    error::handle(e);
+		}
+
         const texture_coordinate* get_texture_coordinates() const
         {
             rs2_error* e = nullptr;

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -419,7 +419,7 @@ namespace rs2
             return (const vertex*)res;
         }
 
-		void export_to_ply(const std::string& fname, video_frame texture) 
+        void export_to_ply(const std::string& fname, video_frame texture) 
 		{
             rs2_frame* ptr = nullptr;
             std::swap(texture.frame_ref, ptr);

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -30,23 +30,24 @@ namespace librealsense
         const int w = ptr->get_width(), h = ptr->get_height();
         int x = std::min(std::max(int(u*w + .5f), 0), w - 1);
         int y = std::min(std::max(int(v*h + .5f), 0), h - 1);
-        int idx = x * ptr->get_bpp() + y * ptr->get_stride();
+        int idx = x * ptr->get_bpp() / 8 + y * ptr->get_stride();
         const auto texture_data = reinterpret_cast<const uint8_t*>(ptr->get_frame_data());
         return std::tuple<uint8_t, uint8_t, uint8_t>(
             texture_data[idx], texture_data[idx + 1], texture_data[idx + 2]);
     }
 
-	void points::export_to_ply(const std::string& fname, frame_holder texture) 
+	void points::export_to_ply(const std::string& fname, const frame_holder& texture) 
 	{
         const auto vertices = get_vertices();
         const auto texcoords = get_texture_coordinates();
-//        const auto tex = reinterpret_cast<const uint8_t*>(texture.get_data());
+        //const auto tex = reinterpret_cast<const uint8_t*>(texture.get_data());
         std::vector<float3> new_vertices;
         //std::vector<texture_coordinate> new_texcoords;
         std::vector<std::tuple<uint8_t, uint8_t, uint8_t>> new_tex;
         new_vertices.reserve(get_vertex_count());
         //new_texcoords.reserve(points.size());
         new_tex.reserve(get_vertex_count());
+      //  LOG_INFO("Vertex count: " << get_vertex_count());
         assert(get_vertex_count());
         for (size_t i = 0; i < get_vertex_count(); ++i)
             if (std::abs(vertices[i].x) >= 1e-6 || std::abs(vertices[i].y) >= 1e-6 || std::abs(vertices[i].z) >= 1e-6)
@@ -55,10 +56,10 @@ namespace librealsense
                 if (texture)
                 {
                     //new_texcoords.push_back(texcoords[i]);
-                    auto color = get_texcolor(texture, texcoords->x, texcoords->y);
+                    auto color = get_texcolor(texture, texcoords[i].x, texcoords[i].y);
+                    //LOG_INFO("i: " << i << "Color: " << (int)std::get<0>(color) << ", " << (int)std::get<1>(color) << ", " << (int)std::get<2>(color));
                     new_tex.push_back(color);
                 }
-                
             }
 
         std::ofstream out(fname);

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -46,8 +46,8 @@ namespace librealsense
         new_tex.reserve(get_vertex_count());
         assert(get_vertex_count());
         for (size_t i = 0; i < get_vertex_count(); ++i)
-            if (std::abs(vertices[i].x) >= MIN_DISTANCE || std::abs(vertices[i].y) >= MIN_DISTANCE ||
-                std::abs(vertices[i].z) >= MIN_DISTANCE)
+            if (fabs(vertices[i].x) >= MIN_DISTANCE || fabs(vertices[i].y) >= MIN_DISTANCE ||
+                fabs(vertices[i].z) >= MIN_DISTANCE)
             {
                 new_vertices.push_back(vertices[i]);
                 if (texture)

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -21,6 +21,11 @@ namespace librealsense
         return xyz;
     }
 
+	void points::export_to_ply(const std::string& fname) 
+	{
+        std::cout << "export file here" << std::endl;
+	}
+
     size_t points::get_vertex_count() const
     {
         return data.size() / (sizeof(float3) + sizeof(int2));

--- a/src/archive.h
+++ b/src/archive.h
@@ -124,6 +124,7 @@ namespace librealsense
     {
     public:
         float3* get_vertices();
+        void export_to_ply(const std::string& fname);
         size_t get_vertex_count() const;
         float2* get_texture_coordinates();
     };

--- a/src/archive.h
+++ b/src/archive.h
@@ -124,7 +124,7 @@ namespace librealsense
     {
     public:
         float3* get_vertices();
-        void export_to_ply(const std::string& fname);
+        void export_to_ply(const std::string& fname, frame_holder texture);
         size_t get_vertex_count() const;
         float2* get_texture_coordinates();
     };

--- a/src/archive.h
+++ b/src/archive.h
@@ -124,7 +124,7 @@ namespace librealsense
     {
     public:
         float3* get_vertices();
-        void export_to_ply(const std::string& fname, frame_holder texture);
+        void export_to_ply(const std::string& fname, const frame_holder& texture);
         size_t get_vertex_count() const;
         float2* get_texture_coordinates();
     };

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -52,13 +52,14 @@ namespace librealsense
 
 
 
-        if (!_stream.get() || _depth_stream != depth_frame->get_stream().get() || stream_changed(_depth_stream,depth_frame->get_stream().get()))
+        if (!_output_stream.get() || _depth_stream != depth_frame->get_stream().get() || stream_changed(_depth_stream,depth_frame->get_stream().get()))
         {
-            _stream = depth_frame->get_stream()->clone();
+            _output_stream = depth_frame->get_stream()->clone();
             _depth_stream = depth_frame->get_stream().get();
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_stream, *depth_frame->get_stream());
+            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_output_stream, *depth_frame->get_stream());
             _depth_intrinsics_ptr = nullptr;
             _depth_units_ptr = nullptr;
+            _extrinsics_ptr = nullptr;
         }
 
         bool found_depth_intrinsics = false;
@@ -83,11 +84,15 @@ namespace librealsense
             found_depth_units = true;
         }
 
-//                if (found_depth_units != found_depth_intrinsics)
-//                {
-//                    throw wrong_api_call_sequence_exception("Received depth frame that doesn't provide either intrinsics or depth units!");
-//                }
-
+        if (_other_stream && !_extrinsics_ptr)
+        {
+            if (environment::get_instance().get_extrinsics_graph().try_fetch_extrinsics(
+                *_depth_stream, *_other_stream, &_extrinsics
+            ))
+            {
+                _extrinsics_ptr = &_extrinsics;
+            }
+        }
     }
 
     void pointcloud::inspect_other_frame(const rs2::frame& other)
@@ -95,32 +100,32 @@ namespace librealsense
         auto other_frame = (frame_interface*)other.get();
         std::lock_guard<std::mutex> lock(_mutex);
 
-        if (_mapped && _invalidate_mapped)
+        if (_other_stream && _invalidate_mapped)
         {
-            _mapped = nullptr;
+            _other_stream = nullptr;
             _invalidate_mapped = false;
         }
 
-        if (!_mapped.get())
+        if (!_other_stream.get())
         {
-            _mapped = other_frame->get_stream();
-            _mapped_intrinsics_ptr = nullptr;
+            _other_stream = other_frame->get_stream();
+            _other_intrinsics_ptr = nullptr;
             _extrinsics_ptr = nullptr;
         }
 
-        if (!_mapped_intrinsics_ptr)
+        if (!_other_intrinsics_ptr)
         {
-            if (auto video = dynamic_cast<video_stream_profile_interface*>(_mapped.get()))
+            if (auto video = dynamic_cast<video_stream_profile_interface*>(_other_stream.get()))
             {
-                _mapped_intrinsics = video->get_intrinsics();
-                _mapped_intrinsics_ptr = &_mapped_intrinsics;
+                _other_intrinsics = video->get_intrinsics();
+                _other_intrinsics_ptr = &_other_intrinsics;
             }
         }
 
-        if (_stream && !_extrinsics_ptr)
+        if (_output_stream && !_extrinsics_ptr)
         {
             if (environment::get_instance().get_extrinsics_graph().try_fetch_extrinsics(
-                *_stream, *other_frame->get_stream(), &_extrinsics
+                *_output_stream, *other_frame->get_stream(), &_extrinsics
             ))
             {
                 _extrinsics_ptr = &_extrinsics;
@@ -130,7 +135,7 @@ namespace librealsense
 
     void pointcloud::process_depth_frame(const rs2::depth_frame& depth)
     {
-        frame_holder res = get_source().allocate_points(_stream, (frame_interface*)depth.get());
+        frame_holder res = get_source().allocate_points(_output_stream, (frame_interface*)depth.get());
 
         auto pframe = (points*)(res.frame);
 
@@ -148,9 +153,9 @@ namespace librealsense
         bool map_texture = false;
         {
             std::lock_guard<std::mutex> lock(_mutex);
-            if (_extrinsics_ptr && _mapped_intrinsics_ptr)
+            if (_extrinsics_ptr && _other_intrinsics_ptr)
             {
-                mapped_intr = *_mapped_intrinsics_ptr;
+                mapped_intr = *_other_intrinsics_ptr;
                 extr = *_extrinsics_ptr;
                 map_texture = true;
             }
@@ -188,14 +193,14 @@ namespace librealsense
     pointcloud::pointcloud()
         :_depth_intrinsics_ptr(nullptr),
         _depth_units_ptr(nullptr),
-        _mapped_intrinsics_ptr(nullptr),
+        _other_intrinsics_ptr(nullptr),
         _extrinsics_ptr(nullptr),
-        _mapped(nullptr), _invalidate_mapped(false)
+        _other_stream(nullptr), _invalidate_mapped(false)
     {
 
-        auto mapped_opt = std::make_shared<ptr_option<int>>(0, std::numeric_limits<int>::max(), 1, -1, &_mapped_stream_id, "Mapped stream ID");
+        auto mapped_opt = std::make_shared<ptr_option<int>>(0, std::numeric_limits<int>::max(), 1, -1, &_other_stream_id, "Mapped stream ID");
         register_option(RS2_OPTION_TEXTURE_SOURCE, mapped_opt);
-        float old_value = _mapped_stream_id;
+        float old_value = _other_stream_id;
         mapped_opt->on_set([this, old_value](float x) mutable {
             if (fabs(old_value - x) > 1e-6)
             {
@@ -217,7 +222,7 @@ namespace librealsense
                 }
 
                 composite.foreach([&](const rs2::frame& f) {
-                    if (f.get_profile().unique_id() == _mapped_stream_id)
+                    if (f.get_profile().unique_id() == _other_stream_id)
                     {
                         inspect_other_frame(f);
                     }
@@ -230,7 +235,7 @@ namespace librealsense
                     inspect_depth_frame(f);
                     process_depth_frame(f);
                 }
-                if (f.get_profile().unique_id() == _mapped_stream_id)
+                if (f.get_profile().unique_id() == _other_stream_id)
                 {
                     inspect_other_frame(f);
                 }

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -16,17 +16,17 @@ namespace librealsense
 
         const rs2_intrinsics*   _depth_intrinsics_ptr;
         const float*            _depth_units_ptr;
-        const rs2_intrinsics*   _mapped_intrinsics_ptr;
+        const rs2_intrinsics*   _other_intrinsics_ptr;
         const rs2_extrinsics*   _extrinsics_ptr;
 
         rs2_intrinsics          _depth_intrinsics;
-        rs2_intrinsics          _mapped_intrinsics;
+        rs2_intrinsics          _other_intrinsics;
         float                   _depth_units;
         rs2_extrinsics          _extrinsics;
         std::atomic_bool        _invalidate_mapped;
 
-        std::shared_ptr<stream_profile_interface> _stream, _mapped;
-        int                     _mapped_stream_id = -1;
+        std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
+        int                     _other_stream_id = -1;
         stream_profile_interface* _depth_stream = nullptr;
 
         void inspect_depth_frame(const rs2::frame& depth);

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -13,17 +13,12 @@ namespace librealsense
 
     private:
         std::mutex              _mutex;
-
-        const rs2_intrinsics*   _depth_intrinsics_ptr;
-        const float*            _depth_units_ptr;
-        const rs2_intrinsics*   _other_intrinsics_ptr;
-        const rs2_extrinsics*   _extrinsics_ptr;
-
-        rs2_intrinsics          _depth_intrinsics;
-        rs2_intrinsics          _other_intrinsics;
-        float                   _depth_units;
-        rs2_extrinsics          _extrinsics;
-        std::atomic_bool        _invalidate_mapped;
+        
+        optional_value<rs2_intrinsics>         _depth_intrinsics;
+        optional_value<rs2_intrinsics>         _other_intrinsics;
+        optional_value<float>                  _depth_units;
+        optional_value<rs2_extrinsics>         _extrinsics;
+        std::atomic_bool                       _invalidate_mapped;
 
         std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
         int                     _other_stream_id = -1;

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1585,6 +1585,15 @@ rs2_vertex* rs2_get_frame_vertices(const rs2_frame* frame, rs2_error** error) BE
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, frame)
 
+void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(frame);
+    VALIDATE_NOT_NULL(fname);
+    auto points = VALIDATE_INTERFACE((frame_interface*)frame, librealsense::points);
+    points->export_to_ply(fname);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, frame, fname)
+
 rs2_pixel* rs2_get_frame_texture_coordinates(const rs2_frame* frame, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(frame);

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1585,12 +1585,12 @@ rs2_vertex* rs2_get_frame_vertices(const rs2_frame* frame, rs2_error** error) BE
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, frame)
 
-void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_error** error) BEGIN_API_CALL
+void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_frame* texture, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(frame);
     VALIDATE_NOT_NULL(fname);
     auto points = VALIDATE_INTERFACE((frame_interface*)frame, librealsense::points);
-    points->export_to_ply(fname);
+    points->export_to_ply(fname, (frame_interface*)texture);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, frame, fname)
 

--- a/wrappers/python/examples/export_ply_example.py
+++ b/wrappers/python/examples/export_ply_example.py
@@ -2,7 +2,7 @@
 ## Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
 #####################################################
-##              Align Depth to Color               ##
+##                  Export to PLY                  ##
 #####################################################
 
 # First import the library
@@ -19,25 +19,22 @@ pipe = rs.pipeline()
 #Start streaming with default recommended configuration
 pipe.start();
 
-c = rs.colorizer()
-
-# Streaming loop
 try:
-    while True:
-        # Wait for the next set of frames from the camera
-        frames = pipe.wait_for_frames();
+    # Wait for the next set of frames from the camera
+    frames = pipe.wait_for_frames()
 
-        depth = frames.get_depth_frame();
+    # Fetch color and depth frames
+    depth = frames.get_depth_frame()
+    color = frames.get_color_frame()
 
-        # Generate the pointcloud and texture mappings
-        points = pc.calculate(depth);
+    # Tell pointcloud object to map to this color frame
+    pc.map_to(color)
 
-        color = c.colorize(depth);
+    # Generate the pointcloud and texture mappings
+    points = pc.calculate(depth)
 
-        # Tell pointcloud object to map to this color frame
-        pc.map_to(color);
-
-        export_to_ply("1.ply", color)
-
+    print("Saving to 1.ply...")
+    points.export_to_ply("1.ply", color)
+    print("Done")
 finally:
-    pipeline.stop()
+    pipe.stop()

--- a/wrappers/python/examples/export_ply_example.py
+++ b/wrappers/python/examples/export_ply_example.py
@@ -1,0 +1,43 @@
+## License: Apache 2.0. See LICENSE file in root directory.
+## Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#####################################################
+##              Align Depth to Color               ##
+#####################################################
+
+# First import the library
+import pyrealsense2 as rs
+
+
+# Declare pointcloud object, for calculating pointclouds and texture mappings
+pc = rs.pointcloud()
+# We want the points object to be persistent so we can display the last cloud when a frame drops
+points = rs.points()
+
+# Declare RealSense pipeline, encapsulating the actual device and sensors
+pipe = rs.pipeline()
+#Start streaming with default recommended configuration
+pipe.start();
+
+c = rs.colorizer()
+
+# Streaming loop
+try:
+    while True:
+        # Wait for the next set of frames from the camera
+        frames = pipe.wait_for_frames();
+
+        depth = frames.get_depth_frame();
+
+        # Generate the pointcloud and texture mappings
+        points = pc.calculate(depth);
+
+        color = c.colorize(depth);
+
+        # Tell pointcloud object to map to this color frame
+        pc.map_to(color);
+
+        export_to_ply("1.ply", color)
+
+finally:
+    pipeline.stop()

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -403,6 +403,7 @@ PYBIND11_PLUGIN(NAME) {
                    return BufData(const_cast<rs2::texture_coordinate*>(self.get_texture_coordinates()),
                                           sizeof(rs2::texture_coordinate), std::string("@ff"), self.size());
                }, py::keep_alive<0, 1>())
+          .def("export_to_ply", &rs2::points::export_to_ply)
           .def("size", &rs2::points::size);
 
     py::class_<rs2::frameset, rs2::frame> frameset(m, "composite_frame");


### PR DESCRIPTION
Addressing #862

1. Added function `export_to_ply` to API.
2. Added function `export_to_ply` to python wrapper.
3. Added example file `export_to_ply_example.py`.
4. Fixed bug in `pointcloud`, which was causing texture coordinates be all zeros before calling `calculate` for the second time, now coordinates are valid after the first call (possibly related to #900).