### PR TITLE
-Wformat-security

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,7 +560,7 @@ if(UNIX)
 
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_BSD_SOURCE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pedantic -g -Wno-missing-field-initializers")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar -Wsequence-point")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar -Wsequence-point -Wformat-security")
 
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_VARIABLE MACHINE)
     if(${MACHINE} MATCHES "arm-linux-gnueabihf")

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3277,7 +3277,7 @@ namespace rs2
             auto relative_mouse_y = ImGui::GetMousePos().y - top_y_ruler;
             auto y = (bottom_y_ruler - top_y_ruler) - relative_mouse_y;
             ss << std::fixed << std::setprecision(2) << (y / ratio) << ruler_units;
-            ImGui::SetTooltip(ss.str().c_str());
+            ImGui::SetTooltip("%s", ss.str().c_str());
             colored_ruler_opac = 1.f;
             numbered_ruler_background_opac = hovered_numbered_ruler_opac;
         }
@@ -3297,7 +3297,7 @@ namespace rs2
         static const float x_ruler_val = 4.0f;
         ImGui::SetCursorPos({ x_ruler_val, y_ruler_val });
         const auto font_size = ImGui::GetFontSize();
-        ImGui::Text(std::to_string(static_cast<int>(ruler_length)).c_str());
+        ImGui::TextUnformatted(std::to_string(static_cast<int>(ruler_length)).c_str());
         const auto skip_numbers = ((ruler_length / 10.f) - 1.f);
         auto to_skip = (skip_numbers < 0.f)?0.f: skip_numbers;
         for (int i = ruler_length - 1; i > 0; --i)
@@ -3307,7 +3307,7 @@ namespace rs2
             if (((to_skip--) > 0))
                 continue;
 
-            ImGui::Text(std::to_string(i).c_str());
+            ImGui::TextUnformatted(std::to_string(i).c_str());
             to_skip = skip_numbers;
         }
         y_ruler_val += ((bottom_y_ruler - top_y_ruler) / ruler_length);


### PR DESCRIPTION
As mentioned in PR #915 , to prevent potential security issues, fixed warnings and added the the flag to CMake.