### PR TITLE
Playback repeat

### DIFF
--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -233,6 +233,7 @@ EXPORTS
     rs2_config_enable_all_stream
     rs2_config_enable_device
     rs2_config_enable_device_from_file
+    rs2_config_enable_device_from_file_repeat_option
     rs2_config_enable_record_to_file
     rs2_config_disable_stream
     rs2_config_disable_indexed_stream

--- a/examples/record-playback/rs-record-playback.cpp
+++ b/examples/record-playback/rs-record-playback.cpp
@@ -147,7 +147,7 @@ int main(int argc, char * argv[]) try
                     pipe->stop(); // Stop streaming with default configuration
                     pipe = std::make_shared<rs2::pipeline>();
                     rs2::config cfg;
-                    cfg.enable_device_from_file("a.bag", false);
+                    cfg.enable_device_from_file("a.bag");
                     pipe->start(cfg); //File will be opened in read mode at this point
                     device = pipe->get_active_profile().get_device();
                 }

--- a/examples/record-playback/rs-record-playback.cpp
+++ b/examples/record-playback/rs-record-playback.cpp
@@ -147,7 +147,7 @@ int main(int argc, char * argv[]) try
                     pipe->stop(); // Stop streaming with default configuration
                     pipe = std::make_shared<rs2::pipeline>();
                     rs2::config cfg;
-                    cfg.enable_device_from_file("a.bag");
+                    cfg.enable_device_from_file("a.bag", false);
                     pipe->start(cfg); //File will be opened in read mode at this point
                     device = pipe->get_active_profile().get_device();
                 }

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -235,8 +235,8 @@ extern "C" {
     * Select a recorded device from a file, to be used by the pipeline through playback.
     * The device available streams are as recorded to the file, and \c resolve() considers only this device and configuration
     * as available.
-    * By default, playback is repeated once the file ends. To control this, see 'rs2_config_enable_device_from_file_repeat_option'.
     * This request cannot be used if enable_record_to_file() is called for the current config, and vise versa
+    * By default, playback is repeated once the file ends. To control this, see 'rs2_config_enable_device_from_file_repeat_option'.
     *
     * \param[in] config    A pointer to an instance of a config
     * \param[in] file_name  The playback file of the device
@@ -252,7 +252,8 @@ extern "C" {
     *
     * \param[in] config    A pointer to an instance of a config
     * \param[in] file_name  The playback file of the device
-    * \param[in] repeat_playback indicates whether to repeat playback once or in an infinite loop
+    * \param[in] repeat_playback  if true, when file ends the playback starts again, in an infinite loop;
+                                  if false, when file ends playback does not start again, and should by stopped manually by the user.
     * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     */
     void rs2_config_enable_device_from_file_repeat_option(rs2_config* config, const char* file, int repeat_playback, rs2_error ** error);

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -235,13 +235,27 @@ extern "C" {
     * Select a recorded device from a file, to be used by the pipeline through playback.
     * The device available streams are as recorded to the file, and \c resolve() considers only this device and configuration
     * as available.
+    * By default, playback is repeated once the file ends. To control this, see 'rs2_config_enable_device_from_file_repeat_option'.
     * This request cannot be used if enable_record_to_file() is called for the current config, and vise versa
     *
     * \param[in] config    A pointer to an instance of a config
     * \param[in] file_name  The playback file of the device
     * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     */
-    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, int repeat_playback, rs2_error ** error);
+    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error);
+
+    /**
+    * Select a recorded device from a file, to be used by the pipeline through playback.
+    * The device available streams are as recorded to the file, and \c resolve() considers only this device and configuration
+    * as available.
+    * This request cannot be used if enable_record_to_file() is called for the current config, and vise versa
+    *
+    * \param[in] config    A pointer to an instance of a config
+    * \param[in] file_name  The playback file of the device
+    * \param[in] repeat_playback indicates whether to repeat playback once or in an infinite loop
+    * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
+    void rs2_config_enable_device_from_file_repeat_option(rs2_config* config, const char* file, int repeat_playback, rs2_error ** error);
 
     /**
     * Requires that the resolved device would be recorded to file

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -241,7 +241,7 @@ extern "C" {
     * \param[in] file_name  The playback file of the device
     * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     */
-    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool repeat_playback, rs2_error ** error);
+    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, int repeat_playback, rs2_error ** error);
 
     /**
     * Requires that the resolved device would be recorded to file

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -241,7 +241,7 @@ extern "C" {
     * \param[in] file_name  The playback file of the device
     * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     */
-    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool do_loop, rs2_error ** error);
+    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool repeat_playback, rs2_error ** error);
 
     /**
     * Requires that the resolved device would be recorded to file

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -241,7 +241,7 @@ extern "C" {
     * \param[in] file_name  The playback file of the device
     * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
     */
