### PR TITLE
OSX CI fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,9 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew uninstall xctool;
       brew install xctool --HEAD;
-      brew install homebrew/versions/glfw3;
+      brew update;
+      brew doctor;
+      brew install glfw;
     fi
 
   # Install linux required packages


### PR DESCRIPTION
A fix to workaround/resolve travis CI error in osx build:
> Error: homebrew/versions was deprecated. This tap is now empty as all its formulae were migrated.
