### PR TITLE
Fixed bug DSO-9096 save the original resolution and use it to ROI calculation.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1585,6 +1585,7 @@ namespace rs2
     {
         dev = d;
         original_profile = p;
+
         profile = p;
         texture->colorize = d->depth_colorizer;
 
@@ -1593,7 +1594,11 @@ namespace rs2
             size = {
                 static_cast<float>(vd.width()),
                 static_cast<float>(vd.height()) };
-        };
+
+            original_size = {
+                static_cast<float>(vd.width()),
+                static_cast<float>(vd.height()) };
+        }
         _stream_not_alive.reset();
 
     }
@@ -1633,7 +1638,7 @@ namespace rs2
                 {
                     // Convert from local (pixel) coordinate system to device coordinate system
                     auto r = roi_display_rect;
-                    r = r.normalize(stream_rect).unnormalize(_normalized_zoom.unnormalize(get_stream_bounds()));
+                    r = r.normalize(stream_rect).unnormalize(_normalized_zoom.unnormalize(get_original_stream_bounds()));
                     dev->roi_rect = r; // Store new rect in device coordinates into the subdevice object
 
                     // Send it to firmware:
@@ -1694,7 +1699,7 @@ namespace rs2
             if (!capturing_roi)
             {
                 auto r = dev->roi_rect; // Take the current from device, convert to local coordinates
-                r = r.normalize(_normalized_zoom.unnormalize(get_stream_bounds())).unnormalize(stream_rect).cut_by(stream_rect);
+                r = r.normalize(_normalized_zoom.unnormalize(get_original_stream_bounds())).unnormalize(stream_rect).cut_by(stream_rect);
                 roi_display_rect = r;
             }
 

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -415,7 +415,9 @@ namespace rs2
         rect layout;
         std::unique_ptr<texture_buffer> texture;
         float2 size;
-        rect get_stream_bounds() const { return { 0, 0, size.x, size.y }; }
+        float2 original_size;
+        rect get_stream_bounds() const { return { 0, 0, size.x, size.y };}
+        rect get_original_stream_bounds() const { return{ 0, 0, original_size.x, original_size.y };}
         stream_profile original_profile;
         stream_profile profile;
         std::chrono::high_resolution_clock::time_point last_frame;


### PR DESCRIPTION
When decimation filter is enabled, the resolution of the processed frame is changed but the original frame is stay the same, so all the ROI calculations should use the original resolution.