### PR TITLE
Isolate Cmake 3.8 to predefined modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
-
-option(BUILD_WITH_CUDA "Enable CUDA" OFF)
-
-if(BUILD_WITH_CUDA)
-    project(librealsense2 LANGUAGES CXX C CUDA)
-else()
-    project(librealsense2 LANGUAGES CXX C)
-endif()
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 macro(info msg)
     message(STATUS "Info: ${msg}")
@@ -16,6 +8,17 @@ endmacro()
 macro(infoValue variableName)
     info("${variableName}=\${${variableName}}")
 endmacro()
+
+option(BUILD_WITH_CUDA "Enable CUDA" OFF)
+
+if(BUILD_WITH_CUDA)
+	info("Building with CUDA requires CMake v3.8+")
+	cmake_minimum_required(VERSION 3.8.0)
+    project(librealsense2 LANGUAGES CXX C CUDA)
+else()
+    project(librealsense2 LANGUAGES CXX C)
+endif()
+
 
 ##################################################################
 # Parse librealsense version and assign it to CMake variables    #
@@ -34,7 +37,6 @@ function(assign_version_property VER_COMPONENT)
     set(REALSENSE_VERSION_${VER_COMPONENT} ${tmp} PARENT_SCOPE)
 endfunction()
 
-
 set(REALSENSE_VERSION_MAJOR -1)
 set(REALSENSE_VERSION_MINOR -1)
 set(REALSENSE_VERSION_PATCH -1)
@@ -48,7 +50,6 @@ infoValue(REALSENSE_VERSION_STRING)
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # View the makefile commands during build
 #set(CMAKE_VERBOSE_MAKEFILE on)
-
 
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/doc/android/CMakeLists.txt_
+++ b/doc/android/CMakeLists.txt_
@@ -3,8 +3,7 @@
 
 # Sets the minimum version of CMake required to build the native library.
 
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.4.1)
 
 set(ANDROID on CACHE BOOL "ANDROID")
 set(APP_PLATFORM "android-16" CACHE STRING "ANDROID")

--- a/examples/C/color/CMakeLists.txt
+++ b/examples/C/color/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamples-Color)
 

--- a/examples/C/depth/CMakeLists.txt
+++ b/examples/C/depth/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamples-Depth)
 

--- a/examples/C/distance/CMakeLists.txt
+++ b/examples/C/distance/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamples-Distance)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamples)
 

--- a/examples/align/CMakeLists.txt
+++ b/examples/align/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesAlign)
 

--- a/examples/capture/CMakeLists.txt
+++ b/examples/capture/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesCapture)
 

--- a/examples/measure/CMakeLists.txt
+++ b/examples/measure/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesMeasure)
 

--- a/examples/multicam/CMakeLists.txt
+++ b/examples/multicam/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesMulticam)
 

--- a/examples/pointcloud/CMakeLists.txt
+++ b/examples/pointcloud/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesPointcloud)
 

--- a/examples/post-processing/CMakeLists.txt
+++ b/examples/post-processing/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesPost-Processing)
 

--- a/examples/record-playback/CMakeLists.txt
+++ b/examples/record-playback/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesRecord-Playback)
 

--- a/examples/save-to-disk/CMakeLists.txt
+++ b/examples/save-to-disk/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesSaveToDisk)
 

--- a/examples/sensor-control/CMakeLists.txt
+++ b/examples/sensor-control/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesSensorControl)
 

--- a/examples/software-device/CMakeLists.txt
+++ b/examples/software-device/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesSoftwareDevice)
 

--- a/third-party/glfw/CMakeLists.txt
+++ b/third-party/glfw/CMakeLists.txt
@@ -1,5 +1,7 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+# ubuntu 12.04 LTS cmake version 2.8.7
+# ubuntu 14.04 LTS cmake version 2.8.12.2
+# ubuntu 16.04 LTS cmake version 3.5.1	
+cmake_minimum_required(VERSION 2.8.3)
 
 project(GLFW3)
 

--- a/third-party/libusb/CMakeLists.txt
+++ b/third-party/libusb/CMakeLists.txt
@@ -1,5 +1,7 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+# ubuntu 12.04 LTS cmake version 2.8.7
+# ubuntu 14.04 LTS cmake version 2.8.12.2
+# ubuntu 16.04 LTS cmake version 3.5.1	
+cmake_minimum_required(VERSION 2.8.3)
 
 project(usb)
 

