### PR TITLE
Fixed infinite loop on viewer - loop until queue is empty and then render the last frame.

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -496,7 +496,7 @@ namespace rs2
             viewer(viewer),
             keep_calculating(true),
             depth_stream_active(false),
-            resulting_queue(20),
+            resulting_queue(resulting_queue_max_size),
 //            frames_queue(4),
             t([this]() {render_loop(); })
         {
@@ -539,7 +539,7 @@ namespace rs2
         std::map<int, rs2::frame_queue> frames_queue;
         rs2::frame_queue syncer_queue;
         rs2::frame_queue resulting_queue;
-
+        const size_t resulting_queue_max_size = 20;
 
     private:
         viewer_model& viewer;

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -167,7 +167,15 @@ namespace rs2
                 profile = stream_profile(s);
 #endif
         }
-        frame(frame&& other) noexcept : frame_ref(other.frame_ref) { other.frame_ref = nullptr; }
+
+        frame(frame&& other) noexcept : frame_ref(other.frame_ref)
+        {
+            other.frame_ref = nullptr;
+#ifdef _DEBUG
+            frame_number = other.frame_number;
+            profile = other.profile;
+#endif
+        }
         frame& operator=(frame other)
         {
             swap(other);
@@ -181,6 +189,11 @@ namespace rs2
         void swap(frame& other)
         {
             std::swap(frame_ref, other.frame_ref);
+
+#ifdef _DEBUG
+            std::swap(frame_number, other.frame_number);
+            std::swap(profile, other.profile);
+#endif
         }
 
         /**

--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -166,11 +166,6 @@ namespace librealsense
 
     std::shared_ptr<matcher> ds5_color::create_matcher(const frame_holder& frame) const
     {
-        if(!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
-        {
-            return device::create_matcher(frame);
-        }
-
         return std::make_shared<identity_matcher>( _color_stream->get_unique_id(), _color_stream->get_stream_type());
     }
 }

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -302,17 +302,16 @@ namespace librealsense
 
     std::shared_ptr<matcher> ds5_device::create_matcher(const frame_holder& frame) const
     {
-        if(!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
-        {
-            return device::create_matcher(frame);
-        }
-
         std::set<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get()};
         std::vector<std::shared_ptr<matcher>> depth_matchers;
 
         for (auto& s : streams)
             depth_matchers.push_back(std::make_shared<identity_matcher>( s->get_unique_id(), s->get_stream_type()));
 
+        if (!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
+        {
+            return std::make_shared<timestamp_composite_matcher>(depth_matchers);
+        }
         return std::make_shared<frame_number_composite_matcher>(depth_matchers);
     }
 

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -416,11 +416,6 @@ namespace librealsense
 
     std::shared_ptr<matcher> ds5_motion::create_matcher(const frame_holder& frame) const
     {
-        if(!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
-        {
-            return device::create_matcher(frame);
-        }
-
         std::set<stream_interface*> streams = { _fisheye_stream.get() , _accel_stream.get() , _gyro_stream.get()};
         std::vector<std::shared_ptr<matcher>> mm_matchers;
 

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -301,14 +301,7 @@ namespace librealsense
 
     std::shared_ptr<matcher> sr300_camera::create_matcher(const frame_holder& frame) const
     {
-        if(!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
-        {
-            return device::create_matcher(frame);
-        }
         std::vector<std::shared_ptr<matcher>> depth_matchers;
-
-
-
 
         std::vector<stream_interface*> streams = { _depth_stream.get(), _ir_stream.get()};
 
@@ -317,7 +310,15 @@ namespace librealsense
             depth_matchers.push_back(std::make_shared<identity_matcher>( s->get_unique_id(), s->get_stream_type()));
         }
         std::vector<std::shared_ptr<matcher>> matchers;
-        matchers.push_back( std::make_shared<frame_number_composite_matcher>(depth_matchers));
+        if (!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
+        {
+            matchers.push_back(std::make_shared<timestamp_composite_matcher>(depth_matchers));
+        }
+        else
+        {
+            matchers.push_back(std::make_shared<frame_number_composite_matcher>(depth_matchers));
+        }
+        
 
         auto color_matcher = std::make_shared<identity_matcher>( _color_stream->get_unique_id(), _color_stream->get_stream_type());
         matchers.push_back(color_matcher);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -515,7 +515,7 @@ namespace librealsense
         }
 
         //next expected of the missing stream didn't updated yet
-        if((*synced_frame)->get_frame_timestamp() > next_expected && std::abs((*synced_frame)->get_frame_timestamp()- next_expected)<MAX_GAP)
+        if((*synced_frame)->get_frame_timestamp() > next_expected && abs((*synced_frame)->get_frame_timestamp()- next_expected)<MAX_GAP)
         {
             return false;
         }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -6,6 +6,8 @@
 
 namespace librealsense
 {
+    const int MAX_GAP = 1000;
+
     matcher::matcher(std::vector<stream_id> streams_id)
         : _streams_id(streams_id){}
 
@@ -293,6 +295,15 @@ namespace librealsense
                         synced_frames.clear();
                         break;
                     }
+                    else
+                    {
+                        std::stringstream s;
+                        s << "skipped missing stream: " << _name<<" ";
+                        for (auto&& stream : i->get_streams())
+                            s << stream;
+
+                        LOG_DEBUG(s.str());
+                    }
                 }
             }
 
@@ -316,7 +327,7 @@ namespace librealsense
 
 
                 std::stringstream s;
-                s<<"MATCHED: ";
+                s<<"MATCHED: "<<_name;
                 for(auto&& f: match)
                 {
                     auto composite = dynamic_cast<composite_frame*>(f.frame);
@@ -325,11 +336,11 @@ namespace librealsense
                         for (int i = 0; i < composite->get_embedded_frames_count(); i++)
                         {
                             auto matched = composite->get_frame(i);
-                            s << matched->get_stream()->get_stream_type()<<" "<<f->get_frame_number()<<" "<<matched->get_frame_timestamp()<<" ";
+                            s << matched->get_stream()->get_stream_type()<<" "<<f->get_frame_number()<<" "<<std::fixed << matched->get_frame_timestamp()<<" ";
                         }
                     }
                     else {
-                         s<<f->get_stream()->get_stream_type()<<" "<<f->get_frame_number()<<" "<<(double)f->get_frame_timestamp()<<" ";
+                         s<<f->get_stream()->get_stream_type()<<" "<<f->get_frame_number()<<" "<<std::fixed <<(double)f->get_frame_timestamp()<<" ";
                     }
 
 
@@ -504,7 +515,7 @@ namespace librealsense
         }
 
         //next expected of the missing stream didn't updated yet
-        if((*synced_frame)->get_frame_timestamp() > next_expected)
+        if((*synced_frame)->get_frame_timestamp() > next_expected && std::abs((*synced_frame)->get_frame_timestamp()- next_expected)<MAX_GAP)
         {
             return false;
         }


### PR DESCRIPTION
If the render take more time then the FPS this caused to infinite loop  (poll and render)
so now we render only the last frame after we empty the queue.