### PR TITLE
Added support in metadata for post-processing frames

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -451,7 +451,7 @@ namespace librealsense
 
     bool frame::supports_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const
     {
-        auto md_parsers = owner->get_md_parsers();
+        auto md_parsers = owner->get_md_parsers(_sensor_type);
 
         // verify preconditions
         if (!md_parsers)

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -1,4 +1,5 @@
 #include "metadata-parser.h"
+#include "api.h"
 #include "archive.h"
 #include <fstream>
 
@@ -6,6 +7,34 @@
 
 namespace librealsense
 {
+
+    frame::frame(frame&& r)
+        : ref_count(r.ref_count.exchange(0)), _kept(r._kept.exchange(false)),
+        owner(r.owner), on_release()
+    {
+        *this = std::move(r);
+        if (owner == nullptr) return;
+        auto sensor = owner->get_sensor();
+        if (sensor) _sensor_type = sensor->get_sensor_type();
+    }
+
+    frame& frame::operator=(frame&& r)
+    {
+        data = move(r.data);
+        owner = r.owner;
+        ref_count = r.ref_count.exchange(0);
+        _kept = r._kept.exchange(false);
+        on_release = std::move(r.on_release);
+        additional_data = std::move(r.additional_data);
+        r.owner.reset();
+        if (owner)
+        {
+            auto sensor = owner->get_sensor();
+            if(sensor) _sensor_type = owner->get_sensor()->get_sensor_type();
+        }
+        return *this;
+    }
+
     std::shared_ptr<sensor_interface> frame::get_sensor() const
     {
         auto res = sensor.lock();
@@ -16,7 +45,11 @@ namespace librealsense
         }
         return res;
     }
-    void frame::set_sensor(std::shared_ptr<sensor_interface> s) { sensor = s;}
+    void frame::set_sensor(std::shared_ptr<sensor_interface> s) 
+    { 
+        sensor = s;
+        if (s) _sensor_type = s->get_sensor_type();
+    }
 
     float3* points::get_vertices()
     {
@@ -122,7 +155,7 @@ namespace librealsense
         int pending_frames = 0;
         std::recursive_mutex mutex;
         std::shared_ptr<platform::time_service> _time_service;
-        std::shared_ptr<metadata_parser_map> _metadata_parsers = nullptr;
+        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> _metadata_parsers;
 
         std::weak_ptr<sensor_interface> _sensor;
         std::shared_ptr<sensor_interface> get_sensor() const override { return _sensor.lock(); }
@@ -241,7 +274,7 @@ namespace librealsense
         {
             if (frame && frame->get_stream())
             {
-                auto callback_ended = _time_service?_time_service->get_time():0;
+                auto callback_ended = _time_service ? _time_service->get_time() : 0;
                 auto callback_warning_duration = 1000 / (frame->get_stream()->get_framerate() + 1);
                 auto callback_duration = callback_ended - frame->get_frame_callback_start_time_point();
 
@@ -251,24 +284,34 @@ namespace librealsense
                 if (callback_duration > callback_warning_duration)
                 {
                     LOG_DEBUG("Frame Callback [" << librealsense::get_string(frame->get_stream()->get_stream_type())
-                             << "#" << std::dec << frame->additional_data.frame_number
-                             << "] overdue. (Duration: " << callback_duration
-                             << "ms, FPS: " << frame->get_stream()->get_framerate() << ", Max Duration: " << callback_warning_duration << "ms)");
+                        << "#" << std::dec << frame->additional_data.frame_number
+                        << "] overdue. (Duration: " << callback_duration
+                        << "ms, FPS: " << frame->get_stream()->get_framerate() << ", Max Duration: " << callback_warning_duration << "ms)");
                 }
             }
         }
 
-        std::shared_ptr<metadata_parser_map> get_md_parsers() const { return _metadata_parsers; };
+        std::shared_ptr<metadata_parser_map> get_md_parsers(rs2_extension sensor_type) const override
+        {
+            if(_metadata_parsers.find(sensor_type) != _metadata_parsers.end())
+                return _metadata_parsers.at(sensor_type);
+            return nullptr;
+        };
+
+        void set_md_parsers(const rs2_extension sensor_type, const std::shared_ptr<metadata_parser_map> metadata_parsers) override
+        {
+            _metadata_parsers[sensor_type] = metadata_parsers;
+        }
 
         friend class frame;
 
     public:
         explicit frame_archive(std::atomic<uint32_t>* in_max_frame_queue_size,
-                             std::shared_ptr<platform::time_service> ts,
-                             std::shared_ptr<metadata_parser_map> parsers)
+            std::shared_ptr<platform::time_service> ts,
+			std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> parsers)
             : max_frame_queue_size(in_max_frame_queue_size),
