### PR TITLE
Fixing LibRS installation fail on MacOS 

### DIFF
--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -12,6 +12,7 @@
   * `brew install cmake`
 4. Generate XCode project:
   * `mkdir build && cd build`
+  * `sudo xcode-select --reset`
   * `cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -G Xcode`
 5. Open and build the XCode project
 


### PR DESCRIPTION
Follow the document, when running cmake, will get error message “No CMAKE_C_COMPILER”.
Adding this link(`sudo xcode-select --reset`) before cmake can fix it.