### PR TITLE
Added depth map scaling ruler to realsense-viewer tool

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <algorithm>
 #include <regex>
+#include <random>
 
 #include <librealsense2/rs_advanced_mode.hpp>
 #include <librealsense2/rsutil.h>
@@ -2059,8 +2060,9 @@ namespace rs2
     {
         const auto top_bar_height = 32.f;
         auto num_of_buttons = 4;
-        if (!viewer.allow_stream_close) num_of_buttons--;
-        if (viewer.streams.size() > 1) num_of_buttons++;
+        if (!viewer.allow_stream_close) --num_of_buttons;
+        if (viewer.streams.size() > 1) ++num_of_buttons;
+        if (RS2_STREAM_DEPTH == profile.stream_type()) ++num_of_buttons;
 
         auto flags = ImGuiWindowFlags_NoResize |
             ImGuiWindowFlags_NoMove |
@@ -2119,6 +2121,37 @@ namespace rs2
         ImGui::PopTextWrapPos();
 
         ImGui::SetCursorPos({ stream_rect.w - 32 * num_of_buttons, 0 });
+
+        if (RS2_STREAM_DEPTH == profile.stream_type())
+        {
+            label = to_string() << textual_icons::bar_chart << "##Color map";
+            if (viewer.show_map_ruler)
+            {
+                ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
+                ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue);
+                if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+                {
+                    viewer.show_map_ruler = false;
+                }
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("Hide color map ruler");
+                }
+                ImGui::PopStyleColor(2);
+            }
+            else
+            {
+                if (ImGui::Button(label.c_str(), { 24, top_bar_height }))
+                {
+                    viewer.show_map_ruler = true;
+                }
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("Show color map ruler");
+                }
+            }
+            ImGui::SameLine();
+        }
 
         auto p = dev->dev.as<playback>();
         if (dev->is_paused() || (p && p.current_status() == RS2_PLAYBACK_STATUS_PAUSED))
@@ -2281,8 +2314,16 @@ namespace rs2
             ImGui::PushStyleColor(ImGuiCol_ButtonHovered, header_window_bg);
             ImGui::PushStyleColor(ImGuiCol_ButtonActive, header_window_bg);
             ImGui::PushStyleColor(ImGuiCol_WindowBg, from_rgba(9, 11, 13, 100));
-            ImGui::SetNextWindowPos({ stream_rect.x + stream_rect.w - 275, stream_rect.y + 5 });
-            ImGui::SetNextWindowSize({ 270, 45 });
+            static const auto width_info_rect = 270.f;
+            static const auto height_info_rect = 45.f;
+            static const auto y_offset_info_rect = 5.f;
+            static const auto x_offset_info_rect = 275.f;
+            curr_info_rect = rect{ stream_rect.x + stream_rect.w - x_offset_info_rect,
+                                   stream_rect.y + y_offset_info_rect,
+                                   width_info_rect,
+                                   height_info_rect };
+            ImGui::SetNextWindowPos({ curr_info_rect.x, curr_info_rect.y });
+            ImGui::SetNextWindowSize({ curr_info_rect.w, curr_info_rect.h });
             std::string label = to_string() << "Stream Info of " << profile.unique_id();
             ImGui::Begin(label.c_str(), nullptr, flags);
 
@@ -3072,7 +3113,7 @@ namespace rs2
     {
         texture_buffer* texture_frame = nullptr;
         points p;
-        frame f{}, res{};
+        frame f{}, depth{};
 
         std::map<int, frame> last_frames;
         try
@@ -3098,7 +3139,7 @@ namespace rs2
                         }
 
                         if (frame.is<depth_frame>() && !paused)
-                            res = frame;
+                            depth = frame;
 
                         auto texture = upload_frame(std::move(frame));
 
@@ -3134,7 +3175,7 @@ namespace rs2
 
         popup_if_error(window.get_font(), error_message);
 
-        return res;
+        return depth;
     }
 
     void viewer_model::reset_camera(float3 p)
@@ -3165,6 +3206,163 @@ namespace rs2
             up.y /= -up_len;
             up.z /= -up_len;
         }
