### PR TITLE
Align refactoring

### DIFF
--- a/src/core/processing.h
+++ b/src/core/processing.h
@@ -47,4 +47,20 @@ namespace librealsense
 
         virtual ~processing_block_interface() = default;
     };
+
+    template<class T>
+    class internal_frame_processor_callback : public rs2_frame_processor_callback
+    {
+        T on_frame_function;
+    public:
+        explicit internal_frame_processor_callback(T on_frame) : on_frame_function(on_frame) {}
+
+        void on_frame(rs2_frame * f, rs2_source * source) override
+        {
+            frame_holder front((frame_interface*)f);
+            on_frame_function(std::move(front), source->source);
+        }
+
+        void release() override { delete this; }
+    };
 }

--- a/src/proc/align.h
+++ b/src/proc/align.h
@@ -16,18 +16,7 @@ namespace librealsense
         align(rs2_stream align_to);
 
     private:
-        static void update_frame_info(const frame_interface* frame, optional_value<rs2_intrinsics>& intrin, std::shared_ptr<stream_profile_interface>& profile, bool register_extrin);
-        void update_align_info(const frame_interface* depth_frame);
-
-        std::mutex _mutex;
-        optional_value<rs2_intrinsics> _from_intrinsics;
-        optional_value<rs2_intrinsics> _to_intrinsics;
-        optional_value<rs2_extrinsics> _extrinsics;
-        optional_value<float> _depth_units;
-        optional_value<int> _from_bytes_per_pixel;
-        optional_value<rs2_stream> _from_stream_type;
+        void on_frame(frame_holder frameset, librealsense::synthetic_source_interface* source);
         rs2_stream _to_stream_type;
-        std::shared_ptr<stream_profile_interface> _from_stream_profile;
-        std::shared_ptr<stream_profile_interface> _to_stream_profile;
     };
 }

--- a/src/sync.h
+++ b/src/sync.h
@@ -16,22 +16,6 @@ namespace librealsense
 
     typedef int stream_id;
 
-    template<class T>
-    class internal_frame_processor_callback : public rs2_frame_processor_callback
-    {
-        T on_frame_function;
-    public:
-        explicit internal_frame_processor_callback(T on_frame) : on_frame_function(on_frame) {}
-
-        void on_frame(rs2_frame * f, rs2_source * source) override
-        {
-            frame_holder front((frame_interface*)f);
-            on_frame_function(std::move(front), source->source);
-        }
-
-        void release() override { delete this; }
-    };
-
     class sync_lock
     {
     public:

--- a/src/types.h
+++ b/src/types.h
@@ -756,22 +756,6 @@ namespace librealsense
     };
 
     template<class T>
-    class internal_frame_processor_callback : public rs2_frame_processor_callback
-    {
-        T on_frame_function;
-    public:
-        explicit internal_frame_processor_callback(T on_frame) : on_frame_function(on_frame) {}
-
-        void on_frame(rs2_frame * f, rs2_source * source) override
-        {
-            frame_holder front((frame_interface*)f);
-            on_frame_function(std::move(front), source->source);
-        }
-
-        void release() override { delete this; }
-    };
-
-    template<class T>
     class internal_frame_callback : public rs2_frame_callback
     {
         T on_frame_function; //Callable of type: void(frame_interface* frame)

--- a/src/types.h
+++ b/src/types.h
@@ -756,6 +756,22 @@ namespace librealsense
     };
 
     template<class T>
+    class internal_frame_processor_callback : public rs2_frame_processor_callback
+    {
+        T on_frame_function;
+    public:
+        explicit internal_frame_processor_callback(T on_frame) : on_frame_function(on_frame) {}
+
+        void on_frame(rs2_frame * f, rs2_source * source) override
+        {
+            frame_holder front((frame_interface*)f);
+            on_frame_function(std::move(front), source->source);
+        }
+
+        void release() override { delete this; }
+    };
+
+    template<class T>
     class internal_frame_callback : public rs2_frame_callback
     {
         T on_frame_function; //Callable of type: void(frame_interface* frame)


### PR DESCRIPTION
Refactored align processing block.
1. Fixed stream-to-depth alignment 
    * Using depth deprojection to "reverse" map each frame, instead of previous method of reversing the transformation
2.  Added support for multiple-streams-to-depth alignment.
    * E.g. passing Color+Infrared+Depth to align when aligning **to depth** will return a frameset of 3 images where both Color and Ingrared frames are aligned to depth

### Depth to Color:
![image](https://user-images.githubusercontent.com/22654243/35339371-169887d8-0129-11e8-84ac-538f56353b94.png)

### Color to Depth:
![image](https://user-images.githubusercontent.com/22654243/35339542-87868936-0129-11e8-9753-5dd34313394c.png)

#### Technical changes
1. Made align object stateless (up to which stream to align against).
    * Intrinsics / extrinsics / etc.. are fetched per frame (non-noticeable performance impact)
2. Moved `internal_frame_processor_callback` to `types.h` to make it common (and used it in align).