### PR TITLE
[Node.js] Fix FrameSet.getFrame() throwing exception issue

### DIFF
--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -1624,6 +1624,16 @@ class RSFrameSet : public Nan::ObjectWrap {
 
     rs2_stream stream = static_cast<rs2_stream>(info[0]->IntegerValue());
     auto stream_index = info[1]->IntegerValue();
+    // if RS2_STREAM_ANY is used, we return the first frame.
+    if (stream == RS2_STREAM_ANY && me->frame_count_) {
+      rs2_frame* frame = GetNativeResult<rs2_frame*>(rs2_extract_frame,
+          &me->error_, me->frames_, 0, &me->error_);
+      if (!frame) return;
+
+      info.GetReturnValue().Set(RSFrame::NewInstance(frame));
+      return;
+    }
+
     for (uint32_t i=0; i < me->frame_count_; i++) {
       rs2_frame* frame = GetNativeResult<rs2_frame*>(rs2_extract_frame,
           &me->error_, me->frames_, i, &me->error_);

--- a/wrappers/nodejs/test/test-functional-online.js
+++ b/wrappers/nodejs/test/test-functional-online.js
@@ -579,3 +579,17 @@ describe('new record/playback test', function() {
     fs.unlinkSync(file);
   }).timeout(5000);
 });
+
+describe('frameset misc test', function() {
+  it('get any frame twice test', () => {
+    let pipe = new rs2.Pipeline();
+    pipe.start();
+    let frames = pipe.waitForFrames();
+    let frame = frames.getFrame(rs2.stream.STREAM_ANY);
+    assert.equal(frame instanceof rs2.Frame, true);
+    frame = frames.getFrame(rs2.stream.STREAM_ANY);
+    assert.equal(frame instanceof rs2.Frame, true);
+    pipe.stop();
+    rs2.cleanup();
+  });
+});


### PR DESCRIPTION
FrameSet.getFrame() didn't consider stream.STREAM_ANY which
lead to invalid Frame instances in cache.