+    }
+
+    void viewer_model::draw_color_ruler(const mouse_info& mouse,
+                                        const stream_model& s_model,
+                                        const rect& stream_rect,
+                                        std::vector<rgb_per_distance> rgb_per_distance_vec,
+                                        double ruler_length, const std::string& ruler_units)
+    {
+        assert(ruler_length > 0.0);
+        if (rgb_per_distance_vec.empty())
+            return;
+
+        std::sort(rgb_per_distance_vec.begin(), rgb_per_distance_vec.end(), [](const rgb_per_distance& a,
+            const rgb_per_distance& b) {
+            return a.depth_val < b.depth_val;
+        });
+
+        const auto stream_height = stream_rect.y + stream_rect.h;
+        const auto stream_width = stream_rect.x + stream_rect.w;
+
+        static const auto ruler_distance_offset = 10;
+        auto bottom_y_ruler = stream_height - ruler_distance_offset;
+        if (s_model.texture->zoom_preview)
+        {
+            bottom_y_ruler = s_model.texture->curr_preview_rect.y - ruler_distance_offset;
+        }
+
+        static const auto top_y_offset = 50;
+        auto top_y_ruler = stream_rect.y + top_y_offset;
+        if (s_model.show_stream_details)
+        {
+            top_y_ruler = s_model.curr_info_rect.y + s_model.curr_info_rect.h + ruler_distance_offset;
+        }
+
+        static const auto left_x_colored_ruler_offset = 45;
+        static const auto colored_ruler_width = 20;
+        const auto left_x_colored_ruler = stream_width - left_x_colored_ruler_offset;
+        const auto right_x_colored_ruler = stream_width - (left_x_colored_ruler_offset - colored_ruler_width);
+        const auto first_rgb = rgb_per_distance_vec.begin()->rgb_val;
+        assert((bottom_y_ruler - top_y_ruler) != 0.f);
+        const auto ratio = (bottom_y_ruler - top_y_ruler) / ruler_length;
+
+        // Draw numbered ruler
+        float y_ruler_val = 0.f;
+        auto flags = ImGuiWindowFlags_NoResize |
+                     ImGuiWindowFlags_NoMove |
+                     ImGuiWindowFlags_NoCollapse |
+                     ImGuiWindowFlags_NoTitleBar;
+        static const auto numbered_ruler_width = 16.f;
+        const auto numbered_ruler_height = bottom_y_ruler - top_y_ruler;
+        ImGui::SetNextWindowPos({ right_x_colored_ruler, top_y_ruler });
+        ImGui::SetNextWindowSize({ numbered_ruler_width, numbered_ruler_height });
+        ImGui::PushStyleColor(ImGuiCol_WindowBg, { 0.f, 0.f, 0.f, 0.f });
+        ImGui::Begin("numbered_ruler", nullptr, flags);
+
+        const auto right_x_numbered_ruler = right_x_colored_ruler + numbered_ruler_width;
+        static const auto hovered_numbered_ruler_opac = 0.8f;
+        static const auto unhovered_numbered_ruler_opac = 0.5f;
+        float colored_ruler_opac = unhovered_numbered_ruler_opac;
+        float numbered_ruler_background_opac = unhovered_numbered_ruler_opac;
+        bool is_ruler_hovered = false;
+        if (mouse.cursor.x >= left_x_colored_ruler &&
+            mouse.cursor.x <= right_x_numbered_ruler &&
+            mouse.cursor.y >= top_y_ruler &&
+            mouse.cursor.y <= bottom_y_ruler)
+            is_ruler_hovered = true;
+
+        if (is_ruler_hovered)
+        {
+            std::stringstream ss;
+            auto relative_mouse_y = ImGui::GetMousePos().y - top_y_ruler;
+            auto y = (bottom_y_ruler - top_y_ruler) - relative_mouse_y;
+            ss << std::fixed << std::setprecision(2) << (y / ratio) << ruler_units;
+            ImGui::SetTooltip(ss.str().c_str());
+            colored_ruler_opac = 1.f;
+            numbered_ruler_background_opac = hovered_numbered_ruler_opac;
+        }
+
+        // Draw a background to the numbered ruler
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glColor4f(0.0, 0.0, 0.0, numbered_ruler_background_opac);
+        glBegin(GL_POLYGON);
+        glVertex2f(right_x_colored_ruler, top_y_ruler);
+        glVertex2f(right_x_numbered_ruler , top_y_ruler);
+        glVertex2f(right_x_numbered_ruler , bottom_y_ruler);
+        glVertex2f(right_x_colored_ruler, bottom_y_ruler);
+        glEnd();
+
+        static const float x_ruler_val = 5.f;
+        ImGui::SetCursorPos({ x_ruler_val, y_ruler_val });
+        const auto font_size = ImGui::GetFontSize();
+        ImGui::Text(std::to_string((int)ruler_length).c_str());
+        for (int i = ruler_length - 1; i > 0; --i)
+        {
+            y_ruler_val += ((bottom_y_ruler - top_y_ruler) / ruler_length);
+            ImGui::SetCursorPos({ x_ruler_val, y_ruler_val - font_size / 2 });
+            ImGui::Text(std::to_string(i).c_str());
+        }
+        y_ruler_val += ((bottom_y_ruler - top_y_ruler) / ruler_length);
+        ImGui::SetCursorPos({ x_ruler_val, y_ruler_val - (font_size * 1.5f) });
+        ImGui::Text("0");
+        ImGui::End();
+        ImGui::PopStyleColor();
+
+        auto total_depth_scale = rgb_per_distance_vec.back().depth_val - rgb_per_distance_vec.front().depth_val;
+        static const auto sensitivity_factor = 0.01f;
+        auto sensitivity = sensitivity_factor * total_depth_scale;
+
+        // Draw colored ruler
+        auto last_y = bottom_y_ruler;
+        auto last_depth_value = 0.f;
+        auto last_index = 0;
+        for (auto i = 1; i < rgb_per_distance_vec.size(); ++i)
+        {
+            auto curr_depth = rgb_per_distance_vec[i].depth_val;
+            if (((curr_depth - last_depth_value) < sensitivity) && (i != rgb_per_distance_vec.size() - 1))
+                continue;
+
+            glEnable(GL_BLEND);
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            glBegin(GL_QUADS);
+            glColor4f(rgb_per_distance_vec[last_index].rgb_val.r / 255.f,
+                      rgb_per_distance_vec[last_index].rgb_val.g / 255.f,
+                      rgb_per_distance_vec[last_index].rgb_val.b / 255.f,
+                      colored_ruler_opac);
+            glVertex2f(left_x_colored_ruler, last_y);
+            glVertex2f(right_x_colored_ruler, last_y);
+
+            last_depth_value = curr_depth;
+            last_index = i;
+
+            auto y = bottom_y_ruler - ((rgb_per_distance_vec[i].depth_val) * ratio);
+            if (i == rgb_per_distance_vec.size() - 1)
+                y = top_y_ruler;
+
+            glColor4f(rgb_per_distance_vec[i].rgb_val.r / 255.f,
+                      rgb_per_distance_vec[i].rgb_val.g / 255.f,
+                      rgb_per_distance_vec[i].rgb_val.b / 255.f,
+                      colored_ruler_opac);
+
+            glVertex2f(right_x_colored_ruler, y);
+            glVertex2f(left_x_colored_ruler, y);
+            last_y = y;
+            glEnd();
+        }
+
+        // Draw ruler border
+        static const auto top_line_offset = 0.5f;
+        static const auto right_line_offset = top_line_offset / 2;
+        glColor4f(0.0, 0.0, 0.0, colored_ruler_opac);
+        glBegin(GL_LINE_LOOP);
+        glVertex2f(left_x_colored_ruler - top_line_offset, top_y_ruler - top_line_offset);
+        glVertex2f(right_x_numbered_ruler + right_line_offset / 2, top_y_ruler - top_line_offset);
+        glVertex2f(right_x_numbered_ruler + right_line_offset / 2, bottom_y_ruler + top_line_offset);
+        glVertex2f(left_x_colored_ruler - top_line_offset, bottom_y_ruler + top_line_offset);
+        glEnd();
     }
 
     void viewer_model::render_2d_view(const rect& view_rect,
@@ -3230,6 +3428,51 @@ namespace rs2
             stream_rect.h += 32;
             stream_rect.w += 1;
             draw_rect(stream_rect);
+
+            auto frame = streams[stream].texture->get_last_frame().as<video_frame>();
+            auto textured_frame = streams[stream].texture->get_last_frame(true).as<video_frame>();
+            if (show_map_ruler && frame && textured_frame &&
+                RS2_STREAM_DEPTH == stream_mv.profile.stream_type() &&
+                RS2_FORMAT_Z16 == stream_mv.profile.format())
+            {
+                static const double depth_max_distance = 6.0;
+                static const std::string depth_units = "m";
+                std::vector<rgb_per_distance> rgb_per_distance_vec;
+                if (!stream_mv.dev->is_paused())
+                {
+                    auto depth_vid_profile = stream_mv.profile.as<video_stream_profile>();
+                    auto depth_width = depth_vid_profile.width();
+                    auto depth_height = depth_vid_profile.height();
+                    auto num_of_pixels = depth_width * depth_height;
+                    auto depth_data = static_cast<const uint16_t*>(frame.get_data());
+                    auto textured_depth_data = static_cast<const uint8_t*>(textured_frame.get_data());
+                    static const auto skip_factor = 30;
+                    for (uint64_t i = 0; i < depth_height; i+= skip_factor)
+                    {
+                        for (uint64_t j = 0; j < depth_width; j+= skip_factor)
+                        {
+                            auto depth_index = i*depth_width + j;
+                            auto length = depth_data[depth_index] * stream_mv.dev->depth_units;
+                            if (length > 0.f && length <= depth_max_distance)
+                            {
+                                auto textured_depth_index = depth_index * 3;
+                                auto r = textured_depth_data[textured_depth_index];
+                                auto g = textured_depth_data[textured_depth_index + 1];
+                                auto b = textured_depth_data[textured_depth_index + 2];
+                                rgb_per_distance_vec.push_back({ length,{ r, g, b } });
+                            }
+                        }
+                    }
+
+                    _last_rgb_per_distance_vec = rgb_per_distance_vec;
+                }
+                else
+                {
+                    rgb_per_distance_vec = _last_rgb_per_distance_vec;
+                }
+
+                draw_color_ruler(mouse, streams[stream], stream_rect, rgb_per_distance_vec, depth_max_distance, depth_units);
+            }
         }
 
         // Metadata overlay windows shall be drawn after textures to preserve z-buffer functionality

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -121,6 +121,7 @@ namespace rs2
         static const textual_icon plus_circle              { u8"\uf055" };
         static const textual_icon download                 { u8"\uf019" };
         static const textual_icon upload                   { u8"\uf093" };
