### PR TITLE
fixed no label error in wrappers/csharp/copy_dependencies.bat

### DIFF
--- a/wrappers/csharp/copy_dependencies.bat
+++ b/wrappers/csharp/copy_dependencies.bat
@@ -5,11 +5,11 @@ if not exist "%3..\..\build\%2" goto nolocal
 echo Copying from local compilation
 xcopy /Y "%3..\..\build\%2\realsense2.dll" %4
 exit 0
-nolocal:
+:nolocal
 if not exist "C:\Program Files (x86)\Intel RealSense SDK 2.0" goto noinstall
 echo Copying from installed SDK
 xcopy /Y "C:\Program Files (x86)\Intel RealSense SDK 2.0\bin\%1\realsense2.dll" %4
 exit 0
-noinstall:
+:noinstall
 echo "realsense2.dll NOT FOUND! Please build it from source using CMake or install Intel RealSense SDK 2.0 from GitHub releases"
 exit 1


### PR DESCRIPTION
small fix of bat file because of incorrect labels
targeting issue [989](https://github.com/IntelRealSense/librealsense/issues/989)

