### PR TITLE
Add MacOS frameworks to fix build

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -48,6 +48,12 @@ if(BUILD_GRAPHICAL_EXAMPLES)
                       /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
                       /usr/X11R6/lib
         )
+        if(APPLE)
+            find_library(COCOA_LIBRARY Cocoa)
+            find_library(IOKIT_LIBRARY IOKit)
+            find_library(COREVIDEO_LIBRARY CoreVideo)
+            LIST(APPEND DEPENDENCIES ${COCOA_LIBRARY} ${IOKIT_LIBRARY} ${COREVIDEO_LIBRARY})
+        endif()
         list(APPEND DEPENDENCIES m ${GLFW_LIBRARIES} ${LIBUSB1_LIBRARIES})
         include_directories(${GLFW_INCLUDE_DIR})
     endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -53,6 +53,12 @@ if(BUILD_GRAPHICAL_EXAMPLES)
                       /usr/local/lib/${CMAKE_LIBRARY_ARCHITECTURE}
                       /usr/X11R6/lib
         )
+        if(APPLE)
+            find_library(COCOA_LIBRARY Cocoa)
+            find_library(IOKIT_LIBRARY IOKit)
+            find_library(COREVIDEO_LIBRARY CoreVideo)
+            LIST(APPEND DEPENDENCIES ${COCOA_LIBRARY} ${IOKIT_LIBRARY} ${COREVIDEO_LIBRARY})
+        endif()
         list(APPEND DEPENDENCIES m ${GLFW_LIBRARIES} ${LIBUSB1_LIBRARIES})
         include_directories(${GLFW_INCLUDE_DIR})
     endif()


### PR DESCRIPTION
In some environments, glfw requires these frameworks.
Without this change, "Apple Mach-O Linkter (ld) Error"
happens when it builds the targets which links glfw.

This is fix for #1025 .
