### PR TITLE
Occlusion filter for Pointcloud from RGB and Depth streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ set(REALSENSE_CPP
     src/proc/align.cpp
     src/proc/colorizer.cpp
     src/proc/pointcloud.cpp
+    src/proc/occlusion-filter.cpp
     src/proc/synthetic-stream.cpp
     src/proc/syncer-processing-block.cpp
     src/proc/decimation-filter.cpp
@@ -222,6 +223,7 @@ set(REALSENSE_HPP
     src/proc/align.h
     src/proc/colorizer.h
     src/proc/pointcloud.h
+    src/proc/occlusion-filter.h
     src/proc/synthetic-stream.h
     src/proc/decimation-filter.h
     src/proc/spatial-filter.h
@@ -446,6 +448,7 @@ if(WIN32)
         src/proc/synthetic-stream.cpp
         src/proc/align.cpp
         src/proc/pointcloud.cpp
+        src/proc/occlusion-filter.cpp
         src/proc/decimation-filter.cpp
         src/proc/spatial-filter.cpp
         src/proc/temporal-filter.cpp
@@ -457,6 +460,7 @@ if(WIN32)
         src/proc/colorizer.h
         src/proc/align.h
         src/proc/pointcloud.h
+        src/proc/occlusion-filter.h
         src/proc/synthetic-stream.h
         src/proc/decimation-filter.h
         src/proc/spatial-filter.h

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -349,7 +349,7 @@ namespace rs2
         {
             auto desc = endpoint->get_option_description(opt);
 
-            // remain optionto append to the current line
+            // remain option to append to the current line
             if (!new_line)
                 ImGui::SameLine();
 
@@ -624,8 +624,6 @@ namespace rs2
             auto opt = static_cast<rs2_option>(i);
 
             std::stringstream ss;
-            /*ss << "##" << dev.get_info(RS2_CAMERA_INFO_NAME)
-                << "/" << s.get_info(RS2_CAMERA_INFO_NAME)*/
             ss << opt_base_label << "/" << rs2_option_to_string(opt);
             metadata.id = ss.str();
             metadata.opt = opt;
@@ -672,7 +670,6 @@ namespace rs2
     }
 
     subdevice_model::subdevice_model(
-        viewer_model& viewer,
         device& dev,
         std::shared_ptr<sensor> s, std::string& error_message)
         : s(s), dev(dev), ui(), last_valid_ui(),
@@ -759,14 +756,6 @@ namespace rs2
                 // the block will be internally available, but removed from UI
                 //post_processing.push_back(disparity_to_depth);
             }
-        }
-        else
-        {
-            temporal_filter = std::make_shared<processing_block_model>(
-                this, "Temporal Filter", viewer.ppf.get_pc(),
-                [&viewer](rs2::frame f) { return viewer.ppf.get_pc()->calculate(f); }, error_message);
-            temporal_filter->enabled = true;
-            post_processing.push_back(temporal_filter);
         }
 
         std::stringstream ss;
@@ -1353,12 +1342,12 @@ namespace rs2
             }
         }
     }
-    
+
     uint64_t subdevice_model::num_supported_non_default_options() const
     {
         return (uint64_t)std::count_if(
-            std::begin(options_metadata), 
-            std::end(options_metadata), 
+            std::begin(options_metadata),
+            std::end(options_metadata),
             [](const std::pair<int, option_model>& p) {return p.second.supported && p.second.opt != RS2_OPTION_FRAMES_QUEUE_SIZE; });
     }
 
@@ -1929,7 +1918,7 @@ namespace rs2
             if (s.second.is_stream_visible() &&
                 s.second.profile.stream_type() == RS2_STREAM_POSE)
             {
-                render_pose = true;                
+                render_pose = true;
             }
         }
         if (render_pose)
@@ -1944,19 +1933,19 @@ namespace rs2
 
             // Draw selection buttons on the pose header
             ImGui::SetCursorPos({ stream_rect.w - 32 * num_of_pose_buttons - 5, 0 });
-            
+
             // Draw camera object button
             if (ImGui::Button(tm2.camera_object_button.get_icon().c_str(), { 24, top_bar_height }))
             {
                 tm2.camera_object_button.toggle_button();
-            }            
+            }
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("%s", tm2.camera_object_button.get_tooltip().c_str());
 
-            // Draw trajectory button            
+            // Draw trajectory button
             ImGui::SameLine();
             bool color_icon = tm2.trajectory_button.is_pressed(); //draw trajectory is on - color the icon
-            if (color_icon) 
+            if (color_icon)
             {
                 ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
                 ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, light_blue);
@@ -1968,7 +1957,7 @@ namespace rs2
             if (color_icon)
             {
                 ImGui::PopStyleColor(2);
-            }            
+            }
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("%s", tm2.trajectory_button.get_tooltip().c_str());
 
@@ -1993,7 +1982,7 @@ namespace rs2
 
             ImGui::End();
         }
-        
+
         ImGui::PopStyleColor(6);
         ImGui::PopStyleVar();
 
@@ -2006,7 +1995,7 @@ namespace rs2
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, header_window_bg);
         ImGui::PushStyleColor(ImGuiCol_ButtonActive, header_window_bg);
         ImGui::PushStyleColor(ImGuiCol_WindowBg, dark_sensor_bg);
-        
+
         ImGui::SetNextWindowPos({ stream_rect.x + stream_rect.w - 265, stream_rect.y + total_top_bar_height + 5 });
         ImGui::SetNextWindowSize({ 260, 65 });
         ImGui::Begin("3D Info box", nullptr, flags);
@@ -2432,11 +2421,12 @@ namespace rs2
                 }
             }
 
+            // Render pixel coordinate with magenta color to improve text readability
             label = ss.str();
             ImGui::PushStyleColor(ImGuiCol_Text, { 0.8f, 0.f, 0.8f, 1.f });
             ImGui::Text("%s", label.c_str());
             ImGui::PopStyleColor();
-            
+
         }
 
         ImGui::End();
@@ -2643,7 +2633,7 @@ namespace rs2
     {
         for (auto&& sub : dev.query_sensors())
         {
-            auto model = std::make_shared<subdevice_model>(viewer, dev, std::make_shared<sensor>(sub), error_message);
+            auto model = std::make_shared<subdevice_model>(dev, std::make_shared<sensor>(sub), error_message);
             subdevices.push_back(model);
         }
 
@@ -3618,12 +3608,12 @@ namespace rs2
                 auto pose = f.as<pose_frame>();
                 if (!pose)
                     continue;
-                
+
                 rs2_pose pose_data = pose.get_pose_data();
                 matrix4 pose_trans = tm2_pose_to_world_transformation(pose_data);
                 float model[16];
                 pose_trans.to_column_major(model);
-                
+
                 // set the pose transformation as the model matrix to draw the axis
                 glMatrixMode(GL_MODELVIEW);
                 glPushMatrix();
@@ -4221,7 +4211,7 @@ namespace rs2
             available_controllers.clear();
             return;
         }
-        
+
         if (controllers.size() > 0 || available_controllers.size() > 0)
         {
             int flags = dev.is<playback>() ? ImGuiButtonFlags_Disabled : 0;
@@ -4681,7 +4671,7 @@ namespace rs2
                 rs2_stream stream_type = p.stream_type();
                 std::string stream_format_key = to_string() << "stream-" << to_lower(rs2_stream_to_string(stream_type)) << "-format";
                 std::string stream_format_value = rs2_format_to_string(p.format());
-                
+
                 if (stream_type == RS2_STREAM_DEPTH)
                 {
                     stream_format_key = "stream-depth-format";
@@ -4794,8 +4784,8 @@ namespace rs2
             }
             //Disable every stream
             for (auto&& sub : subdevices)
-                for (auto& s : sub->stream_enabled) 
-                    s.second = false; 
+                for (auto& s : sub->stream_enabled)
+                    s.second = false;
         }
 
         for (auto&& kvp : requrested_streams)
@@ -4888,7 +4878,7 @@ namespace rs2
                 advanced.load_json(str);
                 for (auto&& sub : subdevices)
                 {
-                    //If json was loaded correctly, we want the presets combo box to show the name of the configuration file 
+                    //If json was loaded correctly, we want the presets combo box to show the name of the configuration file
                     // And as a workaround, set the current preset to "custom", so that if the file is removed the preset will show "custom"
                     if (auto dpt = sub->s->as<depth_sensor>())
                     {
@@ -4900,7 +4890,6 @@ namespace rs2
                         }
                     }
                 }
-                
             }
             load_viewer_configurations(str);
             get_curr_advanced_controls = true;
@@ -4985,8 +4974,6 @@ namespace rs2
                         i++;
                     }
                     std::transform(files_labels.begin(), files_labels.end(), std::back_inserter(labels), [](const std::string& s) { return s.c_str(); });
-                    
-                    ///////////////////////////////////////////
 
                     try
                     {
@@ -5161,7 +5148,7 @@ namespace rs2
         ImGui::PushFont(window.get_large_font());
         ImGui::PushStyleColor(ImGuiCol_Button, device_header_background_color);
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, device_header_background_color);
-        
+
         ////////////////////////////////////////
         // Draw device name
         ////////////////////////////////////////
@@ -5262,9 +5249,9 @@ namespace rs2
             return sm->streaming;
         });
         draw_controllers_panel(window.get_font(), is_streaming);
-        
+
         pos = ImGui::GetCursorPos();
