### PR TITLE
Fix glfw dep name and version

### DIFF
--- a/wrappers/nodejs/examples/CMakeLists.txt
+++ b/wrappers/nodejs/examples/CMakeLists.txt
@@ -28,16 +28,16 @@ string(REPLACE "ia32" "x86" ARCH ${ARCH})
 set(PKG_STR node${NODE_VERSOIN}-${OS}-${ARCH})
 
 add_custom_command(
-  OUTPUT ${PROJECT_SOURCE_DIR}/node_modules/node-glfw-3/build/Release/glfw.node
+  OUTPUT ${PROJECT_SOURCE_DIR}/node_modules/node-glfw/build/Release/glfw.node
   COMMAND npm install
   DEPENDS BUILD_NODE_ADDON package.json
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-  COMMENT "Build node-glfw-3"
+  COMMENT "Build node-glfw"
 )
 
 add_custom_target(
   BUILD_NODE_EXAMPLES ALL
-  DEPENDS ${PROJECT_SOURCE_DIR}/node_modules/node-glfw-3/build/Release/glfw.node
+  DEPENDS ${PROJECT_SOURCE_DIR}/node_modules/node-glfw/build/Release/glfw.node
 )
 set_target_properties(BUILD_NODE_EXAMPLES PROPERTIES FOLDER Wrappers/NodeJS)
 
@@ -89,4 +89,4 @@ set_target_properties(RealsenseNodeJSExamples PROPERTIES FOLDER Wrappers/NodeJS)
 install(PROGRAMS ${packagedExamples} DESTINATION ${CMAKE_INSTALL_BINDIR})
 # TODO: Use buildtype instead of hardcode of Release
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../build/Release/node_librealsense.node DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/node_modules/node-glfw-3/build/Release/glfw.node DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/node_modules/node-glfw/build/Release/glfw.node DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/wrappers/nodejs/examples/glfw-window.js
+++ b/wrappers/nodejs/examples/glfw-window.js
@@ -4,7 +4,7 @@
 
 'use strict';
 
-const glfw = require('node-glfw-3');
+const glfw = require('node-glfw');
 const rs2 = require('../index.js');
 const now = require('performance-now');
 

--- a/wrappers/nodejs/examples/package-lock.json
+++ b/wrappers/nodejs/examples/package-lock.json
@@ -93,6 +93,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -538,11 +543,12 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
       "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
     },
-    "node-glfw-3": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/node-glfw-3/-/node-glfw-3-0.3.2.tgz",
-      "integrity": "sha1-dR7PVchis2cWCiXp1K9Paf7mlSE=",
+    "node-glfw": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/node-glfw/-/node-glfw-0.4.6.tgz",
+      "integrity": "sha1-y3X8irKSUiOoGS3WFQSIZDm88Vg=",
       "requires": {
+        "bindings": "1.3.0",
         "nan": "2.7.0"
       }
     },

--- a/wrappers/nodejs/examples/package.json
+++ b/wrappers/nodejs/examples/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "node-glfw-3": "^0.3.2",
+    "node-glfw": "^0.4.6",
     "performance-now": "^2.1.0",
     "pkg": "^4.2.4"
   }


### PR DESCRIPTION
The node glfw package appears to have a different name than the one in the nodejs wrapper source.

This change allows the nodejs wrapper to build on my machine (macOS High Sierra).