### PR TITLE
Python free() bug

### DIFF
--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -296,7 +296,6 @@ PYBIND11_MODULE(NAME, m) {
          .def("get_frame_timestamp_domain", &rs2::frame::get_frame_timestamp_domain, "Retrieve the timestamp domain.")
          .def_property_readonly("frame_timestamp_domain", &rs2::frame::get_frame_timestamp_domain, "Retrieve the timestamp domain.")
          .def("get_frame_metadata", &rs2::frame::get_frame_metadata, "Retrieve the current value of a single frame_metadata.", "frame_metadata"_a)
-         .def_property_readonly("frame_metadata", &rs2::frame::get_frame_metadata, "Retrieve the current value of a single frame_metadata.", "frame_metadata"_a)
          .def("supports_frame_metadata", &rs2::frame::supports_frame_metadata, "Determine if the device allows a specific metadata to be queried.", "frame_metadata"_a)
          .def("get_frame_number", &rs2::frame::get_frame_number, "Retrieve the frame number.")
          .def_property_readonly("frame_number", &rs2::frame::get_frame_number, "Retrieve the frame number.")


### PR DESCRIPTION
Fixing issue #1087 .
Removing python binding for `get_frame_metadata()` as pybind11 property.
This function is not a property (it acts as an indexer - takes a parameter), and caused an unexpected behavior to pybind11 which crashed python upon termination.