-        
+
         int info_control_panel_height = 0;
         if (show_device_info)
         {
@@ -5471,7 +5458,7 @@ namespace rs2
                             if (opt == RS2_OPTION_FRAMES_QUEUE_SIZE) continue;
                             if (std::find(drawing_order.begin(), drawing_order.end(), opt) == drawing_order.end())
                             {
-                                if (dev.is<advanced_mode>() && opt == RS2_OPTION_VISUAL_PRESET) 
+                                if (dev.is<advanced_mode>() && opt == RS2_OPTION_VISUAL_PRESET)
                                     continue;
                                 if (sub->draw_option(opt, dev.is<playback>() || update_read_only_options, error_message, viewer.not_model))
                                 {
@@ -6097,9 +6084,9 @@ namespace rs2
         else //draw axis
         {
             texture_buffer::draw_axis(0.1f, 1.f);
-        }        
+        }
     }
-    
+
     void tm2_model::draw_trajectory(tracked_point& p)
     {
         if (!trajectory_button.is_pressed())
@@ -6167,7 +6154,7 @@ namespace rs2
             }
         }
     }
-    
+
     void tm2_model::draw_boundary(tracked_point& p)
     {
         if (!boundary_button.is_pressed())
@@ -6179,7 +6166,7 @@ namespace rs2
                 boundary.clear();
             }
             return;
-        }       
+        }
 
         // if new boundary - grab from trajectory
         if (boundary.size() == 0)
@@ -6190,8 +6177,8 @@ namespace rs2
             {
                 // project the trajectory on XZ plane - ignore y coordinate of the point
                 float2 p{ v.first.x, v.first.z };
-                trajectory_projection.push_back(p);                
-            }            
+                trajectory_projection.push_back(p);
+            }
             boundary = simplify_line(trajectory_projection);
         }
         // check if there is any boundary to render
@@ -6224,7 +6211,7 @@ namespace rs2
             }
             glVertex3f(boundary[0].x, height, boundary[0].y);
             glEnd();
-        }        
+        }
 
         // draw vertical lines along the boundary
         glLineWidth(1.0f);
@@ -6234,10 +6221,7 @@ namespace rs2
         {
             glVertex3f(v.x, -1.0f, v.y);
             glVertex3f(v.x, 1.0f, v.y);
-        }        
+        }
         glEnd();
     }
-      
-
-
 }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2383,17 +2383,6 @@ namespace rs2
 
     void stream_model::show_stream_footer(const rect &stream_rect, const  mouse_info& mouse)
     {
-        auto flags = ImGuiWindowFlags_NoResize |
-            ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoCollapse |
-            ImGuiWindowFlags_NoTitleBar;
-
-        ImGui::PushStyleColor(ImGuiCol_WindowBg, transparent);
-        ImGui::SetNextWindowPos({ stream_rect.x, stream_rect.y + stream_rect.h - 30 });
-        ImGui::SetNextWindowSize({ stream_rect.w, 30 });
-        std::string label = to_string() << "Footer for stream of " << profile.unique_id();
-        ImGui::Begin(label.c_str(), nullptr, flags);
-
         if (stream_rect.contains(mouse.cursor))
         {
             std::stringstream ss;
@@ -2414,24 +2403,37 @@ namespace rs2
             if (texture->get_last_frame().is<depth_frame>())
             {
                 auto meters = texture->get_last_frame().as<depth_frame>().get_distance(x, y);
-                if (meters > 0)
+                //if (meters > 0)
                 {
                     ss << std::dec << ", "
                         << std::setprecision(2) << meters << " meters";
                 }
             }
 
-            // Render pixel coordinate with magenta color to improve text readability
-            label = ss.str();
-            ImGui::PushStyleColor(ImGuiCol_Text, { 0.8f, 0.f, 0.8f, 1.f });
-            ImGui::Text("%s", label.c_str());
-            ImGui::PopStyleColor();
+            std::string msg(ss.str().c_str());
 
+            auto flags = ImGuiWindowFlags_NoResize |
+                ImGuiWindowFlags_NoMove |
+                ImGuiWindowFlags_NoCollapse |
+                ImGuiWindowFlags_NoTitleBar |
+                ImGuiWindowFlags_NoInputs;
+
+            // adjust windows size to the message length
+            ImGui::SetNextWindowPos({ stream_rect.x, stream_rect.y + stream_rect.h - 35 });
+            ImGui::SetNextWindowSize({ float(msg.size()*8), 20 });
+
+            std::string label = to_string() << "Footer for stream of " << profile.unique_id();
+            ImGui::Begin(label.c_str(), nullptr, flags);
+
+            ImGui::PushStyleColor(ImGuiCol_WindowBg, from_rgba(9, 11, 13, 100));
+            ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
+            ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, white);
+
+            ImGui::Text("%s", msg.c_str());
+            ImGui::PopStyleColor(3);
+
+            ImGui::End();
         }
-
-        ImGui::End();
-        ImGui::PopStyleColor();
-        ImGui::PopFont();
     }
 
     void stream_model::snapshot_frame(const char* filename, viewer_model& viewer) const

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2917,7 +2917,6 @@ namespace rs2
 
     rs2::frame post_processing_filters::apply_filters(rs2::frame f)
     {
-
         if (f.get_profile().stream_type() == RS2_STREAM_DEPTH)
         {
             for (auto&& s : viewer.streams)
@@ -2955,6 +2954,14 @@ namespace rs2
                 }
             }
         }
+
+        // TODO Evgeni - refactor
+        // Override the value of the first pixel to use as invalidation value for the occlusion filter
+        if (f.get_profile().stream_type() == RS2_STREAM_COLOR)
+        {
+            auto rgb_stream = const_cast<void*>(f.get_data());
+            memset(rgb_stream, 0, 3);
+        }
         return f;
     }
 
@@ -2977,6 +2984,7 @@ namespace rs2
             }
             if(viewer.is_3d_texture_source(f))
             {
+                //TODO Evgeni - refactor
                 update_texture(filtered);
             }
         }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2947,7 +2947,10 @@ namespace rs2
             get_pc_model()->get_option(rs2_option::RS2_OPTION_FILTER_MAGNITUDE).value)
         {
             auto rgb_stream = const_cast<uint8_t*>(static_cast<const uint8_t*>(f.get_data()));
-            rgb_stream[0] = rgb_stream[2] = 0xff; // Use magenta to highlight the occlusion areas
+            memset(rgb_stream, 0, 3); // Override the zero pixel with black color for occlusion marking
+            // Alternatively, enable the next two lines to render invalidation with magenta color for inspection
+            //rgb_stream[0] = rgb_stream[2] = 0xff; // Use magenta to highlight the occlusion areas
+            //rgb_stream[1] = 0;
         }
 
         return f;

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1675,7 +1675,7 @@ namespace rs2
         return ImGui::Combo(id.c_str(), &new_index, device_names_chars.data(), static_cast<int>(device_names.size()));
     }
 
-    void viewer_model::show_3dviewer_header(ImFont* font, rs2::rect stream_rect, bool& paused)
+    void viewer_model::show_3dviewer_header(ImFont* font, rs2::rect stream_rect, bool& paused, std::string& error_message)
     {
         //frame texture_map;
         //static auto last_frame_number = 0;
@@ -1833,26 +1833,10 @@ namespace rs2
             selected_tex_source_uid = tex_sources[selected_tex_source];
             texture.colorize = streams[selected_tex_source].texture->colorize;
             ImGui::PopItemWidth();
-        }
 
-        // Draw occlusion option checkbox
-        if (true)
-        {
-            /*ImGui::SameLine();
-            ImGui::SetCursorPosY(7);
-            ImGui::PushItemWidth(100);
-            draw_combo_box("##Occlusion Removal", {"abc","bbc","ccc"}, occlusion_removal);
-            ImGui::PopItemWidth();*/
-            //pc->set_occlusion(viewer.occlusion_removal);
-
-            /*ImGui::SameLine();
-            ImGui::SetCursorPosY(7);
-            ImGui::PushItemWidth(50);*/
-            std::string abc;
-            // render options block in the same line and use option description as a name rather than the option's name
-            ppf.get_pc_model()->get_option(rs2_option::RS2_OPTION_FILTER_MAGNITUDE).draw(abc, not_model,false,false);
-            //ImGui::PopItemWidth();
-            //ImGui::Checkbox("Occlusion Removal:", &occlusion_mark);
+            // Occlusion control for RGB UV-Map only - render in the same line and use option's description as name
+            if (RS2_STREAM_COLOR==streams[selected_tex_source_uid].profile.stream_type())
+                ppf.get_pc_model()->get_option(rs2_option::RS2_OPTION_FILTER_MAGNITUDE).draw(error_message, not_model, false, false);
         }
 
         //ImGui::SetCursorPosY(9);
@@ -2984,7 +2968,6 @@ namespace rs2
             }
             if(viewer.is_3d_texture_source(f))
             {
-                //TODO Evgeni - refactor
                 update_texture(filtered);
             }
         }
@@ -5814,7 +5797,7 @@ namespace rs2
             if (paused)
                 show_paused_icon(window.get_large_font(), static_cast<int>(panel_width + 15), static_cast<int>(panel_y + 15 + 32), 0);
 
-            show_3dviewer_header(window.get_font(), viewer_rect, paused);
+            show_3dviewer_header(window.get_font(), viewer_rect, paused, error_message);
 
             update_3d_camera(viewer_rect, window.get_mouse());
 

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1834,7 +1834,7 @@ namespace rs2
             texture.colorize = streams[selected_tex_source].texture->colorize;
             ImGui::PopItemWidth();
 
-            // Occlusion control for RGB UV-Map only - render in the same line and use option's description as name
+            // Occlusion control for RGB UV-Map will appear in the same line and use option's description as name
             if (RS2_STREAM_COLOR==streams[selected_tex_source_uid].profile.stream_type())
                 ppf.get_pc_model()->get_option(rs2_option::RS2_OPTION_FILTER_MAGNITUDE).draw(error_message, not_model, false, false);
         }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2476,7 +2476,10 @@ namespace rs2
             }
 
             label = ss.str();
