### PR TITLE
D400 With Motion Module

### DIFF
--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -84,8 +84,8 @@ namespace librealsense
                 {
                     auto motion = dynamic_cast<motion_stream_profile_interface*>(p.get()); 
                     assert(motion); //Expecting to succeed for motion stream (since we are under the "if")
-					auto intrinsics = get_motion_intrinsics(p->get_stream_type());
-                    motion->set_intrinsics([intrinsics]() { return intrinsics; });
+                    auto st = p->get_stream_type();
+                    motion->set_intrinsics([this, st]() { return get_motion_intrinsics(st); });
                 }
             }
 

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -75,7 +75,7 @@ namespace librealsense
                 if (p->get_stream_type() == RS2_STREAM_GYRO)
                     assign_stream(_owner->_gyro_stream, p);
                 if (p->get_stream_type() == RS2_STREAM_GPIO)
-                    assign_stream(_owner->_gpio_streams[p->get_stream_index()], p);
+                    assign_stream(_owner->_gpio_streams[p->get_stream_index()-1], p);
                 if (p->get_framerate() == 1000)
                     p->make_default();
 

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -51,23 +51,23 @@ namespace librealsense
 
         // Bandwidth parameters from BOSCH BMI 055 spec'
         std::vector<std::pair<std::string, stream_profile>> sensor_name_and_hid_profiles =
-            {{"gyro_3d",  {RS2_STREAM_GYRO,  1, 1, 1, 200,  RS2_FORMAT_MOTION_RAW}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  1, 1, 1, 400,  RS2_FORMAT_MOTION_RAW}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  1, 1, 1, 1000, RS2_FORMAT_MOTION_RAW}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  1, 1, 1, 200,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  1, 1, 1, 400,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  1, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 125,  RS2_FORMAT_MOTION_RAW}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 250,  RS2_FORMAT_MOTION_RAW}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 500,  RS2_FORMAT_MOTION_RAW}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 1000, RS2_FORMAT_MOTION_RAW}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 125,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 250,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 500,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 1, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
-             {"HID Sensor Class Device: Gyroscope",     { RS2_STREAM_GYRO,  1, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}} ,
-             {"HID Sensor Class Device: Accelerometer", { RS2_STREAM_ACCEL, 1, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
-             {"HID Sensor Class Device: Custom",        { RS2_STREAM_ACCEL, 1, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}}};
+            {{"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_RAW}},
+             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 400,  RS2_FORMAT_MOTION_RAW}},
+             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_RAW}},
+             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_XYZ32F}},
+             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 400,  RS2_FORMAT_MOTION_XYZ32F}},
+             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 125,  RS2_FORMAT_MOTION_RAW}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 250,  RS2_FORMAT_MOTION_RAW}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 500,  RS2_FORMAT_MOTION_RAW}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_RAW}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 125,  RS2_FORMAT_MOTION_XYZ32F}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 250,  RS2_FORMAT_MOTION_XYZ32F}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 500,  RS2_FORMAT_MOTION_XYZ32F}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
+             {"HID Sensor Class Device: Gyroscope",     { RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}} ,
+             {"HID Sensor Class Device: Accelerometer", { RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
+             {"HID Sensor Class Device: Custom",        { RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}}};
 
         std::map<rs2_stream, std::map<unsigned, unsigned>> fps_and_sampling_frequency_per_rs2_stream =
                                                          {{RS2_STREAM_ACCEL, {{125,  1},

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -748,8 +748,8 @@ namespace librealsense
                 auto p = elem.second;
                 platform::stream_profile sp{ 1, 1, p.fps, stream_to_fourcc(p.stream) };
                 auto profile = std::make_shared<motion_stream_profile>(sp);
+                profile->set_stream_index(p.index);
                 profile->set_stream_type(p.stream);
-                profile->set_stream_index(0);
                 profile->set_format(p.format);
                 profile->set_framerate(p.fps);
                 profiles.push_back(profile);


### PR DESCRIPTION
This patch re-enables support for D400 (prototype) camera with integrated motion module.
The viewer will offer Wide FOV (Fish-eye) stream with software auto-exposure and motion module streams (Gyro, Accelerometer and GPIOs 1-4) 
![screenshot from 2018-01-10 06-39-17](https://user-images.githubusercontent.com/6958867/34771022-1381c61c-f5d1-11e7-9bba-0d68d1f6d41d.png)
