### PR TITLE
Roi sensor bug

### DIFF
--- a/src/core/roi.h
+++ b/src/core/roi.h
@@ -32,5 +32,24 @@ namespace librealsense
         virtual void set_roi_method(std::shared_ptr<region_of_interest_method> roi_method) = 0;
     };
 
+    class roi_sensor_base : public roi_sensor_interface
+    {
+    public:
+        region_of_interest_method& get_roi_method() const override
+        {
+            if (!_roi_method.get())
+                throw librealsense::not_implemented_exception("Region-of-interest is not implemented for this device!");
+            return *_roi_method;
+        }
+
+        void set_roi_method(std::shared_ptr<region_of_interest_method> roi_method) override
+        {
+            _roi_method = roi_method;
+        }
+
+    private:
+        std::shared_ptr<region_of_interest_method> _roi_method = nullptr;
+    };
+
     MAP_EXTENSION(RS2_EXTENSION_ROI, librealsense::roi_sensor_interface);
 }

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -75,7 +75,7 @@ namespace librealsense
         _hw_monitor->send(cmd);
     }
 
-    class ds5_depth_sensor : public uvc_sensor, public video_sensor_interface, public depth_stereo_sensor
+    class ds5_depth_sensor : public uvc_sensor, public video_sensor_interface, public depth_stereo_sensor, public roi_sensor_base
     {
     public:
         explicit ds5_depth_sensor(ds5_device* owner,
@@ -356,7 +356,6 @@ namespace librealsense
         std::unique_ptr<frame_timestamp_reader> ds5_timestamp_reader_backup(new ds5_timestamp_reader(backend.create_time_service()));
         auto depth_ep = std::make_shared<ds5_depth_sensor>(this, std::make_shared<platform::multi_pins_uvc_device>(depth_devices),
                                                        std::unique_ptr<frame_timestamp_reader>(new ds5_timestamp_reader_from_metadata(std::move(ds5_timestamp_reader_backup))));
-
         depth_ep->register_xu(depth_xu); // make sure the XU is initialized every time we power the camera
 
         depth_ep->register_pixel_format(pf_z16); // Depth
@@ -510,8 +509,9 @@ namespace librealsense
                 std::make_shared<asic_and_projector_temperature_options>(depth_ep,
                     RS2_OPTION_ASIC_TEMPERATURE));
         }
-
-        depth_ep.set_roi_method(std::make_shared<ds5_auto_exposure_roi_method>(*_hw_monitor));
+        roi_sensor_interface* roi_sensor;
+        if (roi_sensor = dynamic_cast<roi_sensor_interface*>(&depth_ep))
+            roi_sensor->set_roi_method(std::make_shared<ds5_auto_exposure_roi_method>(*_hw_monitor));
 
         depth_ep.register_option(RS2_OPTION_STEREO_BASELINE, std::make_shared<const_value_option>("Distance in mm between the stereo imagers",
             lazy<float>([this]() { return get_stereo_baseline_mm(); })));

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -98,7 +98,7 @@ namespace librealsense
         const ds5_motion* _owner;
     };
 
-    class ds5_fisheye_sensor : public uvc_sensor, public video_sensor_interface
+    class ds5_fisheye_sensor : public uvc_sensor, public video_sensor_interface, public roi_sensor_base
     {
     public:
         explicit ds5_fisheye_sensor(ds5_motion* owner, std::shared_ptr<platform::uvc_device> uvc_device,

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -254,18 +254,6 @@ namespace librealsense
         }
     }
 
-    region_of_interest_method& uvc_sensor::get_roi_method() const
-    {
-        if (!_roi_method.get())
-            throw librealsense::not_implemented_exception("Region-of-interest is not implemented for this device!");
-        return *_roi_method;
-    }
-
-    void uvc_sensor::set_roi_method(std::shared_ptr<region_of_interest_method> roi_method)
-    {
-        _roi_method = roi_method;
-    }
-
     stream_profiles uvc_sensor::init_stream_profiles()
     {
         std::unordered_set<std::shared_ptr<video_stream_profile>> results;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -172,17 +172,13 @@ namespace librealsense
         uint32_t fps_to_sampling_frequency(rs2_stream stream, uint32_t fps) const;
     };
 
-    class uvc_sensor : public sensor_base,
-                       public roi_sensor_interface
+    class uvc_sensor : public sensor_base
     {
     public:
         explicit uvc_sensor(std::string name, std::shared_ptr<platform::uvc_device> uvc_device,
                             std::unique_ptr<frame_timestamp_reader> timestamp_reader, device* dev);
 
         ~uvc_sensor();
-
-        region_of_interest_method& get_roi_method() const override;
-        void set_roi_method(std::shared_ptr<region_of_interest_method> roi_method) override;
 
         void open(const stream_profiles& requests) override;
 
@@ -256,6 +252,5 @@ namespace librealsense
         std::vector<platform::extension_unit> _xus;
         std::unique_ptr<power> _power;
         std::unique_ptr<frame_timestamp_reader> _timestamp_reader;
-        std::shared_ptr<region_of_interest_method> _roi_method = nullptr;
     };
 }


### PR DESCRIPTION
Added roi_sensor_base class which derives from roi_sensor_interface, and all roi sensors derive from it. uvc_sensor now doesn't derive from roi_sensor (fix for a bug where roi sensors could be constructed from sensors which don't have roi_method, leading to crush).