### PR TITLE
Fixes compilation and installation when using Catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,6 @@ if(WIN32)
         include/librealsense2/h/rs_processing.h
         include/librealsense2/h/rs_record_playback.h
         include/librealsense2/h/rs_pipeline.h
-        include/librealsense2/h/rs_streaming.h
         include/librealsense2/h/rs_internal.h
 
         include/librealsense2/rsutil.h
@@ -763,9 +762,16 @@ if (USE_SYSTEM_LIBUSB)
     target_include_directories(realsense2 PRIVATE ${LIBUSB1_INCLUDE_DIRS})
 endif()
 
-target_include_directories(realsense2 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                                            $<INSTALL_INTERFACE:include>
-                                     PRIVATE ${USB_INCLUDE_DIRS})
+target_include_directories(realsense2 PUBLIC 
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+  PRIVATE ${USB_INCLUDE_DIRS})
+
+set_target_properties(realsense2
+  PROPERTIES
+  PUBLIC_HEADER 
+  "include/librealsense2/rs.hpp;include/librealsense2/rs.h;include/librealsense2/h/rs_context.h;include/librealsense2/h/rs_device.h;include/librealsense2/h/rs_frame.h;include/librealsense2/h/rs_types.h;include/librealsense2/h/rs_sensor.h;include/librealsense2/h/rs_option.h;include/librealsense2/h/rs_processing.h;include/librealsense2/h/rs_record_playback.h;include/librealsense2/h/rs_pipeline.h;include/librealsense2/h/rs_internal.h;include/librealsense2/rsutil.h;include/librealsense2/rs_advanced_mode.h;include/librealsense2/h/rs_advanced_mode_command.h;include/librealsense2/hpp/rs_types.hpp;include/librealsense2/hpp/rs_context.hpp;include/librealsense2/hpp/rs_device.hpp;include/librealsense2/hpp/rs_frame.hpp;include/librealsense2/hpp/rs_processing.hpp;include/librealsense2/hpp/rs_pipeline.hpp;include/librealsense2/hpp/rs_record_playback.hpp;include/librealsense2/hpp/rs_sensor.hpp;include/librealsense2/hpp/rs_internal.hpp;include/librealsense2/rs_advanced_mode.hpp"
+  )
 
 set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/realsense2")
 
@@ -774,6 +780,7 @@ EXPORT realsense2Targets
 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/include/librealsense2"
 )
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/librealsense2 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/package.xml
+++ b/package.xml
@@ -31,4 +31,8 @@
   <depend>linux-headers-generic</depend>
   <depend>libssl-dev</depend>
   <depend>dkms</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Deletes a file that doesn't exist from CMake and makes the librealsense installation work from a ROS catkin workspace.