+        static const textual_icon bar_chart                { u8"\uf080" };
     }
 
     class subdevice_model;
@@ -432,6 +433,7 @@ namespace rs2
         rect _normalized_zoom{0, 0, 1, 1};
         int color_map_idx = 1;
         bool show_stream_details = false;
+        rect curr_info_rect{};
         temporal_event _stream_not_alive;
     };
 
@@ -838,6 +840,7 @@ namespace rs2
         bool is_output_collapsed = false;
         bool is_3d_view = false;
         bool paused = false;
+        bool show_map_ruler = true;
 
 
         void draw_viewport(const rect& viewer_rect, ux_window& window, int devices, std::string& error_message, texture_buffer* texture, rs2::points  f = rs2::points());
@@ -860,12 +863,26 @@ namespace rs2
 
         rs2::asynchronous_syncer s;
     private:
+        struct rgb {
+            uint32_t r, g, b;
+        };
+
+        struct rgb_per_distance {
+            float depth_val;
+            rgb rgb_val;
+        };
 
         friend class post_processing_filters;
         std::map<int, rect> get_interpolated_layout(const std::map<int, rect>& l);
         void show_icon(ImFont* font_18, const char* label_str, const char* text, int x, int y,
                        int id, const ImVec4& color, const std::string& tooltip = "");