+            ImGui::PushStyleColor(ImGuiCol_Text, { 0.8f, 0.f, 0.8f, 1.f });
             ImGui::Text("%s", label.c_str());
+            ImGui::PopStyleColor();
+            
         }
 
         ImGui::End();
@@ -2939,13 +2942,14 @@ namespace rs2
             }
         }
 
-        // TODO Evgeni - refactor
-        // Override the value of the first pixel to use as invalidation value for the occlusion filter
-        if (f.get_profile().stream_type() == RS2_STREAM_COLOR)
+        // Override the the first pixel in Depth->RGB map to be used as a mark when occlusion filter is active
+        if ((f.get_profile().stream_type() == RS2_STREAM_COLOR) &&
+            get_pc_model()->get_option(rs2_option::RS2_OPTION_FILTER_MAGNITUDE).value)
         {
-            auto rgb_stream = const_cast<void*>(f.get_data());
-            memset(rgb_stream, 0, 3);
+            auto rgb_stream = const_cast<uint8_t*>(static_cast<const uint8_t*>(f.get_data()));
+            rgb_stream[0] = rgb_stream[2] = 0xff; // Use magenta to highlight the occlusion areas
         }
+
         return f;
     }
 
@@ -3686,7 +3690,7 @@ namespace rs2
         }
 
         glColor4f(1.f, 1.f, 1.f, 1.f);
-        
+
         if (draw_frustrum && last_points)
         {
             glLineWidth(1.f);

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -462,7 +462,7 @@ namespace rs2
                     if (new_line)
                         ImGui::SetCursorPosX(135);
 
-                    ImGui::PushItemWidth(new_line? -1:100);
+                    ImGui::PushItemWidth(new_line? -1.f:100.f);
 
                     std::vector<const char*> labels;
                     auto selected = 0, counter = 0;
@@ -1780,9 +1780,11 @@ namespace rs2
             texture.colorize = streams[selected_tex_source].texture->colorize;
             ImGui::PopItemWidth();
 
-            // Occlusion control for RGB UV-Map will appear in the same line and use option's description as name
+            // Occlusion control for RGB UV-Map uses option's description as label
+            // Position is dynamically adjusted to avoid overlapping on resize
             if (RS2_STREAM_COLOR==streams[selected_tex_source_uid].profile.stream_type())
-                ppf.get_pc_model()->get_option(rs2_option::RS2_OPTION_FILTER_MAGNITUDE).draw(error_message, not_model, false, false);
+                ppf.get_pc_model()->get_option(rs2_option::RS2_OPTION_FILTER_MAGNITUDE).draw(error_message,
+                    not_model, stream_rect.w < 1000, false);
         }
 
         //ImGui::SetCursorPosY(9);

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -190,7 +190,6 @@ namespace rs2
         rs2_option opt;
         option_range range;
         std::shared_ptr<options> endpoint;
-        bool* invalidate_flag;
         bool supported = false;
         bool read_only = false;
         float value = 0.0f;
@@ -247,11 +246,6 @@ namespace rs2
             std::function<rs2::frame(rs2::frame)> invoker,
             std::string& error_message);
 
-        processing_block_model(const std::string& name,
-            std::shared_ptr<options> block,
-            std::function<rs2::frame(rs2::frame)> invoker,
-            std::string& error_message);
-
         const std::string& get_name() const { return _name; }
 
         option_model& get_option(rs2_option opt) { return options_metadata[opt]; }
@@ -271,9 +265,7 @@ namespace rs2
     {
     public:
         static void populate_options(std::map<int, option_model>& opt_container,
-            const device& dev,
-            const sensor& s,
-            bool* options_invalidated,
+            const std::string& opt_base_label,
             subdevice_model* model,
             std::shared_ptr<options> options,
             std::string& error_message);
@@ -616,7 +608,7 @@ namespace rs2
             pc(new pointcloud())
         {
             std::string s;
-            pc_gen = std::make_shared<processing_block_model>("Pointclould Engine", pc, [=](rs2::frame f) { return pc->calculate(f); }, s);
+            pc_gen = std::make_shared<processing_block_model>(nullptr, "Pointclould Engine", pc, [=](rs2::frame f) { return pc->calculate(f); }, s);
             processing_block.start(resulting_queue);
         }
 

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -272,7 +272,7 @@ namespace rs2
             std::shared_ptr<options> options,
             std::string& error_message);
 
-        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message);
+        subdevice_model(viewer_model& viewer, device& dev, std::shared_ptr<sensor> s, std::string& error_message);
         bool is_there_common_fps() ;
         bool draw_stream_selection();
         bool is_selected_combination_supported();
@@ -607,14 +607,15 @@ namespace rs2
             resulting_queue_max_size(20),
             resulting_queue(static_cast<unsigned int>(resulting_queue_max_size)),
 //            frames_queue(4),
-            t([this]() {render_loop(); })
+            t([this]() {render_loop(); }),
+            pc(new pointcloud())
         {
             processing_block.start(resulting_queue);
         }
 
         ~post_processing_filters() { stop(); }
 
-        void update_texture(frame f) { pc.map_to(f); }
+        void update_texture(frame f) { pc->map_to(f); }
 
         void stop()
         {
@@ -650,6 +651,11 @@ namespace rs2
         rs2::frame_queue syncer_queue;
         rs2::frame_queue resulting_queue;
 
+        std::shared_ptr<pointcloud> get_pc()
+        {
+            return pc;
+        }
+
     private:
         viewer_model& viewer;
 
@@ -660,7 +666,7 @@ namespace rs2
         rs2::frame apply_filters(rs2::frame f);
         rs2::frame last_tex_frame;
         rs2::processing_block processing_block;
-        pointcloud pc;
+        std::shared_ptr<pointcloud> pc;
         rs2::frameset model;
         std::atomic<bool> keep_calculating;
 

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -258,7 +258,6 @@ namespace rs2
         std::map<int, option_model> options_metadata;
         std::string _name;
         std::function<rs2::frame(rs2::frame)> _invoker;
-        bool options_invalidated = true;
     };
 
     class subdevice_model
@@ -270,7 +269,7 @@ namespace rs2
             std::shared_ptr<options> options,
             std::string& error_message);
 
-        subdevice_model(viewer_model& viewer, device& dev, std::shared_ptr<sensor> s, std::string& error_message);
+        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message);
         bool is_there_common_fps() ;
         bool draw_stream_selection();
         bool is_selected_combination_supported();
@@ -499,8 +498,8 @@ namespace rs2
             viewer_model& viewer,
             bool update_read_only_options);
         bool prompt_toggle_advanced_mode(bool enable_advanced_mode, const std::string& message_text,
-            std::vector<std::string>& restarting_device_info, 
-            viewer_model& view, 
+            std::vector<std::string>& restarting_device_info,
+            viewer_model& view,
             ux_window& window);
         void load_viewer_configurations(const std::string& json_str);
         void save_viewer_configurations(std::ofstream& outfile, nlohmann::json& j);
@@ -686,8 +685,8 @@ namespace rs2
             icon[pressed] = icon_pressed;
         }
 
-        void toggle_button() { state_pressed = !state_pressed; }            
-        void set_button_pressed(bool p) { state_pressed = p; }            
+        void toggle_button() { state_pressed = !state_pressed; }
+        void set_button_pressed(bool p) { state_pressed = p; }
         bool is_pressed() { return state_pressed; }
         std::string get_tooltip() { return(state_pressed ? tooltip[pressed]: tooltip[unpressed]); }
         std::string get_icon() { return(state_pressed ? icon[pressed] : icon[unpressed]); }
@@ -700,7 +699,7 @@ namespace rs2
         };
 
         bool state_pressed = false;
-        std::string tooltip[2];        
+        std::string tooltip[2];
         std::string icon[2];
     };
 
@@ -763,10 +762,10 @@ namespace rs2
         colored_cube camera_box{ { { f1,colors[0] },{ f2,colors[1] },{ f3,colors[2] },{ f4,colors[3] },{ f5,colors[4] },{ f6,colors[5] } } };
         float3 center_left{ v5.x + len_x / 3, v6.y - len_y / 3, v5.z };
         float3 center_right{ v6.x - len_x / 3, v6.y - len_y / 3, v5.z };
-                
+
         std::vector<tracked_point> trajectory;
         std::vector<float2> boundary;
-        
+
     };
 
     class viewer_model
@@ -850,7 +849,6 @@ namespace rs2
 
         bool allow_3d_source_change = true;
         bool allow_stream_close = true;
-        int occlusion_removal = 0;
 
         std::array<float3, 4> roi_rect;
         bool draw_plane = false;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -612,21 +612,11 @@ namespace rs2
             depth_stream_active(false),
             resulting_queue_max_size(20),
             resulting_queue(static_cast<unsigned int>(resulting_queue_max_size)),
-//            frames_queue(4),
             t([this]() {render_loop(); }),
             pc(new pointcloud())
         {
             std::string s;
             pc_gen = std::make_shared<processing_block_model>("Pointclould Engine", pc, [=](rs2::frame f) { return pc->calculate(f); }, s);
-                /*
-                auto decimate = std::make_shared<rs2::decimation_filter>();
-                decimation_filter = std::make_shared<processing_block_model>(
-                this, "Decimation Filter", decimate,
-                [=](rs2::frame f) { return decimate->process(f); },
-                error_message);
-                decimation_filter->enabled = true;
-                post_processing.push_back(decimation_filter);
-                */
             processing_block.start(resulting_queue);
         }
 
