### PR TITLE
Pipeline playback repeat

### DIFF
--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -72,6 +72,8 @@ namespace librealsense
         std::unique_ptr<syncer_process_unit> _syncer;
         std::unique_ptr<pipeline_processing_block> _pipeline_process;
         std::shared_ptr<pipeline_config> _prev_conf;
+        int _playback_stopped_token = -1;
+        dispatcher _dispatcher;
     };
 
     class pipeline_config


### PR DESCRIPTION
Adding playback repeat to pipeline with device from file.
Now, when a pipeline is started with a config that was requested to `enable_device_from_file`, the pipeline will play the frames from the file, and upon EOF, will start the playback over, thus playing endlessly. 