### PR TITLE
Added backend timestamp to metadata fields.

### DIFF
--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -37,6 +37,7 @@ typedef enum rs2_frame_metadata_value
     RS2_FRAME_METADATA_WHITE_BALANCE        , /**< White Balance setting as a color temperature. Kelvin degrees*/
     RS2_FRAME_METADATA_TIME_OF_ARRIVAL      , /**< Time of arrival in system clock */
     RS2_FRAME_METADATA_TEMPERATURE          , /**< Temperature of the device, measured at the time of the frame capture. Celsius degrees */
+    RS2_FRAME_METADATA_BACKEND_TIMESTAMP    , /**< Timestamp get from uvc driver. usec*/
     RS2_FRAME_METADATA_COUNT
 } rs2_frame_metadata_value;
 const char* rs2_frame_metadata_to_string(rs2_frame_metadata_value metadata);

--- a/src/archive.h
+++ b/src/archive.h
@@ -27,14 +27,16 @@ struct frame_additional_data
     uint32_t        metadata_size = 0;
     bool            fisheye_ae_mode = false;
     std::array<uint8_t,MAX_META_DATA_SIZE> metadata_blob;
+    rs2_time_t      backend_timestamp = 0;
 
     frame_additional_data() {};
 
-    frame_additional_data(double in_timestamp, unsigned long long in_frame_number, double in_system_time, uint8_t md_size, const uint8_t* md_buf)
+    frame_additional_data(double in_timestamp, unsigned long long in_frame_number, double in_system_time, uint8_t md_size, const uint8_t* md_buf, double backend_time )
         : timestamp(in_timestamp),
           frame_number(in_frame_number),
           system_time(in_system_time),
-          metadata_size(md_size)
+          metadata_size(md_size),
+          backend_timestamp(backend_time)
     {
         // Copy up to 255 bytes to preserve metadata as raw data
         if (metadata_size)

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -12,10 +12,16 @@
 #endif
 
 #include "backend.h"
-
 void librealsense::platform::control_range::populate_raw_data(std::vector<uint8_t>& vec, int32_t value)
 {
     vec.resize(sizeof(value));
     auto data = reinterpret_cast<const uint8_t*>(&value);
     std::copy(data, data + sizeof(value), vec.data());
+}
+
+double librealsense::monotonic_to_realtime(double monotonic)
+{
+    auto realtime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    auto time_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+    return monotonic + (realtime - time_since_epoch);
 }

--- a/src/backend.h
+++ b/src/backend.h
@@ -170,6 +170,8 @@ namespace librealsense
             uint8_t         metadata_size;
             const void *    pixels;
             const void *    metadata;
+            rs2_time_t      backend_time;
+
         };
 
         typedef std::function<void(stream_profile, frame_object, std::function<void()>)> frame_callback;

--- a/src/backend.h
+++ b/src/backend.h
@@ -852,6 +852,8 @@ namespace librealsense
             virtual ~device_watcher() {};
         };
     }
+
+    double monotonic_to_realtime(double monotonic);
 }
 
 #endif

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -43,8 +43,6 @@
 
 #include <sys/signalfd.h>
 #include <signal.h>
-#include <time.h>
-#include "environment.h"
 #pragma GCC diagnostic ignored "-Woverflow"
 
 const size_t MAX_DEV_PARENT_DIR = 10;
@@ -52,7 +50,7 @@ const size_t MAX_DEV_PARENT_DIR = 10;
 
 #ifdef ANDROID
 
-//#include <sys/sysmacros.h> // minor(...), major(...)
+#include <sys/sysmacros.h> // minor(...), major(...)
 
 // https://android.googlesource.com/platform/bionic/+/master/libc/include/bits/lockf.h
 #define F_ULOCK 0
@@ -712,18 +710,6 @@ namespace librealsense
             }
         }
 