@@ -835,7 +825,7 @@ namespace rs2
 
         void show_event_log(ImFont* font_14, float x, float y, float w, float h);
 
-        void show_3dviewer_header(ImFont* font, rs2::rect stream_rect, bool& paused);
+        void show_3dviewer_header(ImFont* font, rs2::rect stream_rect, bool& paused, std::string& error_message);
 
         void update_3d_camera(const rect& viewer_rect,
                               mouse_info& mouse, bool force = false);

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -319,17 +319,17 @@ namespace rs2
             column_major[1] = mat[1][0];
             column_major[2] = mat[2][0];
             column_major[3] = mat[3][0];
-            column_major[4] = mat[0][1]; 
+            column_major[4] = mat[0][1];
             column_major[5] = mat[1][1];
             column_major[6] = mat[2][1];
             column_major[7] = mat[3][1];
-            column_major[8] = mat[0][2]; 
+            column_major[8] = mat[0][2];
             column_major[9] = mat[1][2];
-            column_major[10] = mat[2][2]; 
+            column_major[10] = mat[2][2];
             column_major[11] = mat[3][2];
             column_major[12] = mat[0][3];
-            column_major[13] = mat[1][3]; 
-            column_major[14] = mat[2][3]; 
+            column_major[13] = mat[1][3];
+            column_major[14] = mat[2][3];
             column_major[15] = mat[3][3];
         }
     };
@@ -426,7 +426,7 @@ namespace rs2
             else
             {
                 res.insert(res.end(), res_second_half.begin(), res_second_half.end());
-            }            
+            }
         }
         else
         {
@@ -448,12 +448,10 @@ namespace rs2
             {
                 inside = !inside;
             }
-                
         }
         return inside;
     }
 
-    
     struct mouse_info
     {
         float2 cursor;
@@ -1395,7 +1393,7 @@ namespace rs2
 
             draw_grid();
             draw_axis(0.3f, 2.f);
-            
+
             // Drawing pose:
             matrix4 pose_trans = tm2_pose_to_world_transformation(pose);
             float model[16];

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -999,7 +999,7 @@ namespace rs2
             last_queue[idx].poll_for_frame(&last[idx]);
             return last[idx];
         }
-		
+
         texture_buffer() : last_queue(), texture(),
             colorize(std::make_shared<colorizer>()) {}
 

--- a/examples/software-device/rs-software-device.cpp
+++ b/examples/software-device/rs-software-device.cpp
@@ -70,7 +70,7 @@ public:
         if (now - last > std::chrono::milliseconds(1))
         {
             app_state.yaw -= 1;
-            wave_base += 0.1;
+            wave_base += 0.1f;
             last = now;
 
             for (int i = 0; i < depth_frame.y; i++)

--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -113,7 +113,7 @@ rs2_sensor_list* rs2_query_sensors(const rs2_device* device, rs2_error** error);
 * \param[in]  from_file  Path to bag file with raw data for loopback
 * \param[out] error      If non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
-void rs2_loopback_enable(const rs2_device* device, const char* from_file, rs2_error** error); 
+void rs2_loopback_enable(const rs2_device* device, const char* from_file, rs2_error** error);
 
 /**
 * Restores the given device into normal operation mode

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -498,6 +498,10 @@ namespace rs2
                 rs2_error* e = nullptr;
                 _size = rs2_get_frame_points_count(get(), &e);
                 error::handle(e);
+                /*_width = rs2_get_frame_width(get(), &e);
+                error::handle(e);
+                _height = rs2_get_frame_height(get(), &e);
+                error::handle(e);*/
             }
         }
 
@@ -533,6 +537,8 @@ namespace rs2
 
     private:
         size_t _size;
+        /*size_t _width;
+        size_t _height;*/
     };
 
     class depth_frame : public video_frame

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -498,10 +498,6 @@ namespace rs2
                 rs2_error* e = nullptr;
                 _size = rs2_get_frame_points_count(get(), &e);
                 error::handle(e);
-                /*_width = rs2_get_frame_width(get(), &e);
-                error::handle(e);
-                _height = rs2_get_frame_height(get(), &e);
-                error::handle(e);*/
             }
         }
 
@@ -537,8 +533,6 @@ namespace rs2
 
     private:
         size_t _size;
-        /*size_t _width;
-        size_t _height;*/
     };
 
     class depth_frame : public video_frame

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -188,7 +188,7 @@ namespace rs2
         /**
         * returns scale and bias of a the motion stream profile
         */
-        rs2_motion_device_intrinsic get_motion_intrinsics() 
+        rs2_motion_device_intrinsic get_motion_intrinsics()
         {
             rs2_error* e = nullptr;
             rs2_motion_device_intrinsic intrin;
@@ -557,7 +557,7 @@ namespace rs2
             return r;
         }
     };
-	
+
     class disparity_frame : public depth_frame
     {
     public:
@@ -580,7 +580,7 @@ namespace rs2
             return r;
         }
     };
-    
+
     class motion_frame : public frame
     {
     public:
@@ -601,7 +601,7 @@ namespace rs2
             return rs2_vector{data[0], data[1], data[2]};
         }
     };
-    
+
     class pose_frame : public frame
     {
     public:

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -151,7 +151,6 @@ namespace rs2
             error::handle(e);
             return dev;
         }
-       
 
     public:
         software_device()
@@ -172,7 +171,6 @@ namespace rs2
             error::handle(e);
 
             return software_sensor(sensor);
