### PR TITLE
Adding holes filling Left/Near/Far Neighbor methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ set(REALSENSE_HPP
     src/proc/temporal-filter.h
     src/proc/syncer-processing-block.h
     src/proc/disparity-transform.h
+    src/proc/spatial-holes-fill.h
     src/algo.h
     src/option.h
     src/metadata.h
@@ -492,6 +493,7 @@ if(WIN32)
         src/proc/temporal-filter.h
         src/proc/syncer-processing-block.h
         src/proc/disparity-transform.h
+        src/proc/spatial-holes-fill.h
         )
 
     if(BUILD_WITH_STATIC_CRT)

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -7,7 +7,6 @@
 #endif
 #endif
 
-#include <regex>
 #include <thread>
 #include <algorithm>
 #include <regex>
@@ -389,7 +388,7 @@ namespace rs2
                     ImGui::Text("%s", txt.c_str());
 
                     ImGui::SameLine();
-                    ImGui::SetCursorPosX(read_only ? 268 : 245);
+                    ImGui::SetCursorPosX(read_only ? 268.f : 245.f);
                     ImGui::PushStyleColor(ImGuiCol_Text, grey);
                     ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, grey);
                     ImGui::PushStyleColor(ImGuiCol_ButtonActive, { 1.f,1.f,1.f,0.f });
@@ -1239,7 +1238,7 @@ namespace rs2
 
         // Verify that the number of found matches corrseponds to the number of the requested streams
         // TODO - review whether the comparison can be made strict (==)
-        return results.size() >= std::count_if(stream_enabled.begin(), stream_enabled.end(), [](const std::pair<int, bool>& kpv)-> bool { return kpv.second == true; });
+        return results.size() >= size_t(std::count_if(stream_enabled.begin(), stream_enabled.end(), [](const std::pair<int, bool>& kpv)-> bool { return kpv.second == true; }));
     }
 
     std::vector<stream_profile> subdevice_model::get_selected_profiles()

--- a/common/realsense-ui-advanced-mode.h
+++ b/common/realsense-ui-advanced-mode.h
@@ -75,7 +75,7 @@ inline bool string_to_int(const std::string& str, float& result)
 }
 
 template<class T, class S>
