### PR TITLE
Fix bug in kernel patch script for Ubuntu 18.04

### DIFF
--- a/scripts/patch-realsense-ubuntu-lts.sh
+++ b/scripts/patch-realsense-ubuntu-lts.sh
@@ -32,7 +32,7 @@ LINUX_BRANCH=$(uname -r)
 kernel_branch=$(choose_kernel_branch $LINUX_BRANCH)
 # Construct branch name from distribution codename {xenial,bionic,..} and kernel version
 ubuntu_codename=`. /etc/os-release; echo ${UBUNTU_CODENAME/*, /}`
-if [ -z "$UBUNTU_CODENAME" ];
+if [ -z "$ubuntu_codename" ];
 then
 	# Trusty Tahr shall use xenial code base
 	ubuntu_codename="xenial"

--- a/scripts/patch-realsense-ubuntu-lts.sh
+++ b/scripts/patch-realsense-ubuntu-lts.sh
@@ -32,7 +32,7 @@ LINUX_BRANCH=$(uname -r)
 kernel_branch=$(choose_kernel_branch $LINUX_BRANCH)
 # Construct branch name from distribution codename {xenial,bionic,..} and kernel version
 ubuntu_codename=`. /etc/os-release; echo ${UBUNTU_CODENAME/*, /}`
-if [ -z "$ubuntu_codename" ];
+if [ -z "${ubuntu_codename}" ];
 then
 	# Trusty Tahr shall use xenial code base
 	ubuntu_codename="xenial"


### PR DESCRIPTION
This pull request fixes a minor bug in `scripts/patch-realsense-ubuntu-lts.sh`, where the script was always making drivers for Ubuntu 16.04 `xenial`, even when a later version of Ubuntu was being used.

This script was always overriding the found `ubuntu_codename` with `"xenial"`, even when Ubuntu had a different version. This was due to the variable `UBUNTU_CODENAME` being used instead of `ubuntu_codename`.

This resulted in the error: `modprobe: ERROR: could not insert 'videodev': Exec format error`, as it was compiling the scripts with an older Ubuntu version for Xenial.

This has now been corrected.