### PR TITLE
Pipeline streaming restart fix

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -237,7 +237,7 @@ namespace librealsense
                         {
                             try
                             {
-                                auto dev = dev_info->create_device();
+                                auto dev = dev_info->create_device(true);
                                 _resolved_profile = std::make_shared<pipeline_profile>(dev, config, _device_request.record_output);
                                 return _resolved_profile;
                             }


### PR DESCRIPTION
This change enables the device created in pipeline to monitor themselves (this enables the pipeline to restart a device in case of re-connections).
Without this change, in case the device disconnects and re connects while streaming the pipeline will fail to use that device unless the user stops and start the pipeline again.
This behavior already exists in the pipeline when creating a device using the `device_hub` (when user did not call `enable_stream`), so this change merely makes the behavior consistent. 