-inline void slider_int(std::string& error_message, char* id, T* val, S T::* field, bool& to_set)
+inline void slider_int(std::string& error_message, const char* id, T* val, S T::* field, bool& to_set)
 {
     ImGui::Text("%s", id);
     int temp = val->*field;

--- a/src/proc/spatial-filter.cpp
+++ b/src/proc/spatial-filter.cpp
@@ -8,7 +8,9 @@
 #include "context.h"
 #include "software-device.h"
 #include "proc/synthetic-stream.h"
+#include "proc/spatial-holes-fill.h"
 #include "proc/spatial-filter.h"
+
 
 namespace librealsense
 {
@@ -31,10 +33,10 @@ namespace librealsense
     const uint8_t filter_iter_step = 1;
 
     // The holes filling mode
-    const uint8_t holes_fill_min = 0;  // Disabled
-    const uint8_t holes_fill_max = 5;  // Unlimited
-    const uint8_t holes_fill_step = 1; // In-between the boundaries the holes filling ("smearing") range is 2^val pixels
-    const uint8_t holes_fill_def = 0;  // disabled on start due to its artefactory nature
+    const uint8_t holes_fill_min = hf_disabled;
+    const uint8_t holes_fill_max = hf_max_value-1;
+    const uint8_t holes_fill_step = 1;
+    const uint8_t holes_fill_def = hf_disabled;  // disabled on start due to its intrusive characteristic
 
     spatial_filter::spatial_filter() :
         _spatial_alpha_param(alpha_default_val),
@@ -81,7 +83,6 @@ namespace librealsense
             filter_iter_def,
             &_spatial_iterations, "Filtering iterations");
 
-
         auto holes_filling_mode = std::make_shared<ptr_option<uint8_t>>(
             holes_fill_min,
             holes_fill_max,
@@ -89,12 +90,15 @@ namespace librealsense
             holes_fill_def,
             &_holes_filling_mode, "Holes filling mode");
 
-        holes_filling_mode->set_description(0, "Disabled");
-        holes_filling_mode->set_description(1, "2-pixel radius");
-        holes_filling_mode->set_description(2, "4-pixel radius");
-        holes_filling_mode->set_description(3, "8-pixel radius");
-        holes_filling_mode->set_description(4, "16-pixel radius");
-        holes_filling_mode->set_description(5, "Unlimited");
+        holes_filling_mode->set_description(hf_disabled,            "Disabled");
+        holes_filling_mode->set_description(hf_2_pixel_radius,      "2-pixel radius");
+        holes_filling_mode->set_description(hf_4_pixel_radius,      "4-pixel radius");
+        holes_filling_mode->set_description(hf_8_pixel_radius,      "8-pixel radius");
+        holes_filling_mode->set_description(hf_16_pixel_radius,     "16-pixel radius");
+        holes_filling_mode->set_description(hf_unlimited_radius,    "Unlimited");
+        holes_filling_mode->set_description(hf_fill_from_left,      "Fill from Left");
+        holes_filling_mode->set_description(hf_farest_from_around,  "Farest from around");
+        holes_filling_mode->set_description(hf_nearest_from_around, "Nearest from around");
 
         holes_filling_mode->on_set([this, holes_filling_mode](float val)
         {
@@ -107,14 +111,20 @@ namespace librealsense
             _holes_filling_mode = static_cast<uint8_t>(val);
             switch (_holes_filling_mode)
             {
-            case holes_fill_min:
+            case hf_disabled:
                 _holes_filling_radius = 0;      // disabled
                 break;
-            case holes_fill_max:
+            case hf_unlimited_radius:
                 _holes_filling_radius = 0xff;   // The maximul smearing is not particulary useful
                 break;
+            case hf_2_pixel_radius:
+            case hf_4_pixel_radius:
+            case hf_8_pixel_radius:
+            case hf_16_pixel_radius:
+                _holes_filling_radius = 0x1 << _holes_filling_mode; // 2's exponential radius
+                break;
             default:
-                _holes_filling_radius = 0x1 << _holes_filling_mode; // exponential radius
+                _holes_filling_radius = 0; // n/a for these modes
                 break;
             }
         });

--- a/src/proc/spatial-filter.cpp
+++ b/src/proc/spatial-filter.cpp
@@ -115,7 +115,7 @@ namespace librealsense
                 _holes_filling_radius = 0;      // disabled
                 break;
             case hf_unlimited_radius:
-                _holes_filling_radius = 0xff;   // The maximul smearing is not particulary useful
+                _holes_filling_radius = 0xff;   // Unrealistic smearing; not particulary useful
                 break;
             case hf_2_pixel_radius:
             case hf_4_pixel_radius:
@@ -232,8 +232,6 @@ namespace librealsense
         return tgt;
     }
 
-
-
     void spatial_filter::recursive_filter_horizontal_fp(void * image_data, float alpha, float deltaZ)
     {
         float *image = reinterpret_cast<float*>(image_data);
@@ -248,7 +246,7 @@ namespace librealsense
 
             im++;
             float innovation = *im;
-            u = _width - 1;
+            u = int(_width) - 1;
             if (!(*(int*)&previousInnovation > 0))
                 goto CurrentlyInvalidLR;
             // else fall through
@@ -305,7 +303,7 @@ namespace librealsense
             // right to left
             im = image + (v + 1) * _width - 2;  // end of row - two pixels
             previousInnovation = state = im[1];
-            u = _width - 1;
+            u = int(_width) - 1;
             innovation = *im;
             if (!(*(int*)&previousInnovation > 0))
                 goto CurrentlyInvalidRL;
@@ -376,7 +374,7 @@ namespace librealsense
             float state = im[0];
             float previousInnovation = state;
 
-            v = _height - 1;
+            v = int(_height) - 1;
             im += _width;
             float innovation = *im;
 
@@ -437,7 +435,7 @@ namespace librealsense
             state = im[_width];
             previousInnovation = state;
             innovation = *im;
-            v = _height - 1;
+            v = int(_height) - 1;
             if (!(*(int*)&previousInnovation > 0))
                 goto CurrentlyInvalidBT;
             // else fall through

--- a/src/proc/spatial-filter.h
+++ b/src/proc/spatial-filter.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <cmath>
 
+#include "spatial-holes-fill.h"
 #include "../include/librealsense2/hpp/rs_frame.hpp"
 #include "../include/librealsense2/hpp/rs_processing.hpp"
 

--- a/src/proc/spatial-filter.h
+++ b/src/proc/spatial-filter.h
@@ -46,7 +46,7 @@ namespace librealsense
             }
 
             // Disparity domain holes filling requires a second pass over the frame data
