### PR TITLE
Added timestamp metadata to post processing frames

### DIFF
--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -491,11 +491,6 @@ namespace librealsense
         return additional_data.frame_number;
     }
 
-    std::array<uint8_t, MAX_META_DATA_SIZE> frame::get_metadata_blob() const
-    {
-        return additional_data.metadata_blob;
-    }
-
     rs2_time_t frame::get_frame_system_time() const
     {
         return additional_data.system_time;

--- a/src/archive.h
+++ b/src/archive.h
@@ -16,46 +16,46 @@ namespace librealsense
     class frame;
 }
 
-struct frame_additional_data
-{
-    rs2_time_t timestamp = 0;
-    unsigned long long frame_number = 0;
-    rs2_timestamp_domain timestamp_domain = RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK;
-    rs2_time_t      system_time = 0;
-    rs2_time_t      frame_callback_started = 0;
-    uint32_t        metadata_size = 0;
-    bool            fisheye_ae_mode = false;
-    std::array<uint8_t,MAX_META_DATA_SIZE> metadata_blob;
-    rs2_time_t      backend_timestamp = 0;
-    rs2_time_t last_timestamp = 0;
-    unsigned long long last_frame_number = 0;
-
-    frame_additional_data() {};
-
-    frame_additional_data(double in_timestamp,
-        unsigned long long in_frame_number,
-        double in_system_time,
-        uint8_t md_size,
-        const uint8_t* md_buf,
-        double backend_time,
-        rs2_time_t last_timestamp,
-        unsigned long long last_frame_number)
-        : timestamp(in_timestamp),
-          frame_number(in_frame_number),
-          system_time(in_system_time),
-          metadata_size(md_size),
-          backend_timestamp(backend_time),
-          last_timestamp(last_timestamp),
-          last_frame_number(last_frame_number)
-    {
-        // Copy up to 255 bytes to preserve metadata as raw data
-        if (metadata_size)
-            std::copy(md_buf,md_buf+ std::min(md_size,MAX_META_DATA_SIZE),metadata_blob.begin());
-    }
-};
-
 namespace librealsense
 {
+    struct frame_additional_data
+    {
+        rs2_time_t timestamp = 0;
+        unsigned long long frame_number = 0;
+        rs2_timestamp_domain timestamp_domain = RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK;
+        rs2_time_t      system_time = 0;
+        rs2_time_t      frame_callback_started = 0;
+        uint32_t        metadata_size = 0;
+        bool            fisheye_ae_mode = false;
+        std::array<uint8_t, MAX_META_DATA_SIZE> metadata_blob;
+        rs2_time_t      backend_timestamp = 0;
+        rs2_time_t last_timestamp = 0;
+        unsigned long long last_frame_number = 0;
+
+        frame_additional_data() {};
+
+        frame_additional_data(double in_timestamp,
+            unsigned long long in_frame_number,
+            double in_system_time,
+            uint8_t md_size,
+            const uint8_t* md_buf,
+            double backend_time,
+            rs2_time_t last_timestamp,
+            unsigned long long last_frame_number)
+            : timestamp(in_timestamp),
+            frame_number(in_frame_number),
+            system_time(in_system_time),
+            metadata_size(md_size),
+            backend_timestamp(backend_time),
+            last_timestamp(last_timestamp),
+            last_frame_number(last_frame_number)
+        {
+            // Copy up to 255 bytes to preserve metadata as raw data
+            if (metadata_size)
+                std::copy(md_buf, md_buf + std::min(md_size, MAX_META_DATA_SIZE), metadata_blob.begin());
+        }
+    };
+
     typedef std::map<rs2_frame_metadata_value, std::shared_ptr<md_attribute_parser_base>> metadata_parser_map;
 
     // Define a movable but explicitly noncopyable buffer type to hold our frame data
@@ -80,12 +80,11 @@ namespace librealsense
         rs2_timestamp_domain get_frame_timestamp_domain() const override;
         void set_timestamp(double new_ts) override { additional_data.timestamp = new_ts; }
         unsigned long long get_frame_number() const override;
-        std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const override;
         void set_timestamp_domain(rs2_timestamp_domain timestamp_domain) override
         {
             additional_data.timestamp_domain = timestamp_domain;
         }
-
+        frame_additional_data get_frame_additional_data() const override { return additional_data; }
         rs2_time_t get_frame_system_time() const override;
 
         std::shared_ptr<stream_profile_interface> get_stream() const override { return stream; }
@@ -205,9 +204,9 @@ namespace librealsense
         {
             return first()->get_sensor();
         }
-        std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const override
-        {
-            return first()->get_metadata_blob();
+        frame_additional_data get_frame_additional_data() const override 
+        { 
+            return first()->get_frame_additional_data();
         }
     };
 

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -17,6 +17,7 @@ namespace librealsense
     class sensor_interface;
     class archive_interface;
     class device_interface;
+    struct frame_additional_data;
 
     class sensor_part
     {
@@ -71,10 +72,9 @@ namespace librealsense
         virtual rs2_timestamp_domain get_frame_timestamp_domain() const = 0;
         virtual void set_timestamp(double new_ts) = 0;
         virtual unsigned long long get_frame_number() const = 0;
-
+        virtual frame_additional_data get_frame_additional_data() const = 0;
         virtual void set_timestamp_domain(rs2_timestamp_domain timestamp_domain) = 0;
         virtual rs2_time_t get_frame_system_time() const = 0;
-        virtual std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const = 0;
         virtual std::shared_ptr<stream_profile_interface> get_stream() const = 0;
         virtual void set_stream(std::shared_ptr<stream_profile_interface> sp) = 0;
 

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -90,13 +90,6 @@ namespace librealsense
             vf = static_cast<video_frame*>(original);
         }
 
-        frame_additional_data data{};
-        data.frame_number = original->get_frame_number();
-        data.timestamp = original->get_frame_timestamp();
-        data.timestamp_domain = original->get_frame_timestamp_domain();
-        data.metadata_size = 0;
-        data.system_time = _actual_source.get_time();
-        data.metadata_blob = original->get_metadata_blob();
         auto width = new_width;
         auto height = new_height;
         auto bpp = new_bpp * 8;
@@ -126,6 +119,7 @@ namespace librealsense
             height = vf->get_height();
         }
 
