### PR TITLE
[Node.js] Prepare for 2.9.0 release to npmjs

### DIFF
--- a/wrappers/nodejs/index.js
+++ b/wrappers/nodejs/index.js
@@ -4654,8 +4654,8 @@ const notification_category = {
      */
     notification_category_hardware_error: 'hardware-error',
     /**
-     * String literal of <code>'hardware-event'</code>. <br>General hardware notification reported from the sensor
-     * <br>Equivalent to its uppercase counterpart.
+     * String literal of <code>'hardware-event'</code>. <br>General hardware notification reported
+     * from the sensor <br>Equivalent to its uppercase counterpart.
      */
     notification_category_hardware_event: 'hardware-event',
     /**
@@ -4680,7 +4680,8 @@ const notification_category = {
      */
     NOTIFICATION_CATEGORY_HARDWARE_ERROR: RS2.RS2_NOTIFICATION_CATEGORY_HARDWARE_ERROR,
     /**
-     * General hardware notification reported from the sensor <br>Equivalent to its lowercase counterpart
+     * General hardware notification reported from the sensor <br>Equivalent to its lowercase
+     * counterpart
      * @type {Integer}
      */
     NOTIFICATION_CATEGORY_HARDWARE_EVENT: RS2.NOTIFICATION_CATEGORY_HARDWARE_EVENT,

--- a/wrappers/nodejs/package-lock.json
+++ b/wrappers/nodejs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-librealsense",
-  "version": "0.283.0",
+  "version": "0.290.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/wrappers/nodejs/package.json
+++ b/wrappers/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-librealsense",
-  "version": "0.283.0",
+  "version": "0.290.0",
   "description": "Node.js API for Intel® RealSense™ SDK 2.0",
   "main": "index.js",
   "directories": {

--- a/wrappers/nodejs/scripts/npm_dist/build-librealsense.js
+++ b/wrappers/nodejs/scripts/npm_dist/build-librealsense.js
@@ -4,7 +4,7 @@
 
 // Purpose: build native librealsense
 
-const {exec} = require('child_process');
+const {spawn} = require('child_process');
 const os = require('os');
 
 function buildNativeLib() {
@@ -18,19 +18,16 @@ function buildNativeLib() {
 }
 
 function buildNativeLibLinux() {
-  exec('./scripts/npm_dist/build-dist.sh',
-       (error, stdout, stderr) => {
-    if (error) {
-      console.log('Failed to build librealsense, error:', error);
-      throw error;
-    }
-
-    if (stdout) {
-      process.stdout.write(stdout);
-    }
-
-    if (stderr) {
-      process.stderr.write(stderr);
+  let child = spawn('./scripts/npm_dist/build-dist.sh');
+  child.stderr.on('data', (data) => {
+    console.error(`${data}`);
+  });
+  child.stdout.on('data', (data) => {
+    console.log(`${data}`);
+  });
+  child.on('close', (code) => {
+    if (code) {
+      throw new Error('Failed to build librealsense, build-dist.sh exited with code ${code}');
     }
   });
 }
@@ -38,22 +35,18 @@ function buildNativeLibLinux() {
 function buildNativeLibWindows() {
   const cmakeGenPlatform = process.arch;
   const msBuildPlatform = process.arch=='ia32'?'Win32':process.arch;
-
-  exec('cmd /c .\\scripts\\npm_dist\\build-dist.bat ' + cmakeGenPlatform + ' ' + msBuildPlatform,
-       (error, stdout, stderr) => {
-    if (stdout) {
-      process.stdout.write(stdout);
-    }
-
-    if (stderr) {
-      process.stderr.write(stderr);
-    }
-
-    if (error) {
-      console.log('Failed to build librealsense, error:', error);
-      throw error;
+  let child = spawn('cmd', ['/c', '.\\scripts\\npm_dist\\build-dist.bat', cmakeGenPlatform,
+      msBuildPlatform]);
+  child.stderr.on('data', (data) => {
+    console.error(`${data}`);
+  });
+  child.stdout.on('data', (data) => {
+    console.log(`${data}`);
+  });
+  child.on('close', (code) => {
+    if (code) {
+      throw new Error('Failed to build librealsense, build-dist.bat exited with code ${code}');
     }
   });
 }
-
 buildNativeLib();


### PR DESCRIPTION
1. Use child_process.spawn instead of exec as child_process.exec
is not suitable for receiving large amount of data from stdout
of child process which may cause crash. child_process.spawn is the better choice.
2. Change version in package.json and package-lock.json
3. Fix lint error of exceeding max length