### PR TITLE
[Node.js] Avoid playback test failure

### DIFF
--- a/wrappers/nodejs/test/test-functional.js
+++ b/wrappers/nodejs/test/test-functional.js
@@ -449,9 +449,12 @@ describe('Sensor tests', function() {
       sensors[0].open(profiles0[0]);
       sensors[0].start((frame) => {
         assert.equal(frame instanceof rs2.Frame, true);
-        sensors[0].stop();
-        sensors[0].close();
-        resolve();
+        // Add a timeout to stop to avoid failure during playback test
+        setTimeout(() => {
+          sensors[0].stop();
+          sensors[0].close();
+          resolve();
+        }, 0);
       });
     });
   });


### PR DESCRIPTION
Avoid stopping the sensor among frame callbacks which may fail during playback
test.