### PR TITLE
Changing realseance to librealseance in the python wrapper

### DIFF
--- a/wrappers/python/readme.md
+++ b/wrappers/python/readme.md
@@ -39,7 +39,7 @@ Windows users can install the RealSense SDK 2.0 from the release tab to get pre-
   * `sudo make install`
 4. update your PYTHONPATH environment variable to add the path to the pyrealsense library
   * `export PYTHONPATH=$PYTHONPATH:/usr/local/lib`
-5. Alternatively, copy the build output (`realsense2.so` and `pyrealsense2.so`) next to your script.
+5. Alternatively, copy the build output (`librealsense2.so` and `pyrealsense2.so`) next to your script.
 
 
 


### PR DESCRIPTION
The lib was renamed into librealsense in the readme in the python wrapper not reflect this