### PR TITLE
Add rs2::frameset::get_infrared_frame()

### DIFF
--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -686,6 +686,24 @@ namespace rs2
             }
             return f;
         }
+
+        video_frame get_infrared_frame(const size_t index = 0) const
+        {
+            frame f;
+            if (!index)
+            {
+                f = first_or_default(RS2_STREAM_INFRARED);
+            }
+            else
+            {
+                foreach([&f, index](const frame& frame) {
+                    if (frame.get_profile().stream_type() == RS2_STREAM_INFRARED && frame.get_profile().stream_index() == index)
+                        f = frame;
+                });
+            }
+            return f;
+        }
+
         size_t size() const
         {
             return _size;


### PR DESCRIPTION
This pull request proposes adding <code>rs2::frameset::get_infrared_frame()</code>.
This function returns the infrared video_frame like <code>rs2::frameset::get_color_frame()</code>.
If this function called with a stream index argument, It returns the infrared frame with that stream index.

```cpp
// set stream config
rs2::config config;
config.enable_stream(RS2_STREAM_INFRARED, 1, width, height, RS2_FORMAT_Y8, fps);
config.enable_stream(RS2_STREAM_INFRARED, 2, width, height, RS2_FORMAT_Y8, fps);

// start pipeline
rs2::pipeline pipeline;
rs2::pipeline_profile pipeline_profile = pipeline.start(config);

// wait for frames and get frameset
rs2::frameset frameset = pipeline.wait_for_frames();

// get single infrared frame from frameset
rs2::video_frame ir_frame = frameset.get_infrared_frame();

// get left and right infrared frames from frameset
rs2::video_frame ir_frame_left = frameset.get_infrared_frame(1);
rs2::video_frame ir_frame_right = frameset.get_infrared_frame(2);
```

What do you think?
Thanks,