--- a/third-party/realsense-file/CMakeLists.txt
+++ b/third-party/realsense-file/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 2.8.9)
 
 project(realsense-file)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseTools)
 

--- a/tools/convert/CMakeLists.txt
+++ b/tools/convert/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseToolsConvert)
 set(RS_TARGET rs-convert)

--- a/tools/data-collect/CMakeLists.txt
+++ b/tools/data-collect/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseToolsDataCollect)
 

--- a/tools/depth-quality/CMakeLists.txt
+++ b/tools/depth-quality/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseToolsDepthQuality)
 

--- a/tools/enumerate-devices/CMakeLists.txt
+++ b/tools/enumerate-devices/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseExamplesEnumerateDevices)
 

--- a/tools/fw-logger/CMakeLists.txt
+++ b/tools/fw-logger/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseToolsFirmwareLogger)
 

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseToolsRealSenseViewer)
 

--- a/tools/rosbag-inspector/CMakeLists.txt
+++ b/tools/rosbag-inspector/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+# ubuntu 16.04 LTS cmake version 3.5.1
+cmake_minimum_required(VERSION 2.8.3)
 
 project(RealsenseToolsRosbagInspector)
 

--- a/tools/terminal/CMakeLists.txt
+++ b/tools/terminal/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseToolsTerminal)
 

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseUnitTests)
 

--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseWrappers)
 

--- a/wrappers/csharp/Intel.RealSense/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.1.0 )
+cmake_minimum_required( VERSION 3.8.0 )
 
 project(Intel.RealSense)
 

--- a/wrappers/csharp/Intel.RealSense/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.8.0 )
+cmake_minimum_required( VERSION 3.1.0 )
 
 project(Intel.RealSense)
 

--- a/wrappers/nodejs/CMakeLists.txt
+++ b/wrappers/nodejs/CMakeLists.txt
@@ -2,8 +2,7 @@
 # Use of this source code is governed by an Apache 2.0 license
 # that can be found in the LICENSE file.
 
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseNodeJSWrappers)
 

--- a/wrappers/nodejs/examples/CMakeLists.txt
+++ b/wrappers/nodejs/examples/CMakeLists.txt
@@ -2,8 +2,7 @@
 # Use of this source code is governed by an Apache 2.0 license
 # that can be found in the LICENSE file.
 
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseNodeJSExamples)
 

--- a/wrappers/opencv/CMakeLists.txt
+++ b/wrappers/opencv/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsenseCVExamples)
 

--- a/wrappers/opencv/dnn/CMakeLists.txt
+++ b/wrappers/opencv/dnn/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealSenseDNNExample)
 

--- a/wrappers/opencv/grabcuts/CMakeLists.txt
+++ b/wrappers/opencv/grabcuts/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealSenseGrabCutsExample)
 

--- a/wrappers/opencv/imshow/CMakeLists.txt
+++ b/wrappers/opencv/imshow/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealSenseImShowExample)
 

--- a/wrappers/opencv/latency-tool/CMakeLists.txt
+++ b/wrappers/opencv/latency-tool/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealSenseLatencyToolExample)
 

--- a/wrappers/pcl/CMakeLists.txt
+++ b/wrappers/pcl/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsensePCLExamples)
 

--- a/wrappers/pcl/pcl/CMakeLists.txt
+++ b/wrappers/pcl/pcl/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealSensePCLExample)
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -1,5 +1,5 @@
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+#  minimum required cmake version: 3.1.0
+cmake_minimum_required(VERSION 3.1.0)
 
 project(RealsensePythonWrappers)
 

--- a/wrappers/python/third_party/pybind11/CMakeLists.txt
+++ b/wrappers/python/third_party/pybind11/CMakeLists.txt
@@ -5,8 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-#  minimum required cmake version: 3.8.0
-cmake_minimum_required(VERSION 3.8.0)
+cmake_minimum_required(VERSION 2.8.12)
 
 if (POLICY CMP0048)
   # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:


### PR DESCRIPTION
Revert CMake minimal version as prerequisite of Debian distribution build.
CMake 3.8 shall be applied only for designated projects that require it (CUDA/C#).
