### PR TITLE
Software device fix

### DIFF
--- a/examples/software-device/rs-software-device.cpp
+++ b/examples/software-device/rs-software-device.cpp
@@ -154,6 +154,9 @@ int main(int argc, char * argv[]) try
     dev.create_matcher(RS2_MATCHER_DLR_C);
     rs2::syncer sync;
 
+    depth_sensor.open(depth_stream);
+    color_sensor.open(color_stream);
+
     depth_sensor.start(sync);
     color_sensor.start(sync);
 
@@ -161,7 +164,7 @@ int main(int argc, char * argv[]) try
 
     while (app) // Application still alive?
     {
-        synthetic_frame depth_frame = app_data.get_synthetic_depth(app_state);
+        synthetic_frame& depth_frame = app_data.get_synthetic_depth(app_state);
 
         depth_sensor.on_video_frame({ depth_frame.frame.data(), // Frame pixels from capture API
             [](void*) {}, // Custom deleter (if required)

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -90,24 +90,44 @@ namespace librealsense
 
     void software_sensor::open(const stream_profiles& requests)
     {
+        if (_is_streaming)
+            throw wrong_api_call_sequence_exception("open(...) failed. Software device is streaming!");
+        else if (_is_opened)
+            throw wrong_api_call_sequence_exception("open(...) failed. Software device is already opened!");
+        _is_opened = true;
         set_active_streams(requests);
     }
 
     void software_sensor::close()
     {
+        if (_is_streaming)
+            throw wrong_api_call_sequence_exception("close() failed. Software device is streaming!");
+        else if (!_is_opened)
+            throw wrong_api_call_sequence_exception("close() failed. Software device was not opened!");
+        _is_opened = false;
         set_active_streams({});
     }
 
     void software_sensor::start(frame_callback_ptr callback)
     {
+        if (_is_streaming)
+            throw wrong_api_call_sequence_exception("start_streaming(...) failed. Software device is already streaming!");
+        else if (!_is_opened)
+            throw wrong_api_call_sequence_exception("start_streaming(...) failed. Software device was not opened!");
+        _source.get_published_size_option()->set(0);
         _source.init(_metadata_parsers);
         _source.set_sensor(this->shared_from_this());
         _source.set_callback(callback);
+        _is_streaming = true;
         raise_on_before_streaming_changes(true);
     }
 
     void software_sensor::stop()
     {
+        if (!_is_streaming)
+            throw wrong_api_call_sequence_exception("stop_streaming() failed. Software device is not streaming!");
+
+        _is_streaming = false;
         raise_on_before_streaming_changes(false);
         _source.flush();
         _source.reset();
@@ -124,8 +144,10 @@ namespace librealsense
             RS2_EXTENSION_DEPTH_FRAME : RS2_EXTENSION_VIDEO_FRAME;
 
         auto frame = _source.alloc_frame(extension, 0, data, false);
-        if (!frame) return;
-
+        if (!frame)
+        {
+            return;
+        }
         auto vid_profile = dynamic_cast<video_stream_profile_interface*>(software_frame.profile->profile);
         auto vid_frame = dynamic_cast<video_frame*>(frame);
         vid_frame->assign(vid_profile->get_width(), vid_profile->get_height(), software_frame.stride, software_frame.bpp);

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -4152,6 +4152,7 @@ TEST_CASE("Syncer sanity with software-device device", "[live][software-device]"
         auto ir = profiles[1];
 
         syncer sync;
+        s.open(profiles);
         s.start(sync);
        
         std::vector<uint8_t> pixels(W * H * BPP, 0);
@@ -4244,6 +4245,7 @@ TEST_CASE("Syncer clean_inactive_streams by frame number with software-device de
         auto ir = profiles[1];
 
         syncer sync(10);
+        s.open(profiles);
         s.start(sync);
 
         std::vector<uint8_t> pixels(W * H * BPP, 0);


### PR DESCRIPTION
### Changes
1. Fixing software-device example to use reference for `synthetic_frame` : 
`synthetic_frame depth_frame = ...` --> `synthetic_frame & depth_frame = ...`
Without this - a copy was maid which was deleted at the end of the `while{}` block. Since `on_video_frame` takes a pointer to the data of the synthetic frame, any internal reference count on that data would be meaningless since the data is deleted at the end of the scope (because the vector's destructor is called). 
**Note**: This should be made clear for software device users - they should never delete the data themselves since the internal frame that is created does this for them when ref-count reaches zero. The example makes it difficult to understand this by providing a reference to the internal member of the  `custom_frame_source` class, and always overwriting the data of the vector.

2. Updated state for `sensor_base`'s protected members (`is_streaming`/`is_opened`). - This was important for the recorder.

3. Updated example to use `sensor.open()` per stream.

### Impact
This fix makes it possible to add a recorder to the example and actually record data, by simply adding this line **after** the software device, its sensor, and their streams are created:
`rs2::recorder rec("rs-software-device.bag", dev);`

(It is important to create the recorder **after**, because its constructor investigates the device, and hooks to its sensors, but they are added after the device is craeted (by the user) and the recorder has not idea about it.