### PR TITLE
Making sure all API headers are self-contained and adding such check …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,11 @@ script:
       set -e;
       pyenv install 3.6.1;
       pyenv local `pyenv versions|sed 's/ //g'|grep "^3"|tail -1`;
+
+      cd scripts;
+      ./api_check.sh;
+      cd ..;
+
       mkdir build && cd build;
       cmake .. -DBUILD_EXAMPLES:BOOL=true -DBUILD_PYTHON_BINDINGS:BOOL=true -DBUILD_NODEJS_BINDINGS:BOOL=true;
       make -j $CPU_NUM;

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 #include "rs_types.h"
+#include "rs_sensor.h"
 
     /**
     * Create a pipeline instance

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
 #include "rs_types.h"
+#include "rs_sensor.h"
 
 /**
 * Creates Depth-Colorizer processing block that can be used to quickly visualize the depth data

--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -15,7 +15,6 @@ extern "C" {
 #endif
 
 #include "rs_types.h"
-#include "rs_device.h"
 
 /** \brief Read-only strings that can be queried from the device.
    Not all information attributes are available on all camera types.

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -5,6 +5,7 @@
 #define LIBREALSENSE_RS2_INTERNAL_HPP
 
 #include "rs_types.hpp"
+#include "rs_context.hpp"
 #include "../h/rs_internal.h"
 
 namespace rs2

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -4,7 +4,8 @@
 #ifndef LIBREALSENSE_RSUTIL2_H
 #define LIBREALSENSE_RSUTIL2_H
 
-#include "librealsense2/h/rs_types.h"
+#include "h/rs_types.h"
+#include "h/rs_sensor.h"
 #include "assert.h"
 
 #include <math.h>
@@ -32,9 +33,9 @@ static void rs2_project_point_to_pixel(float pixel[2], const struct rs2_intrinsi
     if (intrin->model == RS2_DISTORTION_FTHETA)
     {
         float r = sqrt(x*x + y*y);
-            auto rd = (1.0f / intrin->coeffs[0] * atan(2 * r* tan(intrin->coeffs[0] / 2.0f)));
-            x *= rd / r;
-            y *= rd / r;
+        float rd = (1.0f / intrin->coeffs[0] * atan(2 * r* tan(intrin->coeffs[0] / 2.0f)));
+        x *= rd / r;
+        y *= rd / r;
     }
 
     pixel[0] = x * intrin->fx + intrin->ppx;

--- a/scripts/api_check.sh
+++ b/scripts/api_check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script makes sure every API header can be included in isolation
+
+for filename in $(find ../include -name *.hpp); do
+    echo Checking that $filename is self-contained
+    rm 1.cpp
+    echo "#include \"$filename\"" >> 1.cpp
+    echo "int main() {}" >> 1.cpp
+    g++ -std=c++11 1.cpp || exit 1
+    echo $filename is OK!
+    echo
+done
+
+for filename in $(find ../include -name *.h); do
+    echo Checking that $filename is self-contained
+    rm 1.c
+    echo "#include \"$filename\"" >> 1.c
+    echo "int main() {}" >> 1.c
+    g++ 1.c || exit 1
+    echo $filename is OK!
+    echo
+done
+
+rm 1.cpp
+rm 1.c


### PR DESCRIPTION
Addressing #903 

1. Fixed several headers to ensure they can be included in isolation (thus eliminating any circular dependencies)
2. Added bash script to check this on every build (on Linux only should be sufficient)