### PR TITLE
Fix OpenCV Wrapper and Example

### DIFF
--- a/wrappers/opencv/cv-helpers.hpp
+++ b/wrappers/opencv/cv-helpers.hpp
@@ -24,7 +24,7 @@ cv::Mat frame_to_mat(const rs2::frame& f)
     else if (f.get_profile().format() == RS2_FORMAT_RGB8)
     {
         auto r = Mat(Size(w, h), CV_8UC3, (void*)f.get_data(), Mat::AUTO_STEP);
-        cv::cvtColor(r, r, CV_BGR2RGB);
+        cvtColor(r, r, CV_RGB2BGR);
         return r;
     }
     else if (f.get_profile().format() == RS2_FORMAT_Z16)
@@ -33,7 +33,7 @@ cv::Mat frame_to_mat(const rs2::frame& f)
     }
     else if (f.get_profile().format() == RS2_FORMAT_Y8)
     {
-        return Mat(Size(w, h), CV_8UC1, (void*)f.get_data(), Mat::AUTO_STEP);;
+        return Mat(Size(w, h), CV_8UC1, (void*)f.get_data(), Mat::AUTO_STEP);
     }
 
     throw std::runtime_error("Frame format is not supported yet!");

--- a/wrappers/opencv/dnn/rs-dnn.cpp
+++ b/wrappers/opencv/dnn/rs-dnn.cpp
@@ -20,9 +20,9 @@ const char* classNames[]  = {"background",
 
 int main(int argc, char** argv) try
 {
-    using namespace rs2;
     using namespace cv;
     using namespace cv::dnn;
+    using namespace rs2;
 
     Net net = readNetFromCaffe("MobileNetSSD_deploy.prototxt", 
                                "MobileNetSSD_deploy.caffemodel");
@@ -102,7 +102,7 @@ int main(int argc, char** argv) try
                             (int)(xRightTop - xLeftBottom),
                             (int)(yRightTop - yLeftBottom));
 
-                object = object  & cv::Rect(0, 0, depth_mat.cols, depth_mat.rows);
+                object = object  & Rect(0, 0, depth_mat.cols, depth_mat.rows);
 
                 // Calculate mean depth inside the detection region
                 // This is a very naive way to estimate objects depth

--- a/wrappers/opencv/grabcuts/rs-grabcuts.cpp
+++ b/wrappers/opencv/grabcuts/rs-grabcuts.cpp
@@ -7,6 +7,7 @@
 
 int main(int argc, char * argv[]) try
 {
+    using namespace cv;
     using namespace rs2;
 
     // Define colorizer and align processing-blocks
@@ -17,16 +18,15 @@ int main(int argc, char * argv[]) try
     pipeline pipe;
     pipe.start();
 
-    using namespace cv;
     const auto window_name = "Display Image";
     namedWindow(window_name, WINDOW_AUTOSIZE);
 
     // We are using StructuringElement for erode / dilate operations
     auto gen_element = [](int erosion_size)
     {
-        return getStructuringElement(cv::MORPH_RECT,
-            cv::Size(erosion_size + 1, erosion_size + 1),
-            cv::Point(erosion_size, erosion_size));
+        return getStructuringElement(MORPH_RECT,
+            Size(erosion_size + 1, erosion_size + 1),
+            Point(erosion_size, erosion_size));
     };
 
     const int erosion_size = 3;
@@ -35,7 +35,7 @@ int main(int argc, char * argv[]) try
 
     // The following operation is taking grayscale image,
     // performs threashold on it, closes small holes and erodes the white area
-    auto create_mask_from_depth = [&](cv::Mat& depth, int thresh, ThresholdTypes type)
+    auto create_mask_from_depth = [&](Mat& depth, int thresh, ThresholdTypes type)
     {
         threshold(depth, depth, thresh, 255, type);
         dilate(depth, depth, erode_less);
@@ -82,12 +82,12 @@ int main(int argc, char * argv[]) try
 
         // Run Grab-Cut algorithm:
         Mat bgModel, fgModel; 
-        cv::grabCut(color_mat, mask, Rect(), bgModel, fgModel, 1, cv::GC_INIT_WITH_MASK);
+        grabCut(color_mat, mask, Rect(), bgModel, fgModel, 1, GC_INIT_WITH_MASK);
 
         // Extract foreground pixels based on refined mask from the algorithm
-        cv::Mat3b foreground = cv::Mat3b::zeros(color_mat.rows, color_mat.cols);
-        color_mat.copyTo(foreground, (mask == cv::GC_FGD) | (mask == cv::GC_PR_FGD));
-        cv::imshow(window_name, foreground);
+        Mat3b foreground = Mat3b::zeros(color_mat.rows, color_mat.cols);
+        color_mat.copyTo(foreground, (mask == GC_FGD) | (mask == GC_PR_FGD));
+        imshow(window_name, foreground);
     }
 
     return EXIT_SUCCESS;

--- a/wrappers/opencv/latency-tool/rs-latency-tool.cpp
+++ b/wrappers/opencv/latency-tool/rs-latency-tool.cpp
@@ -7,6 +7,7 @@
 // See ReadMe.md for more information
 int main(int argc, char * argv[]) try
 {
+    using namespace cv;
     using namespace rs2;
 
     // Start RealSense camera
@@ -41,10 +42,9 @@ int main(int argc, char * argv[]) try
     //syncer pipe;
     //sensor.start(pipe);
 
-    using namespace cv;
     const auto window_name = "Display Image";
     namedWindow(window_name, CV_WINDOW_NORMAL);
-    cvSetWindowProperty(window_name, CV_WND_PROP_FULLSCREEN, CV_WINDOW_FULLSCREEN);
+    setWindowProperty(window_name, WND_PROP_FULLSCREEN, WINDOW_FULLSCREEN);
 
     const int display_w = 1280;
     const int digits = 16;


### PR DESCRIPTION
* Unify the writing by omitting "cv" namespace (<code>cv::XXX()</code> -> <code>XXX()</code>)
* Remove unnecessary semicolon
* Change to C++ API (<code>setWindowProperty()</code>)
* Change to eunm type of correct meaning in cvtColor (In case of <code>RS2_FORMAT_RGB8</code>, It should use <code>CV_RGB2BGR</code>.)