+        frame_additional_data data = original->get_frame_additional_data();
         auto res = _actual_source.alloc_frame(frame_type, stride * height, data, true);
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = static_cast<video_frame*>(res);

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -531,6 +531,7 @@ TEST_CASE("Sync start stop", "[live]") {
         REQUIRE(image.get_height() == other_video.height());
     }
 }
+
 TEST_CASE("Device metadata enumerates correctly", "[live]")
 {
     rs2::context ctx;
@@ -2956,6 +2957,7 @@ static const std::map< dev_type, device_profiles> pipeline_default_configuration
 /* RS400/PSR*/          { { "0AD1", true}  ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true}},
 /* RS410/ASR*/          { { "0AD2", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true }},
 /* D410/USB2*/          { { "0AD2", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 15, true } },
+/* D430/USB2*/          { { "0AD6", false } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 } }, 30, true } },
 /* RS415/ASRC*/         { { "0AD3", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true }},
 /* D415/USB2*/          { { "0AD3", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 640, 480, 0 } }, 15, true } },
 /* RS430/AWG*/          { { "0AD4", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 } }, 30, true }},
@@ -4613,4 +4615,78 @@ TEST_CASE("C API Compilation", "[live]") {
     rs2_error* e;
     REQUIRE_NOTHROW(rs2_set_devices_changed_callback(NULL, dev_changed, NULL, &e));
     REQUIRE(e != nullptr);
+}
+
+void compare_frame_md(rs2::frame origin_depth, rs2::frame result_depth)
+{
+    for (auto i = 0; i < rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT; i++)
+    {
+        bool origin_supported = origin_depth.supports_frame_metadata((rs2_frame_metadata_value)i);
+        bool result_supported = result_depth.supports_frame_metadata((rs2_frame_metadata_value)i);
+        REQUIRE(origin_supported == result_supported);
+        if (origin_supported && result_supported)
+        {
+            rs2_metadata_type origin_val = origin_depth.get_frame_metadata((rs2_frame_metadata_value)i);
+            rs2_metadata_type result_val = result_depth.get_frame_metadata((rs2_frame_metadata_value)i);
+            CAPTURE(i);
+            CAPTURE(origin_val);
+            CAPTURE(result_val);
+            REQUIRE(origin_val == result_val);
+        }
+    }
+}
+TEST_CASE("Post-Processing Filters metadata validation", "[live][post-processing-filters]")
+{
+    rs2::context ctx;
+
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    {
+        rs2::device dev;
+        rs2::pipeline pipe(ctx);
+        rs2::config cfg;
+        rs2::pipeline_profile profile;
+        REQUIRE_NOTHROW(profile = cfg.resolve(pipe));
+        REQUIRE(profile);
+        REQUIRE_NOTHROW(dev = profile.get_device());
+        REQUIRE(dev);
+        disable_sensitive_options_for(dev);
+        dev_type PID = get_PID(dev);
+        CAPTURE(PID.first);
+        CAPTURE(PID.second);
+
+        std::vector<std::shared_ptr<rs2::process_interface>> filters =
+        { std::make_shared<rs2::decimation_filter>(),
+          std::make_shared<rs2::disparity_transform>(true),
+          std::make_shared<rs2::spatial_filter>(),
+          std::make_shared<rs2::temporal_filter>(),
+          std::make_shared<rs2::disparity_transform>(false),
+          std::make_shared<rs2::hole_filling_filter>() };
+
+        auto configurations = pipeline_default_configurations;
+        if (configurations.end() == configurations.find(PID))
+        {
+            WARN("Skipping test - the Device-Under-Test profile is not defined for PID " << PID.first << (PID.second ? " USB3" : " USB2"));
+        }
+        else
+        {
+            REQUIRE(pipeline_default_configurations.at(PID).streams.size() > 0);
+            for (auto req : configurations[PID].streams)
+                REQUIRE_NOTHROW(cfg.enable_stream(req.stream, req.index, req.width, req.height, req.format, configurations[PID].fps));
+            REQUIRE_NOTHROW(pipe.start(cfg));
+            for (auto i = 0; i < 30; i++)
+            {
+                for (auto filter : filters)
+                {
+                    rs2::frameset fset = pipe.wait_for_frames();
+                    REQUIRE(fset);
+                    rs2::frame depth = fset.first_or_default(RS2_STREAM_DEPTH);
+                    REQUIRE(depth);
+                    // ... here the actual filters are being applied
+                    auto filtered_depth = filter->process(depth);
+                    compare_frame_md(depth, filtered_depth);
+                }
+            }
+            REQUIRE_NOTHROW(pipe.stop());
+        }
+    }
 }

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -143,27 +143,6 @@ bool validate_ppf_results(rs2::frame origin_depth, rs2::frame result_depth, cons
     return profile_diffs("./Filterstransform.txt", diff2ref, 0.f, 0, frame_idx);
 }
 
