### PR TITLE
Rectify decimation filter/many-to-many operation mode

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3057,7 +3057,8 @@ namespace rs2
             }
         }
 
-        // Override the zero pixel in texture frame with black color for occlusion invalidatipon
+        // Override the zero pixel in texture frame with black color for occlusion invalidation
+        // TODO - this is a temporal solution to be refactored from the app level into the core library
         switch (stream_type)
         {
         case RS2_STREAM_COLOR:

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -929,7 +929,7 @@ namespace rs2
         float3 target = { 0.0f, 0.0f, 0.0f };
         float3 up;
         bool fixed_up = true;
-        bool render_quads = false;
+        bool render_quads = true;
 
         float view[16];
         bool texture_wrapping_on = true;

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -1060,6 +1060,8 @@ namespace rs2
                     if (auto colorized_frame = colorize->colorize(frame).as<video_frame>())
                     {
                         data = colorized_frame.get_data();
+                        // Override the first pixel in the colorized image for occlusion invalidation.
+                        memset((void*)data,0, colorized_frame.get_bytes_per_pixel());
                         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB,
                                      colorized_frame.get_width(),
                                      colorized_frame.get_height(),

--- a/src/proc/colorizer.cpp
+++ b/src/proc/colorizer.cpp
@@ -196,7 +196,7 @@ namespace librealsense
             {
                 {
                     std::lock_guard<std::mutex> lock(_mutex);
-                    if (!_stream)
+                    if (!_stream || (f.get_profile().get() != _stream->get()))
                     {
                         _stream = std::make_shared<rs2::stream_profile>(f.get_profile().clone(RS2_STREAM_DEPTH, 0, RS2_FORMAT_RGB8));
                         environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_stream->get()->profile, *f.get_profile().get()->profile);

--- a/src/proc/decimation-filter.h
+++ b/src/proc/decimation-filter.h
@@ -27,14 +27,17 @@ namespace librealsense
         void    update_output_profile(const rs2::frame& f);
 
         uint8_t                 _decimation_factor;
+        uint8_t                 _control_val;
         uint8_t                 _patch_size;
         uint8_t                 _kernel_size;
         rs2::stream_profile     _source_stream_profile;
         rs2::stream_profile     _target_stream_profile;
+        std::map<std::tuple<const rs2_stream_profile*, uint8_t>, rs2::stream_profile> _registered_profiles;
         uint16_t                _real_width;        // Number of rows/columns with real datain the decimated image
         uint16_t                _real_height;       // Correspond to w,h in the reference code
         uint16_t                _padded_width;      // Corresponds to w4/h4 in the reference code
         uint16_t                _padded_height;
         bool                    _recalc_profile;
+        bool                    _options_changed;   // Tracking changes imposed by user
     };
 }

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -406,7 +406,6 @@ namespace librealsense
 
     void pointcloud::process_depth_frame(const rs2::depth_frame& depth)
     {
-
         frame_holder res = get_source().allocate_points(_output_stream, (frame_interface*)depth.get());
 
         auto pframe = (points*)(res.frame);


### PR DESCRIPTION
Fix reuse of stream profiles in decimation block
Fix update flow in colorizer block
Fix UV flickering by assigning zero value to [0,0] texture coordinate for invalidation
Fix ROI location in DQT 2D view
Change default rendering mode for 3D Pointcloud to quads