-            
         }
 
         /**
@@ -185,7 +183,6 @@ namespace rs2
             rs2_software_device_create_matcher(_dev.get(), matcher, &e);
             error::handle(e);
         }
-       
     };
 
 }

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -202,19 +202,22 @@ namespace rs2
         size_t _capacity;
     };
 
-    class pointcloud
+    class pointcloud : public options
     {
     public:
         pointcloud() :  _queue(1)
         {
             rs2_error* e = nullptr;
 
-            _block = std::make_shared<processing_block>(
-                                std::shared_ptr<rs2_processing_block>(
-                                                    rs2_create_pointcloud(&e),
-                                                    rs2_delete_processing_block));
+            auto pb = std::shared_ptr<rs2_processing_block>(
+                rs2_create_pointcloud(&e),
+                rs2_delete_processing_block);
+            _block = std::make_shared<processing_block>(pb);
 
             error::handle(e);
+
+            // Redirect options API to the processing block
+            options::operator=(pb);
 
             _block->start(_queue);
         }

--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -368,7 +368,7 @@ namespace rs2
 
             return results;
         }
-        
+
         sensor& operator=(const std::shared_ptr<rs2_sensor> other)
         {
             options::operator=(other);

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -30,12 +30,12 @@ namespace rs2
         error::handle(e);
     }
 
-	inline void log(rs2_log_severity severity, const char* message)
-	{
-		rs2_error* e = nullptr;
-		rs2_log(severity, message, &e);
-		error::handle(e);
-	}
+    inline void log(rs2_log_severity severity, const char* message)
+    {
+        rs2_error* e = nullptr;
+        rs2_log(severity, message, &e);
+        error::handle(e);
+    }
 }
 
 inline std::ostream & operator << (std::ostream & o, rs2_stream stream) { return o << rs2_stream_to_string(stream); }

--- a/src/backend.h
+++ b/src/backend.h
@@ -575,7 +575,7 @@ namespace librealsense
             {
                 return !list_changed(uvc_devices, other.uvc_devices) &&
                     !list_changed(hid_devices, other.hid_devices) &&
-                    !list_changed(playback_devices, other.playback_devices) && 
+                    !list_changed(playback_devices, other.playback_devices) &&
                     !list_changed(tm2_devices, other.tm2_devices);
             }
 

--- a/src/context.h
+++ b/src/context.h
@@ -182,6 +182,6 @@ namespace librealsense
     platform::uvc_device_info get_mi(const std::vector<platform::uvc_device_info>& devices, uint32_t mi);
     std::vector<platform::uvc_device_info> filter_by_mi(const std::vector<platform::uvc_device_info>& devices, uint32_t mi);
 
-	std::vector<platform::usb_device_info> filter_by_product(const std::vector<platform::usb_device_info>& devices, const std::set<uint16_t>& pid_list);
-	void trim_device_list(std::vector<platform::usb_device_info>& devices, const std::vector<platform::usb_device_info>& chosen);
+    std::vector<platform::usb_device_info> filter_by_product(const std::vector<platform::usb_device_info>& devices, const std::set<uint16_t>& pid_list);
+    void trim_device_list(std::vector<platform::usb_device_info>& devices, const std::vector<platform::usb_device_info>& chosen);
 }

--- a/src/core/motion.h
+++ b/src/core/motion.h
@@ -23,7 +23,6 @@ namespace librealsense
 
     MAP_EXTENSION(RS2_EXTENSION_POSE_PROFILE, librealsense::pose_stream_profile_interface);
 
-    
     class tm2_extensions
     {
     public:

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -342,20 +342,19 @@ void record_sensor::wrap_streams()
         {
             std::shared_ptr<stream_profile_interface> snapshot;
             stream->create_snapshot(snapshot);
-	        rs2_extension extension_type;
-	        if (Is<librealsense::video_stream_profile_interface>(stream))
-	            extension_type = RS2_EXTENSION_VIDEO_PROFILE;
-	        else if (Is<librealsense::motion_stream_profile_interface>(stream))
-	            extension_type = RS2_EXTENSION_MOTION_PROFILE;
-	        else if (Is<librealsense::pose_stream_profile_interface>(stream))
-	            extension_type = RS2_EXTENSION_POSE_PROFILE;
-     		else 
-				throw std::runtime_error("Unsupported stream");
+            rs2_extension extension_type;
+            if (Is<librealsense::video_stream_profile_interface>(stream))
+                extension_type = RS2_EXTENSION_VIDEO_PROFILE;
+            else if (Is<librealsense::motion_stream_profile_interface>(stream))
+                extension_type = RS2_EXTENSION_MOTION_PROFILE;
+            else if (Is<librealsense::pose_stream_profile_interface>(stream))
+                extension_type = RS2_EXTENSION_POSE_PROFILE;
+            else 
+                throw std::runtime_error("Unsupported stream");
 
-	        on_extension_change(extension_type, std::dynamic_pointer_cast<extension_snapshot>(snapshot));
+            on_extension_change(extension_type, std::dynamic_pointer_cast<extension_snapshot>(snapshot));
 
            m_recorded_streams_ids.insert(id);
         }
     }
 }
-

--- a/src/proc/occlusion-filter.cpp
+++ b/src/proc/occlusion-filter.cpp
@@ -1,10 +1,9 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
 
 #include "../include/librealsense2/rs.hpp"
 #include "../include/librealsense2/rsutil.h"
 
-//#include "types.h"
 #include "proc/synthetic-stream.h"
 #include "proc/occlusion-filter.h"
 
@@ -15,11 +14,15 @@ namespace librealsense
     {
     }
 
+    void occlusion_filter::set_texel_intrinsics(const rs2_intrinsics& in)
+    {
+        _texels_intrinsics = in;
+        _texels_depth.resize(_texels_intrinsics.value().width*_texels_intrinsics.value().height);
+    }
+
     void occlusion_filter::process(float3* points, size_t points_width, size_t points_height,
                                    float2* uv_map, const std::vector<float2> & pix_coord) const
     {
-        //librealsense::frame_holder res = points.clone();
-
         switch (_occlusion_filter)
         {
         case occlusion_none:
@@ -42,17 +45,17 @@ namespace librealsense
     void occlusion_filter::monotonic_heuristic_invalidation(float3* points, size_t points_width, size_t points_height,
         float2* uv_map, const std::vector<float2> & pix_coord) const
     {
-        float occZTh = 0.2f; //meters   - TODO review and refactor Evgeni
+        float occZTh = 0.2f; //meters
         int occDilationSz = 1;
         auto pixels_ptr = pix_coord.data();
 
-        for (int y = 0; y < points_height; ++y)
+        for (size_t y = 0; y < points_height; ++y)
         {
             float maxInLine = -1;
             float maxZ = 0;
             int occDilationLeft = 0;
 
-            for (int x = 0; x < points_width; ++x)
+            for (size_t x = 0; x < points_width; ++x)
             {
                 if (points->z)
                 {
@@ -83,48 +86,141 @@ namespace librealsense
         }
     }
 
+    // Prepare texture map without occlusion that for every texture coordinate there no more than one depth point that is mapped to it
+    // i.e. for every (u,v) map coordinate we select the depth point with minimum Z. all other points that are mapped to this texel will be invalidated
+    // In the second pass we will and invalidate those pixels
     void occlusion_filter::comprehensive_invalidation(float3* points, size_t points_width, size_t points_height,
         float2* uv_map, const std::vector<float2> & pix_coord) const
     {
-        //TODO
+        auto depth_points = points;
+        auto mapped_pix = pix_coord.data();
+
+        /*auto min_x = 0.f;
+        auto max_x = 0.f;
+        auto min_y = 0.f;
+        auto max_y = 0.f;
+        for (auto i = 0; i < pix_coord.size(); i++)
+        {
+            if (pix_coord[i].x < min_x) min_x = pix_coord[i].x;
+            if (pix_coord[i].x > max_x) max_x = pix_coord[i].x;
+            if (pix_coord[i].y < min_y) min_y = pix_coord[i].y;
+            if (pix_coord[i].y > max_y) max_y = pix_coord[i].y;
+        }*/
+
+        // Clear previous data
+        //std::fill(_texels_map.begin(), _texels_map.end(), 0.f);
+        memset((void*)(_texels_depth.data()), 0, _texels_depth.size() * sizeof(float));
+
+        // Pass1 -generate texels mapping with minimal depth for each texel involved
+        for (size_t i = 0; i < points_height; i++)
+        {
+            for (size_t j = 0; j < points_width; j++)
+            {
+                if ((depth_points->z > 0.0001f) && (mapped_pix->x > 0.f) && (mapped_pix->y > 0))
+                {
+                    size_t texel_index = static_cast<size_t>(std::floor(mapped_pix->y)*points_width + std::floor(mapped_pix->x));
+                    if (_texels_depth[texel_index] > depth_points->z)
+                        _texels_depth[texel_index] = depth_points->z;
+                }
+
+                ++depth_points;
+                ++mapped_pix;
+            }
+        }
+
+        mapped_pix = pix_coord.data();
+        depth_points = points;
+        auto uv_ptr = uv_map;
+
+        // Pass2 -invalidate depth texels with occlusion traits
+        for (size_t i = 0; i < points_height; i++)
+        {
+            for (size_t j = 0; j < points_width; j++)
+            {
+                if ((depth_points->z > 0.0001f) && (mapped_pix->x > 0.f) && (mapped_pix->y > 0.f))
+                {
+                    size_t texel_index = static_cast<size_t>(std::floor(mapped_pix->y)*points_width + std::floor(mapped_pix->x));
+                    if (_texels_depth[texel_index] < depth_points->z)
+                        *uv_ptr = { 0.f, 0.f };
+                }
+
+                ++depth_points;
+                ++mapped_pix;
+                ++uv_ptr;
+            }
+        }
+        /*
+        uint16_t * r = g_color_img_map;
+        float * s = g_color_camera;
+        float * q = g_color_depth;
+
+        int size = width * height;
+        memset(g_color_depth, 0, size * sizeof(float));
+        memset(g_color_img_map, 0, size * 2 * sizeof(uint16_t));
+        memset(g_color_camera, 0, size * 3 * sizeof(float));
+
+        int pos = 0;
+        uint16_t * p = zImage;
+        for (int y = 0; y < height; ++y)
+        {
+            for (int x = 0; x < width; ++x)
+            {
+                if (uint16_t d = *p++)
+                {
+                    float z_image[] = { static_cast<float>, static_cast<float> };
+
+                    float z_camera[3];
+                    rs2_deproject_pixel_to_point(z_camera, &g_intrinsics_depth_scaled, z_image, static_cast<float>(d));
+                    rs2_transform_point_to_point(s, &g_extrinsics_color, z_camera);
+
+                    float color_image[2];
+                    rs2_project_point_to_pixel(color_image, &g_intrinsics_color_scaled, s);
+
+                    r[0] = (uint16_t)color_image[0];
+                    r[1] = (uint16_t)color_image[1];
+
+                    if (r[0] >= 0 && r[0] < width && r[1] >= 0 && r[1] < height && s[2])
+                    {
+
+                        pos = r[1] * width + r[0];
+
+                        if (q[pos] < 0.001f || s[2] < q[pos])
+
+                            q[pos] = s[2];
+                    }
+
+                    else
+                        s[2] = 0;
+                }
+
+                r += 2;
+                s += 3;
+            }
+        }
+
+        q = g_color_depth;
+        r = g_color_img_map;
+        s = g_color_camera;
+
+        for (int y = 0; y < height; ++y)
+        {
+            for (int x = 0; x < width; ++x)
+            {
+                if (s[2])
+
+                {
+
+                    pos = r[1] * width + r[0];
+
+                    if (s[2] > q[pos] + 0.001f)
+
+                        s[2] = 0;
+
+                }
+
+                r += 2;
+                s += 3;
+            }
+        }*/
     }
-    /*void occlusion_filter::update_configuration(const frame_holder& texture_frame)
-    {
-        auto other_frame = (frame_interface*)other.get();
-        std::lock_guard<std::mutex> lock(_mutex);
-
-        if (_other_stream && _invalidate_mapped)
-        {
-            _other_stream = nullptr;
-            _invalidate_mapped = false;
-        }
-
-        if (!_other_stream.get())
-        {
-            _other_stream = other_frame->get_stream();
-            _other_intrinsics = optional_value<rs2_intrinsics>();
-            _extrinsics = optional_value<rs2_extrinsics>();
-        }
-    }*/
-
-    //frame_holder occlusion_filter::prepare_target_points(const frame_holder& f, const rs2::frame_source& source)
-    //{
-    //    // Allocate and copy the content of the original Depth data to the target
-    //    //frame_holder tgt = source.allocate_video_frame(_target_stream_profile, f, int(_bpp), int(_width), int(_height), int(_stride), _extension_type);
-
-    //    frame_holder res = get_source().allocate_points(_output_stream, (frame_interface*)depth.get());
-
-    //    auto pframe = (points*)(res.frame);
-
-    //    /*auto depth_data = (const uint16_t*)depth.get_data();
-
-    //    auto points = depth_to_points((uint8_t*)pframe->get_vertices(), *_depth_intrinsics, depth_data, *_depth_units);
-
-    //    auto vid_frame = depth.as<rs2::video_frame>();
-    //    float2* tex_ptr = pframe->get_texture_coordinates();*/
-
-    //    // Copy the content of points for processing
-    //    memmove(const_cast<void*>(tgt.get_data()), f.get_data(), _current_frm_size_pixels * _bpp);
-    //    return tgt;
-    //}
 }

--- a/src/proc/occlusion-filter.cpp
+++ b/src/proc/occlusion-filter.cpp
@@ -26,21 +26,21 @@ namespace librealsense
         case occlusion_none:
             break;
         case occlusion_monotonic_scan:
