### PR TITLE
Added start_record and stop_record.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1789,7 +1789,7 @@ namespace rs2
             ImGui::PushItemWidth(200);
             draw_combo_box("##Tex Source", tex_sources_str, selected_tex_source);
             selected_tex_source_uid = tex_sources[selected_tex_source];
-            texture.colorize = streams[selected_tex_source].texture->colorize;
+            texture.colorize = streams[tex_sources[selected_tex_source]].texture->colorize;
             ImGui::PopItemWidth();
 
             // Occlusion control for RGB UV-Map uses option's description as label

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -197,9 +197,9 @@ namespace rs2
             texture_data[idx], texture_data[idx + 1], texture_data[idx + 2]);
     }
 
-    void export_to_ply(const std::string& fname, notifications_model& ns, frameset frames, video_frame texture)
+    void export_to_ply(const std::string& fname, notifications_model& ns, frameset frames, video_frame texture, bool notify)
     {
-        std::thread([&ns, frames, texture, fname]() mutable {
+        std::thread([&ns, frames, texture, fname, notify]() mutable {
 
             points p;
 
@@ -214,7 +214,7 @@ namespace rs2
             if (p)
             {
                 p.export_to_ply(fname, texture);
-                ns.add_notification({ to_string() << "Finished saving 3D view " << (texture ? "to " : "without texture to ") << fname,
+                if (notify) ns.add_notification({ to_string() << "Finished saving 3D view " << (texture ? "to " : "without texture to ") << fname,
                     std::chrono::duration_cast<std::chrono::duration<double,std::micro>>(std::chrono::high_resolution_clock::now().time_since_epoch()).count(),
                     RS2_LOG_SEVERITY_INFO,
                     RS2_NOTIFICATION_CATEGORY_UNKNOWN_ERROR });
@@ -3205,7 +3205,7 @@ namespace rs2
 
         popup_if_error(window.get_font(), error_message);
 
-        return depth;
+        return f;
     }
 
     void viewer_model::reset_camera(float3 p)

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -70,6 +70,8 @@ inline ImVec4 blend(const ImVec4& c, float a)
 
 namespace rs2
 {
+    bool frame_metadata_to_csv(const std::string& filename, rs2::frame frame);
+
     struct textual_icon
     {
         explicit constexpr textual_icon(const char (&unicode_icon)[4]) :
@@ -905,7 +907,7 @@ namespace rs2
 
     };
 
-    void export_to_ply(const std::string& file_name, notifications_model& ns, frameset points, video_frame texture);
+    void export_to_ply(const std::string& file_name, notifications_model& ns, frameset points, video_frame texture, bool notify = true);
 
     // Wrapper for cross-platform dialog control
     enum file_dialog_mode {

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -740,7 +740,7 @@ namespace rs2
         class iterator
         {
         public:
-            iterator(frameset* owner, size_t index = 0) : _index(index), _owner(owner) {}
+            iterator(const frameset* owner, size_t index = 0) : _index(index), _owner(owner) {}
             iterator& operator++() { ++_index; return *this; }
             bool operator==(const iterator& other) const { return _index == other._index; }
             bool operator!=(const iterator& other) const { return !(*this == other); }
@@ -748,11 +748,11 @@ namespace rs2
             frame operator*() { return (*_owner)[_index]; }
         private:
             size_t _index = 0;
-            frameset* _owner;
+            const frameset* _owner;
         };
 
-        iterator begin() { return iterator(this); }
-        iterator end() { return iterator(this, size()); }
+        iterator begin() const { return iterator(this); }
+        iterator end() const { return iterator(this, size()); }
     private:
         size_t _size;
     };

--- a/tools/depth-quality/depth-metrics.h
+++ b/tools/depth-quality/depth-metrics.h
@@ -44,7 +44,6 @@ namespace rs2
       
 
         using callback_type = std::function<void(
-            const rs2::video_frame& frame,
             const std::vector<rs2::float3>& points,
             const plane p,
             const rs2::region_of_interest roi,
@@ -193,7 +192,7 @@ namespace rs2
             // Find the distance between the "rectified" fit and the ground truth planes.
             float plane_fit_to_gt_dist_mm = (ground_truth_mm > 0.f) ? (plane_fit_pivot.z * 1000 - ground_truth_mm): 0;
 
-            callback(frame, roi_pixels, p, roi, baseline_mm, intrin->fx, ground_truth_mm, plane_fit_present, plane_fit_to_gt_dist_mm, record, samples);
+            callback(roi_pixels, p, roi, baseline_mm, intrin->fx, ground_truth_mm, plane_fit_present, plane_fit_to_gt_dist_mm, record, samples);
             result.p = p;
             result.plane_corners[0] = approximate_intersection(p, intrin, float(roi.min_x), float(roi.min_y));
             result.plane_corners[1] = approximate_intersection(p, intrin, float(roi.max_x), float(roi.min_y));

--- a/tools/depth-quality/depth-metrics.h
+++ b/tools/depth-quality/depth-metrics.h
@@ -31,8 +31,20 @@ namespace rs2
             plane p;
             std::array<float3, 4> plane_corners;
         };
+      
+        struct single_metric_data
+        {
+            single_metric_data(std::string name, float val) :
+                val(val), name(name) {}
+
+            float val;
+            std::string name;
+        };
+
+      
 
         using callback_type = std::function<void(
+            const rs2::video_frame& frame,
             const std::vector<rs2::float3>& points,
             const plane p,
             const rs2::region_of_interest roi,
@@ -40,7 +52,9 @@ namespace rs2
             const float focal_length_pixels,
             const int ground_thruth_mm,
             const bool plane_fit,
-            const float plane_fit_to_ground_truth_mm)>;
+            const float plane_fit_to_ground_truth_mm,
+            bool record,
+            std::vector<single_metric_data>& samples)>;
 
         inline plane plane_from_point_and_normal(const rs2::float3& point, const rs2::float3& normal)
         {
@@ -130,6 +144,8 @@ namespace rs2
             rs2::region_of_interest roi,
             const int ground_truth_mm,
             bool plane_fit_present,
+            std::vector<single_metric_data>& samples,
+            bool record,
             callback_type callback)
         {
             auto pixels = (const uint16_t*)frame.get_data();
@@ -177,7 +193,7 @@ namespace rs2
             // Find the distance between the "rectified" fit and the ground truth planes.
             float plane_fit_to_gt_dist_mm = (ground_truth_mm > 0.f) ? (plane_fit_pivot.z * 1000 - ground_truth_mm): 0;
 
-            callback(roi_pixels, p, roi, baseline_mm, intrin->fx, ground_truth_mm, plane_fit_present, plane_fit_to_gt_dist_mm);
+            callback(frame, roi_pixels, p, roi, baseline_mm, intrin->fx, ground_truth_mm, plane_fit_present, plane_fit_to_gt_dist_mm, record, samples);
             result.p = p;
             result.plane_corners[0] = approximate_intersection(p, intrin, float(roi.min_x), float(roi.min_y));
             result.plane_corners[1] = approximate_intersection(p, intrin, float(roi.max_x), float(roi.min_y));

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -17,7 +17,8 @@ namespace rs2
               _skew_up(std::chrono::seconds(1)),
               _skew_down(std::chrono::seconds(1)),
               _angle_alert(std::chrono::seconds(4)),
-              _min_dist(300.f), _max_dist(2000.f), _max_angle(10.f)
+              _min_dist(300.f), _max_dist(2000.f), _max_angle(10.f),
+              _metrics_model(_viewer_model)
         {
             _viewer_model.is_3d_view = true;
             _viewer_model.allow_3d_source_change = false;
@@ -661,14 +662,26 @@ namespace rs2
 
                         ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
                         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, white);
-                        if (ImGui::Button(u8"\uf0c7 Save Report", { 140, 25 }))
+                        if (_metrics_model.is_record())
                         {
-                            snapshot_metrics();
+                            if (ImGui::Button(u8"\uf0c7 Stop_record", { 140, 25 }))
+                            {
+                                _metrics_model.stop_record(_device_model.get());
+                            }
                         }
-                        if (ImGui::IsItemHovered())
+                        else
                         {
-                            ImGui::SetTooltip("Save Metrics snapshot. This will create:\nPNG image with the depth frame\nPLY 3D model with the point cloud\nJSON file with camera settings you can load later\nand a CSV with metrics recent values");
+                            if (ImGui::Button(u8"\uf0c7 Start_record", { 140, 25 }))
+                            {
+                                _metrics_model.start_record();
+                            }
+
+                            if (ImGui::IsItemHovered())
+                            {
+                                ImGui::SetTooltip("Save Metrics snapshot. This will create:\nPNG image with the depth frame\nPLY 3D model with the point cloud\nJSON file with camera settings you can load later\nand a CSV with metrics recent values");
+                            }
                         }
+                       
                         ImGui::PopStyleColor(2);
 
                         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
@@ -753,6 +766,7 @@ namespace rs2
             }
 
             _metrics_model.reset();
+            _metrics_model.update_device_data(capture_description());
 
             // Restore GUI controls to the selected configuration
             if (save)
@@ -835,46 +849,7 @@ namespace rs2
             return improved > window_size * 0.4;
         }
 
-        void tool_model::snapshot_metrics()
-        {
-            if (auto ret = file_dialog_open(save_file, NULL, NULL, NULL))
-            {
-                std::string filename_base(ret);
-
-                // Save depth/ir images
-                for (auto const &stream : _viewer_model.streams)
-                {
-                    stream.second.snapshot_frame(ret, _viewer_model);
-                }
-
-                // Export 3d view in PLY format
-                frame ply_texture;
-                if (_viewer_model.selected_tex_source_uid >= 0)
-                {
-                    ply_texture = _viewer_model.streams[_viewer_model.selected_tex_source_uid].texture->get_last_frame();
-                    if (ply_texture)
-                        _viewer_model.ppf.update_texture(ply_texture);
-                }
-                export_to_ply(filename_base + "_3d_mesh.ply", _viewer_model.not_model, _viewer_model.ppf.get_points(), ply_texture);
-
-                // Save Metrics
-                _metrics_model.serialize_to_csv(filename_base + "_depth_metrics.csv", capture_description());
-
-                // Save camera configuration - supported when camera is in advanced mode only
-                if (_device_model.get())
-                {
-                    if (auto adv = _device_model->dev.as<rs400::advanced_mode>())
-                    {
-                        std::string filename = filename_base + "_configuration.json";
-                        std::ofstream out(filename);
-                        out << adv.serialize_json();
-                        out.close();
-                    }
-                }
-            }
-        }
-
-        metrics_model::metrics_model() :
+        metrics_model::metrics_model(viewer_model& viewer_model) :
             _frame_queue(1),
             _depth_scale_units(0.f),
             _stereo_baseline_mm(0.f),
@@ -882,52 +857,60 @@ namespace rs2
             _use_gt(false),
             _plane_fit(false),
             _roi_percentage(0.4f),
-            _active(true)
+            _active(true),
+            _recorder(viewer_model)
         {
             _worker_thread = std::thread([this]() {
                 while (_active)
                 {
-                    rs2::frame depth_frame;
-                    if (!_frame_queue.poll_for_frame(&depth_frame))
+                    rs2::frameset frames;
+                    if (!_frame_queue.poll_for_frame(&frames))
                     {
                         std::this_thread::sleep_for(std::chrono::milliseconds(10));
                         continue;
                     }
 
-                    auto profile = depth_frame.get_profile();
-                    auto stream_type = profile.stream_type();
-
-                    if (RS2_STREAM_DEPTH == stream_type)
+                    std::vector<single_metric_data> samples;
+                    for (auto&& f : frames)
                     {
-                        float su = 0, baseline = -1.f;
-                        rs2_intrinsics intrin{};
-                        int gt_mm{};
-                        bool plane_fit_set{};
-                        region_of_interest roi{};
+                        auto profile = f.get_profile();
+                        auto stream_type = profile.stream_type();
 
+                        if (RS2_STREAM_DEPTH == stream_type)
                         {
-                            std::lock_guard<std::mutex> lock(_m);
-                            su = _depth_scale_units;
-                            baseline = _stereo_baseline_mm;
-                            auto depth_profile = profile.as<video_stream_profile>();
-                            intrin = depth_profile.get_intrinsics();
-                            _depth_intrinsic = intrin;
-                            _roi = { int(intrin.width * (0.5f - 0.5f*this->_roi_percentage)),
-                                int(intrin.height * (0.5f - 0.5f*this->_roi_percentage)),
-                                int(intrin.width * (0.5f + 0.5f*this->_roi_percentage)),
-                                int(intrin.height * (0.5f + 0.5f*this->_roi_percentage)) };
+                            float su = 0, baseline = -1.f;
+                            rs2_intrinsics intrin{};
+                            int gt_mm{};
+                            bool plane_fit_set{};
+                            region_of_interest roi{};
+                            {
+                                std::lock_guard<std::mutex> lock(_m);
+                                su = _depth_scale_units;
+                                baseline = _stereo_baseline_mm;
+                                auto depth_profile = profile.as<video_stream_profile>();
+                                intrin = depth_profile.get_intrinsics();
+                                _depth_intrinsic = intrin;
+                                _roi = { int(intrin.width * (0.5f - 0.5f*this->_roi_percentage)),
+                                    int(intrin.height * (0.5f - 0.5f*this->_roi_percentage)),
+                                    int(intrin.width * (0.5f + 0.5f*this->_roi_percentage)),
+                                    int(intrin.height * (0.5f + 0.5f*this->_roi_percentage)) };
 
-                            roi = _roi;
+                                roi = _roi;
+                            }
+
+                            std::tie(gt_mm, plane_fit_set) = get_inputs();
+                           
+                            auto metrics = analyze_depth_image(f, su, baseline, &intrin, roi, gt_mm, plane_fit_set, samples, _recorder.is_record(), callback);
+
+                            {
+                                std::lock_guard<std::mutex> lock(_m);
+                                _latest_metrics = metrics;
+                            }
                         }
-
-                        std::tie(gt_mm, plane_fit_set) = get_inputs();
-                        auto metrics = analyze_depth_image(depth_frame, su, baseline, &intrin, roi, gt_mm, plane_fit_set,callback);
-
-                        {
-                            std::lock_guard<std::mutex> lock(_m);
-                            _latest_metrics = metrics;
-                        }
+                       
                     }
+                    if (_recorder.is_record())
+                        _recorder.add_sample(frames, samples);
 
                     // Artificially slow down the calculation, so even on small ROIs / resolutions
                     // the output is updated within reasonable interval (keeping it human readable)
@@ -950,6 +933,7 @@ namespace rs2
         {
             auto res = std::make_shared<metric_plot>(name, min, max, units, description, requires_plane_fit);
             _metrics_model.add_metric(res);
+            _metrics_model._recorder.add_matric({ name,units });
             return res;
         }
 
@@ -1094,39 +1078,114 @@ namespace rs2
             }
         }
 
-        void metrics_model::serialize_to_csv(const std::string& filename, const std::string& camera_info) const
+        void metrics_recorder::serialize_to_csv() const
         {
             std::ofstream csv;
 
-            csv.open(filename);
+            csv.open(_filename_base + "_depth_metrics.csv");
 
             // Store the device info and the streaming profile details
-            csv << camera_info;
+            csv << _metrics->_camera_info;
 
             //Store metric environment
-            csv << "\nEnvironment:\nPlane-Fit_distance_mm," << (_plane_fit ? std::to_string(_latest_metrics.distance) : "N/A") << std::endl;
-            csv << "Ground-Truth_Distance_mm," << (_use_gt ? std::to_string(_ground_truth_mm ) : "N/A") << std::endl;
+            csv << "\nEnvironment:\nPlane-Fit_distance_mm," << (_metrics->_plane_fit ? std::to_string(_metrics->_latest_metrics.distance) : "N/A") << std::endl;
+            csv << "Ground-Truth_Distance_mm," << (_metrics->_use_gt ? std::to_string(_metrics->_ground_truth_mm ) : "N/A") << std::endl;
 
             // Generate columns header
-            csv << "\nSample Id,Timestamp (ms),";
-            for (auto&& plot : _plots)
+            csv << "\nSample Id,Frame #,Timestamp (ms),";
+            for (auto&& matric : _metric_data)
             {
-                csv << plot->_name << " " << plot->_units << ",";
+                csv << matric.name << " " << matric.units << ",";
             }
             csv << std::endl;
 
-            // Populate metrics data using the fill-rate persistent metric as pivot
-            for (size_t i = _plots[0]->_first_idx, rec = 0; i != _plots[0]->_idx; i = (1+i) % metric_plot::SIZE)
+            //// Populate metrics data using the fill-rate persistent metric as pivot
+            auto i = 0;
+            for (auto&& it: _samples)
             {
-                csv << ++rec << "," << std::fixed << std::setprecision(4) << _plots[0]->_timestamps[i] << ",";
-                for (auto&& plot : _plots)
+                csv << i++ << ","<< it.frame_number << "," << std::fixed << std::setprecision(4) << it.timestamp << ",";
+                for (auto&& matric : _metric_data)
                 {
-                    csv << plot->_vals[i] << ",";
+                    auto samp = std::find_if(it.samples.begin(), it.samples.end(), [&](single_metric_data s) {return s.name == matric.name; });
+                    if(samp != it.samples.end())  csv << samp->val << ",";
                 }
                 csv << std::endl;
             }
 
             csv.close();
         }
-    }
-}
+
+        void metrics_recorder::record_frame(rs2::frameset & frames) const
+        {
+           
+            // Trim the file extension when provided. Note that this may amend user-provided file name in case it uses the "." character, e.g. "my.file.name"
+            auto filename_base = _filename_base;
+
+            auto loc = filename_base.find_last_of(".");
+            if (loc != std::string::npos)
+                filename_base.erase(loc, std::string::npos);
+
+            std::stringstream fn;
+            fn << frames.get_frame_number();
+
+            colorizer colorize;
+
+            for (auto&& frame : frames)
+            {
+
+                // Snapshot the color-augmented version of the frame
+                if (auto colorized_frame = colorize.colorize(frame).as<video_frame>())
+                {
+
+                    auto stream_desc = rs2_stream_to_string(colorized_frame.get_profile().stream_type());
+                    auto filename_png = filename_base + "_" + stream_desc + "_" + fn.str() + ".png";
+                    save_to_png(filename_png.data(), colorized_frame.get_width(), colorized_frame.get_height(), colorized_frame.get_bytes_per_pixel(),
+                        colorized_frame.get_data(), colorized_frame.get_width() * colorized_frame.get_bytes_per_pixel());
+
+                }
+                auto original_frame = frame.as<video_frame>();
+
+                // For Depth-originated streams also provide a copy of the raw data accompanied by sensor-specific metadata
+                if (original_frame && val_in_range(original_frame.get_profile().stream_type(), { RS2_STREAM_DEPTH , RS2_STREAM_INFRARED }))
+                {
+                    auto stream_desc = rs2_stream_to_string(original_frame.get_profile().stream_type());
+
+                    //Capture raw frame
+                    auto filename = filename_base + "_" + stream_desc + "_" + fn.str() + ".raw";
+                    if (!save_frame_raw_data(filename, original_frame))
+                        _viewer_model.not_model.add_notification({ to_string() << "Failed to save frame raw data  " << filename,
+                            0, RS2_LOG_SEVERITY_INFO, RS2_NOTIFICATION_CATEGORY_UNKNOWN_ERROR });
+
+
+                    // And the frame's attributes
+                    filename = filename_base + "_" + stream_desc + "_" + fn.str() + "_metadata.csv";
+                    if (!frame_metadata_to_csv(filename, original_frame))
+                        _viewer_model.not_model.add_notification({ to_string() << "Failed to save frame metadata file " << filename,
+                            0, RS2_LOG_SEVERITY_INFO, RS2_NOTIFICATION_CATEGORY_UNKNOWN_ERROR });
+
+                }
+            }
+            // Export 3d view in PLY format
+            rs2::frame ply_texture;
+            pointcloud pc;
+
+            if (_viewer_model.selected_tex_source_uid >= 0)
+            {
+                for (auto&& frame : frames)
+                {
+                    if (frame.get_profile().unique_id() == _viewer_model.selected_tex_source_uid)
+                    {
+                        ply_texture = frame;
+                        pc.map_to(ply_texture);
+                        break;
+                    }
+                }
+
+                if (ply_texture )
+                    export_to_ply(filename_base + "_" + fn.str() + "_3d_mesh.ply", _viewer_model.not_model, frames, ply_texture, false);
+            }
+            
+        }
+
+     }
+ }

--- a/tools/depth-quality/depth-quality-model.h
+++ b/tools/depth-quality/depth-quality-model.h
@@ -16,6 +16,99 @@ namespace rs2
     namespace depth_quality
     {
         class metrics_model;
+        struct sample
+        {
+            sample(std::vector<single_metric_data> samples, double timestamp, unsigned long long frame_number) :
+                samples(std::move(samples)), timestamp(timestamp), frame_number(frame_number) {}
+
+            std::vector<single_metric_data> samples;
+
+            double timestamp;
+            unsigned long long frame_number;
+        };
+
+        struct metric_data
+        {
+            std::string name;
+            std::string units;
+        };
+
+        class metrics_recorder
+        {
+        public:
+            metrics_recorder(viewer_model& viewer_model) :
+                _record(false), _viewer_model(viewer_model)
+            {}
+
+            void add_matric(const metric_data& data)
+            {
+                std::lock_guard<std::mutex> lock(_m);
+                _metric_data.push_back(data);
+            }
+
+            void add_sample(rs2::frameset& frames, std::vector<single_metric_data> samples)
+            {
+                std::lock_guard<std::mutex> lock(_m);
+                if (_record)
+                {
+                    record_frame(frames);
+
+                    if (samples.size())
+                        _samples.push_back({ samples, _model_timer.elapsed_ms(), frames.get_frame_number() });
+                }
+            }
+            void start_record(metrics_model* metrics)
+            {
+                std::lock_guard<std::mutex> lock(_m);
+                _metrics = metrics;
+                if (auto ret = file_dialog_open(save_file, NULL, NULL, NULL))
+                {
+                    _filename_base = ret;
+                    _record = true;
+                }
+            }
+
+            void stop_record(device_model* dev)
+            {
+                std::lock_guard<std::mutex> lock(_m);
+                _record = false;
+                serialize_to_csv();
+
+                if (dev)
+                {
+                    if (auto adv = dev->dev.as<rs400::advanced_mode>())
+                    {
+                        std::string filename = _filename_base + "_configuration.json";
+                        std::ofstream out(filename);
+                        out << adv.serialize_json();
+                        out.close();
+                    }
+                }
+                _samples.clear();
+                _viewer_model.not_model.add_notification({ to_string() << "Finished to record frames and matrics data " ,
+                    0, RS2_LOG_SEVERITY_INFO, RS2_NOTIFICATION_CATEGORY_UNKNOWN_ERROR });
+            }
+
+            bool is_record()
+            {
+                return _record;
+            }
+
+        private:
+
+            friend class metrics_model;
+
+            void serialize_to_csv() const;
+            void record_frame(rs2::frameset & frame) const;
+            viewer_model& _viewer_model;
+            std::vector<metric_data> _metric_data;
+            std::vector<sample> _samples;
+            timer _model_timer;
+            std::mutex _m;
+            bool _record;
+            std::string _filename_base;
+            metrics_model* _metrics;
+        };
 
         class metric_plot : public std::enable_shared_from_this<metric_plot>
         {
@@ -91,6 +184,7 @@ namespace rs2
 
             bool enabled() const { return _enabled; }
             bool requires_plane_fit() const { return _requires_plane_fit; }
+            std::string get_name() { return _name; }
 
         private:
             bool has_trend(bool positive);
@@ -118,7 +212,7 @@ namespace rs2
         class metrics_model
         {
         public:
-            metrics_model();
+            metrics_model(viewer_model& viewer_model);
             ~metrics_model();
 
             void render(ux_window& win);
@@ -157,8 +251,6 @@ namespace rs2
             }
 
             void begin_process_frame(rs2::frame f) { _frame_queue.enqueue(std::move(f)); }
-
-            void serialize_to_csv(const std::string& filename, const std::string& camera_info) const;
 
             void add_metric(std::shared_ptr<metric_plot> metric) { _plots.push_back(metric); }
 
@@ -204,6 +296,25 @@ namespace rs2
                 while (_frame_queue.poll_for_frame(&f));
             }
 
+            void update_device_data(const std::string& camera_info)
+            {
+                _camera_info = camera_info;
+            }
+            bool is_record()
+            {
+                return _recorder.is_record();
+            }
+            void start_record()
+            {
+                _recorder.start_record(this);
+            }
+            void stop_record(device_model* dev)
+            {
+                _recorder.stop_record(dev);
+
+                
+               
+            }
         private:
             metrics_model(const metrics_model&);
 
@@ -220,9 +331,13 @@ namespace rs2
             float                   _roi_percentage;
             snapshot_metrics        _latest_metrics;
             bool                    _active;
-
             std::vector<std::shared_ptr<metric_plot>> _plots;
+            metrics_recorder _recorder;
+            std::string  _camera_info;
             mutable std::mutex      _m;
+
+            friend class  metrics_recorder;
+            friend class  tool_model;
         };
 
         using metric = std::shared_ptr<metric_plot>;
@@ -240,8 +355,6 @@ namespace rs2
 
             void reset(ux_window& win);
 
-            void snapshot_metrics();
-
             bool draw_instructions(ux_window& win, const rect& viewer_rect, bool& distance, bool& orientation);
 
             void draw_guides(ux_window& win, const rect& viewer_rect, bool distance_guide, bool orientation_guide);
@@ -254,6 +367,7 @@ namespace rs2
             void on_frame(callback_type callback) { _metrics_model.callback = callback; }
 
             rs2::device get_active_device(void) const;
+
         private:
 
             std::string capture_description();

--- a/tools/depth-quality/rs-depth-quality.cpp
+++ b/tools/depth-quality/rs-depth-quality.cpp
@@ -66,6 +66,7 @@ int main(int argc, const char * argv[]) try
     // ===============================
 
     model.on_frame([&](
+        const rs2::video_frame& frame,
         const std::vector<rs2::float3>& points,
         const rs2::plane p,
         const rs2::region_of_interest roi,
@@ -73,7 +74,9 @@ int main(int argc, const char * argv[]) try
         const float focal_length_pixels,
         const int ground_truth_mm,
         const bool plane_fit,
-        const float plane_fit_to_ground_truth_mm)
+        const float plane_fit_to_ground_truth_mm,
+        bool record,
+        std::vector<single_metric_data>& samples)
     {
         static const float TO_METERS = 0.001f;
         static const float TO_MM = 1000.f;
@@ -82,6 +85,7 @@ int main(int argc, const char * argv[]) try
         // Calculate fill rate relative to the ROI
         auto fill_rate = points.size() / float((roi.max_x - roi.min_x)*(roi.max_y - roi.min_y)) * TO_PERCENT;
         fill->add_value(fill_rate);
+        if(record) samples.push_back({fill->get_name(),  fill_rate });
 
         if (!plane_fit) return;
 
@@ -129,6 +133,8 @@ int main(int argc, const char * argv[]) try
             auto gt_median = gt_errors[gt_errors.size() / 2];
             auto accuracy = TO_PERCENT * (gt_median / ground_truth_mm);
             z_accuracy->add_value(accuracy);
+            if (record) samples.push_back({ z_accuracy->get_name(),  accuracy });
+
         }
 
         // Calculate Sub-pixel RMS for Stereo-based Depth sensors
@@ -139,11 +145,13 @@ int main(int argc, const char * argv[]) try
         }
         auto rms_subpixel_val = static_cast<float>(std::sqrt(total_sq_disparity_diff / disparities.size()));
         sub_pixel_rms_error->add_value(rms_subpixel_val);
+        if (record) samples.push_back({ sub_pixel_rms_error->get_name(),  rms_subpixel_val });
 
         // Calculate Plane Fit RMS  (Spatial Noise) mm
         double plane_fit_err_sqr_sum = std::inner_product(distances.begin(), distances.end(), distances.begin(), 0.);
         auto rms_error_val = static_cast<float>(std::sqrt(plane_fit_err_sqr_sum / distances.size()));
         plane_fit_rms_error->add_value(rms_error_val);
+        if (record) samples.push_back({ plane_fit_rms_error->get_name(),  rms_error_val });
     });
 
     // ===============================

--- a/tools/depth-quality/rs-depth-quality.cpp
+++ b/tools/depth-quality/rs-depth-quality.cpp
@@ -66,7 +66,6 @@ int main(int argc, const char * argv[]) try
     // ===============================
 
     model.on_frame([&](
-        const rs2::video_frame& frame,
         const std::vector<rs2::float3>& points,
         const rs2::plane p,
         const rs2::region_of_interest roi,


### PR DESCRIPTION
1. Fixed issue DSO-8638 - inconsistently between frame and metrics,
by added start_record and stop_record and save the frames and the metrics results from the same thread,  

2. Concatenate the frame# to the file names of frame and to the metrics results.
3. Fixed bug on show_3dviewer_header.

