### PR TITLE
Fix a small markdown format error

### DIFF
--- a/examples/post-processing/readme.md
+++ b/examples/post-processing/readme.md
@@ -227,7 +227,8 @@ The `processing_thread` will do the following actions, to make the main thread m
           {
               filtered = disparity_to_depth.process(filtered);
           }
-    ```
+  ```
+
 3. Push the original depth frame, and the filtered one, each to its respective queue:
 
   ```cpp


### PR DESCRIPTION
Fix a small markdown format error in examples/post-processing/readme.md