### PR TITLE
Add support for conversions between C++ and Python time objects

### DIFF
--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -9,6 +9,9 @@ Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 // STL conversions
 #include <pybind11/stl.h>
 
+// std::chrono::*
+#include <pybind11/chrono.h>
+
 // makes certain STL containers opaque to prevent expensive copies
 #include <pybind11/stl_bind.h>
 


### PR DESCRIPTION
Add support for conversions between C++ std::chrono types and Python datetime types to fix #1545.

In python, `pyrealsense2.playback.seek()` should now accept `datetime.timedelta`s and `float`s as parameters.
Additionally, `pyrealsense2.playback.get_duration()` now returns a native python `datetime.timedelta` object