### PR TITLE
Added USE_SYSTEM_LIBUSB flag to CMake file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,15 @@ before_install:
       brew uninstall xctool;
       brew install xctool --HEAD;
       brew install homebrew/versions/glfw3;
+      brew install libusb;
     fi
 
   # Install linux required packages
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
       sudo apt-get update;
-      sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev libudev-dev;
+      sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
+      sudo apt-get install -qq libusb-1.0-0-dev;
       sudo apt-get install -qq libgtk-3-dev;
       sudo apt-get install -qq python python-dev;
       sudo apt-get install gcc-5 g++-5;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,11 @@ option(BUILD_GRAPHICAL_EXAMPLES "Build graphical examples and tools." ON)
 
 option(BUILD_WITH_OPENMP "Use OpenMP" ON)
 
+option(USE_SYSTEM_LIBUSB "Use the distribution libusb package" ON)
+if (WIN32)
+    set(USE_SYSTEM_LIBUSB OFF)
+endif()
+
 option(ENABLE_ZERO_COPY "Enable zero copy functionality" OFF)
 if (ENABLE_ZERO_COPY)
     add_definitions(-DZERO_COPY)
@@ -66,6 +71,7 @@ if(ANDROID_NDK_TOOLCHAIN_INCLUDED)
     unset(WIN32)
     unset(UNIX)
     unset(APPLE)
+    set(USE_SYSTEM_LIBUSB OFF)
     set(BUILD_WITH_OPENMP OFF)
     set(FORCE_LIBUVC ON)
     set(BUILD_GRAPHICAL_EXAMPLES OFF)
@@ -555,6 +561,17 @@ if(UNIX)
         message(FATAL_ERROR "\n\n PkgConfig package is missing!\n\n")
     endif()
 
+    if (USE_SYSTEM_LIBUSB)
+        pkg_search_module(LIBUSB1 REQUIRED libusb-1.0)
+        if(LIBUSB1_FOUND)
+            include_directories(SYSTEM ${LIBUSB1_INCLUDE_DIRS})
+            link_directories(${LIBUSB1_LIBRARY_DIRS})
+            list(APPEND librealsense_PKG_DEPS "libusb-1.0")
+        else()
+            message( FATAL_ERROR "Failed to find libusb-1.0" )
+        endif(LIBUSB1_FOUND)
+    endif()
+
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_BSD_SOURCE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pedantic -g -Wno-missing-field-initializers")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar -Wsequence-point -Wformat-security")
@@ -585,10 +602,12 @@ if(HWM_OVER_XU)
     add_definitions(-DHWM_OVER_XU)
 endif()
 
-if(NOT WIN32)
-    add_subdirectory(third-party/libusb/)
-elseif(FORCE_LIBUVC)
-    add_subdirectory(third-party/libusb/)
+if (NOT USE_SYSTEM_LIBUSB)
+    if(NOT WIN32)
+        add_subdirectory(third-party/libusb/)
+    elseif(FORCE_LIBUVC)
+        add_subdirectory(third-party/libusb/)
+    endif()
 endif()
 
 add_subdirectory(third-party/realsense-file)
@@ -677,10 +696,14 @@ set_target_properties(realsense2 PROPERTIES VERSION ${REALSENSE_VERSION_STRING}
                                 SOVERSION ${REALSENSE_VERSION_MAJOR})
 target_link_libraries(realsense2 PRIVATE realsense-file ${CMAKE_THREAD_LIBS_INIT} ${TRACKING_DEVICE_LIBS})
 
-if(NOT WIN32)
-    target_link_libraries(realsense2 PRIVATE usb)
-elseif(FORCE_LIBUVC)
-    target_link_libraries(realsense2 PRIVATE usb)
+if (NOT USE_SYSTEM_LIBUSB)
+    if(NOT WIN32)
+        target_link_libraries(realsense2 PRIVATE usb)
+    elseif(FORCE_LIBUVC)
+        target_link_libraries(realsense2 PRIVATE usb)
+    endif()
+else()
+    target_link_libraries(realsense2 PRIVATE ${LIBUSB1_LIBRARIES})
 endif()
 
 
@@ -706,6 +729,10 @@ target_include_directories(realsense2 PRIVATE
         ${BOOST_INCLUDE_PATH}
         ${LZ4_INCLUDE_PATH}
         )
+
+if (USE_SYSTEM_LIBUSB)
+    target_include_directories(realsense2 PRIVATE ${LIBUSB1_INCLUDE_DIRS})
+endif()
 
 target_include_directories(realsense2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                             $<INSTALL_INTERFACE:include>

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -22,7 +22,7 @@
     * Complete the boot, login and verify that the required kernel version (4.4.0-79 or 4.8.0-54 as of June 17th 2017) is in place with `uname -r`
 
 2. Install the packages required for *librealsense* build:
-  * *libudev-dev*, *pkg-config* and *libgtk-3*: `sudo apt-get install libudev-dev pkg-config libgtk-3-dev`.
+  * *libusb-1.0*, *pkg-config* and *libgtk-3*: `sudo apt-get install libusb-1.0-0-dev pkg-config libgtk-3-dev`.
   * **Note:** glfw3 and gtk is only required if you plan to build the example code, not for the *librealsense* core library.
 
   * *glfw3*:


### PR DESCRIPTION
The RealSense SDK will compile by default against the `distro libusb-dev package` on Linux OS instead of the embedded one. This behavior can be controlled by the `USE_SYSTEM_LIBUSB` CMake flag.
On Android and Windows OS it will compile against the embedded `libusb` as before.