### PR TITLE
Adding protection against missing OpenGL drivers

### DIFF
--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -45,6 +45,9 @@ namespace rs2
         // Create GUI Windows
         _win = glfwCreateWindow(_width, _height, _title_str.c_str(),
             (_fullscreen ? primary : nullptr), nullptr);
+        if (!_win) 
+            throw std::runtime_error("Could not open OpenGL window, please check your graphic drivers or use the textual SDK tools");
+
         glfwMakeContextCurrent(_win);
         ImGui_ImplGlfw_Init(_win, true);
 

--- a/examples/example.hpp
+++ b/examples/example.hpp
@@ -142,6 +142,8 @@ public:
     {
         glfwInit();
         win = glfwCreateWindow(width, height, title, nullptr, nullptr);
+        if (!win)
+            throw std::runtime_error("Could not open OpenGL window, please check your graphic drivers or use the textual SDK tools");
         glfwMakeContextCurrent(win);
 
         glfwSetWindowUserPointer(win, this);

--- a/tools/rosbag-inspector/rs-rosbag-inspector.cpp
+++ b/tools/rosbag-inspector/rs-rosbag-inspector.cpp
@@ -44,6 +44,8 @@ public:
         _first_frame(true),
         _w(0), _h(0)
     {
+        if (!_window) 
+            throw std::runtime_error("Could not open OpenGL window, please check your graphic drivers");
         init_window();
     }
     operator bool()


### PR DESCRIPTION
When OpenGL window cannot be opened, report readable error instead of crashing (DSO-8545)