### PR TITLE
Fix D430 failure with rs-pointcloud and rs-capture

### DIFF
--- a/examples/capture/rs-capture.cpp
+++ b/examples/capture/rs-capture.cpp
@@ -28,6 +28,10 @@ int main(int argc, char * argv[]) try
         rs2::frame depth = color_map(data.get_depth_frame()); // Find and colorize the depth data
         rs2::frame color = data.get_color_frame();            // Find the color data
 
+        // For cameras that don't have RGB sensor, we'll render infrared frames instead of color
+        if (!color)
+            color = data.get_infrared_frame();
+
         // Render depth on to the first half of the screen and color on to the second
         depth_image.render(depth, { 0,               0, app.width() / 2, app.height() });
         color_image.render(color, { app.width() / 2, 0, app.width() / 2, app.height() });

--- a/examples/pointcloud/rs-pointcloud.cpp
+++ b/examples/pointcloud/rs-pointcloud.cpp
@@ -40,6 +40,10 @@ int main(int argc, char * argv[]) try
 
         auto color = frames.get_color_frame();
 
+        // For cameras that don't have RGB sensor, we'll map the pointcloud to infrared instead of color
+        if (!color)
+            color = frames.get_infrared_frame();
+
         // Tell pointcloud object to map to this color frame
         pc.map_to(color);
 

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -20,7 +20,7 @@
 #include "stream.h"
 #include "environment.h"
 #include "ds5-color.h"
-
+#include "ds5-rolling-shutter.h"
 
 namespace librealsense
 {
@@ -98,6 +98,13 @@ namespace librealsense
             uvc_sensor::open(requests);
         }
 
+        /*
+        Infrared profiles are initialized with the following logic:
+        - If device has color sensor (D415 / D435), infrared profile is chosen with Y8 format
+        - If device does not have color sensor:
+           * if it is a rolling shutter device (D400 / D410 / D415 / D405), infrared profile is chosen with RGB8 format
+           * for other devices (D420 / D430), infrared profile is chosen with Y8 format
+        */
         stream_profiles init_stream_profiles() override
         {
             auto lock = environment::get_instance().get_extrinsics_graph().lock();
@@ -105,6 +112,7 @@ namespace librealsense
             auto results = uvc_sensor::init_stream_profiles();
 
             auto color_dev = dynamic_cast<const ds5_color*>(&get_device());
+            auto rolling_shutter_dev = dynamic_cast<const ds5_rolling_shutter*>(&get_device());
 
             std::vector< video_stream_profile_interface*> depth_candidates;
             std::vector< video_stream_profile_interface*> infrared_candidates;
@@ -144,12 +152,6 @@ namespace librealsense
                 if (candidate(vid_profile, { 640, 480, 15, RS2_FORMAT_Z16 }, RS2_STREAM_DEPTH, 0))
                     depth_candidates.push_back(vid_profile);
 
-                if (candidate(vid_profile, { 1280, 720, 30, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
-                    infrared_candidates.push_back(vid_profile);
-
-                if (candidate(vid_profile, { 640, 480, 15, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
-                    infrared_candidates.push_back(vid_profile);
-
                 // Global Shutter sensor does not support synthetic color
                 if (candidate(vid_profile, { 848, 480, 30, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
                     infrared_candidates.push_back(vid_profile);
@@ -174,11 +176,23 @@ namespace librealsense
                 }
                 else
                 {
-                    if (candidate(vid_profile, { 1280, 720, 30, RS2_FORMAT_RGB8 }, RS2_STREAM_INFRARED, 0))
-                        infrared_candidates.push_back(vid_profile);
+                    if (rolling_shutter_dev)
+                    { 
+                        if (candidate(vid_profile, { 1280, 720, 30, RS2_FORMAT_RGB8 }, RS2_STREAM_INFRARED, 0))
+                            infrared_candidates.push_back(vid_profile);
 
-                    if (candidate(vid_profile, { 640, 480, 15, RS2_FORMAT_RGB8 }, RS2_STREAM_INFRARED, 0))
-                        infrared_candidates.push_back(vid_profile);
+                        if (candidate(vid_profile, { 640, 480, 15, RS2_FORMAT_RGB8 }, RS2_STREAM_INFRARED, 0))
+                            infrared_candidates.push_back(vid_profile);
+                    }
+                    else
+                    {
+                        if (candidate(vid_profile, { 1280, 720, 30, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
+                            infrared_candidates.push_back(vid_profile);
+
+                        if (candidate(vid_profile, { 640, 480, 15, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
+                            infrared_candidates.push_back(vid_profile);
+                    }
+                    
                 }
 
                 // Register intrinsics

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -144,6 +144,12 @@ namespace librealsense
                 if (candidate(vid_profile, { 640, 480, 15, RS2_FORMAT_Z16 }, RS2_STREAM_DEPTH, 0))
                     depth_candidates.push_back(vid_profile);
 
+                if (candidate(vid_profile, { 1280, 720, 30, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
+                    infrared_candidates.push_back(vid_profile);
+
+                if (candidate(vid_profile, { 640, 480, 15, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
+                    infrared_candidates.push_back(vid_profile);
+
                 // Global Shutter sensor does not support synthetic color
                 if (candidate(vid_profile, { 848, 480, 30, RS2_FORMAT_Y8 }, RS2_STREAM_INFRARED, 1))
                     infrared_candidates.push_back(vid_profile);


### PR DESCRIPTION
Bug fix: in cameras that have no RGB sensor,  wrong profiles (with RGB8 format) were previously chosen.
In USB3 the correct profiles with Y8 format are now chosen.
Additionally, `rs-pointcloud` and `rs-capture` were fixed to work with cameras without RGB sensor (working with infrared instead).

A known issue is that for USB2, the fix currenly doesn't work because cameras share PID and therefore D420\D430 which do not support RGB8 format, are mistaken for D410 which does support RGB8. This will be deprecated in the future, as the PID will be changed to per-camera PID.
A workaround for now is to avoid using the default configuration in the pipeline when working with D420/D430 on USB2, instead use the following configuration:

```
rs2::config cfg;
cfg.enable_stream(RS2_STREAM_INFRARED, RS2_FORMAT_Y8);
pipe.start(cfg);
```

Tracked on: DSO-9397