-              mutex(), recycle_frames(true), _time_service(ts),
-              _metadata_parsers(parsers)
+            mutex(), recycle_frames(true), _time_service(ts),
+            _metadata_parsers(parsers)
         {
             published_frames_count = 0;
         }
@@ -330,16 +373,16 @@ namespace librealsense
     };
 
     std::shared_ptr<archive_interface> make_archive(rs2_extension type,
-                                                    std::atomic<uint32_t>* in_max_frame_queue_size,
-                                                    std::shared_ptr<platform::time_service> ts,
-                                                    std::shared_ptr<metadata_parser_map> parsers)
+        std::atomic<uint32_t>* in_max_frame_queue_size,
+        std::shared_ptr<platform::time_service> ts,
+		std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> parsers)
     {
-        switch(type)
+        switch (type)
         {
-        case RS2_EXTENSION_VIDEO_FRAME :
+        case RS2_EXTENSION_VIDEO_FRAME:
             return std::make_shared<frame_archive<video_frame>>(in_max_frame_queue_size, ts, parsers);
 
-        case RS2_EXTENSION_COMPOSITE_FRAME :
+        case RS2_EXTENSION_COMPOSITE_FRAME:
             return std::make_shared<frame_archive<composite_frame>>(in_max_frame_queue_size, ts, parsers);
 
         case RS2_EXTENSION_MOTION_FRAME:
@@ -383,22 +426,24 @@ namespace librealsense
     {
         owner = new_owner;
         _kept = false;
+        auto sensor = owner->get_sensor();
+        if (sensor) _sensor_type = sensor->get_sensor_type();
         return owner->publish_frame(this);
     }
 
     rs2_metadata_type frame::get_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const
     {
-        auto md_parsers = owner->get_md_parsers();
+        auto md_parsers = owner->get_md_parsers(_sensor_type);
 
         if (!md_parsers)
             throw invalid_value_exception(to_string() << "metadata not available for "
-                                          << get_string(get_stream()->get_stream_type())<<" stream");
+                << get_string(get_stream()->get_stream_type()) << " stream");
 
         auto it = md_parsers.get()->find(frame_metadata);
         if (it == md_parsers.get()->end())          // Possible user error - md attribute is not supported by this frame type
             throw invalid_value_exception(to_string() << get_string(frame_metadata)
-                                          << " attribute is not applicable for "
-                                          << get_string(get_stream()->get_stream_type()) << " stream ");
+                << " attribute is not applicable for "
+                << get_string(get_stream()->get_stream_type()) << " stream ");
 
         // Proceed to parse and extract the required data attribute
         return it->second->get(*this);
@@ -446,6 +491,11 @@ namespace librealsense
         return additional_data.frame_number;
     }
 
+    std::array<uint8_t, MAX_META_DATA_SIZE> frame::get_metadata_blob() const
+    {
+        return additional_data.metadata_blob;
+    }
+
     rs2_time_t frame::get_frame_system_time() const
     {
         return additional_data.system_time;
@@ -477,9 +527,9 @@ namespace librealsense
         if (callback_duration > callback_warning_duration)
         {
             LOG_INFO("Frame Callback " << librealsense::get_string(get_stream()->get_stream_type())
-                     << "#" << std::dec << get_frame_number()
-                     << "overdue. (Duration: " << callback_duration
-                     << "ms, FPS: " << get_stream()->get_framerate() << ", Max Duration: " << callback_warning_duration << "ms)");
+                << "#" << std::dec << get_frame_number()
+                << "overdue. (Duration: " << callback_duration
+                << "ms, FPS: " << get_stream()->get_framerate() << ", Max Duration: " << callback_warning_duration << "ms)");
         }
     }
 

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -74,7 +74,7 @@ namespace librealsense
 
         virtual void set_timestamp_domain(rs2_timestamp_domain timestamp_domain) = 0;
         virtual rs2_time_t get_frame_system_time() const = 0;
-
+        virtual std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const = 0;
         virtual std::shared_ptr<stream_profile_interface> get_stream() const = 0;
         virtual void set_stream(std::shared_ptr<stream_profile_interface> sp) = 0;
 
@@ -120,11 +120,12 @@ namespace librealsense
         virtual frame_callback_ptr get_frames_callback() const = 0;
         virtual void set_frames_callback(frame_callback_ptr cb) = 0;
         virtual bool is_streaming() const = 0;
-
         virtual const device_interface& get_device() = 0;
+        virtual rs2_extension get_sensor_type() = 0;
 
         virtual ~sensor_interface() = default;
     };
