### PR TITLE
Reduce the queue size in pipeline to 1, to reduce latency.

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -12,7 +12,7 @@
 namespace librealsense
 {
     pipeline_processing_block::pipeline_processing_block(const std::vector<int>& streams_to_aggregate) :
-        _queue(new single_consumer_queue<frame_holder>()),
+        _queue(new single_consumer_queue<frame_holder>(1)),
         _streams_ids(streams_to_aggregate)
     {
         auto processing_callback = [&](frame_holder frame, synthetic_source_interface* source)


### PR DESCRIPTION
Related to #935 
Output queue from pipeline was with default capacity, allowing for latency when the main thread was not polling frames fast enough.