### PR TITLE
Fix exceptions error building node module on macOS

### DIFF
--- a/wrappers/nodejs/binding.gyp
+++ b/wrappers/nodejs/binding.gyp
@@ -53,6 +53,13 @@
             ],
           }
         ],
+        ['OS=="mac"',
+          {
+            'xcode_settings': {
+              'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+            }
+          }
+        ],
         [
           "OS!=\"win\"",
           {

--- a/wrappers/nodejs/scripts/npm_dist/binding.gyp
+++ b/wrappers/nodejs/scripts/npm_dist/binding.gyp
@@ -48,6 +48,13 @@
             ],
           }
         ],
+        ['OS=="mac"',
+          {
+            'xcode_settings': {
+              'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+            }
+          }
+        ],
         [
           "OS!=\"win\"",
           {


### PR DESCRIPTION
On macOS, building the Node module results in errors about using `'throw' with exceptions disabled`:

```
$ npm install

> node-librealsense@0.290.0 install /Users/dan/workspace/ar/librealsense/wrappers/nodejs
> node-gyp rebuild

  CXX(target) Release/obj.target/node_librealsense/src/addon.o
In file included from ../src/addon.cpp:8:
../../../include/librealsense2/hpp/rs_types.hpp:130:17: error: cannot use 'throw' with exceptions disabled
                throw camera_disconnected_error(e);
                ^
../../../include/librealsense2/hpp/rs_types.hpp:132:17: error: cannot use 'throw' with exceptions disabled
                throw backend_error(e);
                ^
../../../include/librealsense2/hpp/rs_types.hpp:134:17: error: cannot use 'throw' with exceptions disabled
                throw invalid_value_error(e);
                ^
../../../include/librealsense2/hpp/rs_types.hpp:136:17: error: cannot use 'throw' with exceptions disabled
                throw wrong_api_call_sequence_error(e);
                ^
../../../include/librealsense2/hpp/rs_types.hpp:138:17: error: cannot use 'throw' with exceptions disabled
                throw not_implemented_error(e);
                ^
../../../include/librealsense2/hpp/rs_types.hpp:140:17: error: cannot use 'throw' with exceptions disabled
                throw device_in_recovery_mode_error(e);
                ^
../../../include/librealsense2/hpp/rs_types.hpp:142:17: error: cannot use 'throw' with exceptions disabled
                throw error(e);
                ^
```

This PR fixes that error by setting the correct flag to enable exceptions in GCC on the Mac.