+        void draw_color_ruler(const mouse_info& mouse,
+                              const stream_model& s_model,
+                              const rect& stream_rect,
+                              std::vector<rgb_per_distance> rgb_per_distance_vec,
+                              double ruler_length, const std::string& ruler_units);
 
+        std::vector<rgb_per_distance> _last_rgb_per_distance_vec;
         streams_layout _layout;
         streams_layout _old_layout;
         std::chrono::high_resolution_clock::time_point _transition_start_time;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -435,6 +435,8 @@ namespace rs2
         bool show_stream_details = false;
         rect curr_info_rect{};
         temporal_event _stream_not_alive;
+        bool show_map_ruler = true;
+        std::vector<float> _depth_max_distances;
     };
 
     std::pair<std::string, std::string> get_device_name(const device& dev);
@@ -840,7 +842,6 @@ namespace rs2
         bool is_output_collapsed = false;
         bool is_3d_view = false;
         bool paused = false;
-        bool show_map_ruler = true;
 
 
         void draw_viewport(const rect& viewer_rect, ux_window& window, int devices, std::string& error_message, texture_buffer* texture, rs2::points  f = rs2::points());
@@ -880,8 +881,9 @@ namespace rs2
                               const stream_model& s_model,
                               const rect& stream_rect,
                               std::vector<rgb_per_distance> rgb_per_distance_vec,