-            if (fp && _holes_filling_mode)
+            if (_holes_filling_mode)
             {
                 apply_holes_filling<T>(frame_data, _width, _height, _stride,
                     static_cast<holes_filling_types>(_holes_filling_mode), _holes_filling_radius);

--- a/src/proc/spatial-filter.h
+++ b/src/proc/spatial-filter.h
@@ -48,8 +48,8 @@ namespace librealsense
             // Disparity domain holes filling requires a second pass over the frame data
             if (fp && _holes_filling_mode)
             {
-                holes_filling_types mode = static_cast<holes_filling_types>(_holes_filling_mode);
-                holes_filling_pass<hf_4_pixel_radius>(frame_data);
+                apply_holes_filling<T>(frame_data, _width, _height, _stride,
+                    static_cast<holes_filling_types>(_holes_filling_mode), _holes_filling_radius);
             }
         }
 
@@ -215,34 +215,6 @@ namespace librealsense
                     im += 1;
                 }
             }
-        }
-
-        enum holes_filling_types : uint8_t
-        {
-            hf_disabled,
-            hf_2_pixel_radius,
-            hf_4_pixel_radius,
-            hf_8_pixel_radius,
-            hf_16_pixel_radius,
-            hf_unlimited_radius,
-            hf_fill_from_left,
-            hf_farest_from_around,
-            hf_nearest_from_around
-        };
-
-        template <holes_filling_types T>
-        void holes_filling_pass(void * image_data)
-        {
-        }
-
-        template<>
-        void holes_filling_pass<hf_fill_from_left>(void * image_data)
-        {
-        }
-
-        template<>
-        void holes_filling_pass<hf_farest_from_around>(void * image_data)
-        {
         }
 
     private:

--- a/src/proc/spatial-holes-fill.h
+++ b/src/proc/spatial-holes-fill.h
@@ -1,0 +1,36 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2018 Intel Corporation. All Rights Reserved
+// The routies used to perform the actual holes filling when the depth is presented as disparity (floating point) data
+#pragma once
+
+namespace librealsense
+{
+    enum holes_filling_types : uint8_t
+    {
+        hf_disabled,
+        hf_2_pixel_radius,
+        hf_4_pixel_radius,
+        hf_8_pixel_radius,
+        hf_16_pixel_radius,
+        hf_unlimited_radius,
+        hf_fill_from_left,
+        hf_farest_from_around,
+        hf_nearest_from_around,
+        hf_max_value
+    };
+
+    template <holes_filling_types T>
+    void holes_filling_pass(void * image_data)
+    {
+    }
+
+    template<>
+    void holes_filling_pass<hf_fill_from_left>(void * image_data)
+    {
+    }
+
+    template<>
+    void holes_filling_pass<hf_farest_from_around>(void * image_data)
+    {
+    }
+}

--- a/src/proc/spatial-holes-fill.h
+++ b/src/proc/spatial-holes-fill.h
@@ -19,18 +19,171 @@ namespace librealsense
         hf_max_value
     };
 
-    template <holes_filling_types T>
-    void holes_filling_pass(void * image_data)
+    template<typename T>
+    inline void intertial_holes_fill(T* image_data, size_t width, size_t height, size_t stride, uint8_t radius)
     {
+        size_t cur_fill = 0;
+
+        T* p = image_data;
+        for (int j = 0; j < height; ++j)
+        {
+            ++p;
+            cur_fill = 0;
+
+            //Left to Right
+            for (size_t i = 1; i < width; ++i)
+            {
+                //if (!*((int *)p)) // Evgeni - requires verification
+                if (!*p && *(p - 1))
+                {
+                    if (++cur_fill < radius)
+                        *p = *(p - 1);
+                }
+                else
+                    cur_fill = 0;
+
+                ++p;
+            }
+
+            --p;
+            cur_fill = 0;
+            //Right to left
+            for (size_t i = 1; i < width; ++i)
+            {
+                //if (!*((int *)p)) // Evgeni - requires verification
+                if (!*p)
+                {
+                    if (++cur_fill < radius)
+                        *p = *(p + 1);
+                }
+                else
+                    cur_fill = 0;
+                --p;
+            }
+            p += width;
+        }
     }
 
