### PR TITLE
Fixed bug -  Setting Depth Units in realsense_viewer fails

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -560,19 +560,14 @@ namespace rs2
                         }
                         else
                         {
-                            auto step = fmod(range.step, 1);
-                            int pow_val = 10;
-                            while ((step *= 10.f) < 0.f)
-                            {
-                                pow_val *= 10;
-                            }
-
                             if (ImGui::SliderFloat(id.c_str(), &value,
                                 range.min, range.max, "%.4f"))
                             {
+                                auto loffset = fmod(value, range.step);
+                                auto roffset = range.step - loffset;
+                                value = (loffset < roffset) ? value - loffset : value + roffset;
                                 value = (value < range.min) ? range.min : value;
                                 value = (value > range.max) ? range.max : value;
-                                value = (int)(value * pow_val) / (float)(pow_val);
                                 model.add_log(to_string() << "Setting " << opt << " to " << value);
                                 endpoint->set_option(opt, value);
                                 *invalidate_flag = true;

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -563,9 +563,12 @@ namespace rs2
                             if (ImGui::SliderFloat(id.c_str(), &value,
                                 range.min, range.max, "%.4f"))
                             {
-                                auto loffset = fmod(value, range.step);
+                                auto loffset = std::abs(fmod(value, range.step));
                                 auto roffset = range.step - loffset;
-                                value = (loffset < roffset) ? value - loffset : value + roffset;
+                                if (value >= 0)
+                                    value = (loffset < roffset) ? value - loffset : value + roffset;
+                                else
+                                    value = (loffset < roffset) ? value + loffset : value - roffset; 
                                 value = (value < range.min) ? range.min : value;
                                 value = (value > range.max) ? range.max : value;
                                 model.add_log(to_string() << "Setting " << opt << " to " << value);


### PR DESCRIPTION
The method for calculating the float value that is passed from the realsense_viewer controls slider has been changed. We calculate the left and right offset between the received slider input and the next step and set the value that is closer.
For example: for slider input: 0.4 and step: 0.25 the nearest value will be 0.5.
Tracked on: DSO-9736
