### PR TITLE
[Node.js] Add marked 0.3.9 as dependency as security vulnerability workaround

### DIFF
--- a/wrappers/nodejs/package-lock.json
+++ b/wrappers/nodejs/package-lock.json
@@ -61,7 +61,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.6",
+        "marked": "0.3.12",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -95,9 +95,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "minimist": {

--- a/wrappers/nodejs/package.json
+++ b/wrappers/nodejs/package.json
@@ -31,6 +31,7 @@
     "pngjs": "^3.3.0"
   },
   "devDependencies": {
+    "marked": "~0.3.9",
     "jsdoc": "^3.5.5"
   }
 }


### PR DESCRIPTION
The security issue is https://github.com/jsdoc3/jsdoc/issues/1489

The manually added dependency is to force to use the secure version before
jsdoc released its secure version.