### PR TITLE
[Node.js] Remove getMotionIntrinsics from Sensor

### DIFF
--- a/wrappers/nodejs/index.js
+++ b/wrappers/nodejs/index.js
@@ -814,31 +814,6 @@ class Sensor extends Options {
       return array;
     }
   }
-
-  /**
-   * Motion Sensor intrinsics: scale, bias, and variances.
-   * @typedef {Object} MotionIntrinsics
-   * @property {Float32[]} data - Array(12), Interpret data array values. Indices are:
-   *   <br>[0 - Scale X, 1 - cross axis, 2 - cross axis, 3 - Bias X,
-   *   <br> 4 - cross axis, 5 - Scale Y, 6 - cross axis, 7 - Bias Y,
-   *   <br> 8 - cross axis, 9 - cross axis, 10 - Scale Z, 11 - Bias Z]
-   * @property {Float32[]} noiseVariances - Array(3), Variance of noise for X, Y, and Z axis
-   * @property {Float32[]} biasVariances - Array(3), Variance of bias for X, Y, and Z axis
-   * @see [Sensor.getMotionIntrinsics()]{@link Sensor#getMotionIntrinsics}
-   */
-
-  /**
-   * Returns scale and bias of a motion stream.
-   * @param {String|Integer} stream - type of stream, see [enum stream]{@link stream} for available
-   * stream value
-   * @return {MotionIntrinsics} {@link MotionIntrinsics}
-   */
-  getMotionIntrinsics(stream) {
-    const funcName = 'Sensor.getMotionIntrinsics()';
-    checkArgumentLength(1, 1, arguments.length, funcName);
-    const s = checkArgumentType(arguments, constants.stream, 0, funcName);
-    return this.cxxSensor.getMotionIntrinsics(s);
-  }
 }
 
 /**

--- a/wrappers/nodejs/test/test-sensor.js
+++ b/wrappers/nodejs/test/test-sensor.js
@@ -37,21 +37,6 @@ describe('Sensor test', function() {
       assert.equal(typeof sensor.isValid, 'boolean');
     });
   });
-  it('Testing method getMotionIntrinsics', () => {
-    sensors.forEach((sensor) => {
-      Object.keys(rs2.stream).forEach((o) => {
-        if (o === 'STREAM_COUNT' || o === 'streamToString') return;
-        const m = sensor.getMotionIntrinsics(rs2.stream[o]);
-        assert.equal(typeof m, 'object');
-        assert.equal(Object.prototype.toString.call(m.data), '[object Array]');
-        assert.equal(m.data.length, 12);
-        assert.equal(Object.prototype.toString.call(m.noiseVariances), '[object Array]');
-        assert.equal(m.noiseVariances.length, 3);
-        assert.equal(Object.prototype.toString.call(m.biasVariances), '[object Array]');
-        assert.equal(m.biasVariances.length, 3);
-      });
-    });
-  });
 
   it('Testing method isOptionReadOnly', () => {
     sensors.forEach((sensor) => {


### PR DESCRIPTION
Remove this API to be consistent with native code
