### PR TITLE
Inter-camera HW Sync control

### DIFF
--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -63,6 +63,7 @@ typedef enum rs2_option
     RS2_OPTION_HOLES_FILL                                 , /**< Enhance depth data post-processing with holes filling where appropriate*/
     RS2_OPTION_STEREO_BASELINE                            , /**< The distance in mm between the first and the second imagers in stereo-based depth cameras*/
     RS2_OPTION_AUTO_EXPOSURE_CONVERGE_STEP                , /**< Allows dynamically ajust the converge step value of the target exposure in Auto-Exposure algorithm*/
+    RS2_OPTION_INTER_CAM_SYNC_MODE                        , /**< Impose Inter-camera HW synchronization mode. Applicable for D400/Rolling Shutter SKUs */
     RS2_OPTION_COUNT                                        /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_option;
 const char* rs2_option_to_string(rs2_option option);

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -400,4 +400,39 @@ namespace librealsense
     {
         return *_range;
     }
+
+    external_sync_mode::external_sync_mode(hw_monitor& hwm)
+        : _hwm(hwm)
+    {
+        _range = [this]()
+        {
+            return option_range{ ds::inter_cam_sync_mode::INTERCAM_SYNC_DEFAULT,
+                                 ds::inter_cam_sync_mode::INTERCAM_SYNC_MAX - 1,
+                                 ds::inter_cam_sync_mode::INTERCAM_SYNC_DEFAULT, 1 };
+        };
+    }
+
+    void external_sync_mode::set(float value)
+    {
+        command cmd(ds::SET_CAM_SYNC);
+        cmd.param1 = static_cast<int>(value);
+
+        _hwm.send(cmd);
+        _record_action(*this);
+    }
+
+    float external_sync_mode::query() const
+    {
+        command cmd(ds::GET_CAM_SYNC);
+        auto res = _hwm.send(cmd);
+        if (res.empty())
+            throw invalid_value_exception("external_sync_mode::query result is empty!");
+
+        return (res.front());
+    }
+
+    option_range external_sync_mode::get_range() const
+    {
+        return *_range;
+    }
 }

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -205,4 +205,28 @@ namespace librealsense
         lazy<option_range> _range;
         hw_monitor& _hwm;
     };
+
+    class external_sync_mode : public option
+    {
+    public:
+        external_sync_mode(hw_monitor& hwm);
+        virtual ~external_sync_mode() = default;
+        virtual void set(float value) override;
+        virtual float query() const override;
+        virtual option_range get_range() const override;
+        virtual bool is_enabled() const override { return true; }
+
+        const char* get_description() const override
+        {
+            return "Inter-camera synchronization mode: 0:Default, 1:Master, 2:Slave";
+        }
+        void enable_recording(std::function<void(const option &)> record_action)
+        {
+            _record_action = record_action;
+        }
+    private:
+        std::function<void(const option &)> _record_action = [](const option&) {};
+        lazy<option_range> _range;
+        hw_monitor& _hwm;
+    };
 }

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -98,6 +98,8 @@ namespace librealsense
             GETAEROI        = 0x45,     // get auto-exposure region of interest
             MMER            = 0x4F,     // MM EEPROM read ( from DS5 cache )
             GET_EXTRINSICS  = 0x53,     // get extrinsics
+            SET_CAM_SYNC    = 0x69,     // set Inter-cam HW sync mode [0-default, 1-master, 2-slave]
+            GET_CAM_SYNC    = 0x6A,     // fet Inter-cam HW sync mode
         };
 
         const int etDepthTableControl = 9; // Identifier of the depth table control
@@ -107,6 +109,14 @@ namespace librealsense
             GET_VAL = 0,
             GET_MIN = 1,
             GET_MAX = 2,
+        };
+
+        enum inter_cam_sync_mode
+        {
+            INTERCAM_SYNC_DEFAULT,
+            INTERCAM_SYNC_MASTER,
+            INTERCAM_SYNC_SLAVE,
+            INTERCAM_SYNC_MAX
         };
 
         const std::string DEPTH_STEREO = "Stereo Module";

--- a/src/ds5/ds5-rolling-shutter.cpp
+++ b/src/ds5/ds5-rolling-shutter.cpp
@@ -38,5 +38,11 @@ namespace librealsense
             get_depth_sensor().register_pixel_format(pf_uyvyl);
             get_depth_sensor().register_pixel_format(pf_rgb888);
         }
+
+        if ((_fw_version >= firmware_version("5.9.13.6")))
+        {
+            get_depth_sensor().register_option(RS2_OPTION_INTER_CAM_SYNC_MODE,
+                std::make_shared<external_sync_mode>(*_hw_monitor));
+        }
     }
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -260,6 +260,7 @@ namespace librealsense
             CASE(STEREO_BASELINE)
             CASE(HOLES_FILL)
             CASE(AUTO_EXPOSURE_CONVERGE_STEP)
+            CASE(INTER_CAM_SYNC_MODE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/wrappers/csharp/Intel.RealSense/Types.cs
+++ b/wrappers/csharp/Intel.RealSense/Types.cs
@@ -203,6 +203,7 @@ namespace Intel.RealSense
         HolesFill = 39,
         StereoBaseline = 40,
         AutoExposureConvergeStep = 41,
+        InterCamSyncMode = 42,
     }
 
     public enum Sr300VisualPreset


### PR DESCRIPTION
Add control to select master/slave hw sync mode for multi-cam scenarios.
Applies to rolling-shutter SKUs with FW 5.9.14+.
Stream window header in viewer to provide camera id. required in multi-cam/multi-sensor scenarios (Referenced from DSO-9123)
Tracked on: DSO-7602