-    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error);
+    void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool do_loop, rs2_error ** error);
 
     /**
     * Requires that the resolved device would be recorded to file

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -224,7 +224,7 @@ namespace rs2
         void enable_device_from_file(const std::string& file_name, bool repeat_playback = true)
         {
             rs2_error* e = nullptr;
-            rs2_config_enable_device_from_file(_config.get(), file_name.c_str(), repeat_playback, &e);
+            rs2_config_enable_device_from_file_repeat_option(_config.get(), file_name.c_str(), repeat_playback, &e);
             error::handle(e);
         }
 

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -221,10 +221,10 @@ namespace rs2
         *
         * \param[in] file_name  The playback file of the device
         */
-        void enable_device_from_file(const std::string& file_name)
+        void enable_device_from_file(const std::string& file_name, bool do_loop = true)
         {
             rs2_error* e = nullptr;
-            rs2_config_enable_device_from_file(_config.get(), file_name.c_str(), &e);
+            rs2_config_enable_device_from_file(_config.get(), file_name.c_str(), do_loop, &e);
             error::handle(e);
         }
 

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -221,10 +221,10 @@ namespace rs2
         *
         * \param[in] file_name  The playback file of the device
         */
-        void enable_device_from_file(const std::string& file_name, bool do_loop = true)
+        void enable_device_from_file(const std::string& file_name, bool repeat_playback = true)
         {
             rs2_error* e = nullptr;
-            rs2_config_enable_device_from_file(_config.get(), file_name.c_str(), do_loop, &e);
+            rs2_config_enable_device_from_file(_config.get(), file_name.c_str(), repeat_playback, &e);
             error::handle(e);
         }
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -109,7 +109,7 @@ namespace librealsense
         _device_request.serial = serial;
     }
 
-    void pipeline_config::enable_device_from_file(const std::string& file)
+    void pipeline_config::enable_device_from_file(const std::string& file, bool do_loop)
     {
         std::lock_guard<std::mutex> lock(_mtx);
         if (!_device_request.record_output.empty())
@@ -118,6 +118,7 @@ namespace librealsense
         }
         _resolved_profile.reset();
         _device_request.filename = file;
+        _playback_loop = do_loop;
     }
 
     void pipeline_config::enable_record_to_file(const std::string& file)
@@ -379,6 +380,10 @@ namespace librealsense
         return default_profiles;
     }
 