+
 
     class matcher;
 

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -3,6 +3,8 @@
 
 #include "playback_sensor.h"
 #include "core/motion.h"
+#include "api.h"
+#include "software-device.h"
 #include <map>
 #include "types.h"
 #include "context.h"
@@ -293,4 +295,13 @@ void playback_sensor::unregister_before_start_callback(int token)
 void playback_sensor::raise_notification(const notification& n)
 {
     _notifications_processor.raise_notification(n);
+}
+
+rs2_extension playback_sensor::get_sensor_type()
+{
+    if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_sensor)) return RS2_EXTENSION_DEPTH_SENSOR;
+    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_stereo_sensor)) return RS2_EXTENSION_DEPTH_STEREO_SENSOR;
+    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::video_sensor_interface)) return RS2_EXTENSION_VIDEO;
+    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::software_sensor)) return RS2_EXTENSION_SOFTWARE_SENSOR;
+    else return RS2_EXTENSION_UNKNOWN;
 }

--- a/src/media/playback/playback_sensor.h
+++ b/src/media/playback/playback_sensor.h
@@ -49,6 +49,7 @@ namespace librealsense
         stream_profiles get_active_streams() const override;
         int register_before_streaming_changes_callback(std::function<void(bool)> callback) override;
         void unregister_before_start_callback(int token) override;
+        rs2_extension get_sensor_type() override;
         void raise_notification(const notification& n);
     private:
         void register_sensor_streams(const stream_profiles& vector);

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -3,6 +3,7 @@
 
 #include "record_sensor.h"
 #include "api.h"
+#include "software-device.h"
 #include "stream.h"
 
 using namespace librealsense;
@@ -359,4 +360,13 @@ void record_sensor::wrap_streams()
            m_recorded_streams_ids.insert(id);
         }
     }
+}
+
+rs2_extension record_sensor::get_sensor_type()
+{
+    if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_sensor)) return RS2_EXTENSION_DEPTH_SENSOR;
+    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_stereo_sensor)) return RS2_EXTENSION_DEPTH_STEREO_SENSOR;
+    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::video_sensor_interface)) return RS2_EXTENSION_VIDEO;
+    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::software_sensor)) return RS2_EXTENSION_SOFTWARE_SENSOR;
+    else return RS2_EXTENSION_UNKNOWN;
 }

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -42,6 +42,7 @@ namespace librealsense
         stream_profiles get_active_streams() const override;
         int register_before_streaming_changes_callback(std::function<void(bool)> callback) override;
         void unregister_before_start_callback(int token) override;
+        virtual rs2_extension get_sensor_type() override;
         signal<record_sensor, const notification&> on_notification;
         signal<record_sensor, frame_holder> on_frame;
         signal<record_sensor, rs2_extension, std::shared_ptr<extension_snapshot>> on_extension_change;

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -150,7 +150,11 @@ namespace librealsense
             m_version = read_file_version(m_file);
             m_samples_view = nullptr;
             m_frame_source = std::make_shared<frame_source>(m_version == 1 ? 128 : 32);
-            m_frame_source->init(m_metadata_parser_map);
+            std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers;
+            metadata_parsers[RS2_EXTENSION_DEPTH_SENSOR] = m_metadata_parser_map;
+            metadata_parsers[RS2_EXTENSION_DEPTH_STEREO_SENSOR] = m_metadata_parser_map;
+            metadata_parsers[RS2_EXTENSION_VIDEO] = m_metadata_parser_map;
+            m_frame_source->init(metadata_parsers);
             m_initial_device_description = read_device_description(get_static_file_info_timestamp(), true);
         }
 

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
 #include "core/video.h"
+#include "api.h"
 #include "proc/synthetic-stream.h"
 
 namespace librealsense
@@ -21,7 +22,7 @@ namespace librealsense
         : _source_wrapper(_source)
     {
         register_option(RS2_OPTION_FRAMES_QUEUE_SIZE, _source.get_published_size_option());
-        _source.init(std::make_shared<metadata_parser_map>());
+        _source.init(std::map<rs2_extension, std::shared_ptr<metadata_parser_map>>());
     }
 
     void processing_block::invoke(frame_holder f)
@@ -95,7 +96,7 @@ namespace librealsense
         data.timestamp_domain = original->get_frame_timestamp_domain();
         data.metadata_size = 0;
         data.system_time = _actual_source.get_time();
-
+        data.metadata_blob = original->get_metadata_blob();
         auto width = new_width;
         auto height = new_height;
         auto bpp = new_bpp * 8;
@@ -129,9 +130,15 @@ namespace librealsense
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = static_cast<video_frame*>(res);
         vf->assign(width, height, stride, bpp);
