### PR TITLE
Python API additions

### DIFF
--- a/examples/align/readme.md
+++ b/examples/align/readme.md
@@ -157,11 +157,11 @@ At this point the `align` object is valid and will be able to align depth frames
 
 ```cpp
     //Get processed aligned frame
-    auto proccessed = align.proccess(frameset);
+    auto processed = align.process(frameset);
 
     // Trying to get both color and aligned depth frames
-    rs2::video_frame other_frame = proccessed.first_or_default(align_to);
-    rs2::depth_frame aligned_depth_frame = proccessed.get_depth_frame();
+    rs2::video_frame other_frame = processed.first_or_default(align_to);
+    rs2::depth_frame aligned_depth_frame = processed.get_depth_frame();
 
     //If one of them is unavailable, continue iteration
     if (!aligned_depth_frame || !other_frame)

--- a/wrappers/opencv/grabcuts/readme.md
+++ b/wrappers/opencv/grabcuts/readme.md
@@ -16,7 +16,7 @@ We start by getting a pair of spatially and temporally synchronized frames:
 frameset data = pipe.wait_for_frames();
 // Make sure the frameset is spatialy aligned 
 // (each pixel in depth image corresponds to the same pixel in the color image)
-frameset aligned_set = align_to.proccess(data);
+frameset aligned_set = align_to.process(data);
 frame depth = aligned_set.get_depth_frame();
 auto color_mat = frame_to_mat(aligned_set.get_color_frame());
 ```

--- a/wrappers/python/examples/align-depth2color.py
+++ b/wrappers/python/examples/align-depth2color.py
@@ -48,7 +48,7 @@ try:
         # frames.get_depth_frame() is a 640x360 depth image
         
         # Align the depth frame to color frame
-        aligned_frames = align.proccess(frames)
+        aligned_frames = align.process(frames)
         
         # Get aligned frames
         aligned_depth_frame = aligned_frames.get_depth_frame() # aligned_depth_frame is a 640x480 depth image

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -465,7 +465,7 @@ PYBIND11_MODULE(NAME, m) {
 
     py::class_<rs2::align> align(m, "align");
     align.def(py::init<rs2_stream>(), "align_to"_a)
-        .def("proccess", &rs2::align::process, "depth"_a);
+        .def("process", &rs2::align::process, "depth"_a);
 
     /* rs2_record_playback.hpp */
     py::class_<rs2::playback, rs2::device> playback(m, "playback");

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -18,6 +18,7 @@ Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 #include "../include/librealsense2/rs.h"
 #include "../include/librealsense2/rs.hpp"
 #include "../include/librealsense2/rs_advanced_mode.hpp"
+#include "../include/librealsense2/rsutil.h"
 #define NAME pyrealsense2
 #define SNAME "pyrealsense2"
 #define BIND_RAW_ARRAY(class, name, type, size) #name, [](const class &c) -> const std::array<type, size>& { return reinterpret_cast<const std::array<type, size>&>(c.name); }
@@ -498,8 +499,10 @@ PYBIND11_MODULE(NAME, m) {
         .def(BIND_DOWNCAST(stream_profile, stream_profile))
         .def(BIND_DOWNCAST(stream_profile, video_stream_profile))
         .def("stream_name", &rs2::stream_profile::stream_name)
+        .def("is_default", &rs2::stream_profile::is_default)
         .def("__nonzero__", &rs2::stream_profile::operator bool)
         .def("get_extrinsics_to", &rs2::stream_profile::get_extrinsics_to, "to"_a)
+        .def("register_extrinsics_to", &rs2::stream_profile::register_extrinsics_to, "to"_a, "extrinsics"_a)
         .def("__repr__", [](const rs2::stream_profile& self)
     {
         std::stringstream ss;
@@ -893,4 +896,33 @@ PYBIND11_MODULE(NAME, m) {
     m.def("log_to_console", &rs2::log_to_console, "min_severity"_a);
     m.def("log_to_file", &rs2::log_to_file, "min_severity"_a, "file_path"_a);
 
+    /* rsutil.h */
+    m.def("rs2_project_point_to_pixel", [](const rs2_intrinsics& intrin, const std::array<float, 3>& point)->std::array<float, 2>
+    {
+        std::array<float, 2> pixel{};
+        rs2_project_point_to_pixel(pixel.data(), &intrin, point.data());
+        return pixel;
+    }, "Given a point in 3D space, compute the corresponding pixel coordinates in an image with no distortion or forward distortion coefficients produced by the same camera");
+
+    m.def("rs2_deproject_pixel_to_point", [](const rs2_intrinsics& intrin, const std::array<float, 2>& pixel, float depth)->std::array<float, 3>
+    {
+        std::array<float, 3> point{};
+        rs2_deproject_pixel_to_point(point.data(), &intrin, pixel.data(), depth);
+        return point;
+    }, "Given pixel coordinates and depth in an image with no distortion or inverse distortion coefficients, compute the corresponding point in 3D space relative to the same camera");
+
+    m.def("rs2_transform_point_to_point", [](const rs2_extrinsics& extrin, const std::array<float, 3>& from_point)->std::array<float, 3>
+    {
+        std::array<float, 3> to_point{};
+        rs2_transform_point_to_point(to_point.data(), &extrin, from_point.data());
+        return to_point;
+    }, "Transform 3D coordinates relative to one sensor to 3D coordinates relative to another viewpoint");
+
+    m.def("rs2_fov", [](const rs2_intrinsics& intrin)->std::array<float, 2>
+    {
+        std::array<float, 2> to_fow{};
+        rs2_fov(&intrin, to_fow.data());
+        return to_fow;
+
+    }, "Calculate horizontal and vertical feild of view, based on video intrinsics");
 }


### PR DESCRIPTION
## API Changes

Renamed `align.proccess` to `process`, fixed example code to match.

## API Additions:
Adding missing functions to `stream_profile`:
* is_default
* register_extrinsics_to

(Following PR #1106)
and for `rsutil.h` projection related functions:

* `rs2_deproject_pixel_to_point`
* `rs2_transform_point_to_point`
* `rs2_project_point_to_pixel`
* `rs2_fov`

Example usage:
```py
import pyrealsense2 as rs
pipeline = rs.pipeline()
pipe_profile = pipeline.start()
frames = pipeline.wait_for_frames()
depth_frame = frames.get_depth_frame()
color_frame = frames.get_color_frame()
depth_intrin = depth_frame.profile.as_video_stream_profile().intrinsics
color_intrin = color_frame.profile.as_video_stream_profile().intrinsics
depth_to_color_extrin = depth_frame.profile.get_extrinsics_to(color_frame.profile)
depth_sensor = pipe_profile.get_device().first_depth_sensor()
depth_scale = depth_sensor.get_depth_scale()
depth_pixel = [200, 200]
depth_point = rs.rs2_deproject_pixel_to_point(depth_intrin, depth_pixel, depth_scale)
color_point = rs.rs2_transform_point_to_point(depth_to_color_extrin, depth_point)
color_pixel = rs.rs2_project_point_to_pixel(color_intrin, color_point)
pipeline.stop()
```
