### PR TITLE
Update the visual presets of  D4XX cameras

### DIFF
--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -87,7 +87,7 @@ const char* rs2_sr300_visual_preset_to_string(rs2_sr300_visual_preset preset);
 typedef enum rs2_rs400_visual_preset
 {
     RS2_RS400_VISUAL_PRESET_CUSTOM,
-    RS2_RS400_VISUAL_PRESET_SHORT_RANGE,
+    RS2_RS400_VISUAL_PRESET_DEFAULT,
     RS2_RS400_VISUAL_PRESET_HAND,
     RS2_RS400_VISUAL_PRESET_HIGH_ACCURACY,
     RS2_RS400_VISUAL_PRESET_HIGH_DENSITY,

--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -61,7 +61,7 @@ namespace librealsense
         virtual void toggle_advanced_mode(bool enable) = 0;
 
         virtual void apply_preset(const std::vector<platform::stream_profile>& configuration,
-                                  rs2_rs400_visual_preset preset) = 0;
+                                  rs2_rs400_visual_preset preset, uint16_t device_pid) = 0;
 
         virtual void get_depth_control_group(STDepthControlGroup* ptr, int mode = 0) const = 0;
         virtual void get_rsm(STRsm* ptr, int mode = 0) const = 0;
@@ -109,7 +109,7 @@ namespace librealsense
         bool is_enabled() const override;
         void toggle_advanced_mode(bool enable) override;
         void apply_preset(const std::vector<platform::stream_profile>& configuration,
-                          rs2_rs400_visual_preset preset) override;
+                          rs2_rs400_visual_preset preset, uint16_t device_pid) override;
 
         void get_depth_control_group(STDepthControlGroup* ptr, int mode = 0) const override;
         void get_rsm(STRsm* ptr, int mode = 0) const override;
@@ -192,6 +192,7 @@ namespace librealsense
         uvc_sensor& _depth_sensor;
         lazy<ds5_color_sensor*> _color_sensor;
         lazy<bool> _enabled;
+        std::shared_ptr<advanced_mode_preset_option> _preset_opt;
 
         static const uint16_t HW_MONITOR_COMMAND_SIZE = 1000;
         static const uint16_t HW_MONITOR_BUFFER_SIZE = 1024;
@@ -254,6 +255,8 @@ namespace librealsense
         const char* get_value_description(float val) const override;
 
     private:
+        uint16_t get_device_pid(const uvc_sensor& sensor) const;
+
         std::mutex _mtx;
         uvc_sensor& _ep;
         ds5_advanced_mode_base& _advanced;

--- a/src/ds5/advanced_mode/advanced_mode.cpp
+++ b/src/ds5/advanced_mode/advanced_mode.cpp
@@ -20,13 +20,13 @@ namespace librealsense
             assert_no_error(ds::fw_cmd::UAMG, results);
             return results[4] > 0;
         };
-        _depth_sensor.register_option(RS2_OPTION_VISUAL_PRESET,
-            std::make_shared<advanced_mode_preset_option>(*this,
-                                                          _depth_sensor,
-                                                          option_range{ 0,
-                                                                        RS2_RS400_VISUAL_PRESET_COUNT - 1,
-                                                                        1,
-                                                                        RS2_RS400_VISUAL_PRESET_CUSTOM }));
+        _preset_opt = std::make_shared<advanced_mode_preset_option>(*this,
+            _depth_sensor,
+            option_range{ 0,
+            RS2_RS400_VISUAL_PRESET_COUNT - 1,
+            1,
+            RS2_RS400_VISUAL_PRESET_CUSTOM });
+        _depth_sensor.register_option(RS2_OPTION_VISUAL_PRESET, _preset_opt);
         _color_sensor = [this]() {
             auto& dev = _depth_sensor.get_device();
             for (size_t i = 0; i < dev.get_sensors_count(); ++i)
@@ -52,18 +52,40 @@ namespace librealsense
     }
 
     void ds5_advanced_mode_base::apply_preset(const std::vector<platform::stream_profile>& configuration,
-                                              rs2_rs400_visual_preset preset)
+                                              rs2_rs400_visual_preset preset, uint16_t device_pid)
     {
         auto p = get_all();
         auto res = get_res_type(configuration.front().width, configuration.front().height);
 
         switch (preset)
         {
+        case RS2_RS400_VISUAL_PRESET_DEFAULT:
+            switch (device_pid)
+            {
+            case ds::RS410_PID:
+            case ds::RS415_PID:
+                default_410(p);
+                break;
+            case ds::RS430_PID:
+            case ds::RS435_RGB_PID:
+                default_430(p);
+                break;
+            case ds::RS405_PID:
+                default_405(p);
+                break;
+            case ds::RS400_PID:
+                default_400(p);
+                break;
+            case ds::RS420_PID:
+                default_420(p);
+                break;
+            default:
+                throw invalid_value_exception(to_string() << "apply_preset(...) failed! Invalid product ID (" << device_pid << ")");
+                break;
+            }
+            break;
         case RS2_RS400_VISUAL_PRESET_HAND:
             hand_gesture(p);
-            break;
-        case RS2_RS400_VISUAL_PRESET_SHORT_RANGE:
-            short_range(p);
             break;
         case RS2_RS400_VISUAL_PRESET_HIGH_ACCURACY:
             switch (res)
@@ -108,7 +130,7 @@ namespace librealsense
             }
             break;
         default:
-            throw invalid_value_exception(to_string() << "Invalid preset! " << preset);
+            throw invalid_value_exception(to_string() << "apply_preset(...) failed! Invalid preset! (" << preset << ")");
         }
         set_all(p);
     }
