### PR TITLE
Fixing signature for rs2_set_devices_changed_callback

### DIFF
--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -44,7 +44,7 @@ void rs2_set_devices_changed_callback_cpp(rs2_context* context, rs2_devices_chan
 * \param[in] callback function pointer to register as per-notifications callback
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
-void rs2_set_devices_changed_callback(rs2_context* context, rs2_devices_changed_callback_ptr callback, rs2_error** error);
+void rs2_set_devices_changed_callback(const rs2_context* context, rs2_devices_changed_callback_ptr callback, void* user, rs2_error** error);
 
 /**
  * Create a new device and add it to the context

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -4302,3 +4302,9 @@ ADD_ENUM_TEST_CASE(rs2_extension, RS2_EXTENSION_COUNT)
 ADD_ENUM_TEST_CASE(rs2_frame_metadata_value, RS2_FRAME_METADATA_COUNT)
 ADD_ENUM_TEST_CASE(rs2_rs400_visual_preset, RS2_RS400_VISUAL_PRESET_COUNT)
 
+void dev_changed(rs2_device_list* removed_devs, rs2_device_list* added_devs, void* ptr) {};
+TEST_CASE("C API Compilation", "[live]") {
+    rs2_error* e;
+    REQUIRE_NOTHROW(rs2_set_devices_changed_callback(NULL, dev_changed, NULL, &e));
+    REQUIRE(e != nullptr);
+}


### PR DESCRIPTION
Addressing issue #1082 , fixing linker issue when compiling usage of `rs2_set_devices_changed_callback`