+        case occlusion_exhaustic_search:
             monotonic_heuristic_invalidation(points, uv_map, pix_coord);
             break;
-        case occlusion_exhaustic_search:
+        /*case occlusion_exhaustic_search:                              TODO - additional validation work is required
             comprehensive_invalidation(points, uv_map, pix_coord);
-            break;
+            break;*/
         default:
             throw std::runtime_error(to_string() << "Unsupported occlusion filter type " << _occlusion_filter << " requested");
             break;
         }
     }
 
-    // Heuristic occlusion invalidation algorithm that works as follows:
     // IMPORTANT! This implementation is based on the assumption that the RGB sensor is positioned strictly to the left of the depth sensor.
     // namely D415/D435 and SR300. The implementation WILL NOT work properly for different setups
-    // Algorithm flow:
+    // Heuristic occlusion invalidation algorithm:
     // -  Use the uv texels calculated when projecting depth to color
     // -  Scan each line from left to right and check the the U coordinate in the mapping is raising monotonically.
     // -  The occlusion is designated as U coordinate for a given pixel is less than the U coordinate of the predecessing pixel.

--- a/src/proc/occlusion-filter.cpp
+++ b/src/proc/occlusion-filter.cpp
@@ -108,7 +108,7 @@ namespace librealsense
         size_t points_width = _depth_intrinsics->width;
         size_t points_height = _depth_intrinsics->height;
 
-        static const float z_threshold = 0.3f; // Compensate for temporal noise when comparing Z values - significal occlusion
+        static const float z_threshold = 0.05f; // Compensate for temporal noise when comparing Z values - significal occlusion
 
         // Clear previous data
         memset((void*)(_texels_depth.data()), 0, _texels_depth.size() * sizeof(float));

--- a/src/proc/occlusion-filter.cpp
+++ b/src/proc/occlusion-filter.cpp
@@ -6,7 +6,6 @@
 
 #include "proc/synthetic-stream.h"
 #include "proc/occlusion-filter.h"
-#include <iomanip>
 
 namespace librealsense
 {
@@ -20,18 +19,17 @@ namespace librealsense
         _texels_depth.resize(_texels_intrinsics.value().width*_texels_intrinsics.value().height);
     }
 
-    void occlusion_filter::process(float3* points, size_t points_width, size_t points_height,
-                                   float2* uv_map, const std::vector<float2> & pix_coord) const
+    void occlusion_filter::process(float3* points, float2* uv_map, const std::vector<float2> & pix_coord) const
     {
         switch (_occlusion_filter)
         {
         case occlusion_none:
             break;
         case occlusion_monotonic_scan:
-            monotonic_heuristic_invalidation(points, points_width, points_height, uv_map, pix_coord);
+            monotonic_heuristic_invalidation(points, uv_map, pix_coord);
             break;
         case occlusion_exhaustic_search:
-            comprehensive_invalidation(points, points_width, points_height, uv_map, pix_coord);
+            comprehensive_invalidation(points, uv_map, pix_coord);
             break;
         default:
             throw std::runtime_error(to_string() << "Unsupported occlusion filter type " << _occlusion_filter << " requested");
@@ -39,12 +37,22 @@ namespace librealsense
         }
     }
 
