### PR TITLE
[Node.js] Expose all native errors to Javascript world

### DIFF
--- a/wrappers/nodejs/index.js
+++ b/wrappers/nodejs/index.js
@@ -9,6 +9,16 @@ const EventEmitter = require('events');
 const PNG = require('pngjs').PNG;
 const fs = require('fs');
 
+/**
+ * UnrecoverableError is the type of error that jeopardized the modue that restart
+ * is needed.
+ */
+class UnrecoverableError extends Error {
+  constructor(message) {
+    super('Unrecoverable! '+ message);
+  }
+}
+
 // TODO(tingshao): resolve the potential disabled eslint errors
 /* eslint-disable prefer-rest-params, valid-jsdoc, no-unused-vars, camelcase */
 /**
@@ -1088,10 +1098,11 @@ const internal = {
 
   // The callback method called from native side
   errorCallback: function(error) {
-    if (error.recoverable === false) {
-      throw new TypeError('Unrecoverable error, native function ' + error.nativeFunction + ': ' +
-          error.description);
+    let msg = 'error native function ' + error.nativeFunction + ': ' + error.description;
+    if (error.recoverable) {
+      throw new Error(msg);
     }
+    throw new UnrecoverableError(msg);
   },
 
   addContext: function(c) {
@@ -5974,6 +5985,7 @@ function getError() {
 module.exports = {
   cleanup: cleanup,
   getError: getError,
+  UnrecoverableError: UnrecoverableError,
 
   Context: Context,
   Pipeline: Pipeline,

--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -169,8 +169,6 @@ class ErrorUtil {
   void MarkError(bool recoverable, std::string description,
       std::string native_function) {
     error_info_.Update(true, recoverable, description, native_function);
-    if (recoverable) return;
-
     v8::Local<v8::Value> args[1] = { GetJSErrorObject() };
     auto container = Nan::New<v8::Object>(js_error_container_);
     Nan::MakeCallback(container, js_error_callback_name_.c_str(),

--- a/wrappers/nodejs/test/test-functional-online.js
+++ b/wrappers/nodejs/test/test-functional-online.js
@@ -497,7 +497,7 @@ describe('Native error tests', function() {
     assert.throws(() => {
       ctx.loadDevice(file);
     }, (err) => {
-      assert.equal(err instanceof TypeError, true);
+      assert.equal(err instanceof Error, true);
       let errInfo = rs2.getError();
       assert.equal(errInfo.recoverable, false);
       assert.equal(typeof errInfo.description, 'string');
@@ -579,7 +579,7 @@ describe('new record/playback test', function() {
     pipe.stop();
     rs2.cleanup();
     fs.unlinkSync(file);
-  }).timeout(5000);
+  }).timeout(10000);
 });
 
 describe('frameset misc test', function() {

--- a/wrappers/nodejs/test/test-functional.js
+++ b/wrappers/nodejs/test/test-functional.js
@@ -412,12 +412,19 @@ describe('Sensor tests', function() {
       if (p instanceof rs2.VideoStreamProfile) {
         assert.equal(typeof p.width, 'number');
         assert.equal(typeof p.height, 'number');
-        const intrin = p.getIntrinsics();
-        // some stream profiles have no intrinsics, and undefined is returned
-        // so bypass these cases
-        if (!intrin) {
+        let intrin;
+        try {
+          intrin = p.getIntrinsics();
+        } catch (e) {
+          // some stream profiles have no intrinsics, and will trigger exception
+          // so only bypass these cases if it's still recoverable, otherwise,
+          // rethrow it.
+          if (e instanceof rs2.UnrecoverableError) {
+            throw e;
+          }
           return;
         }
+
         assert.equal('width' in intrin, true);
         assert.equal('height' in intrin, true);
         assert.equal('ppx' in intrin, true);
@@ -568,9 +575,7 @@ describe(('syncer test'), function() {
   });
 
   after(() => {
-    sensors.forEach((s) => {
-      s.stop();
-    });
+    sensors[0].stop();
     rs2.cleanup();
   });
   it('sensor.start(syncer)', () => {


### PR DESCRIPTION
Native errors would be exposed no matter recoverable or unrecoverable.
This is to be consistent with how the C++ layer deal with errors
especially to make sure users conscious of native errors even for APIs
without return values. Thus make it easy to target the cause of errors.
Cases are also changed to adpat this.