### PR TITLE
Add missing include for RGB_USING_AVX2

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -10,6 +10,10 @@
 #include <tmmintrin.h> // For SSE3 intrinsic used in unpack_yuy2_sse
 #endif
 
+#ifdef RGB_AVX2
+#include <immintrin.h>
+#endif
+
 #pragma pack(push, 1) // All structs in this file are assumed to be byte-packed
 namespace librealsense
 {


### PR DESCRIPTION
Hi, I couldn't compile with `RGB_USING_AVX2=ON` without this on gcc `7.2` and `8.x`.
*Quick Q*: Is this portable enough? I don't know enough about AVX headers to say so.
If it's not, could you direct me towards the proper solution here?