### PR TITLE
Fixed bug DSO-8782

### DIFF
--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -625,7 +625,7 @@ PYBIND11_MODULE(NAME, m) {
         .def("start", [](const rs2::sensor& self, std::function<void(rs2::frame)> callback)
     { self.start(callback); }, "Start passing frames into user provided callback.", "callback"_a)
         .def("start", [](const rs2::sensor& self, rs2::frame_queue& queue) { self.start(queue); })
-        .def("stop", &rs2::sensor::stop, "Stop streaming.")
+        .def("stop", [](const rs2::sensor& self) { py::gil_scoped_release lock; self.stop(); }, "Stop streaming.")
         .def("get_stream_profiles", &rs2::sensor::get_stream_profiles, "Check if physical sensor is supported.")
         .def_property_readonly("profiles", &rs2::sensor::get_stream_profiles, "Check if physical sensor is supported.")
         .def(py::init<>())


### PR DESCRIPTION
Fixed Deadlock while sensor.stop() in motion module, that caused by python gil lock,
by releasing the lock on python wrapper sensor::stop.