### PR TITLE
Hotfix for version 2.9.0 - streaming in release build

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -511,6 +511,7 @@ namespace rs2
             viewer(viewer),
             keep_calculating(true),
             depth_stream_active(false),
+            resulting_queue_max_size(20),
             resulting_queue(resulting_queue_max_size),
 //            frames_queue(4),
             t([this]() {render_loop(); })
@@ -551,10 +552,10 @@ namespace rs2
 
         std::atomic<bool> depth_stream_active;
 
+        const size_t resulting_queue_max_size;
         std::map<int, rs2::frame_queue> frames_queue;
         rs2::frame_queue syncer_queue;
         rs2::frame_queue resulting_queue;
-        const size_t resulting_queue_max_size = 20;
 
     private:
         viewer_model& viewer;


### PR DESCRIPTION
Hotfix for no streaming in release mode - queue initialization
