### PR TITLE
Improving the Linux CPU utilization issue in multi cameras streaming scenario 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ option(BUILD_GRAPHICAL_EXAMPLES "Build graphical examples and tools." ON)
 
 option(BUILD_WITH_OPENMP "Use OpenMP" ON)
 
+option(ENABLE_ZERO_COPY "Enable zero copy functionality" OFF)
+if (ENABLE_ZERO_COPY)
+    add_definitions(-DZERO_COPY)
+endif()
+
 if(ANDROID_NDK_TOOLCHAIN_INCLUDED)
     unset(WIN32)
     unset(UNIX)

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -822,6 +822,12 @@ namespace librealsense
         }
     }
 
+#ifdef ZERO_COPY
+    constexpr bool requires_processing = false;
+#else
+    constexpr bool requires_processing = true;
+#endif
+
     //////////////////////////
     // Native pixel formats //
     //////////////////////////
@@ -840,11 +846,11 @@ namespace librealsense
                                                                 { true,  &unpack_yuy2<RS2_FORMAT_BGR8 >,                  { { RS2_STREAM_COLOR,    RS2_FORMAT_BGR8 } } },
                                                                 { true,  &unpack_yuy2<RS2_FORMAT_BGRA8>,                  { { RS2_STREAM_COLOR,    RS2_FORMAT_BGRA8 } } } } };
 
-    const native_pixel_format pf_y8         = { 'GREY', 1, 1,{  { true, &copy_pixels<1>,                                { { { RS2_STREAM_INFRARED, 1 }, RS2_FORMAT_Y8  } } } } };
+    const native_pixel_format pf_y8         = { 'GREY', 1, 1,{  { requires_processing, &copy_pixels<1>,                                { { { RS2_STREAM_INFRARED, 1 }, RS2_FORMAT_Y8  } } } } };
     const native_pixel_format pf_y16        = { 'Y16 ', 1, 2,{  { true,  &unpack_y16_from_y16_10,                        { { { RS2_STREAM_INFRARED, 1 }, RS2_FORMAT_Y16 } } } } };
     const native_pixel_format pf_y8i        = { 'Y8I ', 1, 2,{  { true,  &unpack_y8_y8_from_y8i,                         { { { RS2_STREAM_INFRARED, 1 }, RS2_FORMAT_Y8  },{ { RS2_STREAM_INFRARED, 2 }, RS2_FORMAT_Y8 } } } } };
     const native_pixel_format pf_y12i       = { 'Y12I', 1, 3,{  { true,  &unpack_y16_y16_from_y12i_10,                   { { { RS2_STREAM_INFRARED, 1 }, RS2_FORMAT_Y16 },{ { RS2_STREAM_INFRARED, 2 }, RS2_FORMAT_Y16 } } } } };
-    const native_pixel_format pf_z16        = { 'Z16 ', 1, 2,{  { true, &copy_pixels<2>,                                { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16 } } },
+    const native_pixel_format pf_z16        = { 'Z16 ', 1, 2,{  { requires_processing, &copy_pixels<2>,                                { { RS2_STREAM_DEPTH,    RS2_FORMAT_Z16 } } },
                                                                 // The Disparity_Z is not applicable for D4XX. TODO - merge with INVZ when confirmed
                                                                 /*{ false, &copy_pixels<2>,                                { { RS2_STREAM_DEPTH,    RS2_FORMAT_DISPARITY16 } } }*/ } };
     const native_pixel_format pf_invz       = { 'Z16 ', 1, 2, { { false, &copy_pixels<2>,                                { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16 } } } } };

--- a/src/types.h
+++ b/src/types.h
@@ -1246,10 +1246,9 @@ namespace librealsense
 
         void polling(dispatcher::cancellable_timer cancellable_timer)
         {
-            if(cancellable_timer.try_sleep(100))
+            if(cancellable_timer.try_sleep(5000))
             {
-               platform::backend_device_group curr(_backend->query_uvc_devices(), _backend->query_usb_devices(), _backend->query_hid_devices());
-
+                platform::backend_device_group curr(_backend->query_uvc_devices(), _backend->query_usb_devices(), _backend->query_hid_devices());
                 if(list_changed(_devices_data.uvc_devices, curr.uvc_devices ) ||
                    list_changed(_devices_data.usb_devices, curr.usb_devices ) ||
                    list_changed(_devices_data.hid_devices, curr.hid_devices ))


### PR DESCRIPTION
- Reducing the frequency of device_watcher polling by changing the time of sleep from 100ms to 5000ms
- Added ENABLE_ZERO_COPY flag to the CMake and make it OFF by default