-                              double ruler_length, const std::string& ruler_units);
+                              const std::string& ruler_units);
 
+        float _last_avg_distance = 0;
         std::vector<rgb_per_distance> _last_rgb_per_distance_vec;
         streams_layout _layout;
         streams_layout _old_layout;

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -481,6 +481,14 @@ namespace rs2
         float x, y;
         float w, h;
 
+        void operator=(const rect& other)
+        {
+            x = other.x;
+            y = other.y;
+            w = other.w;
+            h = other.h;
+        }
+
         operator bool() const
         {
             return w*w > 0 && h*h > 0;
@@ -972,6 +980,8 @@ namespace rs2
         mutable rs2::frame last[2];
     public:
         std::shared_ptr<colorizer> colorize;
+        bool zoom_preview = false;
+        rect curr_preview_rect{};
 
         texture_buffer(const texture_buffer& other)
         {
@@ -1476,7 +1486,7 @@ namespace rs2
             glDisable(GL_BLEND);
         }
 
-        void show_preview(const rect& r, const rect& normalized_zoom = rect{0, 0, 1, 1}) const
+        void show_preview(const rect& r, const rect& normalized_zoom = rect{0, 0, 1, 1})
         {
             glBindTexture(GL_TEXTURE_2D, texture);
             glEnable(GL_TEXTURE_2D);
@@ -1490,7 +1500,15 @@ namespace rs2
             rect zoomed_rect = normalized_zoom.unnormalize(r);
 
             if (r != zoomed_rect)
+            {
                 draw_texture(unit_square_coordinates, thumbnail);
+                curr_preview_rect = thumbnail;
+                zoom_preview = true;
+            }
+            else
+            {
+                zoom_preview = false;
+            }
 
             glDisable(GL_TEXTURE_2D);
             glBindTexture(GL_TEXTURE_2D, 0);

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -1502,6 +1502,18 @@ namespace rs2
             if (r != zoomed_rect)
             {
                 draw_texture(unit_square_coordinates, thumbnail);
+
+                // Draw thumbnail border
+                static const auto top_line_offset = 0.5f;
+                static const auto right_line_offset = top_line_offset / 2;
+                glColor3f(0.0, 0.0, 0.0);
+                glBegin(GL_LINE_LOOP);
+                glVertex2f(thumbnail.x - top_line_offset, thumbnail.y - top_line_offset);
+                glVertex2f(thumbnail.x + thumbnail.w + right_line_offset / 2, thumbnail.y - top_line_offset);
+                glVertex2f(thumbnail.x + thumbnail.w + right_line_offset / 2, thumbnail.y + thumbnail.h + top_line_offset);
+                glVertex2f(thumbnail.x - top_line_offset, thumbnail.y + thumbnail.h + top_line_offset);
+                glEnd();
+
                 curr_preview_rect = thumbnail;
                 zoom_preview = true;
             }


### PR DESCRIPTION
The map scaling ruler is displayed by default in the right side of depth streaming window and it could be easily hidden by clicking on the bar chart icon (red circled).
![color_map_ruler](https://user-images.githubusercontent.com/17433152/35217853-5b62249c-ff75-11e7-822f-aedeacc8cbfd.png)

