### PR TITLE
Fixed bug DSO-9680 - stop the rendering loop only if all the devices are not streaming.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -5448,6 +5448,14 @@ namespace rs2
     }
 
 
+    bool rs2::device_model::is_streaming()
+    {
+        return std::any_of(subdevices.begin(), subdevices.end(), [](const std::shared_ptr<subdevice_model>& sm)
+        {
+            return sm->streaming;
+        });
+    }
+
     void device_model::draw_controls(float panel_width, float panel_height,
         ux_window& window,
         std::string& error_message,
@@ -5776,7 +5784,6 @@ namespace rs2
                             }))
                             {
                                 // Stopping post processing filter rendering thread
-                                viewer.ppf.stop();
                                 stop_recording = true;
                             }
                         }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -5448,7 +5448,7 @@ namespace rs2
     }
 
 
-    bool rs2::device_model::is_streaming()
+    bool rs2::device_model::is_streaming() const
     {
         return std::any_of(subdevices.begin(), subdevices.end(), [](const std::shared_ptr<subdevice_model>& sm)
         {

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -5783,7 +5783,6 @@ namespace rs2
                                 return sm->streaming;
                             }))
                             {
-                                // Stopping post processing filter rendering thread
                                 stop_recording = true;
                             }
                         }

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -480,7 +480,7 @@ namespace rs2
         void handle_harware_events(const std::string& serialized_data);
 
         std::vector<std::shared_ptr<subdevice_model>> subdevices;
-        bool is_streaming();
+        bool is_streaming() const;
         bool metadata_supported = false;
         bool get_curr_advanced_controls = true;
         device dev;
@@ -658,7 +658,7 @@ namespace rs2
             }
         }
 
-        bool is_rendering()
+        bool is_rendering() const
         {
             return render_thread_active.load();
         }

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -480,7 +480,7 @@ namespace rs2
         void handle_harware_events(const std::string& serialized_data);
 
         std::vector<std::shared_ptr<subdevice_model>> subdevices;
-
+        bool is_streaming();
         bool metadata_supported = false;
         bool get_curr_advanced_controls = true;
         device dev;
@@ -656,6 +656,11 @@ namespace rs2
             {
                 render_thread.join();
             }
+        }
+
+        bool is_rendering()
+        {
+            return render_thread_active.load();
         }
 
         rs2::frameset get_points()

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -421,7 +421,19 @@ int main(int argv, const char** argc) try
                     update_read_only_options,
                     draw_later);
             }
-
+            if (viewer_model.ppf.is_rendering())
+            {
+                if (!std::any_of(device_models.begin(), device_models.end(),
+                    [](device_model& dm)
+                {
+                    return dm.is_streaming();
+                }))
+                {
+                    // Stopping post processing filter rendering thread
+                    viewer_model.ppf.stop();
+                }
+            }
+           
             if (device_to_remove)
             {
                 if (auto p = device_to_remove->dev.as<playback>())


### PR DESCRIPTION
The thread of rendering will be stopped on the main loop instead of  on device_model::draw_controls()
such that we can check if all devices are not streaming.