### PR TITLE
Fixing several issues regarding depth scale ruler length, default resolution and default format

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -436,7 +436,6 @@ namespace rs2
         rect curr_info_rect{};
         temporal_event _stream_not_alive;
         bool show_map_ruler = true;
-        std::vector<float> _depth_max_distances;
     };
 
     std::pair<std::string, std::string> get_device_name(const device& dev);
@@ -881,10 +880,10 @@ namespace rs2
                               const stream_model& s_model,
                               const rect& stream_rect,
                               std::vector<rgb_per_distance> rgb_per_distance_vec,
+                              float ruler_length,
                               const std::string& ruler_units);
+        float calculate_ruler_max_distance(const std::vector<float>& distances) const;
 
-        float _last_avg_distance = 0;
-        std::vector<rgb_per_distance> _last_rgb_per_distance_vec;
         streams_layout _layout;
         streams_layout _old_layout;
         std::chrono::high_resolution_clock::time_point _transition_start_time;

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -18,6 +18,7 @@
 #include "ds5-timestamp.h"
 #include "stream.h"
 #include "environment.h"
+#include "ds5-color.h"
 
 namespace librealsense
 {
@@ -121,10 +122,22 @@ namespace librealsense
                 if (video->get_width() == 1280 && video->get_height() == 720 && video->get_format() == RS2_FORMAT_Z16 && video->get_framerate() == 30)
                     video->make_default();
 
-                if (video->get_width() == 1280 && video->get_height() == 720
+                auto color_dev = dynamic_cast<const ds5_color*>(&get_device());
+                if (color_dev)
+                {
+                    if (video->get_width() == 1280 && video->get_height() == 720
+                        && p->get_stream_type() == RS2_STREAM_INFRARED
+                        && video->get_format() == RS2_FORMAT_Y8 && video->get_framerate() == 30
+                        && p->get_stream_index() == 1)
+                        video->make_default();
+                }
+                else
+                {
+                    if (video->get_width() == 1280 && video->get_height() == 720
                         && p->get_stream_type() == RS2_STREAM_INFRARED
                         && video->get_format() == RS2_FORMAT_RGB8 && video->get_framerate() == 30)
-                    video->make_default();
+                        video->make_default();
+                }
 
                 // Register intrinsics
                 if (p->get_format() != RS2_FORMAT_Y16) // Y16 format indicate unrectified images, no intrinsics are available for these


### PR DESCRIPTION
Depth Scale Ruler:
1. Change the way of calculating the max ruler length (see calculate_ruler_max_distance(...) method).
2. Fix the assertion issue

Default Format and Resolution:
1. Use default stream format as the selected format in the model-view list box.
2. Default format of Infra-Red stream at D400 devices that has RGB sensor is now Y8 instead of RGB8.
3. The default resolution in the model-view resolutions list is now HD.