-    template<>
-    void holes_filling_pass<hf_fill_from_left>(void * image_data)
+    template<typename T>
+    inline void holes_fill_left(T* image_data, size_t width, size_t height, size_t stride)
     {
+        T* p = image_data;
+        for (int j = 0; j < height; ++j)
+        {
+            ++p;
+            for (int i = 1; i < width; ++i)
+            {
+                //if (!*((int *)p)) // Evgeni - requires verification
+                if (!*p)
+                    *p = *(p - 1);
+                ++p;
+            }
+        }
     }
 
-    template<>
-    void holes_filling_pass<hf_farest_from_around>(void * image_data)
+    template<typename T>
+    inline void holes_fill_farest(T* image_data, size_t width, size_t height, size_t stride)
     {
+        T tmp = 0;
+        T * p = image_data + width;
+        T * q = nullptr;
+        for (int j = 1; j < height - 1; ++j)
+        {
+            ++p;
+            for (int i = 1; i < width; ++i)
+            {
+                if (!*((int *)p))
+                {
+                    tmp = *(p - width);
+
+                    q = p - width - 1;
+                    if (*q > tmp)
+                        tmp = *q;
+
+                    q = p - 1;
+                    if (*q > tmp)
+                        tmp = *q;
+
+                    q = p + width - 1;
+                    if (*q > tmp)
+                        tmp = *q;
+
+                    q = p + width;
+                    if (*q > tmp)
+                        tmp = *q;
+
+                    *p = tmp;
+                }
+
+                p++;
+            }
+        }
+    }
+
+    template<typename T>
+    inline void holes_fill_nearest(T* image_data, size_t width, size_t height, size_t stride)
+    {
+        T tmp = 0;
+        T * p = image_data + width;
+        T * q = nullptr;
+        for (int j = 1; j < height - 1; ++j)
+        {
+            ++p;
+            for (int i = 1; i < width; ++i)
+            {
+                if (!*p)
+                {
+                    tmp = *(p - width);
+
+                    q = p - width - 1;
+                    if (*((int *)q) && *q < tmp)
+                        tmp = *q;
+
+                    q = p - 1;
+                    if (*((int *)q) && *q < tmp)
+                        tmp = *q;
+
+                    q = p + width - 1;
+                    if (*((int *)q) && *q < tmp)
+                        tmp = *q;
+
+                    q = p + width;
+                    if (*((int *)q) && *q < tmp)
+                        tmp = *q;
+
+                    *p = tmp;
+                }
+
+                p++;
+            }
+        }
+    }
+
+    template<typename T>
+    void apply_holes_filling(void * image_data, size_t width, size_t height, size_t stride,
+        holes_filling_types mode, uint8_t radius)
+    {
+        T* data= reinterpret_cast<T*>(image_data);
+
+        // The holes fill routines except for the radius-based derived from the reference design
+        switch (mode)
+        {
+        case hf_2_pixel_radius:
+        case hf_4_pixel_radius:
+        case hf_8_pixel_radius:
+        case hf_16_pixel_radius:
+        case hf_unlimited_radius:
+            intertial_holes_fill(data, width, height, stride, radius);
+            break;
+        case hf_fill_from_left:
+            holes_fill_left(data, width, height, stride);
+            break;
+        case hf_farest_from_around:
+            holes_fill_farest(data, width, height, stride);
+            break;
+        case hf_nearest_from_around:
+            holes_fill_nearest(data, width, height, stride);
+            break;
+        }
     }
 }

--- a/src/proc/temporal-filter.h
+++ b/src/proc/temporal-filter.h
@@ -88,7 +88,6 @@ namespace librealsense
         void on_set_delta(float val);
 
         void recalc_persistence_map();
-        std::mutex _mutex;
         uint8_t                 _persistence_param;
 
         float                   _alpha_param;               // The normalized weight of the current pixel


### PR DESCRIPTION
Adding methods for the spatial holes fill option
- Left : filling holes using the left neighbor
- Near : select the (left/right/up/down) neighbor closest to the camera (min z)
- Far : select the (left/right/up/down) neighbor  farthest from the camera (max z).
The new methods are implemented as a separate pass on the data that may impact performance.

Fixes:
- Re enabling the existing hole filling modes for disparity map (#1591)
Remove overriding mutex in derived class.
(const char *) to (char *) cast