### PR TITLE
Fix stderr redirection in the patch script

### DIFF
--- a/scripts/patch-realsense-ubuntu-xenial.sh
+++ b/scripts/patch-realsense-ubuntu-xenial.sh
@@ -3,18 +3,19 @@
 #Break execution on any error received
 set -e
 
-#Locally suppress sterr to avoid raising not relevant messages
-exec 3>&2
-exec 2> /dev/null
+#Locally suppress stderr to avoid raising not relevant messages
+exec 2>/dev/null
 
 if [ $(ls /dev/video* | wc -l) -ne 0 ];
 then
+	# Restore stderr
+	exec 2>&1
 	echo -e "\e[32m"
 	read -p "Remove all RealSense cameras attached. Hit any key when ready"
 	echo -e "\e[0m"
 fi
-# Restore sterr
-exec 2>&3
+# Restore stderr
+exec 2>&1
 
 #Include usability functions
 source ./scripts/patch-utils.sh


### PR DESCRIPTION
The `-p` parameter of [`read`](https://ss64.com/bash/read.html) Bash command prints the message via the standard error pipe. So when running the patch script and a camera is connected the message of `Remove all RealSense cameras attached. Hit any key when ready` didn't show up.