### PR TITLE
Fix software device to enable recording into ROS-bag

### DIFF
--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -93,7 +93,10 @@ namespace librealsense
         set_active_streams(requests);
     }
 
-    void software_sensor::close(){}
+    void software_sensor::close()
+    {
+        set_active_streams({});
+    }
 
     void software_sensor::start(frame_callback_ptr callback)
     {

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -90,22 +90,22 @@ namespace librealsense
 
     void software_sensor::open(const stream_profiles& requests)
     {
-
+        set_active_streams(requests);
     }
-    void software_sensor::close()
-    {
 
-    }
+    void software_sensor::close(){}
 
     void software_sensor::start(frame_callback_ptr callback)
     {
         _source.init(_metadata_parsers);
         _source.set_sensor(this->shared_from_this());
         _source.set_callback(callback);
+        raise_on_before_streaming_changes(true);
     }
 
     void software_sensor::stop()
     {
+        raise_on_before_streaming_changes(false);
         _source.flush();
         _source.reset();
     }
@@ -121,6 +121,7 @@ namespace librealsense
             RS2_EXTENSION_DEPTH_FRAME : RS2_EXTENSION_VIDEO_FRAME;
 
         auto frame = _source.alloc_frame(extension, 0, data, false);
+        if (!frame) return;
 
         auto vid_profile = dynamic_cast<video_stream_profile_interface*>(software_frame.profile->profile);
         auto vid_frame = dynamic_cast<video_frame*>(frame);


### PR DESCRIPTION
Recently a change was introduced to the recorder to allow starting recording mid-streaming (I believe in 2.9.1) 
This change was not reflected in the software device helper class. 
As a result, trying to record the output of software device into ROS-bag was failing. 
This change adds the necessary boilerplate to the software sensor to dynamically connect to the recorder. 