### PR TITLE
Holes Filling capability for the Spatial post-processing filter

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -256,7 +256,7 @@ namespace rs2
                     value = bool_value ? 1.0f : 0.0f;
                     try
                     {
-                        model.add_log(to_string() << "Setting " << opt << " to " 
+                        model.add_log(to_string() << "Setting " << opt << " to "
                             << value << " (" << (bool_value? "ON" : "OFF") << ")");
                         endpoint->set_option(opt, value);
                         *invalidate_flag = true;
@@ -376,7 +376,7 @@ namespace rs2
                             static_cast<int>(labels.size())))
                         {
                             value = range.min + range.step * selected;
-                            model.add_log(to_string() << "Setting " << opt << " to " 
+                            model.add_log(to_string() << "Setting " << opt << " to "
                                 << value << " (" << labels[selected] << ")");
                             endpoint->set_option(opt, value);
                             *invalidate_flag = true;

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -168,7 +168,7 @@ rs2_vertex* rs2_get_frame_vertices(const rs2_frame* frame, rs2_error** error);
 * \param[in] texture     Texture frame
 * \param[out] error      If non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
-void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_frame* texture, rs2_error** error); 
+void rs2_export_to_ply(const rs2_frame* frame, const char* fname, rs2_frame* texture, rs2_error** error);
 
 /**
 * When called on Points frame type, this method returns a pointer to an array of texture coordinates per vertex

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -60,6 +60,7 @@ typedef enum rs2_option
     RS2_OPTION_FILTER_MAGNITUDE                           , /**< The 2D-filter effect. The specific interpretation is given within the context of the filter */
     RS2_OPTION_FILTER_SMOOTH_ALPHA                        , /**< 2D-filter parameter controls the weight/radius for smoothing.*/
     RS2_OPTION_FILTER_SMOOTH_DELTA                        , /**< 2D-filter range/validity threshold*/
+    RS2_OPTION_HOLES_FILL                                 , /**< Enhance depth data post-processing with holes filling where appropriate*/
     RS2_OPTION_STEREO_BASELINE                            , /**< The distance in mm between the first and the second imagers in stereo-based depth cameras*/
     RS2_OPTION_COUNT                                      , /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_option;

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -36,8 +36,8 @@ namespace librealsense
         return std::make_tuple(texture_data[idx], texture_data[idx + 1], texture_data[idx + 2]);
     }
 
-	void points::export_to_ply(const std::string& fname, const frame_holder& texture) 
-	{
+    void points::export_to_ply(const std::string& fname, const frame_holder& texture)
+    {
         const auto vertices = get_vertices();
         const auto texcoords = get_texture_coordinates();
         std::vector<float3> new_vertices;
@@ -91,7 +91,7 @@ namespace librealsense
                 out.write(reinterpret_cast<const char*>(&z), sizeof(uint8_t));
             }
         }
-	}
+    }
 
     size_t points::get_vertex_count() const
     {
@@ -214,11 +214,11 @@ namespace librealsense
                 return nullptr;
             }
             auto new_frame = (max_frames ? published_frames.allocate() : new T());
-            
+
             if (new_frame)
             {
                 if (max_frames) new_frame->mark_fixed();
-                
+
                 ++published_frames_count;
                 *new_frame = std::move(*f);
             }

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -13,7 +13,7 @@ namespace librealsense
 
     private:
         std::mutex              _mutex;
-        
+
         optional_value<rs2_intrinsics>         _depth_intrinsics;
         optional_value<rs2_intrinsics>         _other_intrinsics;
         optional_value<float>                  _depth_units;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -249,6 +249,7 @@ namespace librealsense
         CASE(FILTER_MAGNITUDE)
         CASE(FILTER_SMOOTH_ALPHA)
         CASE(FILTER_SMOOTH_DELTA)
+        CASE(HOLES_FILL)
         CASE(STEREO_BASELINE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -120,6 +120,7 @@ PYBIND11_PLUGIN(NAME) {
         .value("filter_magnitude", RS2_OPTION_FILTER_MAGNITUDE)
         .value("filter_smooth_alpha", RS2_OPTION_FILTER_SMOOTH_ALPHA)
         .value("filter_smooth_delta", RS2_OPTION_FILTER_SMOOTH_DELTA)
+        .value("filter_holes_fill", RS2_OPTION_HOLES_FILL)
         .value("stereo_baseline", RS2_OPTION_STEREO_BASELINE)
         .value("count", RS2_OPTION_COUNT);
 

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -211,6 +211,7 @@ PYBIND11_PLUGIN(NAME) {
         .value("filter_magnitude", RS2_OPTION_FILTER_MAGNITUDE)
         .value("filter_smooth_alpha", RS2_OPTION_FILTER_SMOOTH_ALPHA)
         .value("filter_smooth_delta", RS2_OPTION_FILTER_SMOOTH_DELTA)
+        .value("filter_holes_fill", RS2_OPTION_HOLES_FILL)
         .value("stereo_baseline", RS2_OPTION_STEREO_BASELINE)
         .value("count", RS2_OPTION_COUNT);
 


### PR DESCRIPTION
Extend the spatial filter to apply holes filling (disabled by default)
Add holes filling control to the filter's interface