### PR TITLE
Protecting against Camera-Control / Video-Proc being NULL

### DIFF
--- a/src/win/win-uvc.cpp
+++ b/src/win/win-uvc.cpp
@@ -498,8 +498,7 @@ namespace librealsense
             long val = 0, flags = 0;
             if ((opt == RS2_OPTION_EXPOSURE) || (opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE))
             {
-                if (!_camera_control.p) throw std::runtime_error("No camera control!");
-                auto hr = _camera_control->Get(CameraControl_Exposure, &val, &flags);
+                auto hr = get_camera_control()->Get(CameraControl_Exposure, &val, &flags);
                 if (hr == DEVICE_NOT_READY_ERROR)
                     return false;
 
@@ -512,8 +511,7 @@ namespace librealsense
             {
                 if (opt == pu.option)
                 {
-                    if (!_video_proc.p) throw std::runtime_error("No video proc!");
-                    auto hr = _video_proc->Get(pu.property, &val, &flags);
+                    auto hr = get_video_proc()->Get(pu.property, &val, &flags);
                     if (hr == DEVICE_NOT_READY_ERROR)
                         return false;
 
@@ -528,8 +526,7 @@ namespace librealsense
             {
                 if (opt == ct.option)
                 {
-                    if (!_camera_control.p) throw std::runtime_error("No camera_control!");
-                    auto hr = _camera_control->Get(ct.property, &val, &flags);
+                    auto hr = get_camera_control()->Get(ct.property, &val, &flags);
                     if (hr == DEVICE_NOT_READY_ERROR)
                         return false;
 
@@ -547,7 +544,7 @@ namespace librealsense
         {
             if (opt == RS2_OPTION_EXPOSURE)
             {
-                auto hr = _camera_control->Set(CameraControl_Exposure, from_100micros(value), CameraControl_Flags_Manual);
+                auto hr = get_camera_control()->Set(CameraControl_Exposure, from_100micros(value), CameraControl_Flags_Manual);
                 if (hr == DEVICE_NOT_READY_ERROR)
                     return false;
 
@@ -558,7 +555,7 @@ namespace librealsense
             {
                 if (value)
                 {
-                    auto hr = _camera_control->Set(CameraControl_Exposure, 0, CameraControl_Flags_Auto);
+                    auto hr = get_camera_control()->Set(CameraControl_Exposure, 0, CameraControl_Flags_Auto);
                     if (hr == DEVICE_NOT_READY_ERROR)
                         return false;
 
@@ -567,13 +564,13 @@ namespace librealsense
                 else
                 {
                     long min, max, step, def, caps;
-                    auto hr = _camera_control->GetRange(CameraControl_Exposure, &min, &max, &step, &def, &caps);
+                    auto hr = get_camera_control()->GetRange(CameraControl_Exposure, &min, &max, &step, &def, &caps);
                     if (hr == DEVICE_NOT_READY_ERROR)
                         return false;
 
                     CHECK_HR(hr);
 
-                    hr = _camera_control->Set(CameraControl_Exposure, def, CameraControl_Flags_Manual);
+                    hr = get_camera_control()->Set(CameraControl_Exposure, def, CameraControl_Flags_Manual);
                     if (hr == DEVICE_NOT_READY_ERROR)
                         return false;
 
@@ -581,6 +578,9 @@ namespace librealsense
                 }
                 return true;
             }
+
+            
+
             for (auto & pu : pu_controls)
             {
                 if (opt == pu.option)
@@ -589,7 +589,7 @@ namespace librealsense
                     {
                         if (value)
                         {
-                            auto hr = _video_proc->Set(pu.property, 0, VideoProcAmp_Flags_Auto);
+                            auto hr = get_video_proc()->Set(pu.property, 0, VideoProcAmp_Flags_Auto);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
@@ -598,13 +598,13 @@ namespace librealsense
                         else
                         {
                             long min, max, step, def, caps;
-                            auto hr = _video_proc->GetRange(pu.property, &min, &max, &step, &def, &caps);
+                            auto hr = get_video_proc()->GetRange(pu.property, &min, &max, &step, &def, &caps);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
                             CHECK_HR(hr);
 
-                            hr = _video_proc->Set(pu.property, def, VideoProcAmp_Flags_Manual);
+                            hr = get_video_proc()->Set(pu.property, def, VideoProcAmp_Flags_Manual);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
@@ -613,7 +613,7 @@ namespace librealsense
                     }
                     else
                     {
-                        auto hr = _video_proc->Set(pu.property, value, VideoProcAmp_Flags_Manual);
+                        auto hr = get_video_proc()->Set(pu.property, value, VideoProcAmp_Flags_Manual);
                         if (hr == DEVICE_NOT_READY_ERROR)
                             return false;
 
@@ -630,7 +630,7 @@ namespace librealsense
                     {
                         if (value)
                         {
-                            auto hr = _camera_control->Set(ct.property, 0, CameraControl_Flags_Auto);
+                            auto hr = get_camera_control()->Set(ct.property, 0, CameraControl_Flags_Auto);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
@@ -639,13 +639,13 @@ namespace librealsense
                         else
                         {
                             long min, max, step, def, caps;
-                            auto hr = _camera_control->GetRange(ct.property, &min, &max, &step, &def, &caps);
+                            auto hr = get_camera_control()->GetRange(ct.property, &min, &max, &step, &def, &caps);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
                             CHECK_HR(hr);
 
-                            hr = _camera_control->Set(ct.property, def, CameraControl_Flags_Manual);
+                            hr = get_camera_control()->Set(ct.property, def, CameraControl_Flags_Manual);
                             if (hr == DEVICE_NOT_READY_ERROR)
                                 return false;
 
@@ -654,7 +654,7 @@ namespace librealsense
                     }
                     else
                     {
-                        auto hr = _camera_control->Set(ct.property, value, CameraControl_Flags_Manual);
+                        auto hr = get_camera_control()->Set(ct.property, value, CameraControl_Flags_Manual);
                         if (hr == DEVICE_NOT_READY_ERROR)
                             return false;
 
@@ -679,7 +679,7 @@ namespace librealsense
             long minVal = 0, maxVal = 0, steppingDelta = 0, defVal = 0, capsFlag = 0;
             if (opt == RS2_OPTION_EXPOSURE)
             {
-                CHECK_HR(_camera_control->GetRange(CameraControl_Exposure, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
+                CHECK_HR(get_camera_control()->GetRange(CameraControl_Exposure, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
                 long min = to_100micros(minVal), max = to_100micros(maxVal), def = to_100micros(defVal);
                 control_range result(min, max, min, def);
                 return result;
@@ -688,8 +688,7 @@ namespace librealsense
             {
                 if (opt == pu.option)
                 {
-                    if (!_video_proc.p) throw std::runtime_error("No video proc!");
-                    CHECK_HR(_video_proc->GetRange(pu.property, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
+                    CHECK_HR(get_video_proc()->GetRange(pu.property, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
                     control_range result(minVal, maxVal, steppingDelta, defVal);
                     return result;
                 }
@@ -698,8 +697,7 @@ namespace librealsense
             {
                 if (opt == ct.option)
                 {
-                    if (!_camera_control.p) throw std::runtime_error("No camera_control!");
-                    CHECK_HR(_camera_control->GetRange(ct.property, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
+                    CHECK_HR(get_camera_control()->GetRange(ct.property, &minVal, &maxVal, &steppingDelta, &defVal, &capsFlag));
                     control_range result(minVal, maxVal, steppingDelta, defVal);
                     return result;
                 }

--- a/src/win/win-uvc.h
+++ b/src/win/win-uvc.h
@@ -79,6 +79,20 @@ namespace librealsense
 
             std::string get_device_location() const override { return _location; }
 
+            IAMVideoProcAmp* get_video_proc() const
+            {
+                if (!_video_proc.p)
+                    throw std::runtime_error("The device does not support adjusting the qualities of an incoming video signal, such as brightness, contrast, hue, saturation, gamma, and sharpness.");
+                return _video_proc.p;
+            }
+
+            IAMCameraControl* get_camera_control() const
+            {
+                if (!_camera_control.p) 
+                    throw std::runtime_error("The device does not support camera settings such as zoom, pan, aperture adjustment, or shutter speed.");
+                return _camera_control.p;
+            }
+
         private:
             friend class source_reader_callback;
 


### PR DESCRIPTION
Protecting from NULL dereference inside the UVC backend when UVC device does not offer Camera Control or Video Proc interface.
Follow-up on #983 