### PR TITLE
[Node.js] Add align object to the pool for gc

### DIFF
--- a/wrappers/nodejs/index.js
+++ b/wrappers/nodejs/index.js
@@ -1696,6 +1696,7 @@ class Align {
     const s = checkArgumentType(arguments, constants.stream, 0, funcName);
     this.cxxAlign = new RS2.RSAlign(s);
     this.frameSet = new FrameSet();
+    internal.addObject(this);
   }
 
   /**


### PR DESCRIPTION
Align objects should be recored in the pool for cleanup()
to avoid leak.