-        double monotonic_to_realtime(double monotonic)
-        {
-            auto realtime = environment::get_instance().get_time_service()->get_time();
-            timespec  vsTime;
-
-            clock_gettime(CLOCK_MONOTONIC, &vsTime);
-
-            long uptime_ms = vsTime.tv_sec* 1000 + (long)round( vsTime.tv_nsec/ 1000000.0);
-            auto diff = realtime - uptime_ms;
-
-            return monotonic + diff;
-        }
 
         void v4l_uvc_device::poll()
         {

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -404,7 +404,6 @@ namespace librealsense
                     // Determine the timestamp for this frame
                     auto timestamp = timestamp_reader->get_frame_timestamp(mode, f);
                     auto timestamp_domain = timestamp_reader->get_frame_timestamp_domain(mode, f);
-
                     auto frame_counter = timestamp_reader->get_frame_counter(mode, f);
 
                     auto requires_processing = mode.requires_processing();
@@ -439,7 +438,8 @@ namespace librealsense
                             frame_counter,
                             system_time,
                             static_cast<uint8_t>(f.metadata_size),
-                            (const uint8_t*)f.metadata);
+                            (const uint8_t*)f.metadata,
+                            f.backend_time);
 
                         frame_holder frame = _source.alloc_frame(stream_to_frame_types(output.first.type), width * height * bpp / 8, additional_data, requires_processing);
                         if (frame.frame)
@@ -1004,5 +1004,6 @@ namespace librealsense
           _user_count(0),
           _timestamp_reader(std::move(timestamp_reader))
     {
+        register_metadata(RS2_FRAME_METADATA_BACKEND_TIMESTAMP,     make_additional_data_parser(&frame_additional_data::backend_timestamp));
     }
 }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -388,13 +388,12 @@ namespace librealsense
                 [this, mode, timestamp_reader, requests](platform::stream_profile p, platform::frame_object f, std::function<void()> continuation) mutable
                 {
                     auto system_time = environment::get_instance().get_time_service()->get_time();
-
                     if (!this->is_streaming())
                     {
                         LOG_WARNING("Frame received with streaming inactive,"
                             << librealsense::get_string(mode.unpacker->outputs.front().first.type)
                             << mode.unpacker->outputs.front().first.index
-                                << ", Arrived," << std::fixed << system_time);
+                                << ", Arrived," << std::fixed << f.backend_time << " " << system_time);
                         return;
                     }
 
@@ -419,7 +418,7 @@ namespace librealsense
                     {
                         LOG_DEBUG("FrameAccepted," << librealsense::get_string(output.first.type) << "," << std::dec << frame_counter
                             << output.first.index << "," << frame_counter
-                            << ",Arrived," << std::fixed << system_time
+                            << ",Arrived," << std::fixed << f.backend_time << " " << std::fixed << system_time<<" diff - "<< system_time- f.backend_time << " "
                             << ",TS," << std::fixed << timestamp << ",TS_Domain," << rs2_timestamp_domain_to_string(timestamp_domain));
 
                         std::shared_ptr<stream_profile_interface> request = nullptr;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -340,6 +340,7 @@ namespace librealsense
                 CASE(WHITE_BALANCE)
                 CASE(TIME_OF_ARRIVAL)
                 CASE(TEMPERATURE)
+                CASE(BACKEND_TIMESTAMP)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/src/win/win-uvc.cpp
+++ b/src/win/win-uvc.cpp
@@ -169,10 +169,11 @@ namespace librealsense
             return count;
         }
 
+       
         STDMETHODIMP source_reader_callback::OnReadSample(HRESULT hrStatus,
             DWORD dwStreamIndex,
             DWORD /*dwStreamFlags*/,
-            LONGLONG /*llTimestamp*/,
+            LONGLONG llTimestamp,
             IMFSample *sample)
         {
             auto owner = _owner.lock();
@@ -205,7 +206,7 @@ namespace librealsense
                                 auto& stream = owner->_streams[dwStreamIndex];
                                 std::lock_guard<std::mutex> lock(owner->_streams_mutex);
                                 auto profile = stream.profile;
-                                frame_object f{ current_length, metadata_size, byte_buffer, metadata };
+                                frame_object f{ current_length, metadata_size, byte_buffer, metadata, monotonic_to_realtime(llTimestamp/10000) };
 
                                 auto continuation = [buffer, this]()
                                 {


### PR DESCRIPTION
Added the timestamp of frame that gets by the v4l and media foundation backends.
This is the time that the frame started to transfer to driver, its can be used to measure the delay between the start of the arriving of frame and the time until the frame arrived to librealsense.
The timestamp arrived from v4l and mf is in monotonic clock so there was need to convert it to realtime  for consistently with the other timestamps. 