### PR TITLE
Add support for UYUV for D4xx with global Shutter sensor

### DIFF
--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -313,6 +313,8 @@ namespace librealsense
         depth_ep->register_pixel_format(pf_z16); // Depth
         depth_ep->register_pixel_format(pf_y8); // Left Only - Luminance
         depth_ep->register_pixel_format(pf_yuyv); // Left Only
+        // RS400 rolling-shutter Skus allow to get low-quality color image from the same viewport as the depth
+        depth_ep->register_pixel_format(pf_uyvyl); // synthetic color from the left imager. Note that for global shutter will produce monochrome image
 
         return depth_ep;
     }

--- a/src/ds5/ds5-rolling-shutter.cpp
+++ b/src/ds5/ds5-rolling-shutter.cpp
@@ -34,9 +34,8 @@ namespace librealsense
                                                          DS5_ENABLE_AUTO_WHITE_BALANCE,
                                                          "Enable Auto White Balance"));
 
-            // RS400 rolling-shutter Skus allow to get low-quality color image from the same viewport as the depth
-            get_depth_sensor().register_pixel_format(pf_uyvyl);
-            get_depth_sensor().register_pixel_format(pf_rgb888);
+            // To be checked whether this is still required
+            // get_depth_sensor().register_pixel_format(pf_rgb888);
         }
     }
 }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -278,6 +278,7 @@ namespace librealsense
                         profile->set_framerate(p.fps);
 
                         results.insert(profile);
+                        registered_formats.insert(p.format);
                     }
                 }
             }
@@ -290,7 +291,7 @@ namespace librealsense
         if (unregistered_formats.size())
         {
             std::stringstream ss;
-            ss << "Unregistered Media formats : [ ";
+            ss << "Unused Media formats : [ ";
             for (auto& elem : unregistered_formats)
             {
                 uint32_t device_fourcc = reinterpret_cast<const big_endian<uint32_t>&>(elem);
@@ -353,7 +354,7 @@ namespace librealsense
         else
             throw invalid_value_exception(to_string()
                 << "Pixel format " << std::hex << std::setw(8) << std::setfill('0') << pf.fourcc
-                << " has been already registered with the sensor " << get_info(RS2_CAMERA_INFO_NAME));
+                << " has been already in use with the sensor " << get_info(RS2_CAMERA_INFO_NAME));
     }
 
     void sensor_base::remove_pixel_format(native_pixel_format pf)

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -4362,7 +4362,7 @@ ADD_ENUM_TEST_CASE(rs2_extension, RS2_EXTENSION_COUNT)
 ADD_ENUM_TEST_CASE(rs2_frame_metadata_value, RS2_FRAME_METADATA_COUNT)
 ADD_ENUM_TEST_CASE(rs2_rs400_visual_preset, RS2_RS400_VISUAL_PRESET_COUNT)
 
-void dev_changed(rs2_device_list* removed_devs, rs2_device_list* added_devs, void* ptr) {};
+void dev_changed(rs2_device_list* removed_devs, rs2_device_list* added_devs, void* ptr){}
 TEST_CASE("C API Compilation", "[live]") {
     rs2_error* e;
     REQUIRE_NOTHROW(rs2_set_devices_changed_callback(NULL, dev_changed, NULL, &e));


### PR DESCRIPTION
The patch allows to select and stream UYUV format for D400 devices with Global Shutter.
 Note that due to HW limitation the actual data type is monochrome.
In addition unused format 'RGB2' was disabled.