-        vf->set_sensor(original->get_sensor());
+        auto original_sensor = original->get_sensor();
+        vf->set_sensor(original_sensor);
+        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers_map;
+        if (original_sensor)
+        {
+            auto sensor_type = original_sensor->get_sensor_type();
+            res->get_owner()->set_md_parsers(sensor_type, original->get_owner()->get_md_parsers(sensor_type));
+        }
         res->set_stream(stream);
-
         if (frame_type == RS2_EXTENSION_DEPTH_FRAME)
         {
             original->acquire();

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -11,6 +11,8 @@
 #include "device.h"
 #include "stream.h"
 #include "sensor.h"
+#include "api.h"
+#include "software-device.h"
 
 namespace librealsense
 {
@@ -85,6 +87,15 @@ namespace librealsense
     void sensor_base::set_frames_callback(frame_callback_ptr callback)
     {
         return _source.set_callback(callback);
+    }
+    rs2_extension sensor_base::get_sensor_type()
+    {
+        if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_sensor)) return RS2_EXTENSION_DEPTH_SENSOR;
+        else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_stereo_sensor)) return RS2_EXTENSION_DEPTH_STEREO_SENSOR;
+        else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::video_sensor_interface)) return RS2_EXTENSION_VIDEO;
+        else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::software_sensor)) return RS2_EXTENSION_SOFTWARE_SENSOR;
+        else return RS2_EXTENSION_UNKNOWN;
+        //TODO: Add support for fisheye sensor type
     }
     std::shared_ptr<notifications_processor> sensor_base::get_notifications_processor()
     {
@@ -379,7 +390,11 @@ namespace librealsense
             throw wrong_api_call_sequence_exception("open(...) failed. UVC device is already opened!");
 
         auto on = std::unique_ptr<power>(new power(std::dynamic_pointer_cast<uvc_sensor>(shared_from_this())));
-        _source.init(_metadata_parsers);
+
+        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers_map;
+        metadata_parsers_map[get_sensor_type()] = _metadata_parsers;
+        _source.init(metadata_parsers_map);
+
         _source.set_sensor(this->shared_from_this());
         auto mapping = resolve_requests(requests);
 
@@ -858,7 +873,11 @@ namespace librealsense
             throw wrong_api_call_sequence_exception("start_streaming(...) failed. Hid device was not opened!");
 
         _source.set_callback(callback);
-        _source.init(_metadata_parsers);
+
+        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers_map;
+        metadata_parsers_map[get_sensor_type()] = _metadata_parsers;
+        _source.init(metadata_parsers_map);
+
         _source.set_sensor(this->shared_from_this());
         raise_on_before_streaming_changes(true); //Required to be just before actual start allow recording to work
         _hid_device->start_capture([this](const platform::sensor_data& sensor_data)

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -50,6 +50,7 @@ namespace librealsense
         std::shared_ptr<notifications_processor> get_notifications_processor();
         virtual frame_callback_ptr get_frames_callback() const override;
         virtual void set_frames_callback(frame_callback_ptr callback) override;
+        virtual rs2_extension get_sensor_type() override;
 
         bool is_streaming() const override
         {

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -115,7 +115,9 @@ namespace librealsense
         else if (!_is_opened)
             throw wrong_api_call_sequence_exception("start_streaming(...) failed. Software device was not opened!");
         _source.get_published_size_option()->set(0);
-        _source.init(_metadata_parsers);
+        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers_map;
+        metadata_parsers_map[this->get_sensor_type()] = _metadata_parsers;
+        _source.init(metadata_parsers_map);
         _source.set_sensor(this->shared_from_this());
         _source.set_callback(callback);
         _is_streaming = true;

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -47,7 +47,7 @@ namespace librealsense
               _ts(environment::get_instance().get_time_service())
     {}
 
-    void frame_source::init(std::shared_ptr<metadata_parser_map> metadata_parsers)
+    void frame_source::init(std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers)
     {
         std::lock_guard<std::mutex> lock(_callback_mutex);
 

--- a/src/source.h
+++ b/src/source.h
@@ -17,7 +17,7 @@ namespace librealsense
     public:
         frame_source(uint32_t max_publish_list_size = 16);
 
-        void init(std::shared_ptr<metadata_parser_map> metadata_parsers);
+        void init(std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers);
 
         callback_invocation_holder begin_callback();
 


### PR DESCRIPTION
-Added metadata copy at post-processing frame creation
-Added the ability to save multiple metadata parsers (for different sensors)

Known issue - metadata is recorded only for depth and IR frames.

Tracked on: DSO-9443