### PR TITLE
[Node.js] Fix getCameraInfo crash issue

### DIFF
--- a/wrappers/nodejs/index.js
+++ b/wrappers/nodejs/index.js
@@ -96,8 +96,8 @@ class Device {
    *
    * @param {String|Integer} [info] - the camera_info type, see {@link camera_info} for available
    * values
-   * @return {CameraInfoObject} if no argument is provided, {CameraInfoObject} is returned.
-   * If a camera_info is provided, the specific camera info value is returned.
+   * @return {CameraInfoObject|String|undefined} if no argument is provided, {CameraInfoObject} is
+   * returned. If a camera_info is provided, the specific camera info value string is returned.
    */
   getCameraInfo(info) {
     const funcName = 'Device.getCameraInfo()';

--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -2122,9 +2122,11 @@ class RSSensor : public Nan::ObjectWrap, Options {
     auto me = Nan::ObjectWrap::Unwrap<RSSensor>(info.Holder());
     if (!me) return;
 
-    std::string value(GetNativeResult<const char*>(rs2_get_sensor_info,
+    auto value = GetNativeResult<const char*>(rs2_get_sensor_info,
         &me->error_, me->sensor_, static_cast<rs2_camera_info>(camera_info),
-        &me->error_));
+        &me->error_);
+    if (me->error_) return;
+
     info.GetReturnValue().Set(Nan::New(value).ToLocalChecked());
   }
 
@@ -2463,9 +2465,9 @@ class RSDevice : public Nan::ObjectWrap {
     auto me = Nan::ObjectWrap::Unwrap<RSDevice>(info.Holder());
     if (!me) return;
 
-    std::string value(GetNativeResult<const char*>(rs2_get_device_info,
+    auto value = GetNativeResult<const char*>(rs2_get_device_info,
         &me->error_, me->dev_, static_cast<rs2_camera_info>(camera_info),
-        &me->error_));
+        &me->error_);
     if (me->error_) return;
 
     info.GetReturnValue().Set(Nan::New(value).ToLocalChecked());

--- a/wrappers/nodejs/test/test-functional-online.js
+++ b/wrappers/nodejs/test/test-functional-online.js
@@ -330,6 +330,14 @@ describe('enum value test', function() {
     for (let i = 0; i < obj.CAMERA_INFO_COUNT; i++) {
       assert.equal(typeof obj.cameraInfoToString(i), 'string');
     }
+    let ctx = new rs2.Context();
+    let dev = ctx.queryDevices().devices[0];
+
+    for (let i = obj.CAMERA_INFO_NAME; i < obj.CAMERA_INFO_COUNT; i++) {
+      let info = dev.getCameraInfo(i);
+      assert.equal((info === undefined) || (typeof info === 'string'), true);
+    }
+    rs2.cleanup();
   });
 });
 


### PR DESCRIPTION
getCameraInfo() of Device and Sensor would return undefined
for unsupported camera_info type instead of crash