### PR TITLE
clarify distortion model coefficients order

### DIFF
--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -60,8 +60,8 @@ typedef struct rs2_intrinsics
     float         ppy;       /**< Vertical coordinate of the principal point of the image, as a pixel offset from the top edge */
     float         fx;        /**< Focal length of the image plane, as a multiple of pixel width */
     float         fy;        /**< Focal length of the image plane, as a multiple of pixel height */
-    rs2_distortion model;     /**< Distortion model of the image */
-    float         coeffs[5]; /**< Distortion coefficients */
+    rs2_distortion model;    /**< Distortion model of the image */
+    float         coeffs[5]; /**< Distortion coefficients, order: k1, k2, p1, p2, k3 */
 } rs2_intrinsics;
 
 /** \brief Motion device intrinsics: scale, bias, and variances */


### PR DESCRIPTION
Documenting the order prevents people from needing to hunt through the code and figure out how they're actually used.  From inspection / comparison [with the formula](https://en.wikipedia.org/wiki/Distortion_(optics)#Software_correction), that was the order I interpreted.

It seems to agree with [the comment here](https://github.com/IntelRealSense/librealsense/issues/479#issuecomment-297263265) as well :smile:

But I also didn't look very closely, and I'm not deeply familiar with the no-tangential shenanigans / modified brown-conrady stuff you all are doing.