### PR TITLE
[Node.js] Support npm installation on macos

### DIFF
--- a/wrappers/nodejs/README.md
+++ b/wrappers/nodejs/README.md
@@ -28,6 +28,14 @@ sudo apt-get install -y nodejs
 #### Windows 10
 Please download the .msi file of v6.x (for example v6.12.0) from [x86](https://nodejs.org/download/release/v6.12.0/node-v6.12.0-x86.msi) or [x64](https://nodejs.org/download/release/v6.12.0/node-v6.12.0-x64.msi) and install it.
 
+#### Mac OS
+**Note:** OSX support for the full range of functionality offered by the SDK is not yet complete.
+
+Install the [Homebrew package manager](http://brew.sh/) via terminal if not installed, then run the following command to install node:
+```
+brew install node
+```
+
 #### Verfication
 The version can be checked through this command:
 
@@ -64,7 +72,7 @@ Note#3: When running `Node.js` 6.x, you might need to [upgrade npm-bundled `node
 
 ## 1.2. Build Native C++ `librealsense` ##
 
-Please refer to [Linux installation doc](../../doc/installation.md) or [Windows installation doc](../../doc/installation_windows.md) to build native C++ librealsense2.
+Please refer to [Linux installation doc](../../doc/installation.md) or [Windows installation doc](../../doc/installation_windows.md) or [Mac OS installation doc](../../doc/installation_osx.md) to build native C++ librealsense2.
 
 ## 1.3. Build Node.js Module/Addon ##
 

--- a/wrappers/nodejs/scripts/npm_dist/README.md
+++ b/wrappers/nodejs/scripts/npm_dist/README.md
@@ -47,6 +47,19 @@ sudo apt install -y libusb-1.0-0-dev pkg-config libgtk-3-dev libglfw3-dev cmake
 
 Please refer to [Linux installation doc](https://github.com/IntelRealSense/librealsense/blob/development/doc/installation.md) or [Windows installation doc](https://github.com/IntelRealSense/librealsense/blob/development/doc/installation_windows.md) for full document of C++ librealsense build environment setup.
 
+### Setup Mac OS Build Environment ###
+
+**Note:** OSX support for the full range of functionality offered by the SDK is not yet complete.
+
+ 1. Install XCode 6.0+ via the AppStore.
+
+ 2. Install the Homebrew package manager via terminal - [link](http://brew.sh/)
+
+ 3. Install the following packages via brew:
+   * `brew install libusb pkg-config`
+   * `brew install homebrew/versions/glfw3`
+   * `brew install cmake`
+
 ### Setup Necessary Global NPM Packages ###
 
 ```

--- a/wrappers/nodejs/scripts/npm_dist/binding.gyp
+++ b/wrappers/nodejs/scripts/npm_dist/binding.gyp
@@ -50,13 +50,21 @@
         ],
         ['OS=="mac"',
           {
+            "libraries": [
+              '<(module_root_dir)/librealsense/build/Release/librealsense2.dylib',
+              # Write the below RPATH into the generated addon
+              '-Wl,-rpath,@loader_path/../../librealsense/build/Release',
+            ],
             'xcode_settings': {
-              'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+              'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+              'CLANG_CXX_LIBRARY': 'libc++',
+              'MACOS_DEPLOYMENT_TARGET': '10.12',
+              'CLANG_CXX_LANGUAGE_STANDARD': 'c++14'
             }
           }
         ],
         [
-          "OS!=\"win\"",
+          'OS=="linux"',
           {
             "libraries": [
               "<(module_root_dir)/librealsense/build/librealsense2.so",

--- a/wrappers/nodejs/scripts/npm_dist/build-dist-mac.sh
+++ b/wrappers/nodejs/scripts/npm_dist/build-dist-mac.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright (c) 2018 Intel Corporation. All rights reserved.
+# Use of this source code is governed by an Apache 2.0 license
+# that can be found in the LICENSE file.
+
+echo 'Buliding librealsense C++ API...'
+pushd .  > /dev/null
+pwd
+
+cd librealsense
+mkdir -p build
+cd build
+
+# Step 1
+cmake .. -DBUILD_EXAMPLES=false -DBUILD_UNIT_TESTS=false -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -G Xcode
+if [ "$?" -gt 0 ]
+then
+	echo 'Failed to configure librealsense'
+	exit 1
+fi
+
+#step 2
+xcodebuild -configuration Release
+if [ "$?" -gt 0 ]
+then
+	echo 'Failed to build librealsense'
+	exit 2
+fi
+
+cd ../..
+
+popd > /dev/null

--- a/wrappers/nodejs/scripts/npm_dist/build-librealsense.js
+++ b/wrappers/nodejs/scripts/npm_dist/build-librealsense.js
@@ -9,12 +9,31 @@ const os = require('os');
 
 function buildNativeLib() {
   console.log('Building librealsense C++ API. It takes time...');
-
-  if (os.type() == 'Windows_NT') {
+  const type = os.type();
+  if (type === 'Windows_NT') {
     buildNativeLibWindows();
-  } else {
+  } else if (type === 'Linux') {
     buildNativeLibLinux();
+  } else if (type === 'Darwin') {
+    buildNativeLibMac();
+  } else {
+    throw new TypeError('Not supported build platform!');
   }
+}
+
+function buildNativeLibMac() {
+  let child = spawn('./scripts/npm_dist/build-dist-mac.sh');
+  child.stderr.on('data', (data) => {
+    console.error(`${data}`);
+  });
+  child.stdout.on('data', (data) => {
+    console.log(`${data}`);
+  });
+  child.on('close', (code) => {
+    if (code) {
+      throw new Error('Failed to build librealsense, build-dist-mac.sh exited with code ${code}');
+    }
+  });
 }
 
 function buildNativeLibLinux() {

--- a/wrappers/nodejs/scripts/npm_dist/gen-dist.sh
+++ b/wrappers/nodejs/scripts/npm_dist/gen-dist.sh
@@ -18,6 +18,7 @@ rsync -a . $MODULEDIR --exclude build --exclude dist --exclude node_modules
 cp -f scripts/npm_dist/binding.gyp $MODULEDIR
 cp -f scripts/npm_dist/package.json $MODULEDIR
 cp -f scripts/npm_dist/README.md $MODULEDIR
+git rev-parse --verify HEAD > $RSDIR/commit
 
 pushd . > /dev/null
 cd $WORKDIR


### PR DESCRIPTION
1. Enable 'npm install' of the package for macos
2. Record the commit hash of librealsense to 'librealsense/commit'
   inside the npm package for reference
3. Update README.md for mac build