### PR TITLE
Updating legacy macOS documentation to remove Homebrew installation instructions

### DIFF
--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -2,19 +2,7 @@
 
 **Note:** Due to the USB 3.0 translation layer between native hardware and virtual machine, the librealsense team does not recommend or support installation in a VM.
 
-The simplest method of installation uses the [Homebrew package manager](http://brew.sh/). First install [Homebrew](http://brew.sh/) via terminal and confirm it's working with ```$ brew doctor```
-
-## Installation via Homebrew
-
-To install the legacy version of librealsense, you can then install either the latest legacy release:
-
-    $ brew install librealsense@1
-
-Or you can install the head version from the legacy branch of the GitHub repository:
-
-    $ brew install librealsense@1 --HEAD
-
-To install with examples, add the ```--with-examples``` flag. Use ```$ brew info librealsense@1``` to retrieve the location of the installation.
+First install the [Homebrew package manager](http://brew.sh/) via terminal and confirm it is working with ```$ brew doctor```
 
 ## Installation from source
 


### PR DESCRIPTION
Removed references to direct installation of legacy librealsense via Homebrew because it was removed by the Homebrew maintainers due to lack of downloads:

https://github.com/Homebrew/homebrew-core/pull/23083

https://github.com/Homebrew/homebrew-core/pull/22165

https://github.com/Homebrew/homebrew-core/commit/286b711774c86c36084890092c0af416f860d935