### PR TITLE
Fixed false reset of sensors pointer in depth_stereo_sensor

### DIFF
--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -507,7 +507,7 @@ namespace rs2
         depth_stereo_sensor(sensor s): depth_sensor(s)
         {
             rs2_error* e = nullptr;
-            if (rs2_is_sensor_extendable_to(_sensor.get(), RS2_EXTENSION_DEPTH_STEREO_SENSOR, &e) == 0 && !e)
+            if (_sensor && rs2_is_sensor_extendable_to(_sensor.get(), RS2_EXTENSION_DEPTH_STEREO_SENSOR, &e) == 0 && !e)
             {
                 _sensor = nullptr;
             }


### PR DESCRIPTION
When calling `is.<depth_stereo_sensor>()` on a valid sensor that `is` not a `depth_sensor`, a null pointer access violation occurs since the `depth_sensor` resets the `_sensor` protected member.