-    void occlusion_filter::monotonic_heuristic_invalidation(float3* points, size_t points_width, size_t points_height,
-        float2* uv_map, const std::vector<float2> & pix_coord) const
+    // Heuristic occlusion invalidation algorithm that works as follows:
+    // IMPORTANT! This implementation is based on the assumption that the RGB sensor is positioned strictly to the left of the depth sensor.
+    // namely D415/D435 and SR300. The implementation WILL NOT work properly for different setups
+    // Algorithm flow:
+    // -  Use the uv texels calculated when projecting depth to color
+    // -  Scan each line from left to right and check the the U coordinate in the mapping is raising monotonically.
+    // -  The occlusion is designated as U coordinate for a given pixel is less than the U coordinate of the predecessing pixel.
+    // -  The UV mapping for the occluded pixel is reset to (0,0). Later on the (0,0) coordinate in the texture map is overwritten 
+    //    with a invalidation color such as black/magenta according to the purpose (production/debugging)
+    void occlusion_filter::monotonic_heuristic_invalidation(float3* points, float2* uv_map, const std::vector<float2> & pix_coord) const
     {
         float occZTh = 0.1f; //meters
         int occDilationSz = 1;
         auto pixels_ptr = pix_coord.data();
+        auto points_width = _depth_intrinsics->width;
+        auto points_height = _depth_intrinsics->height;
 
         for (size_t y = 0; y < points_height; ++y)
         {
@@ -85,14 +93,20 @@ namespace librealsense
 
     // Prepare texture map without occlusion that for every texture coordinate there no more than one depth point that is mapped to it
     // i.e. for every (u,v) map coordinate we select the depth point with minimum Z. all other points that are mapped to this texel will be invalidated
-    // In the second pass we will and invalidate those pixels
-    void occlusion_filter::comprehensive_invalidation(float3* points, size_t points_width, size_t points_height,
-        float2* uv_map, const std::vector<float2> & pix_coord) const
+    // Algo input data:
+    // Vector of 3D [xyz] coordinates of depth_width*depth_height size
+    // Vector of 2D [i,j] coordinates where the val[i,j] stores the texture coordinate (s,t) for the corresponding (i,j) pixel in depth frame
+    // Algo intermediate data:
+    // Vector of depth values (floats) in size of the mapped texture (different from depth width*height) where
+    // each (i,j) cell holds the minimal Z among all the depth pixels that are mapped to the specific texel
+    void occlusion_filter::comprehensive_invalidation(float3* points, float2* uv_map, const std::vector<float2> & pix_coord) const
     {
         auto depth_points = points;
         auto mapped_pix = pix_coord.data();
         size_t mapped_tex_width = _texels_intrinsics->width;
         size_t mapped_tex_height = _texels_intrinsics->height;
+        size_t points_width = _depth_intrinsics->width;
+        size_t points_height = _depth_intrinsics->height;
 
         static const float z_threshold = 0.3f; // Compensate for temporal noise when comparing Z values - significal occlusion
 
@@ -105,10 +119,10 @@ namespace librealsense
             for (size_t j = 0; j < points_width; j++)
             {
                 if ((depth_points->z > 0.0001f) &&
-                    (mapped_pix->x > 0.f) && (mapped_pix->x < mapped_tex_height) &&
-                    (mapped_pix->y > 0.f) && (mapped_pix->y < mapped_tex_width))
+                    (mapped_pix->x > 0.f) && (mapped_pix->x < mapped_tex_width) &&
+                    (mapped_pix->y > 0.f) && (mapped_pix->y < mapped_tex_height))
                 {
-                    size_t texel_index = (size_t)(mapped_pix->x)*points_width + (size_t)(mapped_pix->y);
+                    size_t texel_index = (size_t)(mapped_pix->y)*mapped_tex_width + (size_t)(mapped_pix->x);
 
                     if ((_texels_depth[texel_index] < 0.0001f) || ((_texels_depth[texel_index] + z_threshold) > depth_points->z))
                     {
@@ -131,10 +145,10 @@ namespace librealsense
             for (size_t j = 0; j < points_width; j++)
             {
                 if ((depth_points->z > 0.0001f) &&
-                    (mapped_pix->x > 0.f) && (mapped_pix->x < mapped_tex_height) &&
-                    (mapped_pix->y > 0.f) && (mapped_pix->y < mapped_tex_width))
+                    (mapped_pix->x > 0.f) && (mapped_pix->x < mapped_tex_width) &&
+                    (mapped_pix->y > 0.f) && (mapped_pix->y < mapped_tex_height))
                 {
-                    size_t texel_index = (size_t)(mapped_pix->x)*points_width + (size_t)(mapped_pix->y);
+                    size_t texel_index = (size_t)(mapped_pix->y)*mapped_tex_width + (size_t)(mapped_pix->x);
 
                     if ((_texels_depth[texel_index] > 0.0001f) && ((_texels_depth[texel_index] + z_threshold) < depth_points->z))
                     {

--- a/src/proc/occlusion-filter.cpp
+++ b/src/proc/occlusion-filter.cpp
@@ -1,0 +1,90 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#include "../include/librealsense2/rs.hpp"
+#include "../include/librealsense2/rsutil.h"
+
+#include "proc/synthetic-stream.h"
+#include "proc/occlusion-filter.h"
+
+
+namespace librealsense
+{
+    occlusion_filter::occlusion_filter(): _occlusion_filter(occlusion_none)
+    {
+    }
+
+    rs2::frame occlusion_filter::process(const rs2::frame& points, size_t points_width, size_t points_height,
+        const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height)
+    {
+        rs2::frame res = points;
+
+        switch (_occlusion_filter)
+        {
+        case occlusion_none:
+            break;
+        case occlusion_monotonic_scan:
+            res = monotonic_heuristic_invalidation(points, points_width, points_height, texture_coords, texture_width, texture_height);
+            break;
+        case occlusion_exhostic_search:
+            res = comprehensive_invalidation(points, points_width, points_height, texture_coords, texture_width, texture_height);
+            break;
+        default:
+            throw std::runtime_error(to_string() << "Unsupported occlusion filter type " << _occlusion_filter << " requested");
+            break;
+        }
+
+        return res;
+    }
+
+    rs2::frame occlusion_filter::monotonic_heuristic_invalidation(const rs2::frame& points, size_t points_width, size_t points_height,
+        const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height)
+    {
+        return points;
+    }
+
+    rs2::frame occlusion_filter::comprehensive_invalidation(const rs2::frame& points, size_t points_width, size_t points_height,
+        const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height)
+    {
+        return points;
+    }
+    /*void occlusion_filter::update_configuration(const rs2::frame& texture_frame)
+    {
+        auto other_frame = (frame_interface*)other.get();
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (_other_stream && _invalidate_mapped)
+        {
+            _other_stream = nullptr;
+            _invalidate_mapped = false;
+        }
+
+        if (!_other_stream.get())
+        {
+            _other_stream = other_frame->get_stream();
+            _other_intrinsics = optional_value<rs2_intrinsics>();
+            _extrinsics = optional_value<rs2_extrinsics>();
+        }
+    }*/
+
+    //rs2::frame occlusion_filter::prepare_target_points(const rs2::frame& f, const rs2::frame_source& source)
+    //{
+    //    // Allocate and copy the content of the original Depth data to the target
+    //    //rs2::frame tgt = source.allocate_video_frame(_target_stream_profile, f, int(_bpp), int(_width), int(_height), int(_stride), _extension_type);
+
+    //    frame_holder res = get_source().allocate_points(_output_stream, (frame_interface*)depth.get());
+
+    //    auto pframe = (points*)(res.frame);
+
+    //    /*auto depth_data = (const uint16_t*)depth.get_data();
+
+    //    auto points = depth_to_points((uint8_t*)pframe->get_vertices(), *_depth_intrinsics, depth_data, *_depth_units);
+
+    //    auto vid_frame = depth.as<rs2::video_frame>();
+    //    float2* tex_ptr = pframe->get_texture_coordinates();*/
+
+    //    // Copy the content of points for processing
+    //    memmove(const_cast<void*>(tgt.get_data()), f.get_data(), _current_frm_size_pixels * _bpp);
+    //    return tgt;
+    //}
+}

--- a/src/proc/occlusion-filter.h
+++ b/src/proc/occlusion-filter.h
@@ -5,7 +5,7 @@
 #include "../include/librealsense2/hpp/rs_frame.hpp"
 namespace librealsense
 {
-    enum occlusion_rect_type : uint8_t { occlusion_none, occlusion_monotonic_scan, occlusion_exhostic_search, occlusion_max };
+    enum occlusion_rect_type : uint8_t { occlusion_none, occlusion_monotonic_scan, occlusion_exhostic_search, heuristic_in_place, occlusion_max };
 
     class pointcloud;
 
@@ -16,11 +16,11 @@ namespace librealsense
 
         bool active(void) const { return (occlusion_none != _occlusion_filter); };
 
-        void update_configuration(const rs2::frame& texture_frame);
+        //void update_configuration(const frame_holder& texture_frame);
 
-        rs2::frame process(const rs2::frame& points, const std::vector<float2> & texture_coords);
-        rs2::frame process(const rs2::frame& points, size_t points_width, size_t points_height,
-            const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height);
+        //frame_holder process(const frame_holder& points, const std::vector<float2> & texture_coords); evgeni  -check if the internal members ca do the work here
+        void process(float3* points, size_t points_width, size_t points_height,
+                    float2* uv_map, const std::vector<float2> & pix_coord) const;
 
         void set_mode(uint8_t filter_type) { _occlusion_filter = (occlusion_rect_type)filter_type; }
 
@@ -28,13 +28,13 @@ namespace librealsense
     private:
         friend class pointcloud;
 
-        rs2::frame prepare_target_points(const rs2::frame& f, const rs2::frame_source& source);
+        frame_holder prepare_target_points(const frame_holder& f, const rs2::frame_source& source);
 
-        rs2::frame monotonic_heuristic_invalidation(const rs2::frame& points, size_t points_width, size_t points_height,
-            const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height);
+        void monotonic_heuristic_invalidation(float3* points, size_t points_width, size_t points_height,
+                                              float2* uv_map, const std::vector<float2> & pix_coord) const;
 
-        rs2::frame comprehensive_invalidation(const rs2::frame& points, size_t points_width, size_t points_height,
-            const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height);
+        void comprehensive_invalidation(float3* points, size_t points_width, size_t points_height,
+                                        float2* uv_map, const std::vector<float2> & pix_coord) const;
 
         std::shared_ptr<stream_profile_interface>   _output_stream, _texture_source_stream;
         std::vector<float2>                         _texture_map;

--- a/src/proc/occlusion-filter.h
+++ b/src/proc/occlusion-filter.h
@@ -1,0 +1,44 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved.
+
+#pragma once
+#include "../include/librealsense2/hpp/rs_frame.hpp"
+namespace librealsense
+{
+    enum occlusion_rect_type : uint8_t { occlusion_none, occlusion_monotonic_scan, occlusion_exhostic_search, occlusion_max };
+
+    class pointcloud;
+
+    class occlusion_filter
+    {
+    public:
+        occlusion_filter();
+
+        bool active(void) const { return (occlusion_none != _occlusion_filter); };
+
+        void update_configuration(const rs2::frame& texture_frame);
+
+        rs2::frame process(const rs2::frame& points, const std::vector<float2> & texture_coords);
+        rs2::frame process(const rs2::frame& points, size_t points_width, size_t points_height,
+            const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height);
+
+        void set_mode(uint8_t filter_type) { _occlusion_filter = (occlusion_rect_type)filter_type; }
+
+        occlusion_rect_type                         _occlusion_filter;
+    private:
+        friend class pointcloud;
+
+        rs2::frame prepare_target_points(const rs2::frame& f, const rs2::frame_source& source);
+
+        rs2::frame monotonic_heuristic_invalidation(const rs2::frame& points, size_t points_width, size_t points_height,
+            const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height);
+
+        rs2::frame comprehensive_invalidation(const rs2::frame& points, size_t points_width, size_t points_height,
+            const std::vector<float2> & texture_coords, size_t texture_width, size_t texture_height);
+
+        std::shared_ptr<stream_profile_interface>   _output_stream, _texture_source_stream;
+        std::vector<float2>                         _texture_map;
+        rs2::stream_profile                         _texture_source_stream_profile;
+        
+    };
+}

--- a/src/proc/occlusion-filter.h
+++ b/src/proc/occlusion-filter.h
@@ -16,19 +16,17 @@ namespace librealsense
 
         bool active(void) const { return (occlusion_none != _occlusion_filter); };
 
-        //void update_configuration(const frame_holder& texture_frame);
-
         //frame_holder process(const frame_holder& points, const std::vector<float2> & texture_coords); evgeni  -check if the internal members ca do the work here
         void process(float3* points, size_t points_width, size_t points_height,
                     float2* uv_map, const std::vector<float2> & pix_coord) const;
 
         void set_mode(uint8_t filter_type) { _occlusion_filter = (occlusion_rect_type)filter_type; }
 
-        occlusion_rect_type                         _occlusion_filter;
+        void set_texel_intrinsics(const rs2_intrinsics& in);
+        void set_depth_intrinsics(const rs2_intrinsics& in) { _depth_intrinsics = in; }
     private:
-        friend class pointcloud;
 
-        frame_holder prepare_target_points(const frame_holder& f, const rs2::frame_source& source);
+        friend class pointcloud;
 
         void monotonic_heuristic_invalidation(float3* points, size_t points_width, size_t points_height,
                                               float2* uv_map, const std::vector<float2> & pix_coord) const;
@@ -36,9 +34,12 @@ namespace librealsense
         void comprehensive_invalidation(float3* points, size_t points_width, size_t points_height,
                                         float2* uv_map, const std::vector<float2> & pix_coord) const;
 
-        std::shared_ptr<stream_profile_interface>   _output_stream, _texture_source_stream;
+        /*std::shared_ptr<stream_profile_interface>   _output_stream, _texture_source_stream;
         std::vector<float2>                         _texture_map;
-        rs2::stream_profile                         _texture_source_stream_profile;
-        
+        rs2::stream_profile                         _texture_source_stream_profile;*/
+        optional_value<rs2_intrinsics>              _depth_intrinsics;
+        optional_value<rs2_intrinsics>              _texels_intrinsics;
+        mutable std::vector<float>                  _texels_depth; // Temporal translation table of (mapped_x*mapped_y) holds the minimal depth value among all depth pixels mapped to that texel
+        occlusion_rect_type                         _occlusion_filter;
     };
 }

--- a/src/proc/occlusion-filter.h
+++ b/src/proc/occlusion-filter.h
@@ -5,7 +5,7 @@
 #include "../include/librealsense2/hpp/rs_frame.hpp"
 namespace librealsense
 {
-    enum occlusion_rect_type : uint8_t { occlusion_none, occlusion_monotonic_scan, occlusion_exhostic_search, heuristic_in_place, occlusion_max };
+    enum occlusion_rect_type : uint8_t { occlusion_none, occlusion_monotonic_scan, occlusion_exhaustic_search, occlusion_max };
 
     class pointcloud;
 

--- a/src/proc/occlusion-filter.h
+++ b/src/proc/occlusion-filter.h
@@ -16,9 +16,7 @@ namespace librealsense
 
         bool active(void) const { return (occlusion_none != _occlusion_filter); };
 
-        //frame_holder process(const frame_holder& points, const std::vector<float2> & texture_coords); evgeni  -check if the internal members ca do the work here
-        void process(float3* points, size_t points_width, size_t points_height,
-                    float2* uv_map, const std::vector<float2> & pix_coord) const;
+        void process(float3* points, float2* uv_map, const std::vector<float2> & pix_coord) const;
 
         void set_mode(uint8_t filter_type) { _occlusion_filter = (occlusion_rect_type)filter_type; }
 
@@ -28,15 +26,10 @@ namespace librealsense
 
         friend class pointcloud;
 
-        void monotonic_heuristic_invalidation(float3* points, size_t points_width, size_t points_height,
-                                              float2* uv_map, const std::vector<float2> & pix_coord) const;
+        void monotonic_heuristic_invalidation(float3* points, float2* uv_map, const std::vector<float2> & pix_coord) const;
 
-        void comprehensive_invalidation(float3* points, size_t points_width, size_t points_height,
-                                        float2* uv_map, const std::vector<float2> & pix_coord) const;
+        void comprehensive_invalidation(float3* points, float2* uv_map, const std::vector<float2> & pix_coord) const;
 
-        /*std::shared_ptr<stream_profile_interface>   _output_stream, _texture_source_stream;
-        std::vector<float2>                         _texture_map;
-        rs2::stream_profile                         _texture_source_stream_profile;*/
         optional_value<rs2_intrinsics>              _depth_intrinsics;
         optional_value<rs2_intrinsics>              _texels_intrinsics;
         mutable std::vector<float>                  _texels_depth; // Temporal translation table of (mapped_x*mapped_y) holds the minimal depth value among all depth pixels mapped to that texel

--- a/src/proc/occlusion-filter.h
+++ b/src/proc/occlusion-filter.h
@@ -5,7 +5,11 @@
 #include "../include/librealsense2/hpp/rs_frame.hpp"
 namespace librealsense
 {
-    enum occlusion_rect_type : uint8_t { occlusion_none, occlusion_monotonic_scan, occlusion_exhaustic_search, occlusion_max };
+    enum occlusion_rect_type : uint8_t {
+        occlusion_none,
+        occlusion_monotonic_scan,
+        occlusion_exhaustic_search,
+        occlusion_max };
 
     class pointcloud;
 

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -197,7 +197,7 @@ namespace librealsense
 
             if (_occlusion_filter->active())
             {
-                _occlusion_filter->process(pframe->get_vertices(), width,height,
+                _occlusion_filter->process(pframe->get_vertices(),
                                                  pframe->get_texture_coordinates(),
                                                  _pixels_map);
             }

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -72,6 +72,7 @@ namespace librealsense
                 _depth_intrinsics = video->get_intrinsics();
                 _pixels_map.resize(0);
                 _pixels_map.resize(_depth_intrinsics->height*_depth_intrinsics->width);
+                _occlusion_filter->set_depth_intrinsics(_depth_intrinsics.value());
                 found_depth_intrinsics = true;
             }
         }
@@ -117,6 +118,7 @@ namespace librealsense
             if (auto video = dynamic_cast<video_stream_profile_interface*>(_other_stream.get()))
             {
                 _other_intrinsics = video->get_intrinsics();
+                _occlusion_filter->set_texel_intrinsics(_other_intrinsics.value());
             }
         }
 
@@ -210,6 +212,7 @@ namespace librealsense
                     else
                     {
                         *tex_ptr = { 0.f, 0.f };
+                        *pixels_ptr = { 0.f, 0.f };
                     }
                     ++points;
                     ++tex_ptr;

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -233,7 +233,8 @@ namespace librealsense
         });
         occlusion_invalidation->set_description(0.f, "Off");
         occlusion_invalidation->set_description(1.f, "Heuristic");
-        occlusion_invalidation->set_description(2.f, "Exhaustive");
+        // TODO verify filter's implementation and performance
+        occlusion_invalidation->set_description(2.f, "__"); // Placeholder for Exhaustive
         register_option(RS2_OPTION_FILTER_MAGNITUDE, occlusion_invalidation);
 
         auto on_frame = [this](rs2::frame f, const rs2::frame_source& source)

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -20,12 +20,11 @@ namespace librealsense
         optional_value<rs2_extrinsics>         _extrinsics;
         std::atomic_bool                       _invalidate_mapped;
         std::shared_ptr<occlusion_filter>      _occlusion_filter;
-        std::vector<float2>                    _pixels_map; // Intermedeate translation table of (depth_x*depth_y) holds the mapped texel coordinates for each depth pixel
+        std::vector<float2>                    _pixels_map; // Intermedeate translation table of (depth_x*depth_y) with UV coordinates for each depth pixel
 
         std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
 
-        int                     _other_stream_id = -1;
-        bool                    _occlusion_rectification; // TODO remove after POC is completed
+        int                             _other_stream_id = -1;
         stream_profile_interface*       _depth_stream = nullptr;
 
         void inspect_depth_frame(const rs2::frame& depth);

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -20,7 +20,7 @@ namespace librealsense
         optional_value<rs2_extrinsics>         _extrinsics;
         std::atomic_bool                       _invalidate_mapped;
         std::shared_ptr<occlusion_filter>      _occlusion_filter;
-        std::vector<float2>                    _pixels_map;
+        std::vector<float2>                    _pixels_map; // Intermedeate translation table of (depth_x*depth_y) holds the mapped texel coordinates for each depth pixel
 
         std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
 

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -20,10 +20,11 @@ namespace librealsense
         optional_value<rs2_extrinsics>         _extrinsics;
         std::atomic_bool                       _invalidate_mapped;
         std::shared_ptr<occlusion_filter>      _occlusion_filter;
-        std::vector<float2>                    _pixels_map; // Intermedeate translation table of (depth_x*depth_y) with UV coordinates for each depth pixel
+
+        // Intermediate translation table of (depth_x*depth_y) with actual texel coordinates per depth pixel
+        std::vector<float2>                    _pixels_map;
 
         std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
-
         int                             _other_stream_id = -1;
         stream_profile_interface*       _depth_stream = nullptr;
 

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -5,7 +5,7 @@
 #include "../include/librealsense2/hpp/rs_frame.hpp"
 namespace librealsense
 {
-
+    class occlusion_filter;
     class pointcloud : public processing_block
     {
     public:
@@ -19,11 +19,13 @@ namespace librealsense
         optional_value<float>                  _depth_units;
         optional_value<rs2_extrinsics>         _extrinsics;
         std::atomic_bool                       _invalidate_mapped;
+        std::shared_ptr<occlusion_filter>      _occlusion_filter;
 
         std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
+
         int                     _other_stream_id = -1;
-        bool                    _occlusion_rectification;
-        stream_profile_interface* _depth_stream = nullptr;
+        bool                    _occlusion_rectification; // TODO remove after POC is completed
+        stream_profile_interface*       _depth_stream = nullptr;
 
         void inspect_depth_frame(const rs2::frame& depth);
         void inspect_other_frame(const rs2::frame& other);

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -22,6 +22,7 @@ namespace librealsense
 
         std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
         int                     _other_stream_id = -1;
+        bool                    _occlusion_rectification;
         stream_profile_interface* _depth_stream = nullptr;
 
         void inspect_depth_frame(const rs2::frame& depth);

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -20,6 +20,7 @@ namespace librealsense
         optional_value<rs2_extrinsics>         _extrinsics;
         std::atomic_bool                       _invalidate_mapped;
         std::shared_ptr<occlusion_filter>      _occlusion_filter;
+        std::vector<float2>                    _pixels_map;
 
         std::shared_ptr<stream_profile_interface> _output_stream, _other_stream;
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -166,7 +166,7 @@ namespace librealsense
         explicit pose_stream_profile(platform::stream_profile sp) : stream_profile_base(std::move(sp)) {}
         void update(std::shared_ptr<extension_snapshot> ext) override { /*Nothing to do here*/ }
     };
-	
+
     inline stream_profile to_profile(const stream_profile_interface* sp)
     {
         auto fps = static_cast<uint32_t>(sp->get_framerate());

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -704,7 +704,7 @@ namespace rs2
             _device_model->show_depth_only = true;
             _device_model->show_stream_selection = false;
             _depth_sensor_model = std::shared_ptr<rs2::subdevice_model>(
-                new subdevice_model(dev, dpt_sensor, _error_message));
+                new subdevice_model(_viewer_model,dev, dpt_sensor, _error_message));
             _depth_sensor_model->draw_streams_selector = false;
             _depth_sensor_model->draw_fps_selector = true;
 

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -704,7 +704,7 @@ namespace rs2
             _device_model->show_depth_only = true;
             _device_model->show_stream_selection = false;
             _depth_sensor_model = std::shared_ptr<rs2::subdevice_model>(
-                new subdevice_model(_viewer_model,dev, dpt_sensor, _error_message));
+                new subdevice_model(dev, dpt_sensor, _error_message));
             _depth_sensor_model->draw_streams_selector = false;
             _depth_sensor_model->draw_fps_selector = true;
 

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
     # config-ui
     if(WIN32)
-        add_executable(realsense-viewer WIN32
+        add_executable(realsense-viewer
                 ${RS_VIEWER_CPP} ${CMAKE_CURRENT_SOURCE_DIR}/res/resource.h
                 ${RS_VIEWER_CPP} ${CMAKE_CURRENT_SOURCE_DIR}/res/realsense-viewer.rc
                 ../../common/windows-app-bootstrap.cpp)

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 
     # config-ui
     if(WIN32)
-        add_executable(realsense-viewer
+        add_executable(realsense-viewer WIN32
                 ${RS_VIEWER_CPP} ${CMAKE_CURRENT_SOURCE_DIR}/res/resource.h
                 ${RS_VIEWER_CPP} ${CMAKE_CURRENT_SOURCE_DIR}/res/realsense-viewer.rc
                 ../../common/windows-app-bootstrap.cpp)


### PR DESCRIPTION
Filter to invalidate occluded pixels in pointcloud.
Add UI option to invoke occlusion removal for Depth->RGB texture mapping in realsense-viewer
Minor fixes in viewer