### PR TITLE
[NET wrapper] AdvancedDevice fix

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Device.cs
+++ b/wrappers/csharp/Intel.RealSense/Device.cs
@@ -156,11 +156,14 @@ namespace Intel.RealSense
 
     public class AdvancedDevice : Device
     {
-        private const string AdvancedModeDisabledException = "Advanced mode has not been enabled";
-
         internal AdvancedDevice(IntPtr dev) : base(dev)
         {
 
+        }
+
+        public static AdvancedDevice FromDevice(Device dev)
+        {
+            return new AdvancedDevice(dev.m_instance);
         }
 
         public bool AdvancedModeEnabled

--- a/wrappers/csharp/Intel.RealSense/Device.cs
+++ b/wrappers/csharp/Intel.RealSense/Device.cs
@@ -163,6 +163,12 @@ namespace Intel.RealSense
 
         public static AdvancedDevice FromDevice(Device dev)
         {
+            object error;
+            if (NativeMethods.rs2_is_device_extendable_to(dev.m_instance, Extension.AdvancedMode, out error) == 0)
+            {
+                throw new ArgumentException("Device does not support AdvancedMode");
+            }
+
             return new AdvancedDevice(dev.m_instance);
         }
 


### PR DESCRIPTION
Somehow forgot to add a way to get an `AdvancedDevice` in #1158. Also remove unused string that slipped into the PR.