@@ -360,61 +382,73 @@ namespace librealsense
     void ds5_advanced_mode_base::set_depth_control_group(const STDepthControlGroup& val)
     {
         set(val, advanced_mode_traits<STDepthControlGroup>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_rsm(const STRsm& val)
     {
         set(val, advanced_mode_traits<STRsm>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_rau_support_vector_control(const STRauSupportVectorControl& val)
     {
         set(val, advanced_mode_traits<STRauSupportVectorControl>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_color_control(const STColorControl& val)
     {
         set(val, advanced_mode_traits<STColorControl>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_rau_color_thresholds_control(const STRauColorThresholdsControl& val)
     {
         set(val, advanced_mode_traits<STRauColorThresholdsControl>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_slo_color_thresholds_control(const STSloColorThresholdsControl& val)
     {
         set(val, advanced_mode_traits<STSloColorThresholdsControl>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_slo_penalty_control(const STSloPenaltyControl& val)
     {
         set(val, advanced_mode_traits<STSloPenaltyControl>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_hdad(const STHdad& val)
     {
         set(val, advanced_mode_traits<STHdad>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_color_correction(const STColorCorrection& val)
     {
         set(val, advanced_mode_traits<STColorCorrection>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_depth_table_control(const STDepthTableControl& val)
     {
         set(val, advanced_mode_traits<STDepthTableControl>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_ae_control(const STAEControl& val)
     {
         set(val, advanced_mode_traits<STAEControl>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_census_radius(const STCensusRadius& val)
     {
         set(val, advanced_mode_traits<STCensusRadius>::group);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     void ds5_advanced_mode_base::set_laser_power(const laser_power_control& val)
@@ -597,6 +631,7 @@ namespace librealsense
         auto p = get_all();
         update_structs(json_content, p);
         set_all(p);
+        _preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
     }
 
     preset ds5_advanced_mode_base::get_all() const
@@ -638,18 +673,18 @@ namespace librealsense
 
     void ds5_advanced_mode_base::set_all(const preset& p)
     {
-        set_depth_control_group(p.depth_controls);
-        set_rsm(p.rsm);
-        set_rau_support_vector_control(p.rsvc);
-        set_color_control(p.color_control);
-        set_rau_color_thresholds_control(p.rctc);
-        set_slo_color_thresholds_control(p.sctc);
-        set_slo_penalty_control(p.spc);
-        set_hdad(p.hdad);
-        set_color_correction(p.cc);
-        set_depth_table_control(p.depth_table);
-        set_ae_control(p.ae);
-        set_census_radius(p.census);
+        set(p.depth_controls, advanced_mode_traits<STDepthControlGroup>::group);
+        set(p.rsm           , advanced_mode_traits<STRsm>::group);
+        set(p.rsvc          , advanced_mode_traits<STRauSupportVectorControl>::group);
+        set(p.color_control , advanced_mode_traits<STColorControl>::group);
+        set(p.rctc          , advanced_mode_traits<STRauColorThresholdsControl>::group);
+        set(p.sctc          , advanced_mode_traits<STSloColorThresholdsControl>::group);
+        set(p.spc           , advanced_mode_traits<STSloPenaltyControl>::group);
+        set(p.hdad          , advanced_mode_traits<STHdad>::group);
+        set(p.cc            , advanced_mode_traits<STColorCorrection>::group);
+        set(p.depth_table   , advanced_mode_traits<STDepthTableControl>::group);
+        set(p.ae            , advanced_mode_traits<STAEControl>::group);
+        set(p.census        , advanced_mode_traits<STCensusRadius>::group);
 
         set_laser_state(p.laser_state);
         if (p.laser_state.was_set && p.laser_state.laser_state == 1) // 1 - on
@@ -681,8 +716,7 @@ namespace librealsense
         if (p.color_auto_white_balance.was_set && p.color_auto_white_balance.auto_white_balance == 0)
             set_color_white_balance(p.color_white_balance);
 
-        // TODO: Itay, check the issue of setting PWF to auto
-        //set_color_power_line_frequency(p.color_power_line_frequency);
+        set_color_power_line_frequency(p.color_power_line_frequency);
     }
 
     std::vector<uint8_t> ds5_advanced_mode_base::send_receive(const std::vector<uint8_t>& input) const
@@ -767,7 +801,7 @@ namespace librealsense
         _ep.register_on_open([this](std::vector<platform::stream_profile> configurations) {
             std::lock_guard<std::mutex> lock(_mtx);
             if (_last_preset != RS2_RS400_VISUAL_PRESET_CUSTOM)
-                _advanced.apply_preset(configurations, _last_preset);
+                _advanced.apply_preset(configurations, _last_preset, get_device_pid(_ep));
         });
     }
 
@@ -793,9 +827,8 @@ namespace librealsense
         }
 
         auto uvc_sensor = dynamic_cast<librealsense::uvc_sensor*>(&_ep);
-
         auto configurations = uvc_sensor->get_configuration();
-        _advanced.apply_preset(configurations, preset);
+        _advanced.apply_preset(configurations, preset, get_device_pid(_ep));
         _last_preset = preset;
         _recording_function(*this);
     }
@@ -824,5 +857,15 @@ namespace librealsense
         {
             throw invalid_value_exception(to_string() << "advanced_mode_preset: get_value_description(...) failed! Description of value " << val << " is not found.");
         }
+    }
+
+    uint16_t advanced_mode_preset_option::get_device_pid(const uvc_sensor& sensor) const
+    {
+        auto str_pid = sensor.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
+        uint16_t device_pid{};
+        std::stringstream ss;
+        ss << std::hex << str_pid;
+        ss >> device_pid;
+        return device_pid;
     }
 }

--- a/src/ds5/advanced_mode/presets.cpp
+++ b/src/ds5/advanced_mode/presets.cpp
@@ -5,6 +5,351 @@
 
 namespace librealsense
 {
+    void default_400(preset& p)
+    {
+        p.depth_controls.deepSeaMedianThreshold = 500;
+        p.depth_controls.deepSeaNeighborThreshold = 7;
+        p.depth_controls.deepSeaSecondPeakThreshold = 325;
+        p.depth_controls.lrAgreeThreshold = 24;
+        p.depth_controls.minusDecrement = 10;
+        p.depth_controls.plusIncrement = 10;
+        p.depth_controls.scoreThreshA = 1;
+        p.depth_controls.scoreThreshB = 2047;
+        p.depth_controls.textureCountThreshold = 0;
+        p.depth_controls.textureDifferenceThreshold = 0;
+        p.rsm.diffThresh = 4.f;
+        p.rsm.removeThresh = 63;
+        p.rsm.rsmBypass = 0;
+        p.rsm.sloRauDiffThresh = 1.f;
+        p.rsvc.minEast = 1;
+        p.rsvc.minNorth = 1;
+        p.rsvc.minNSsum = 3;
+        p.rsvc.minSouth = 1;
+        p.rsvc.minWest = 1;
+        p.rsvc.minWEsum = 3;
+        p.rsvc.uShrink = 3;
+        p.rsvc.vShrink = 1;
+        p.color_control.disableRAUColor = 0;
+        p.color_control.disableSADColor = 0;
+        p.color_control.disableSADNormalize = 0;
+        p.color_control.disableSLOLeftColor = 0;
+        p.color_control.disableSLORightColor = 0;
+        p.rctc.rauDiffThresholdBlue = 51;
+        p.rctc.rauDiffThresholdGreen = 51;
+        p.rctc.rauDiffThresholdRed = 51;
+        p.sctc.diffThresholdBlue = 72;
+        p.sctc.diffThresholdGreen = 72;
+        p.sctc.diffThresholdRed = 72;
+        p.spc.sloK1Penalty = 60;
+        p.spc.sloK1PenaltyMod1 = 105;
+        p.spc.sloK1PenaltyMod2 = 70;
+        p.spc.sloK2Penalty = 342;
+        p.spc.sloK2PenaltyMod1 = 190;
+        p.spc.sloK2PenaltyMod2 = 130;
+        p.hdad.lambdaAD = 800.f;
+        p.hdad.lambdaCensus = 26.f;
+        p.cc.colorCorrection1 = 0.4620000123978f;
+        p.cc.colorCorrection2 = 0.5400000214577f;
+        p.cc.colorCorrection3 = 0.5400000214577f;
+        p.cc.colorCorrection4 = 0.2080000042915f;
+        p.cc.colorCorrection5 = -0.3319999873638f;
+        p.cc.colorCorrection6 = -0.2129999995232f;
+        p.cc.colorCorrection7 = -0.2129999995232f;
+        p.cc.colorCorrection8 = 0.6850000023842f;
+        p.cc.colorCorrection9 = 0.930999994278f;
+        p.cc.colorCorrection10 = -0.5540000200272f;
+        p.cc.colorCorrection11 = -0.5540000200272f;
+        p.cc.colorCorrection12 = 0.04600000008941f;
+        p.depth_table.depthClampMax = 65536;
+        p.depth_table.depthClampMin = 0;
+        p.depth_table.depthUnits = 1000;
+        p.depth_table.disparityShift = 0;
+        p.ae.meanIntensitySetPoint = 400;
+        p.census.uDiameter = 9;
+        p.census.vDiameter = 9;
+        p.depth_exposure.exposure = 33000.f;
+        p.depth_auto_exposure.auto_exposure = 1;
+        p.depth_gain.gain = 16.f;
+    }
+
+
+    void default_405(preset& p)
+    {
+        p.depth_controls.deepSeaMedianThreshold = 500;
+        p.depth_controls.deepSeaNeighborThreshold = 7;
+        p.depth_controls.deepSeaSecondPeakThreshold = 325;
+        p.depth_controls.lrAgreeThreshold = 24;
+        p.depth_controls.minusDecrement = 10;
+        p.depth_controls.plusIncrement = 10;
+        p.depth_controls.scoreThreshA = 1;
+        p.depth_controls.scoreThreshB = 2047;
+        p.depth_controls.textureCountThreshold = 0;
+        p.depth_controls.textureDifferenceThreshold = 0;
+        p.rsm.diffThresh = 4.f;
+        p.rsm.removeThresh = 63;
+        p.rsm.rsmBypass = 0;
+        p.rsm.sloRauDiffThresh = 1.f;
+        p.rsvc.minEast = 1;
+        p.rsvc.minNorth = 1;
+        p.rsvc.minNSsum = 3;
+        p.rsvc.minSouth = 1;
+        p.rsvc.minWest = 1;
+        p.rsvc.minWEsum = 3;
+        p.rsvc.uShrink = 3;
+        p.rsvc.vShrink = 1;
+        p.color_control.disableRAUColor = 0;
+        p.color_control.disableSADColor = 0;
+        p.color_control.disableSADNormalize = 0;
+        p.color_control.disableSLOLeftColor = 0;
+        p.color_control.disableSLORightColor = 0;
+        p.rctc.rauDiffThresholdBlue = 51;
+        p.rctc.rauDiffThresholdGreen = 51;
+        p.rctc.rauDiffThresholdRed = 51;
+        p.sctc.diffThresholdBlue = 72;
+        p.sctc.diffThresholdGreen = 72;
+        p.sctc.diffThresholdRed = 72;
+        p.spc.sloK1Penalty = 60;
+        p.spc.sloK1PenaltyMod1 = 105;
+        p.spc.sloK1PenaltyMod2 = 70;
+        p.spc.sloK2Penalty = 342;
+        p.spc.sloK2PenaltyMod1 = 190;
+        p.spc.sloK2PenaltyMod2 = 130;
+        p.hdad.lambdaAD = 800.f;
+        p.hdad.lambdaCensus = 26.f;
+        p.cc.colorCorrection1 = 0.4620000123978f;
+        p.cc.colorCorrection2 = 0.5400000214577f;
+        p.cc.colorCorrection3 = 0.5400000214577f;
+        p.cc.colorCorrection4 = 0.2080000042915f;
+        p.cc.colorCorrection5 = -0.3319999873638f;
+        p.cc.colorCorrection6 = -0.2129999995232f;
+        p.cc.colorCorrection7 = -0.2129999995232f;
+        p.cc.colorCorrection8 = 0.6850000023842f;
+        p.cc.colorCorrection9 = 0.930999994278f;
+        p.cc.colorCorrection10 = -0.5540000200272f;
+        p.cc.colorCorrection11 = -0.5540000200272f;
+        p.cc.colorCorrection12 = 0.04600000008941f;
+        p.depth_table.depthClampMax = 65536;
+        p.depth_table.depthClampMin = 0;
+        p.depth_table.depthUnits = 1000;
+        p.depth_table.disparityShift = 0;
+        p.ae.meanIntensitySetPoint = 400;
+        p.census.uDiameter = 9;
+        p.census.vDiameter = 9;
+        p.laser_state.laser_state = 1;
+        p.laser_power.laser_power = 150.f;
+        p.depth_exposure.exposure = 33000.f;
+        p.depth_auto_exposure.auto_exposure = 1;
+        p.depth_gain.gain = 16.f;
+    }
+
+
+    void default_410(preset& p)
+    {
+        p.depth_controls.deepSeaMedianThreshold = 500;
+        p.depth_controls.deepSeaNeighborThreshold = 7;
+        p.depth_controls.deepSeaSecondPeakThreshold = 325;
+        p.depth_controls.lrAgreeThreshold = 24;
+        p.depth_controls.minusDecrement = 10;
+        p.depth_controls.plusIncrement = 10;
+        p.depth_controls.scoreThreshA = 1;
+        p.depth_controls.scoreThreshB = 2047;
+        p.depth_controls.textureCountThreshold = 0;
+        p.depth_controls.textureDifferenceThreshold = 0;
+        p.rsm.diffThresh = 4.f;
+        p.rsm.removeThresh = 63;
+        p.rsm.rsmBypass = 0;
+        p.rsm.sloRauDiffThresh = 1.f;
+        p.rsvc.minEast = 1;
+        p.rsvc.minNorth = 1;
+        p.rsvc.minNSsum = 3;
+        p.rsvc.minSouth = 1;
+        p.rsvc.minWest = 1;
+        p.rsvc.minWEsum = 3;
+        p.rsvc.uShrink = 3;
+        p.rsvc.vShrink = 1;
+        p.color_control.disableRAUColor = 0;
+        p.color_control.disableSADColor = 0;
+        p.color_control.disableSADNormalize = 0;
+        p.color_control.disableSLOLeftColor = 0;
+        p.color_control.disableSLORightColor = 0;
+        p.rctc.rauDiffThresholdBlue = 51;
+        p.rctc.rauDiffThresholdGreen = 51;
+        p.rctc.rauDiffThresholdRed = 51;
+        p.sctc.diffThresholdBlue = 72;
+        p.sctc.diffThresholdGreen = 72;
+        p.sctc.diffThresholdRed = 72;
+        p.spc.sloK1Penalty = 60;
+        p.spc.sloK1PenaltyMod1 = 105;
+        p.spc.sloK1PenaltyMod2 = 70;
+        p.spc.sloK2Penalty = 342;
+        p.spc.sloK2PenaltyMod1 = 190;
+        p.spc.sloK2PenaltyMod2 = 130;
+        p.hdad.lambdaAD = 800.f;
+        p.hdad.lambdaCensus = 26.f;
+        p.cc.colorCorrection1 = 0.4620000123978f;
+        p.cc.colorCorrection2 = 0.5400000214577f;
+        p.cc.colorCorrection3 = 0.5400000214577f;
+        p.cc.colorCorrection4 = 0.2080000042915f;
+        p.cc.colorCorrection5 = -0.3319999873638f;
+        p.cc.colorCorrection6 = -0.2129999995232f;
+        p.cc.colorCorrection7 = -0.2129999995232f;
+        p.cc.colorCorrection8 = 0.6850000023842f;
+        p.cc.colorCorrection9 = 0.930999994278f;
+        p.cc.colorCorrection10 = -0.5540000200272f;
+        p.cc.colorCorrection11 = -0.5540000200272f;
+        p.cc.colorCorrection12 = 0.04600000008941f;
+        p.depth_table.depthClampMax = 65536;
+        p.depth_table.depthClampMin = 0;
+        p.depth_table.depthUnits = 1000;
+        p.depth_table.disparityShift = 0;
+        p.ae.meanIntensitySetPoint = 400;
+        p.census.uDiameter = 9;
+        p.census.vDiameter = 9;
+        p.laser_state.laser_state = 1;
+        p.laser_power.laser_power = 150.f;
+        p.depth_exposure.exposure = 33000.f;
+        p.depth_auto_exposure.auto_exposure = 1;
+        p.depth_gain.gain = 16.f;
+    }
+
+
+    void default_420(preset& p)
+    {
+        p.depth_controls.deepSeaMedianThreshold = 500;
+        p.depth_controls.deepSeaNeighborThreshold = 7;
+        p.depth_controls.deepSeaSecondPeakThreshold = 325;
+        p.depth_controls.lrAgreeThreshold = 24;
+        p.depth_controls.minusDecrement = 10;
+        p.depth_controls.plusIncrement = 10;
+        p.depth_controls.scoreThreshA = 1;
+        p.depth_controls.scoreThreshB = 2047;
+        p.depth_controls.textureCountThreshold = 0;
+        p.depth_controls.textureDifferenceThreshold = 0;
+        p.rsm.diffThresh = 4.f;
+        p.rsm.removeThresh = 63;
+        p.rsm.rsmBypass = 0;
+        p.rsm.sloRauDiffThresh = 1.f;
+        p.rsvc.minEast = 1;
+        p.rsvc.minNorth = 1;
+        p.rsvc.minNSsum = 3;
+        p.rsvc.minSouth = 1;
+        p.rsvc.minWest = 1;
+        p.rsvc.minWEsum = 3;
+        p.rsvc.uShrink = 3;
+        p.rsvc.vShrink = 1;
+        p.color_control.disableRAUColor = 0;
+        p.color_control.disableSADColor = 0;
+        p.color_control.disableSADNormalize = 0;
+        p.color_control.disableSLOLeftColor = 0;
+        p.color_control.disableSLORightColor = 0;
+        p.rctc.rauDiffThresholdBlue = 51;
+        p.rctc.rauDiffThresholdGreen = 51;
+        p.rctc.rauDiffThresholdRed = 51;
+        p.sctc.diffThresholdBlue = 72;
+        p.sctc.diffThresholdGreen = 72;
+        p.sctc.diffThresholdRed = 72;
+        p.spc.sloK1Penalty = 60;
+        p.spc.sloK1PenaltyMod1 = 105;
+        p.spc.sloK1PenaltyMod2 = 70;
+        p.spc.sloK2Penalty = 342;
+        p.spc.sloK2PenaltyMod1 = 190;
+        p.spc.sloK2PenaltyMod2 = 130;
+        p.hdad.lambdaAD = 800.f;
+        p.hdad.lambdaCensus = 26.f;
+        p.cc.colorCorrection1 = 0.2989999949932f;
+        p.cc.colorCorrection2 = 0.2939999997616f;
+        p.cc.colorCorrection3 = 0.2939999997616f;
+        p.cc.colorCorrection4 = 0.1140000000596f;
+        p.cc.colorCorrection5 = 0.f;
+        p.cc.colorCorrection6 = 0.f;
+        p.cc.colorCorrection7 = 0.f;
+        p.cc.colorCorrection8 = 0.f;
+        p.cc.colorCorrection9 = 0.f;
+        p.cc.colorCorrection10 = 0.f;
+        p.cc.colorCorrection11 = 0.f;
+        p.cc.colorCorrection12 = 0.f;
+        p.depth_table.depthClampMax = 65536;
+        p.depth_table.depthClampMin = 0;
+        p.depth_table.depthUnits = 1000;
+        p.depth_table.disparityShift = 0;
+        p.ae.meanIntensitySetPoint = 1536;
+        p.census.uDiameter = 9;
+        p.census.vDiameter = 9;
+        p.depth_exposure.exposure = 8500.f;
+        p.depth_auto_exposure.auto_exposure = 1;
+        p.depth_gain.gain = 16.f;
+    }
+
+
+    void default_430(preset& p)
+    {
+        p.depth_controls.deepSeaMedianThreshold = 500;
+        p.depth_controls.deepSeaNeighborThreshold = 7;
+        p.depth_controls.deepSeaSecondPeakThreshold = 325;
+        p.depth_controls.lrAgreeThreshold = 24;
+        p.depth_controls.minusDecrement = 10;
+        p.depth_controls.plusIncrement = 10;
+        p.depth_controls.scoreThreshA = 1;
+        p.depth_controls.scoreThreshB = 2047;
+        p.depth_controls.textureCountThreshold = 0;
+        p.depth_controls.textureDifferenceThreshold = 0;
+        p.rsm.diffThresh = 4.f;
+        p.rsm.removeThresh = 63;
+        p.rsm.rsmBypass = 0;
+        p.rsm.sloRauDiffThresh = 1.f;
+        p.rsvc.minEast = 1;
+        p.rsvc.minNorth = 1;
+        p.rsvc.minNSsum = 3;
+        p.rsvc.minSouth = 1;
+        p.rsvc.minWest = 1;
+        p.rsvc.minWEsum = 3;
+        p.rsvc.uShrink = 3;
+        p.rsvc.vShrink = 1;
+        p.color_control.disableRAUColor = 0;
+        p.color_control.disableSADColor = 0;
+        p.color_control.disableSADNormalize = 0;
+        p.color_control.disableSLOLeftColor = 0;
+        p.color_control.disableSLORightColor = 0;
+        p.rctc.rauDiffThresholdBlue = 51;
+        p.rctc.rauDiffThresholdGreen = 51;
+        p.rctc.rauDiffThresholdRed = 51;
+        p.sctc.diffThresholdBlue = 72;
+        p.sctc.diffThresholdGreen = 72;
+        p.sctc.diffThresholdRed = 72;
+        p.spc.sloK1Penalty = 60;
+        p.spc.sloK1PenaltyMod1 = 105;
+        p.spc.sloK1PenaltyMod2 = 70;
+        p.spc.sloK2Penalty = 342;
+        p.spc.sloK2PenaltyMod1 = 190;
+        p.spc.sloK2PenaltyMod2 = 130;
+        p.hdad.lambdaAD = 800.f;
+        p.hdad.lambdaCensus = 26.f;
+        p.cc.colorCorrection1 = 0.2989999949932f;
+        p.cc.colorCorrection2 = 0.2939999997616f;
+        p.cc.colorCorrection3 = 0.2939999997616f;
+        p.cc.colorCorrection4 = 0.1140000000596f;
+        p.cc.colorCorrection5 = 0.f;
+        p.cc.colorCorrection6 = 0.f;
+        p.cc.colorCorrection7 = 0.f;
+        p.cc.colorCorrection8 = 0.f;
+        p.cc.colorCorrection9 = 0.f;
+        p.cc.colorCorrection10 = 0.f;
+        p.cc.colorCorrection11 = 0.f;
+        p.cc.colorCorrection12 = 0.f;
+        p.depth_table.depthClampMax = 65536;
+        p.depth_table.depthClampMin = 0;
+        p.depth_table.depthUnits = 1000;
+        p.depth_table.disparityShift = 0;
+        p.ae.meanIntensitySetPoint = 1536;
+        p.census.uDiameter = 9;
+        p.census.vDiameter = 9;
+        p.laser_state.laser_state = 1;
+        p.laser_power.laser_power = 150.f;
+        p.depth_exposure.exposure = 8500.f;
+        p.depth_auto_exposure.auto_exposure = 1;
+        p.depth_gain.gain = 16.f;
+    }
+
     void high_res_high_accuracy(preset& p)
     {
         p.depth_controls.deepSeaMedianThreshold = 796;
@@ -17,10 +362,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 2893;
         p.depth_controls.textureCountThreshold = 0;
         p.depth_controls.textureDifferenceThreshold = 1722;
-        p.rsm.diffThresh = 1.660570025444;
+        p.rsm.diffThresh = 1.660570025444f;
         p.rsm.removeThresh = 136;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.7269909977913;
+        p.rsm.sloRauDiffThresh = 0.7269909977913f;
         p.rsvc.minEast = 6;
         p.rsvc.minNorth = 3;
         p.rsvc.minNSsum = 7;
@@ -46,8 +391,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 190;
         p.spc.sloK2PenaltyMod1 = 507;
         p.spc.sloK2PenaltyMod2 = 493;
-        p.hdad.lambdaAD = 751;
-        p.hdad.lambdaCensus = 6;
+        p.hdad.lambdaAD = 751.f;
+        p.hdad.lambdaCensus = 6.f;
     }
 
     void high_res_high_density(preset& p)
@@ -62,10 +407,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 1443;
         p.depth_controls.textureCountThreshold = 0;
         p.depth_controls.textureDifferenceThreshold = 2466;
-        p.rsm.diffThresh = 1.228299975395;
+        p.rsm.diffThresh = 1.228299975395f;
         p.rsm.removeThresh = 82;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.2664879858494;
+        p.rsm.sloRauDiffThresh = 0.2664879858494f;
         p.rsvc.minEast = 2;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 6;
@@ -91,8 +436,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 235;
         p.spc.sloK2PenaltyMod1 = 506;
         p.spc.sloK2PenaltyMod2 = 206;
-        p.hdad.lambdaAD = 618;
-        p.hdad.lambdaCensus = 15;
+        p.hdad.lambdaAD = 618.f;
+        p.hdad.lambdaCensus = 15.f;
     }
 
     void high_res_mid_density(preset& p)
@@ -107,10 +452,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 887;
         p.depth_controls.textureCountThreshold = 0;
         p.depth_controls.textureDifferenceThreshold = 0;
-        p.rsm.diffThresh = 1.816750049591;
+        p.rsm.diffThresh = 1.816750049591f;
         p.rsm.removeThresh = 81;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 1;
+        p.rsm.sloRauDiffThresh = 1.f;
         p.rsvc.minEast = 3;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 6;
@@ -136,8 +481,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 342;
         p.spc.sloK2PenaltyMod1 = 390;
         p.spc.sloK2PenaltyMod2 = 151;
-        p.hdad.lambdaAD = 935;
-        p.hdad.lambdaCensus = 26;
+        p.hdad.lambdaAD = 935.f;
+        p.hdad.lambdaCensus = 26.f;
     }
 
     void low_res_high_accuracy(preset& p)
@@ -152,10 +497,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 1890;
         p.depth_controls.textureCountThreshold = 8;
         p.depth_controls.textureDifferenceThreshold = 0;
-        p.rsm.diffThresh = 5.206029891968;
+        p.rsm.diffThresh = 5.206029891968f;
         p.rsm.removeThresh = 86;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.7110940217972;
+        p.rsm.sloRauDiffThresh = 0.7110940217972f;
         p.rsvc.minEast = 1;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 5;
@@ -181,8 +526,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 414;
         p.spc.sloK2PenaltyMod1 = 96;
         p.spc.sloK2PenaltyMod2 = 57;
-        p.hdad.lambdaAD = 74;
-        p.hdad.lambdaCensus = 26;
+        p.hdad.lambdaAD = 74.f;
+        p.hdad.lambdaCensus = 26.f;
         p.census.uDiameter = 8;
         p.census.vDiameter = 9;
     }
@@ -199,10 +544,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 3440;
         p.depth_controls.textureCountThreshold = 0;
         p.depth_controls.textureDifferenceThreshold = 3639;
-        p.rsm.diffThresh = 5.890840053558;
+        p.rsm.diffThresh = 5.890840053558f;
         p.rsm.removeThresh = 68;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.421687990427;
+        p.rsm.sloRauDiffThresh = 0.421687990427f;
         p.rsvc.minEast = 1;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 5;
@@ -228,8 +573,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 386;
         p.spc.sloK2PenaltyMod1 = 86;
         p.spc.sloK2PenaltyMod2 = 60;
-        p.hdad.lambdaAD = 686;
-        p.hdad.lambdaCensus = 26;
+        p.hdad.lambdaAD = 686.f;
+        p.hdad.lambdaCensus = 26.f;
         p.census.uDiameter = 9;
         p.census.vDiameter = 9;
     }
@@ -246,10 +591,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 1885;
         p.depth_controls.textureCountThreshold = 0;
         p.depth_controls.textureDifferenceThreshold = 2817;
-        p.rsm.diffThresh = 6.447229862213;
+        p.rsm.diffThresh = 6.447229862213f;
         p.rsm.removeThresh = 95;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.2744660079479;
+        p.rsm.sloRauDiffThresh = 0.2744660079479f;
         p.rsvc.minEast = 6;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 2;
@@ -275,8 +620,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 410;
         p.spc.sloK2PenaltyMod1 = 80;
         p.spc.sloK2PenaltyMod2 = 74;
-        p.hdad.lambdaAD = 183;
-        p.hdad.lambdaCensus = 26;
+        p.hdad.lambdaAD = 183.f;
+        p.hdad.lambdaCensus = 26.f;
         p.census.uDiameter = 9;
         p.census.vDiameter = 9;
     }
@@ -293,10 +638,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 2047;
         p.depth_controls.textureCountThreshold = 0;
         p.depth_controls.textureDifferenceThreshold = 3474;
-        p.rsm.diffThresh = 3.329339981079;
+        p.rsm.diffThresh = 3.329339981079f;
         p.rsm.removeThresh = 112;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.9618660211563;
+        p.rsm.sloRauDiffThresh = 0.9618660211563f;
         p.rsvc.minEast = 3;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 6;
@@ -322,8 +667,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 182;
         p.spc.sloK2PenaltyMod1 = 41;
         p.spc.sloK2PenaltyMod2 = 63;
-        p.hdad.lambdaAD = 630;
-        p.hdad.lambdaCensus = 26;
+        p.hdad.lambdaAD = 630.f;
+        p.hdad.lambdaCensus = 26.f;
         p.census.uDiameter = 6;
         p.census.vDiameter = 7;
     }
@@ -340,10 +685,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 1949;
         p.depth_controls.textureCountThreshold = 1;
         p.depth_controls.textureDifferenceThreshold = 0;
-        p.rsm.diffThresh = 5.069789886475;
+        p.rsm.diffThresh = 5.069789886475f;
         p.rsm.removeThresh = 75;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 1;
+        p.rsm.sloRauDiffThresh = 1.f;
         p.rsvc.minEast = 7;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 6;
@@ -369,8 +714,8 @@ namespace librealsense
         p.spc.sloK2Penalty = 342;
         p.spc.sloK2PenaltyMod1 = 69;
         p.spc.sloK2PenaltyMod2 = 225;
-        p.hdad.lambdaAD = 850;
-        p.hdad.lambdaCensus = 19;
+        p.hdad.lambdaAD = 850.f;
+        p.hdad.lambdaCensus = 19.f;
         p.census.uDiameter = 9;
         p.census.vDiameter = 3;
     }
@@ -387,10 +732,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 972;
         p.depth_controls.textureCountThreshold = 6;
         p.depth_controls.textureDifferenceThreshold = 0;
-        p.rsm.diffThresh = 5.859620094299;
+        p.rsm.diffThresh = 5.859620094299f;
         p.rsm.removeThresh = 70;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 1;
+        p.rsm.sloRauDiffThresh = 1.f;
         p.rsvc.minEast = 3;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 6;
@@ -416,54 +761,10 @@ namespace librealsense
         p.spc.sloK2Penalty = 397;
         p.spc.sloK2PenaltyMod1 = 21;
         p.spc.sloK2PenaltyMod2 = 226;
-        p.hdad.lambdaAD = 978;
-        p.hdad.lambdaCensus = 21;
+        p.hdad.lambdaAD = 978.f;
+        p.hdad.lambdaCensus = 21.f;
         p.census.uDiameter = 8;
         p.census.vDiameter = 5;
-    }
-
-    void short_range(preset& p)
-    {
-        p.depth_controls.deepSeaMedianThreshold = 528;
-        p.depth_controls.deepSeaNeighborThreshold = 20;
-        p.depth_controls.deepSeaSecondPeakThreshold = 27;
-        p.depth_controls.lrAgreeThreshold = 70;
-        p.depth_controls.minusDecrement = 10;
-        p.depth_controls.plusIncrement = 10;
-        p.depth_controls.scoreThreshA = 10;
-        p.depth_controls.scoreThreshB = 1023;
-        p.depth_controls.textureCountThreshold = 0;
-        p.rsm.diffThresh = 7;
-        p.rsm.removeThresh = 32;
-        p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 3;
-        p.rsvc.minEast = 1;
-        p.rsvc.minNorth = 1;
-        p.rsvc.minNSsum = 1;
-        p.rsvc.minSouth = 1;
-        p.rsvc.minWest = 1;
-        p.rsvc.minWEsum = 1;
-        p.rsvc.uShrink = 1;
-        p.rsvc.vShrink = 1;
-        p.color_control.disableRAUColor = 0;
-        p.color_control.disableSADColor = 0;
-        p.color_control.disableSADNormalize = 0;
-        p.color_control.disableSLOLeftColor = 0;
-        p.color_control.disableSLORightColor = 0;
-        p.rctc.rauDiffThresholdBlue = 599;
-        p.rctc.rauDiffThresholdGreen = 599;
-        p.rctc.rauDiffThresholdRed = 599;
-        p.sctc.diffThresholdBlue = 300;
-        p.sctc.diffThresholdGreen = 300;
-        p.sctc.diffThresholdRed = 300;
-        p.spc.sloK1Penalty = 44;
-        p.spc.sloK1PenaltyMod1 = 23;
-        p.spc.sloK1PenaltyMod2 = 219;
-        p.spc.sloK2Penalty = 502;
-        p.spc.sloK2PenaltyMod1 = 237;
-        p.spc.sloK2PenaltyMod2 = 113;
-        p.hdad.lambdaAD = 2100;
-        p.hdad.lambdaCensus = 26;
     }
 
     void hand_gesture(preset& p)
@@ -478,10 +779,10 @@ namespace librealsense
         p.depth_controls.scoreThreshB = 791;
         p.depth_controls.textureCountThreshold = 0;
         p.depth_controls.textureDifferenceThreshold = 783;
-        p.rsm.diffThresh = 3.80778002739f;
-        p.rsm.removeThresh = 93;
+        p.rsm.diffThresh = 3.8125f;
+        p.rsm.removeThresh = 92;
         p.rsm.rsmBypass = 0;
-        p.rsm.sloRauDiffThresh = 0.4557830095291f;
+        p.rsm.sloRauDiffThresh = 0.46875f;
         p.rsvc.minEast = 3;
         p.rsvc.minNorth = 1;
         p.rsvc.minNSsum = 4;
@@ -496,7 +797,7 @@ namespace librealsense
         p.color_control.disableSLOLeftColor = 0;
         p.color_control.disableSLORightColor = 1;
         p.rctc.rauDiffThresholdBlue = 50;
-        p.rctc.rauDiffThresholdGreen = 74;
+        p.rctc.rauDiffThresholdGreen = 73;
         p.rctc.rauDiffThresholdRed = 141;
         p.sctc.diffThresholdBlue = 130;
         p.sctc.diffThresholdGreen = 244;
@@ -507,7 +808,15 @@ namespace librealsense
         p.spc.sloK2Penalty = 45;
         p.spc.sloK2PenaltyMod1 = 21;
         p.spc.sloK2PenaltyMod2 = 12;
-        p.hdad.lambdaAD = 1001;
-        p.hdad.lambdaCensus = 7;
+        p.hdad.ignoreSAD = 0;
+        p.hdad.lambdaAD = 1001.f;
+        p.hdad.lambdaCensus = 7.f;
+        p.depth_table.depthClampMax = 65535;
+        p.depth_table.depthClampMin = 0;
+        p.depth_table.depthUnits = 1000;
+        p.depth_table.disparityMode = 0;
+        p.depth_table.disparityShift = 0;
+        p.census.uDiameter = 9;
+        p.census.vDiameter = 3;
     }
 }

--- a/src/ds5/advanced_mode/presets.h
+++ b/src/ds5/advanced_mode/presets.h
@@ -130,6 +130,11 @@ namespace librealsense
         power_line_frequency_control   color_power_line_frequency;
     };
 
+    void default_400(preset& p);
+    void default_405(preset& p);
+    void default_410(preset& p);
+    void default_420(preset& p);
+    void default_430(preset& p);
     void high_res_high_accuracy(preset& p);
     void high_res_high_density(preset& p);
     void high_res_mid_density(preset& p);
@@ -139,6 +144,5 @@ namespace librealsense
     void mid_res_high_accuracy(preset& p);
     void mid_res_high_density(preset& p);
     void mid_res_mid_density(preset& p);
-    void short_range(preset& p);
     void hand_gesture(preset& p);
 }

--- a/src/ds5/advanced_mode/rs_advanced_mode.cpp
+++ b/src/ds5/advanced_mode/rs_advanced_mode.cpp
@@ -22,12 +22,12 @@ namespace librealsense
         #define CASE(X) STRCASE(RS400_VISUAL_PRESET, X)
         switch (value)
         {
+        CASE(CUSTOM)
         CASE(HAND)
-        CASE(SHORT_RANGE)
         CASE(HIGH_ACCURACY)
         CASE(HIGH_DENSITY)
         CASE(MEDIUM_DENSITY)
-        CASE(CUSTOM)
+        CASE(DEFAULT)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
         #undef CASE


### PR DESCRIPTION
- Added default preset settings to D4xx series cameras
- Removed Short Range preset
- Change the preset option value to `custom` when an advanced mode control is changed or when a JSON file is loaded