### PR TITLE
Align in .NET bug fix

### DIFF
--- a/wrappers/csharp/src/Processing.cs
+++ b/wrappers/csharp/src/Processing.cs
@@ -95,6 +95,7 @@ namespace Intel.RealSense
         public FrameSet Process(FrameSet original)
         {
             object error;
+            NativeMethods.rs2_frame_add_ref(original.m_instance.Handle, out error);
             NativeMethods.rs2_process_frame(m_instance.Handle, original.m_instance.Handle, out error);
             return queue.WaitForFrames();
         }


### PR DESCRIPTION
Addressing issue #1013.

Fixing bug when using `Align` in .NET wrapper, which caused an exception after about 10 frames.
Reference count of underlying `frameset` required acquiring a new reference prior to call to `process_frame`