-void compare_frame_md(rs2::frame origin_depth, rs2::frame result_depth)
-{
-    for (auto i = 0; i < rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT; i++)
-    {
-        bool origin_supported = origin_depth.supports_frame_metadata((rs2_frame_metadata_value)i);
-        bool result_supported = result_depth.supports_frame_metadata((rs2_frame_metadata_value)i);
-        REQUIRE(origin_supported == result_supported);
-        if (origin_supported && result_supported)
-        {
-            //FRAME_TIMESTAMP and SENSOR_TIMESTAMP metadatas are not included in post proccesing frames,
-            //TIME_OF_ARRIVAL continues to increase  after post proccesing
-            if (i == RS2_FRAME_METADATA_FRAME_TIMESTAMP ||
-                i == RS2_FRAME_METADATA_SENSOR_TIMESTAMP ||
-                i == RS2_FRAME_METADATA_TIME_OF_ARRIVAL) continue;
-            rs2_metadata_type origin_val = origin_depth.get_frame_metadata((rs2_frame_metadata_value)i);
-            rs2_metadata_type result_val = result_depth.get_frame_metadata((rs2_frame_metadata_value)i);
-            REQUIRE(origin_val == result_val);
-        }
-    }
-}
-
 // The test is intended to check the results of filters applied on a sequence of frames, specifically the temporal filter
 // that preserves an internal state. The test utilizes rosbag recordings
 TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post-processing-filters]")
@@ -200,7 +179,6 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
         {
             CAPTURE(ppf_test.first);
             CAPTURE(ppf_test.second);
-
             WARN("PPF test " << ppf_test.first << "[" << ppf_test.second << "]");
 
             // Load the data from configuration and raw frame files
@@ -258,7 +236,6 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
 
                 // Compare the resulted frame versus input
                 validate_ppf_results(depth, filtered_depth, test_cfg, i);
-                compare_frame_md(depth, filtered_depth);
             }
         }
     }


### PR DESCRIPTION
-At post processing frames creation all the additional data of the original frame is copied.
-Added live test to check that the metadata of the original frame is equal to the metadata of the generated post processing frame.

Tracked on: DSO-9443