### PR TITLE
Handle syncer with high exposure value

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1376,6 +1376,12 @@ namespace rs2
 
     texture_buffer* stream_model::upload_frame(frame&& f)
     {
+        if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
+        {
+            auto fps = f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
+            _frame_timeout = (1000.f / (float)fps) * 30;
+
+        }
         if (dev && dev->is_paused() && !dev->dev.is<playback>()) return nullptr;
 
         last_frame = std::chrono::high_resolution_clock::now();

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -606,7 +606,6 @@ namespace rs2
             depth_stream_active(false),
             resulting_queue_max_size(20),
             resulting_queue(static_cast<unsigned int>(resulting_queue_max_size)),
-//            frames_queue(4),
             t([this]() {render_loop(); })
         {
             processing_block.start(resulting_queue);

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -38,6 +38,7 @@ typedef enum rs2_frame_metadata_value
     RS2_FRAME_METADATA_TIME_OF_ARRIVAL      , /**< Time of arrival in system clock */
     RS2_FRAME_METADATA_TEMPERATURE          , /**< Temperature of the device, measured at the time of the frame capture. Celsius degrees */
     RS2_FRAME_METADATA_BACKEND_TIMESTAMP    , /**< Timestamp get from uvc driver. usec*/
+    RS2_FRAME_METADATA_ACTUAL_FPS           , /**< Actual fps */
     RS2_FRAME_METADATA_COUNT
 } rs2_frame_metadata_value;
 const char* rs2_frame_metadata_to_string(rs2_frame_metadata_value metadata);

--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -92,7 +92,7 @@ namespace librealsense
         color_ep->register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
 
         color_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
-        color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS,  std::make_shared<md_attribute_actual_fps> ());
+        color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS,  std::make_shared<md_attribute_actual_fps> (false, [](const rs2_metadata_type& param){return param*100;}));
 
         // attributes of md_capture_timing
         auto md_prop_offset = offsetof(metadata_raw, mode) +

--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -92,6 +92,7 @@ namespace librealsense
         color_ep->register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
 
         color_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
+        color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS,  std::make_shared<md_attribute_actual_fps> ());
 
         // attributes of md_capture_timing
         auto md_prop_offset = offsetof(metadata_raw, mode) +

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -477,6 +477,7 @@ namespace librealsense
         depth_ep.register_metadata((rs2_frame_metadata_value)RS2_FRAME_METADATA_FORMAT, make_attribute_parser(&md_configuration::format, md_configuration_attributes::format_attribute, md_prop_offset));
         depth_ep.register_metadata((rs2_frame_metadata_value)RS2_FRAME_METADATA_WIDTH, make_attribute_parser(&md_configuration::width, md_configuration_attributes::width_attribute, md_prop_offset));
         depth_ep.register_metadata((rs2_frame_metadata_value)RS2_FRAME_METADATA_HEIGHT, make_attribute_parser(&md_configuration::height, md_configuration_attributes::height_attribute, md_prop_offset));
+        depth_ep.register_metadata((rs2_frame_metadata_value)RS2_FRAME_METADATA_ACTUAL_FPS,  std::make_shared<md_attribute_actual_fps> ());
 
         register_info(RS2_CAMERA_INFO_NAME, device_name);
         register_info(RS2_CAMERA_INFO_SERIAL_NUMBER, serial);

--- a/src/ivcam/sr300.h
+++ b/src/ivcam/sr300.h
@@ -363,6 +363,7 @@ namespace librealsense
             color_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp,
                 [](rs2_metadata_type param) { return static_cast<rs2_metadata_type>(param * TIMESTAMP_10NSEC_TO_MSEC); }));
             color_ep->register_metadata(RS2_FRAME_METADATA_FRAME_COUNTER,   make_sr300_attribute_parser(&md_sr300_rgb::frame_counter, md_offset));
+            color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS,      make_sr300_attribute_parser(&md_sr300_rgb::actual_fps, md_offset));
             color_ep->register_metadata(RS2_FRAME_METADATA_SENSOR_TIMESTAMP,make_sr300_attribute_parser(&md_sr300_rgb::frame_latency, md_offset));
             color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE, make_sr300_attribute_parser(&md_sr300_rgb::actual_exposure, md_offset, [](rs2_metadata_type param) { return param*100; }));
             color_ep->register_metadata(RS2_FRAME_METADATA_AUTO_EXPOSURE,   make_sr300_attribute_parser(&md_sr300_rgb::auto_exp_mode, md_offset, [](rs2_metadata_type param) { return (param !=1); }));
@@ -410,6 +411,7 @@ namespace librealsense
             depth_ep->register_metadata(RS2_FRAME_METADATA_FRAME_COUNTER,   make_sr300_attribute_parser(&md_sr300_depth::frame_counter, md_offset));
             depth_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE, make_sr300_attribute_parser(&md_sr300_depth::actual_exposure, md_offset,
                 [](rs2_metadata_type param) { return param * 100; }));
+            depth_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS,      make_sr300_attribute_parser(&md_sr300_depth::actual_fps, md_offset));
 
             return depth_ep;
         }

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -235,23 +235,21 @@ namespace librealsense
             }
             else
             {
-                auto timestamp = frm.get_frame_timestamp();
                 auto frame_number = frm.get_frame_number();
-
                 if(frame_number > _last_frame_number)
                 {
+                    auto timestamp = frm.get_frame_timestamp();
                     _last_diff = (double)(timestamp - _last_time_stamp)/(double)(frame_number-_last_frame_number);
-                    _last_frame_number = frame_number;
-
                 }
                 else if(frame_number < _last_frame_number)
                 {
-                    _last_frame_number = frame_number;
                     _last_diff = 0;
                 }
+                _last_frame_number = frame_number;
             }
