### PR TITLE
Fix CMake libusb include path variable

### DIFF
--- a/CMake/FindLibUSB.cmake
+++ b/CMake/FindLibUSB.cmake
@@ -24,7 +24,7 @@ if ( PKG_CONFIG_FOUND )
 endif ( PKG_CONFIG_FOUND )
 
 if ( PKGCONFIG_LIBUSB_FOUND )
-  set ( LibUSB_INCLUDE_DIRS ${PKGCONFIG_LIBUSB_INCLUDEDIR} )
+  set ( LibUSB_INCLUDE_DIRS ${PKGCONFIG_LIBUSB_INCLUDE_DIRS} )
   foreach ( i ${PKGCONFIG_LIBUSB_LIBRARIES} )
     string ( REGEX MATCH "[^-]*" ibase "${i}" )
     find_library ( ${ibase}_LIBRARY


### PR DESCRIPTION
pkg_check_module set XXX_INCLUDE_DIRS not XXX_INCLUDEDIR.