### PR TITLE
Remove 0.5 pixel offset in UV-mapping

### DIFF
--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -33,7 +33,7 @@ namespace librealsense
 
     float3 transform(const rs2_extrinsics *extrin, const float3 &point) { float3 p = {}; rs2_transform_point_to_point(&p.x, extrin, &point.x); return p; }
     float2 project(const rs2_intrinsics *intrin, const float3 & point) { float2 pixel = {}; rs2_project_point_to_pixel(&pixel.x, intrin, &point.x); return pixel; }
-    float2 pixel_to_texcoord(const rs2_intrinsics *intrin, const float2 & pixel) { return{ (pixel.x + 0.5f) / intrin->width, (pixel.y + 0.5f) / intrin->height }; }
+    float2 pixel_to_texcoord(const rs2_intrinsics *intrin, const float2 & pixel) { return{ pixel.x / intrin->width, pixel.y / intrin->height }; }
     float2 project_to_texcoord(const rs2_intrinsics *intrin, const float3 & point) { return pixel_to_texcoord(intrin, project(intrin, point)); }
 
      bool pointcloud::stream_changed( stream_profile_interface* old, stream_profile_interface* curr)


### PR DESCRIPTION
Undo 0.5 pixel offset when mapping pixel to texture coordinate
Tracked On: DSO-8308

Change-Id: Id43db35b3b1fba284582a1f43cbceec181265ce6
(cherry picked from commit f657787eb1e8b05d6f7081a6d234d17c83e84cce)