+    bool pipeline_config::get_do_loop() {
+        return _playback_loop;
+    }
+
     /*
         .______    __  .______    _______  __       __  .__   __.  _______ 
         |   _  \  |  | |   _  \  |   ____||  |     |  | |  \ |  | |   ____|
@@ -510,7 +515,7 @@ namespace librealsense
                     {
                         //If the pipeline holds a playback device, and it reached the end of file (stopped)
                         //Then we restart it
-                        if (_active_profile)
+                        if (_active_profile && _prev_conf->get_do_loop())
                         {
                             _active_profile->_multistream.open();
                             _active_profile->_multistream.start(syncer_callback);

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -109,7 +109,7 @@ namespace librealsense
         _device_request.serial = serial;
     }
 
-    void pipeline_config::enable_device_from_file(const std::string& file, bool repeat_playback)
+    void pipeline_config::enable_device_from_file(const std::string& file, bool repeat_playback = true)
     {
         std::lock_guard<std::mutex> lock(_mtx);
         if (!_device_request.record_output.empty())

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -109,7 +109,7 @@ namespace librealsense
         _device_request.serial = serial;
     }
 
-    void pipeline_config::enable_device_from_file(const std::string& file, bool do_loop)
+    void pipeline_config::enable_device_from_file(const std::string& file, bool repeat_playback)
     {
         std::lock_guard<std::mutex> lock(_mtx);
         if (!_device_request.record_output.empty())
@@ -118,7 +118,7 @@ namespace librealsense
         }
         _resolved_profile.reset();
         _device_request.filename = file;
-        _playback_loop = do_loop;
+        _playback_loop = repeat_playback;
     }
 
     void pipeline_config::enable_record_to_file(const std::string& file)
@@ -380,7 +380,7 @@ namespace librealsense
         return default_profiles;
     }
 
-    bool pipeline_config::get_do_loop() {
+    bool pipeline_config::get_repeat_playback() {
         return _playback_loop;
     }
 
@@ -515,7 +515,7 @@ namespace librealsense
                     {
                         //If the pipeline holds a playback device, and it reached the end of file (stopped)
                         //Then we restart it
-                        if (_active_profile && _prev_conf->get_do_loop())
+                        if (_active_profile && _prev_conf->get_repeat_playback())
                         {
                             _active_profile->_multistream.open();
                             _active_profile->_multistream.start(syncer_callback);

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -83,12 +83,13 @@ namespace librealsense
         void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate);
         void enable_all_stream();
         void enable_device(const std::string& serial);
-        void enable_device_from_file(const std::string& file);
+        void enable_device_from_file(const std::string& file, bool do_loop);
         void enable_record_to_file(const std::string& file);
         void disable_stream(rs2_stream stream, int index = -1);
         void disable_all_streams();
         std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout = std::chrono::milliseconds(0));
         bool can_resolve(std::shared_ptr<pipeline> pipe);
+        bool get_do_loop();
 
         //Non top level API
         std::shared_ptr<pipeline_profile> get_cached_resolved_profile();
@@ -103,6 +104,7 @@ namespace librealsense
             _enable_all_streams = other._enable_all_streams;
             _stream_requests = other._stream_requests;
             _resolved_profile = nullptr;
+            _playback_loop = other._playback_loop;
         }
     private:
         struct device_request
@@ -120,6 +122,7 @@ namespace librealsense
         std::mutex _mtx;
         bool _enable_all_streams = false;
         std::shared_ptr<pipeline_profile> _resolved_profile;
+        bool _playback_loop;
     };
 
 }

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -83,13 +83,13 @@ namespace librealsense
         void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate);
         void enable_all_stream();
         void enable_device(const std::string& serial);
-        void enable_device_from_file(const std::string& file, bool do_loop);
+        void enable_device_from_file(const std::string& file, bool repeat_playback);
         void enable_record_to_file(const std::string& file);
         void disable_stream(rs2_stream stream, int index = -1);
         void disable_all_streams();
         std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout = std::chrono::milliseconds(0));
         bool can_resolve(std::shared_ptr<pipeline> pipe);
-        bool get_do_loop();
+        bool get_repeat_playback();
 
         //Non top level API
         std::shared_ptr<pipeline_profile> get_cached_resolved_profile();

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1471,7 +1471,7 @@ void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error 
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, serial)
 
-void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool repeat_playback, rs2_error ** error) BEGIN_API_CALL
+void rs2_config_enable_device_from_file(rs2_config* config, const char* file, int repeat_playback, rs2_error ** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(file);

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1471,12 +1471,12 @@ void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error 
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, serial)
 
-void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool do_loop, rs2_error ** error) BEGIN_API_CALL
+void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool repeat_playback, rs2_error ** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(file);
 
-    config->config->enable_device_from_file(file, do_loop);
+    config->config->enable_device_from_file(file, repeat_playback);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1471,12 +1471,21 @@ void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error 
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, serial)
 
-void rs2_config_enable_device_from_file(rs2_config* config, const char* file, int repeat_playback, rs2_error ** error) BEGIN_API_CALL
+void rs2_config_enable_device_from_file_repeat_option(rs2_config* config, const char* file, int repeat_playback, rs2_error ** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(file);
 
     config->config->enable_device_from_file(file, repeat_playback);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
+
+void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(config);
+    VALIDATE_NOT_NULL(file);
+
+    config->config->enable_device_from_file(file, true);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1471,12 +1471,12 @@ void rs2_config_enable_device(rs2_config* config, const char* serial, rs2_error 
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, serial)
 
-void rs2_config_enable_device_from_file(rs2_config* config, const char* file, rs2_error ** error) BEGIN_API_CALL
+void rs2_config_enable_device_from_file(rs2_config* config, const char* file, bool do_loop, rs2_error ** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(file);
 
-    config->config->enable_device_from_file(file);
+    config->config->enable_device_from_file(file, do_loop);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, config, file)
 

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -686,7 +686,7 @@ PYBIND11_MODULE(NAME, m) {
         .def("enable_stream", (void (rs2::config::*)(rs2_stream, int, rs2_format, int)) &rs2::config::enable_stream, "stream_type"_a, "stream_index"_a, "format"_a, "framerate"_a = 0)
         .def("enable_all_streams", &rs2::config::enable_all_streams)
         .def("enable_device", &rs2::config::enable_device, "serial"_a)
-        .def("enable_device_from_file", &rs2::config::enable_device_from_file, "file_name"_a)
+        .def("enable_device_from_file", &rs2::config::enable_device_from_file, "file_name"_a, "repeat_playback"_a = true)
         .def("enable_record_to_file", &rs2::config::enable_record_to_file, "file_name"_a)
         .def("disable_stream", &rs2::config::disable_stream, "stream"_a, "index"_a = -1)
         .def("disable_all_streams", &rs2::config::disable_all_streams)


### PR DESCRIPTION
#1426: Now rs2::config takes an additional parameter, boolean `repeat_playback` which allows the user to control the playback repeat (flase - playback will only play once, true - repeat in an infinite loop).