### PR TITLE
Cpu high usage without streaming fix

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3106,7 +3106,7 @@ namespace rs2
 
     void post_processing_filters::render_loop()
     {
-        while (keep_calculating)
+        while (render_thread_active)
         {
             try
             {
@@ -3128,7 +3128,6 @@ namespace rs2
                     }
                     for (auto&& q : frames_queue_local)
                     {
-
                         frame frm;
                         if (q.second.poll_for_frame(&frm))
                         {
@@ -3975,6 +3974,7 @@ namespace rs2
 
     void viewer_model::begin_stream(std::shared_ptr<subdevice_model> d, rs2::stream_profile p)
     {
+        ppf.start();
         streams[p.unique_id()].begin_stream(d, p);
         ppf.frames_queue.emplace(p.unique_id(), rs2::frame_queue(5));
     }
@@ -5642,6 +5642,7 @@ namespace rs2
                                 return sm->streaming;
                             }))
                             {
+                                viewer.ppf.stop();
                                 stop_recording = true;
                             }
                         }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3974,6 +3974,7 @@ namespace rs2
 
     void viewer_model::begin_stream(std::shared_ptr<subdevice_model> d, rs2::stream_profile p)
     {
+        // Starting post processing filter rendering thread
         ppf.start();
         streams[p.unique_id()].begin_stream(d, p);
         ppf.frames_queue.emplace(p.unique_id(), rs2::frame_queue(5));
@@ -5642,6 +5643,7 @@ namespace rs2
                                 return sm->streaming;
                             }))
                             {
+                                // Stopping post processing filter rendering thread
                                 viewer.ppf.stop();
                                 stop_recording = true;
                             }

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -823,6 +823,7 @@ namespace rs2
 
         ~viewer_model()
         {
+            // Stopping post processing filter rendering thread
             ppf.stop();
             streams.clear();
         }

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -128,6 +128,9 @@ void refresh_devices(std::mutex& m,
 
                     viewer_model.ppf.depth_stream_active = false;
 
+                    // Stopping post processing filter rendering thread in case of disconnection
+                    viewer_model.ppf.stop();
+
                     //Remove from devices
                     auto dev_model_itr = std::find_if(begin(device_models), end(device_models),
                         [&](const device_model& other) { return get_device_name(other.dev) == get_device_name(dev); });
@@ -475,7 +478,7 @@ int main(int argv, const char** argc) try
         viewer_model.handle_ready_frames(viewer_rect, window, static_cast<int>(device_models.size()), error_message);
     }
 
-    // Stop calculating 3D model
+    // Stopping post processing filter rendering thread
     viewer_model.ppf.stop();
 
     // Stop all subdevices


### PR DESCRIPTION
Bug fix: The CPU usage is too high by running Realsense Viewer without any streaming.
Found the bug on post processing filters render loop thread
The fix: create the loop thread only when there are live streaming