### PR TITLE
Allowing to call load_json on a recording device

### DIFF
--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -53,7 +53,7 @@ namespace librealsense
     MAP_ADVANCED_MODE(STCensusRadius, etCencusRadius9);
 
 
-    class ds5_advanced_mode_interface
+    class ds5_advanced_mode_interface : public recordable<ds5_advanced_mode_interface>
     {
     public:
         virtual bool is_enabled() const = 0;
@@ -104,6 +104,10 @@ namespace librealsense
     public:
         explicit ds5_advanced_mode_base(std::shared_ptr<hw_monitor> hwm,
                                         uvc_sensor& depth_sensor);
+
+        void create_snapshot(std::shared_ptr<ds5_advanced_mode_interface>& snapshot) const override {};
+        void enable_recording(std::function<void(const ds5_advanced_mode_interface&)> recording_function) override {};
+
         virtual ~ds5_advanced_mode_base() = default;
 
         bool is_enabled() const override;

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -354,6 +354,7 @@ bool librealsense::record_device::extend_to(rs2_extension extension_type, void**
         *ext = this;
         return true;
     case RS2_EXTENSION_OPTIONS         : return extend_to_aux<RS2_EXTENSION_OPTIONS        >(m_device, ext);
+    case RS2_EXTENSION_ADVANCED_MODE   : return extend_to_aux<RS2_EXTENSION_ADVANCED_MODE  >(m_device, ext);
     case RS2_EXTENSION_DEBUG           : return extend_to_aux<RS2_EXTENSION_DEBUG          >(m_device, ext);
     //Other cases are not extensions that we expect a device to have.
     default:


### PR DESCRIPTION
At the moment the recorder does not record advanced mode API calls. This should not prevent users from calling this API while recording. This fix should address this limitation. 
Following-up on #1229 
