### PR TITLE
Removed dependency of package Threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,9 +544,6 @@ if(UNIX)
         message(FATAL_ERROR "\n\n PkgConfig package is missing!\n\n")
     endif()
 
-    find_package (Threads REQUIRED)
-    list(APPEND librealsense_PKG_DEPS "Threads")
-
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_BSD_SOURCE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pedantic -g -Wno-missing-field-initializers")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar")


### PR DESCRIPTION
See https://github.com/IntelRealSense/librealsense/issues/632

Threads-package doesn't seem to exist on Ubuntu 16.04 (which I'm using). I'm frequently rebuilding the SDK from sources and then other libraries which depend on it. This bogus-dependency just introduces a manual step in the build-process.