### PR TITLE
Correct linter.js internal behavior for win32 build

### DIFF
--- a/wrappers/nodejs/tools/linter.js
+++ b/wrappers/nodejs/tools/linter.js
@@ -17,7 +17,7 @@ let errors = [];
 function doCppLint(files) {
   if (!files) return;
 
-  let cpplint = (os.platform == 'win32') ? which.sync('cpplint', {pathExt: '.EXE;.PY'})
+  let cpplint = (os.platform() == 'win32') ? which.sync('cpplint', {pathExt: '.EXE;.PY'})
                                          : which.sync('cpplint.py');
   if (!cpplint) {
     console.log('You need install depot_tools, and add to PATH.' +
@@ -42,7 +42,7 @@ function doJsLint(files) {
 
   for (let linter of ['eslint', 'jshint']) {
     let output = null;
-    if (os.platform == 'win32') {
+    if (os.platform() == 'win32') {
       output = spawn(path.join(jsLinterDir, linter + '.cmd'), files).stdout.toString();
     } else {
       output = spawn('node', [path.join(jsLinterDir, linter)].concat(files)).stdout.toString();


### PR DESCRIPTION
Platform detection of linter.js internally fails because `os.platform` is a function (not a property): https://nodejs.org/api/os.html#os_os_platform

Actually, this is harmless because current depot_tools have cpplint.py & cpplint.bat but not cpplint.exe. Anyway, bug is bug.