### PR TITLE
UV texture mapping to use rectified RGB rotation matrix

### DIFF
--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -33,9 +33,8 @@ namespace librealsense
 
     float3 transform(const rs2_extrinsics *extrin, const float3 &point) { float3 p = {}; rs2_transform_point_to_point(&p.x, extrin, &point.x); return p; }
     float2 project(const rs2_intrinsics *intrin, const float3 & point) { float2 pixel = {}; rs2_project_point_to_pixel(&pixel.x, intrin, &point.x); return pixel; }
-    float2 pixel_to_texcoord(const rs2_intrinsics *intrin, const float2 & pixel) { return{ (pixel.x + 1.5f) / intrin->width, (pixel.y + 0.5f) / intrin->height }; }
+    float2 pixel_to_texcoord(const rs2_intrinsics *intrin, const float2 & pixel) { return{ (pixel.x + 0.5f) / intrin->width, (pixel.y + 0.5f) / intrin->height }; }
     float2 project_to_texcoord(const rs2_intrinsics *intrin, const float3 & point) { return pixel_to_texcoord(intrin, project(intrin, point)); }
-
 
      bool pointcloud::stream_changed( stream_profile_interface* old, stream_profile_interface* curr)
      {


### PR DESCRIPTION
Use RGB-to-left rectified rotation matrix instead of RGB-to-left matrix from the calibration table
Adjust pointcloud UV-texture offset
Tracked On: DSO-8308
