### PR TITLE
Add USB3.2 descriptor type.

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -184,7 +184,8 @@ namespace librealsense
             usb2_type       = 0x0200,
             usb2_1_type     = 0x0210,
             usb3_type       = 0x0300,
-            usb3_1_type     = 0x0310
+            usb3_1_type     = 0x0310,
+            usb3_2_type     = 0x0320,
         };
 
         static const std::map<usb_spec, std::string> usb_spec_names = {
@@ -194,7 +195,8 @@ namespace librealsense
                 { usb2_type,    "2.0" },
                 { usb2_1_type,  "2.1" },
                 { usb3_type,    "3.0" },
-                { usb3_1_type,  "3.1" }
+                { usb3_1_type,  "3.1" },
+                { usb3_2_type,  "3.2" }
         };
 
         struct uvc_device_info

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -423,19 +423,20 @@ namespace librealsense
         auto& depth_ep = get_depth_sensor();
         auto advanced_mode = is_camera_in_advanced_mode();
 
-        auto _usb_mode = platform::usb3_type;
-        std::string usb_type_str(platform::usb_spec_names.at(_usb_mode));
+        using namespace platform;
+        auto _usb_mode = usb3_type;
+        std::string usb_type_str(usb_spec_names.at(_usb_mode));
         bool usb_modality = (_fw_version >= firmware_version("5.9.8.0"));
         if (usb_modality)
         {
             _usb_mode = depth_ep.get_usb_specification();
-            if (platform::usb_undefined != _usb_mode)
-                usb_type_str = platform::usb_spec_names.at(_usb_mode);
+            if (usb_spec_names.count(_usb_mode) && (usb_undefined != _usb_mode))
+                usb_type_str = usb_spec_names.at(_usb_mode);
             else  // Backend fails to provide USB descriptor  - occurs with RS3 build. Requires further work
                 usb_modality = false;
         }
 
-        if (advanced_mode && (_usb_mode >= platform::usb3_type))
+        if (advanced_mode && (_usb_mode >= usb3_type))
         {
             depth_ep.register_pixel_format(pf_y8i); // L+R
             depth_ep.register_pixel_format(pf_y12i); // L+R - Calibration not rectified
@@ -518,7 +519,7 @@ namespace librealsense
             depth_ep.register_option(RS2_OPTION_DEPTH_UNITS, std::make_shared<const_value_option>("Number of meters represented by a single depth unit",
                 lazy<float>([]() { return 0.001f; })));
         // Metadata registration
-        depth_ep.register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
+        depth_ep.register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&uvc_header::timestamp));
 
         // attributes of md_capture_timing
         auto md_prop_offset = offsetof(metadata_raw, mode) +
@@ -526,7 +527,7 @@ namespace librealsense
             offsetof(md_depth_y_normal_mode, intel_capture_timing);
 
         depth_ep.register_metadata(RS2_FRAME_METADATA_FRAME_COUNTER, make_attribute_parser(&md_capture_timing::frame_counter, md_capture_timing_attributes::frame_counter_attribute, md_prop_offset));
-        depth_ep.register_metadata(RS2_FRAME_METADATA_SENSOR_TIMESTAMP, make_rs400_sensor_ts_parser(make_uvc_header_parser(&platform::uvc_header::timestamp),
+        depth_ep.register_metadata(RS2_FRAME_METADATA_SENSOR_TIMESTAMP, make_rs400_sensor_ts_parser(make_uvc_header_parser(&uvc_header::timestamp),
             make_attribute_parser(&md_capture_timing::sensor_timestamp, md_capture_timing_attributes::sensor_timestamp_attribute, md_prop_offset)));
 
         // attributes of md_capture_stats

--- a/src/win/win-helpers.h
+++ b/src/win/win-helpers.h
@@ -29,8 +29,8 @@ namespace librealsense
 
         bool parse_usb_path(uint16_t & vid, uint16_t & pid, uint16_t & mi, std::string & unique_id, const std::string & path);
 
-        std::tuple<std::string, usb_spec> get_usb_descriptors(uint16_t device_vid, uint16_t device_pid,
-            const std::string& device_uid);
+        bool get_usb_descriptors(uint16_t device_vid, uint16_t device_pid, const std::string& device_uid,
+            std::string& location, usb_spec& spec);
 
         class event_base
         {

--- a/src/win/win-uvc.cpp
+++ b/src/win/win-uvc.cpp
@@ -951,7 +951,7 @@ namespace librealsense
             std::shared_ptr<const wmf_backend> backend)
             : _streamIndex(MAX_PINS), _info(info), _is_flushed(), _has_started(), _backend(std::move(backend)),
             _systemwide_lock(info.unique_id.c_str(), WAIT_FOR_MUTEX_TIME_OUT),
-            _location(""), _device_usb_spec(usb_undefined)
+            _location(""), _device_usb_spec(usb3_type)
         {
             if (!is_connected(info))
             {
@@ -959,11 +959,15 @@ namespace librealsense
             }
             try
             {
-                std::tie(_location, _device_usb_spec) = get_usb_descriptors(info.vid, info.pid, info.unique_id);
+                if (!get_usb_descriptors(info.vid, info.pid, info.unique_id, _location, _device_usb_spec))
+                {
+                    LOG_WARNING("Could not retrieve USB descriptor for device " << std::hex << info.vid << ":"
+                        << info.pid << " , id:" << info.unique_id);
+                }
             }
-            catch (...) 
+            catch (...)
             {
-                LOG_WARNING("Could not retrieve USB descriptor for device " << std::hex << info.vid << ":" 
+                LOG_WARNING("Accessing USB info failed for " << std::hex << info.vid << ":" 
                     << info.pid << " , id:" << info.unique_id);
             }
         }


### PR DESCRIPTION
Register USB3.2 Descriptor type.
Change default USB setting to USB3 type to tackle Win10 RS3 build changes.
In case of USB2 connection ,the device core streaming functionalities will not be affected
Refactor USB descriptor retrieval routine to use return code to avoid unnecessary exceptions.

Tracked on: (DSO-9306) - USB3.2 Descriptor support
Tracked on: (DSO-8913) - Y16 format is not presented for D435