+            
             _last_time_stamp = frm.get_frame_timestamp();
-            return _last_diff ? 1000.f/_last_diff:frm.get_stream()->get_framerate();
+            return _last_diff ? 1000.f/ _last_diff :frm.get_stream()->get_framerate();
         }
     private:
 
@@ -261,14 +259,14 @@ namespace librealsense
         double _last_diff = 0;
     };
 
+
     class md_attribute_actual_fps : public md_attribute_parser_base
     {
     public:
         md_attribute_actual_fps()
             :_fps_values {6, 15, 30, 60}
-        {
+        {}
 
-        }
         rs2_metadata_type get(const frame & frm) const override
         {
            if(frm.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE))
@@ -286,7 +284,7 @@ namespace librealsense
            }
            else
            {
-               return (rs2_metadata_type)_fps_calculator.get_fps(frm);
+               return (rs2_metadata_type)_fps_calculator[frm.get_stream()->get_unique_id()].get_fps(frm);
            }
         }
 
@@ -296,7 +294,7 @@ namespace librealsense
         }
 
     private:
-        mutable actual_fps_calculator _fps_calculator;
+        mutable std::map<int,actual_fps_calculator> _fps_calculator;
         const std::vector<int> _fps_values;
     };
 

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -247,7 +247,7 @@ namespace librealsense
 
         std::mutex _mutex;
         double _last_time_stamp = 0;
-        long long _last_frame_number = 0;
+        long long _last_frame_number = 1;
         double _last_diff = 0;
     };
 

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -7,7 +7,7 @@
 #include "types.h"
 #include "archive.h"
 #include "metadata.h"
-
+#include <cmath>
 using namespace librealsense;
 
 namespace librealsense

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -507,6 +507,7 @@ namespace librealsense
         {
             fps = f.frame->get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
         }
+        LOG_DEBUG("fps " <<fps<<" "<< frame_to_string(const_cast<frame_holder&>(f)));
         return fps?fps:f.frame->get_stream()->get_framerate();
     }
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -122,6 +122,7 @@ namespace librealsense
         virtual void update_last_arrived(frame_holder& f, matcher* m) = 0;
 
         void dispatch(frame_holder f, syncronization_environment env) override;
+        std::string frames_to_string(std::vector<librealsense::matcher*> matchers);
         void sync(frame_holder f, syncronization_environment env) override;
         std::shared_ptr<matcher> find_matcher(const frame_holder& f);
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -161,6 +161,7 @@ namespace librealsense
         void update_next_expected(const frame_holder & f) override;
 
     private:
+        int get_fps(const frame_holder & f);
         bool are_equivalent(double a, double b, int fps);
         std::map<matcher*, double> _last_arrived;
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -164,6 +164,7 @@ namespace librealsense
         int get_fps(const frame_holder & f);
         bool are_equivalent(double a, double b, int fps);
         std::map<matcher*, double> _last_arrived;
+        std::map<matcher*, int> _fps;
 
     };
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -341,6 +341,7 @@ namespace librealsense
                 CASE(TIME_OF_ARRIVAL)
                 CASE(TEMPERATURE)
                 CASE(BACKEND_TIMESTAMP)
+                CASE(ACTUAL_FPS)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/src/win/win-uvc.cpp
+++ b/src/win/win-uvc.cpp
@@ -206,7 +206,7 @@ namespace librealsense
                                 auto& stream = owner->_streams[dwStreamIndex];
                                 std::lock_guard<std::mutex> lock(owner->_streams_mutex);
                                 auto profile = stream.profile;
-                                frame_object f{ current_length, metadata_size, byte_buffer, metadata, monotonic_to_realtime(llTimestamp/10000) };
+                                frame_object f{ current_length, metadata_size, byte_buffer, metadata, monotonic_to_realtime(llTimestamp/10000.f) };
 
                                 auto continuation = [buffer, this]()
                                 {

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -208,7 +208,7 @@ void refresh_devices(std::mutex& m,
 
 int main(int argv, const char** argc) try
 {
-    rs2::log_to_console(RS2_LOG_SEVERITY_WARN);
+    rs2::log_to_file(RS2_LOG_SEVERITY_DEBUG);
 
     ux_window window("Intel RealSense Viewer");
 

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -203,6 +203,7 @@ TEST_CASE("Sync sanity", "[live]") {
         }
 
         std::vector<std::vector<double>> all_timestamps;
+        auto actual_fps =  30;
         bool hw_timestamp_domain = false;
         bool system_timestamp_domain = false;
         for (auto i = 0; i < 200; i++)
@@ -213,6 +214,14 @@ TEST_CASE("Sync sanity", "[live]") {
             std::vector<double> timestamps;
             for (auto&& f : frames)
             {
+                if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
+                {
+                    auto val = f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
+                    if (val < actual_fps)
+                    {
+                        actual_fps = val;
+                    }
+                }
                 if (f.get_frame_timestamp_domain() == RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK)
                 {
                     hw_timestamp_domain = true;
@@ -245,7 +254,7 @@ TEST_CASE("Sync sanity", "[live]") {
                 continue;
 
             std::sort(set_timestamps.begin(), set_timestamps.end());
-            REQUIRE(set_timestamps[set_timestamps.size() - 1] - set_timestamps[0] <= DELTA);
+            REQUIRE(set_timestamps[set_timestamps.size() - 1] - set_timestamps[0] <= (float)1000/(float)actual_fps);
         }
 
         CAPTURE(num_of_partial_sync_sets);


### PR DESCRIPTION
Added new metadata field - actual_fps and use it by syncer for its calculation 
instead of requested fps.