### PR TITLE
Adding the rs-fw-logger tool to the executables destination folder

### DIFF
--- a/tools/fw-logger/CMakeLists.txt
+++ b/tools/fw-logger/CMakeLists.txt
@@ -37,12 +37,12 @@ set_target_properties (rs-fw-logger PROPERTIES
     FOLDER Tools
 )
 
-#install(
-#    TARGETS
+install(
+    TARGETS
 
-#    rs-fw-logger
+    rs-fw-logger
 
-#    RUNTIME DESTINATION
-#    ${CMAKE_INSTALL_PREFIX}/bin
-#)
+    RUNTIME DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/bin
+)
 


### PR DESCRIPTION
Copy the compiled rs-fw-logger tool to the Linux executables destination folder during `sudo make install` operation