### PR TITLE
Bug fix: The CPU usage is too high on Viewer 

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3106,7 +3106,7 @@ namespace rs2
 
     void post_processing_filters::render_loop()
     {
-        while (keep_calculating)
+        while (render_thread_active)
         {
             try
             {
@@ -3128,7 +3128,6 @@ namespace rs2
                     }
                     for (auto&& q : frames_queue_local)
                     {
-
                         frame frm;
                         if (q.second.poll_for_frame(&frm))
                         {
@@ -3975,6 +3974,7 @@ namespace rs2
 
     void viewer_model::begin_stream(std::shared_ptr<subdevice_model> d, rs2::stream_profile p)
     {
+        ppf.start();
         streams[p.unique_id()].begin_stream(d, p);
         ppf.frames_queue.emplace(p.unique_id(), rs2::frame_queue(5));
     }
@@ -5642,6 +5642,7 @@ namespace rs2
                                 return sm->streaming;
                             }))
                             {
+                                viewer.ppf.stop();
                                 stop_recording = true;
                             }
                         }


### PR DESCRIPTION
Bug fix: The CPU usage is too high by running Realsense Viewer without any streaming
Found the bug on post processing filters render loop thread
The fix: create the loop thread only when there are live streaming