### PR TITLE
Refactor post processing frame metadata implementation

### DIFF
--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -257,6 +257,7 @@ EXPORTS
     rs2_software_sensor_add_video_stream
     rs2_software_sensor_add_read_only_option
     rs2_software_sensor_update_read_only_option
+    rs2_software_sensor_set_metadata
 
     rs2_loopback_enable
     rs2_loopback_disable

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -104,6 +104,15 @@ rs2_sensor* rs2_software_device_add_sensor(rs2_device* dev, const char* sensor_n
 void rs2_software_sensor_on_video_frame(rs2_sensor* sensor, rs2_software_video_frame frame, rs2_error** error);
 
 /**
+* Set frame metadata for the upcoming frames
+* \param[in] sensor the software sensor
+* \param[in] value metadata key to set
+* \param[in] type metadata value
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+void rs2_software_sensor_set_metadata(rs2_sensor* sensor, rs2_frame_metadata_value value, rs2_metadata_type type, rs2_error** error);
+
+/**
  * Set the wanted matcher type that will be used by the syncer
  * \param[in] dev the software device
  * \param[in] matcher matcher type

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -100,6 +100,18 @@ namespace rs2
         }
 
         /**
+        * Set frame metadata for the upcoming frames
+        * \param[in] value metadata key to set
+        * \param[in] type metadata value
+        */
+        void set_metadata(rs2_frame_metadata_value value, rs2_metadata_type type)
+        {
+            rs2_error* e = nullptr;
+            rs2_software_sensor_set_metadata(_sensor.get(), value, type, &e);
+            error::handle(e);
+        }
+
+        /**
         * Register option that will be supported by the sensor
         *
         * \param[in] option  the option

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -1,5 +1,4 @@
 #include "metadata-parser.h"
-#include "api.h"
 #include "archive.h"
 #include <fstream>
 
@@ -7,34 +6,6 @@
 
 namespace librealsense
 {
-
-    frame::frame(frame&& r)
-        : ref_count(r.ref_count.exchange(0)), _kept(r._kept.exchange(false)),
-        owner(r.owner), on_release()
-    {
-        *this = std::move(r);
-        if (owner == nullptr) return;
-        auto sensor = owner->get_sensor();
-        if (sensor) _sensor_type = sensor->get_sensor_type();
-    }
-
-    frame& frame::operator=(frame&& r)
-    {
-        data = move(r.data);
-        owner = r.owner;
-        ref_count = r.ref_count.exchange(0);
-        _kept = r._kept.exchange(false);
-        on_release = std::move(r.on_release);
-        additional_data = std::move(r.additional_data);
-        r.owner.reset();
-        if (owner)
-        {
-            auto sensor = owner->get_sensor();
-            if(sensor) _sensor_type = owner->get_sensor()->get_sensor_type();
-        }
-        return *this;
-    }
-
     std::shared_ptr<sensor_interface> frame::get_sensor() const
     {
         auto res = sensor.lock();
@@ -45,11 +16,7 @@ namespace librealsense
         }
         return res;
     }
-    void frame::set_sensor(std::shared_ptr<sensor_interface> s) 
-    { 
-        sensor = s;
-        if (s) _sensor_type = s->get_sensor_type();
-    }
+    void frame::set_sensor(std::shared_ptr<sensor_interface> s) { sensor = s; }
 
     float3* points::get_vertices()
     {
@@ -147,7 +114,7 @@ namespace librealsense
         std::atomic<uint32_t>* max_frame_queue_size;
         std::atomic<uint32_t> published_frames_count;
         small_heap<T, RS2_USER_QUEUE_SIZE> published_frames;
-
+        std::shared_ptr<metadata_parser_map> _metadata_parsers = nullptr;
         callbacks_heap callback_inflight;
 
         std::vector<T> freelist; // return frames here
@@ -155,7 +122,6 @@ namespace librealsense
         int pending_frames = 0;
         std::recursive_mutex mutex;
         std::shared_ptr<platform::time_service> _time_service;
-        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> _metadata_parsers;
 
         std::weak_ptr<sensor_interface> _sensor;
         std::shared_ptr<sensor_interface> get_sensor() const override { return _sensor.lock(); }
@@ -291,24 +257,14 @@ namespace librealsense
             }
         }
 
-        std::shared_ptr<metadata_parser_map> get_md_parsers(rs2_extension sensor_type) const override
-        {
-            if(_metadata_parsers.find(sensor_type) != _metadata_parsers.end())
-                return _metadata_parsers.at(sensor_type);
-            return nullptr;
-        };
-
-        void set_md_parsers(const rs2_extension sensor_type, const std::shared_ptr<metadata_parser_map> metadata_parsers) override
-        {
-            _metadata_parsers[sensor_type] = metadata_parsers;
-        }
+        std::shared_ptr<metadata_parser_map> get_md_parsers() const { return _metadata_parsers; };
 
         friend class frame;
 
     public:
         explicit frame_archive(std::atomic<uint32_t>* in_max_frame_queue_size,
             std::shared_ptr<platform::time_service> ts,
-			std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> parsers)
+			std::shared_ptr<metadata_parser_map> parsers)
             : max_frame_queue_size(in_max_frame_queue_size),
             mutex(), recycle_frames(true), _time_service(ts),
             _metadata_parsers(parsers)
@@ -375,7 +331,7 @@ namespace librealsense
     std::shared_ptr<archive_interface> make_archive(rs2_extension type,
         std::atomic<uint32_t>* in_max_frame_queue_size,
         std::shared_ptr<platform::time_service> ts,
-		std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> parsers)
+		std::shared_ptr<metadata_parser_map> parsers)
     {
         switch (type)
         {
@@ -426,21 +382,17 @@ namespace librealsense
     {
         owner = new_owner;
         _kept = false;
-        auto sensor = owner->get_sensor();
-        if (sensor) _sensor_type = sensor->get_sensor_type();
         return owner->publish_frame(this);
     }
 
     rs2_metadata_type frame::get_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const
     {
-        auto md_parsers = owner->get_md_parsers(_sensor_type);
-
-        if (!md_parsers)
+        if (!metadata_parsers)
             throw invalid_value_exception(to_string() << "metadata not available for "
                 << get_string(get_stream()->get_stream_type()) << " stream");
 
-        auto it = md_parsers.get()->find(frame_metadata);
-        if (it == md_parsers.get()->end())          // Possible user error - md attribute is not supported by this frame type
+        auto it = metadata_parsers.get()->find(frame_metadata);
+        if (it == metadata_parsers.get()->end())          // Possible user error - md attribute is not supported by this frame type
             throw invalid_value_exception(to_string() << get_string(frame_metadata)
                 << " attribute is not applicable for "
                 << get_string(get_stream()->get_stream_type()) << " stream ");
@@ -451,14 +403,12 @@ namespace librealsense
 
     bool frame::supports_frame_metadata(const rs2_frame_metadata_value& frame_metadata) const
     {
-        auto md_parsers = owner->get_md_parsers(_sensor_type);
-
         // verify preconditions
-        if (!md_parsers)
+        if (!metadata_parsers)
             return false;                         // No parsers are available or no metadata was attached
 
-        auto it = md_parsers.get()->find(frame_metadata);
-        if (it == md_parsers.get()->end())          // Possible user error - md attribute is not supported by this frame type
+        auto it = metadata_parsers.get()->find(frame_metadata);
+        if (it == metadata_parsers.get()->end())          // Possible user error - md attribute is not supported by this frame type
             return false;
 
         return it->second->supports(*this);
@@ -489,11 +439,6 @@ namespace librealsense
     unsigned long long frame::get_frame_number() const
     {
         return additional_data.frame_number;
-    }
-
-    std::array<uint8_t, MAX_META_DATA_SIZE> frame::get_metadata_blob() const
-    {
-        return additional_data.metadata_blob;
     }
 
     rs2_time_t frame::get_frame_system_time() const

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -74,7 +74,6 @@ namespace librealsense
 
         virtual void set_timestamp_domain(rs2_timestamp_domain timestamp_domain) = 0;
         virtual rs2_time_t get_frame_system_time() const = 0;
-        virtual std::array<uint8_t, MAX_META_DATA_SIZE> get_metadata_blob() const = 0;
         virtual std::shared_ptr<stream_profile_interface> get_stream() const = 0;
         virtual void set_stream(std::shared_ptr<stream_profile_interface> sp) = 0;
 
@@ -121,7 +120,6 @@ namespace librealsense
         virtual void set_frames_callback(frame_callback_ptr cb) = 0;
         virtual bool is_streaming() const = 0;
         virtual const device_interface& get_device() = 0;
-        virtual rs2_extension get_sensor_type() = 0;
 
         virtual ~sensor_interface() = default;
     };

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -3,8 +3,6 @@
 
 #include "playback_sensor.h"
 #include "core/motion.h"
-#include "api.h"
-#include "software-device.h"
 #include <map>
 #include "types.h"
 #include "context.h"
@@ -295,13 +293,4 @@ void playback_sensor::unregister_before_start_callback(int token)
 void playback_sensor::raise_notification(const notification& n)
 {
     _notifications_processor.raise_notification(n);
-}
-
-rs2_extension playback_sensor::get_sensor_type()
-{
-    if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_sensor)) return RS2_EXTENSION_DEPTH_SENSOR;
-    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_stereo_sensor)) return RS2_EXTENSION_DEPTH_STEREO_SENSOR;
-    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::video_sensor_interface)) return RS2_EXTENSION_VIDEO;
-    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::software_sensor)) return RS2_EXTENSION_SOFTWARE_SENSOR;
-    else return RS2_EXTENSION_UNKNOWN;
 }

--- a/src/media/playback/playback_sensor.h
+++ b/src/media/playback/playback_sensor.h
@@ -49,7 +49,6 @@ namespace librealsense
         stream_profiles get_active_streams() const override;
         int register_before_streaming_changes_callback(std::function<void(bool)> callback) override;
         void unregister_before_start_callback(int token) override;
-        rs2_extension get_sensor_type() override;
         void raise_notification(const notification& n);
     private:
         void register_sensor_streams(const stream_profiles& vector);

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -3,7 +3,6 @@
 
 #include "record_sensor.h"
 #include "api.h"
-#include "software-device.h"
 #include "stream.h"
 
 using namespace librealsense;
@@ -360,13 +359,4 @@ void record_sensor::wrap_streams()
            m_recorded_streams_ids.insert(id);
         }
     }
-}
-
-rs2_extension record_sensor::get_sensor_type()
-{
-    if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_sensor)) return RS2_EXTENSION_DEPTH_SENSOR;
-    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_stereo_sensor)) return RS2_EXTENSION_DEPTH_STEREO_SENSOR;
-    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::video_sensor_interface)) return RS2_EXTENSION_VIDEO;
-    else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::software_sensor)) return RS2_EXTENSION_SOFTWARE_SENSOR;
-    else return RS2_EXTENSION_UNKNOWN;
 }

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -42,7 +42,6 @@ namespace librealsense
         stream_profiles get_active_streams() const override;
         int register_before_streaming_changes_callback(std::function<void(bool)> callback) override;
         void unregister_before_start_callback(int token) override;
-        virtual rs2_extension get_sensor_type() override;
         signal<record_sensor, const notification&> on_notification;
         signal<record_sensor, frame_holder> on_frame;
         signal<record_sensor, rs2_extension, std::shared_ptr<extension_snapshot>> on_extension_change;

--- a/src/media/ros/ros_file_format.h
+++ b/src/media/ros/ros_file_format.h
@@ -192,46 +192,6 @@ namespace librealsense
     constexpr const char* FRAME_TIMESTAMP_MD_STR = "frame_timestamp";
     constexpr const char* TRACKER_CONFIDENCE_MD_STR = "Tracker Confidence";
 
-    class md_constant_parser : public md_attribute_parser_base
-    {
-    public:
-        md_constant_parser(rs2_frame_metadata_value type) : _type(type) {}
-        rs2_metadata_type get(const frame& frm) const override
-        {
-            rs2_metadata_type v;
-            if (try_get(frm, v) == false)
-            {
-                throw invalid_value_exception("Frame does not support this type of metadata");
-            }
-            return v;
-        }
-        bool supports(const frame& frm) const override
-        {
-            rs2_metadata_type v;
-            return try_get(frm, v);
-        }
-    private:
-        bool try_get(const frame& frm, rs2_metadata_type& result) const
-        {
-            auto pair_size = (sizeof(rs2_frame_metadata_value) + sizeof(rs2_metadata_type));
-            const uint8_t* pos = frm.additional_data.metadata_blob.data();
-            while (pos <= frm.additional_data.metadata_blob.data() + frm.additional_data.metadata_blob.size())
-            {
-                const rs2_frame_metadata_value* type = reinterpret_cast<const rs2_frame_metadata_value*>(pos);
-                pos += sizeof(rs2_frame_metadata_value);
-                if (_type == *type)
-                {
-                    const rs2_metadata_type* value = reinterpret_cast<const rs2_metadata_type*>(pos);
-                    result = *value;
-                    return true;
-                }
-                pos += sizeof(rs2_metadata_type);
-            }
-            return false;
-        }
-        rs2_frame_metadata_value _type;
-    };
-
     class ros_topic
     {
     public:

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -22,7 +22,7 @@ namespace librealsense
             m_file_path(file),
             m_context(ctx),
             m_version(0),
-            m_metadata_parser_map(create_metadata_parser_map())
+            m_metadata_parser_map(md_constant_parser::create_metadata_parser_map())
         {
             try
             {
@@ -150,11 +150,7 @@ namespace librealsense
             m_version = read_file_version(m_file);
             m_samples_view = nullptr;
             m_frame_source = std::make_shared<frame_source>(m_version == 1 ? 128 : 32);
-            std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers;
-            metadata_parsers[RS2_EXTENSION_DEPTH_SENSOR] = m_metadata_parser_map;
-            metadata_parsers[RS2_EXTENSION_DEPTH_STEREO_SENSOR] = m_metadata_parser_map;
-            metadata_parsers[RS2_EXTENSION_VIDEO] = m_metadata_parser_map;
-            m_frame_source->init(metadata_parsers);
+            m_frame_source->init(m_metadata_parser_map);
             m_initial_device_description = read_device_description(get_static_file_info_timestamp(), true);
         }
 
@@ -299,17 +295,6 @@ namespace librealsense
                 return std::make_shared<serialized_invalid_frame>(timestamp, stream_id);
             }
             return std::make_shared<serialized_frame>(timestamp, stream_id, std::move(frame));
-        }
-
-        static std::shared_ptr<metadata_parser_map> create_metadata_parser_map()
-        {
-            auto md_parser_map = std::make_shared<metadata_parser_map>();
-            for (int i = 0; i < static_cast<int>(rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT); ++i)
-            {
-                auto frame_md_type = static_cast<rs2_frame_metadata_value>(i);
-                md_parser_map->insert(std::make_pair(frame_md_type, std::make_shared<md_constant_parser>(frame_md_type)));
-            }
-            return md_parser_map;
         }
 
         static nanoseconds get_file_duration(const rosbag::Bag& file, uint32_t version)

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -33,6 +33,59 @@ namespace librealsense
         virtual ~md_attribute_parser_base() = default;
     };
 
+    /**\brief metadata parser class - support metadata in format: rs2_frame_metadata_value, rs2_metadata_type */
+    class md_constant_parser : public md_attribute_parser_base
+    {
+    public:
+        md_constant_parser(rs2_frame_metadata_value type) : _type(type) {}
+        rs2_metadata_type get(const frame& frm) const override
+        {
+            rs2_metadata_type v;
+            if (try_get(frm, v) == false)
+            {
+                throw invalid_value_exception("Frame does not support this type of metadata");
+            }
+            return v;
+        }
+        bool supports(const frame& frm) const override
+        {
+            rs2_metadata_type v;
+            return try_get(frm, v);
+        }
+
+        static std::shared_ptr<metadata_parser_map> create_metadata_parser_map()
+        {
+            auto md_parser_map = std::make_shared<metadata_parser_map>();
+            for (int i = 0; i < static_cast<int>(rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT); ++i)
+            {
+                auto frame_md_type = static_cast<rs2_frame_metadata_value>(i);
+                md_parser_map->insert(std::make_pair(frame_md_type, std::make_shared<md_constant_parser>(frame_md_type)));
+            }
+            return md_parser_map;
+        }
+    private:
+        bool try_get(const frame& frm, rs2_metadata_type& result) const
+        {
+            auto pair_size = (sizeof(rs2_frame_metadata_value) + sizeof(rs2_metadata_type));
+            const uint8_t* pos = frm.additional_data.metadata_blob.data();
+            while (pos <= frm.additional_data.metadata_blob.data() + frm.additional_data.metadata_blob.size())
+            {
+                const rs2_frame_metadata_value* type = reinterpret_cast<const rs2_frame_metadata_value*>(pos);
+                pos += sizeof(rs2_frame_metadata_value);
+                if (_type == *type)
+                {
+                    const rs2_metadata_type* value = reinterpret_cast<const rs2_metadata_type*>(pos);
+                    result = *value;
+                    return true;
+                }
+                pos += sizeof(rs2_metadata_type);
+            }
+            return false;
+        }
+        rs2_frame_metadata_value _type;
+    };
+
+
     /**\brief Post-processing adjustment of the metadata attribute
      *  e.g change auto_exposure enum to boolean, change units from nano->ms,etc'*/
     typedef std::function<rs2_metadata_type(const rs2_metadata_type& param)> attrib_modifyer;

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -2,7 +2,6 @@
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
 #include "core/video.h"
-#include "api.h"
 #include "proc/synthetic-stream.h"
 
 namespace librealsense
@@ -22,7 +21,7 @@ namespace librealsense
         : _source_wrapper(_source)
     {
         register_option(RS2_OPTION_FRAMES_QUEUE_SIZE, _source.get_published_size_option());
-        _source.init(std::map<rs2_extension, std::shared_ptr<metadata_parser_map>>());
+        _source.init(std::shared_ptr<metadata_parser_map>());
     }
 
     void processing_block::invoke(frame_holder f)
@@ -70,6 +69,7 @@ namespace librealsense
         return nullptr;
     }
 
+
     frame_interface* synthetic_source::allocate_video_frame(std::shared_ptr<stream_profile_interface> stream,
                                                             frame_interface* original,
                                                             int new_bpp,
@@ -90,13 +90,6 @@ namespace librealsense
             vf = static_cast<video_frame*>(original);
         }
 
-        frame_additional_data data{};
-        data.frame_number = original->get_frame_number();
-        data.timestamp = original->get_frame_timestamp();
-        data.timestamp_domain = original->get_frame_timestamp_domain();
-        data.metadata_size = 0;
-        data.system_time = _actual_source.get_time();
-        data.metadata_blob = original->get_metadata_blob();
         auto width = new_width;
         auto height = new_height;
         auto bpp = new_bpp * 8;
@@ -125,19 +118,15 @@ namespace librealsense
         {
             height = vf->get_height();
         }
-
+        
+        auto of = dynamic_cast<frame*>(original);
+        frame_additional_data data = of->additional_data;
         auto res = _actual_source.alloc_frame(frame_type, stride * height, data, true);
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = static_cast<video_frame*>(res);
+        vf->metadata_parsers = of->metadata_parsers;
         vf->assign(width, height, stride, bpp);
-        auto original_sensor = original->get_sensor();
-        vf->set_sensor(original_sensor);
-        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers_map;
-        if (original_sensor)
-        {
-            auto sensor_type = original_sensor->get_sensor_type();
-            res->get_owner()->set_md_parsers(sensor_type, original->get_owner()->get_md_parsers(sensor_type));
-        }
+        vf->set_sensor(original->get_sensor());
         res->set_stream(stream);
         if (frame_type == RS2_EXTENSION_DEPTH_FRAME)
         {

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1866,6 +1866,14 @@ void rs2_software_sensor_on_video_frame(rs2_sensor* sensor, rs2_software_video_f
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, sensor, frame.pixels)
 
+void rs2_software_sensor_set_metadata(rs2_sensor* sensor, rs2_frame_metadata_value key, rs2_metadata_type value, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(sensor);
+    auto bs = VALIDATE_INTERFACE(sensor->sensor, librealsense::software_sensor);
+    return bs->set_metadata(key, value);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, sensor, key, value)
+
 rs2_stream_profile* rs2_software_sensor_add_video_stream(rs2_sensor* sensor, rs2_video_stream video_stream, rs2_error** error) BEGIN_API_CALL
 {
     auto bs = VALIDATE_INTERFACE(sensor->sensor, librealsense::software_sensor);

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -11,8 +11,6 @@
 #include "device.h"
 #include "stream.h"
 #include "sensor.h"
-#include "api.h"
-#include "software-device.h"
 
 namespace librealsense
 {
@@ -87,15 +85,6 @@ namespace librealsense
     void sensor_base::set_frames_callback(frame_callback_ptr callback)
     {
         return _source.set_callback(callback);
-    }
-    rs2_extension sensor_base::get_sensor_type()
-    {
-        if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_sensor)) return RS2_EXTENSION_DEPTH_SENSOR;
-        else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::depth_stereo_sensor)) return RS2_EXTENSION_DEPTH_STEREO_SENSOR;
-        else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::video_sensor_interface)) return RS2_EXTENSION_VIDEO;
-        else if (VALIDATE_INTERFACE_NO_THROW(this, librealsense::software_sensor)) return RS2_EXTENSION_SOFTWARE_SENSOR;
-        else return RS2_EXTENSION_UNKNOWN;
-        //TODO: Add support for fisheye sensor type
     }
     std::shared_ptr<notifications_processor> sensor_base::get_notifications_processor()
     {
@@ -391,10 +380,7 @@ namespace librealsense
 
         auto on = std::unique_ptr<power>(new power(std::dynamic_pointer_cast<uvc_sensor>(shared_from_this())));
 
-        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers_map;
-        metadata_parsers_map[get_sensor_type()] = _metadata_parsers;
-        _source.init(metadata_parsers_map);
-
+        _source.init(_metadata_parsers);
         _source.set_sensor(this->shared_from_this());
         auto mapping = resolve_requests(requests);
 
@@ -874,10 +860,7 @@ namespace librealsense
 
         _source.set_callback(callback);
 
-        std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers_map;
-        metadata_parsers_map[get_sensor_type()] = _metadata_parsers;
-        _source.init(metadata_parsers_map);
-
+        _source.init(_metadata_parsers);
         _source.set_sensor(this->shared_from_this());
         raise_on_before_streaming_changes(true); //Required to be just before actual start allow recording to work
         _hid_device->start_capture([this](const platform::sensor_data& sensor_data)

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -50,7 +50,6 @@ namespace librealsense
         std::shared_ptr<notifications_processor> get_notifications_processor();
         virtual frame_callback_ptr get_frames_callback() const override;
         virtual void set_frames_callback(frame_callback_ptr callback) override;
-        virtual rs2_extension get_sensor_type() override;
 
         bool is_streaming() const override
         {

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -47,10 +47,12 @@ namespace librealsense
         void on_video_frame(rs2_software_video_frame frame);
         void add_read_only_option(rs2_option option, float val);
         void update_read_only_option(rs2_option option, float val);
-
+        void set_metadata(rs2_frame_metadata_value key, rs2_metadata_type value);
     private:
         friend class software_device;
         stream_profiles _profiles;
+        std::map<rs2_frame_metadata_value, rs2_metadata_type> _metadata_map;
+
     };
     MAP_EXTENSION(RS2_EXTENSION_SOFTWARE_SENSOR, software_sensor);
     MAP_EXTENSION(RS2_EXTENSION_SOFTWARE_DEVICE, software_device);

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -47,7 +47,7 @@ namespace librealsense
               _ts(environment::get_instance().get_time_service())
     {}
 
-    void frame_source::init(std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers)
+    void frame_source::init(std::shared_ptr<metadata_parser_map> metadata_parsers)
     {
         std::lock_guard<std::mutex> lock(_callback_mutex);
 

--- a/src/source.h
+++ b/src/source.h
@@ -17,7 +17,7 @@ namespace librealsense
     public:
         frame_source(uint32_t max_publish_list_size = 16);
 
-        void init(std::map<rs2_extension, std::shared_ptr<metadata_parser_map>> metadata_parsers);
+        void init(std::shared_ptr<metadata_parser_map> metadata_parsers);
 
         callback_invocation_holder begin_callback();
 

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -164,6 +164,28 @@ void compare_frame_md(rs2::frame origin_depth, rs2::frame result_depth)
     }
 }
 
+// Test file name  , Filters configuraiton
+const std::vector< std::pair<std::string, std::string>> ppf_test_cases = {
+    // All the tests below include depth-disparity domain transformation
+    // Downsample scales 2/3
+    { "1525186403504",  "D415_DS(2)" },
+{ "1525186407536",  "D415_DS(3)" },
+// Downsample + Hole-Filling modes 0/1/2
+{ "1525072818314",  "D415_DS(1)_HoleFill(0)" },
+{ "1525072823227",  "D415_DS(1)_HoleFill(1)" },
+{ "1524668713358",  "D435_DS(3)_HoleFill(2)" },
+// Downsample + Spatial Filter parameters
+{ "1525267760676",  "D415_DS(2)+Spat(A:0.85/D:32/I:3)" },
+// Downsample + Temporal Filter
+{ "1525266028697",  "D415_DS(2)+Temp(A:0.25/D:15/P:1)" },
+{ "1525265554250",  "D415_DS(2)+Temp(A:0.25/D:15/P:3)" },
+{ "1525266069476",  "D415_DS(2)+Temp(A:0.25/D:15/P:5)" },
+{ "1525266120520",  "D415_DS(3)+Temp(A:0.25/D:15/P:7)" },
+// Downsample + Spatial + Temporal (+ Hole-Filling)
+{ "1525267168585",  "D415_DS(2)_Spat(A:0.85/D:32/I:3)_Temp(A:0.25/D:15/P:0)" },
+{ "1525089539880",  "D415_DS(2)_Spat(A:0.85/D:32/I:3)_Temp(A:0.25/D:15/P:0)_HoleFill(1)" },
+};
+
 // The test is intended to check the results of filters applied on a sequence of frames, specifically the temporal filter
 // that preserves an internal state. The test utilizes rosbag recordings
 TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post-processing-filters]")
@@ -172,28 +194,6 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
 
     if (make_context(SECTION_FROM_TEST_NAME, &ctx))
     {
-        // Test file name  , Filters configuraiton
-        const std::vector< std::pair<std::string, std::string>> ppf_test_cases = {
-            // All the tests below include depth-disparity domain transformation
-            // Downsample scales 2/3
-            { "1525186403504",  "D415_DS(2)" },
-            { "1525186407536",  "D415_DS(3)" },
-            // Downsample + Hole-Filling modes 0/1/2
-            { "1525072818314",  "D415_DS(1)_HoleFill(0)" },
-            { "1525072823227",  "D415_DS(1)_HoleFill(1)" },
-            { "1524668713358",  "D435_DS(3)_HoleFill(2)" },
-            // Downsample + Spatial Filter parameters
-            { "1525267760676",  "D415_DS(2)+Spat(A:0.85/D:32/I:3)" },
-            // Downsample + Temporal Filter
-            { "1525266028697",  "D415_DS(2)+Temp(A:0.25/D:15/P:1)" },
-            { "1525265554250",  "D415_DS(2)+Temp(A:0.25/D:15/P:3)" },
-            { "1525266069476",  "D415_DS(2)+Temp(A:0.25/D:15/P:5)" },
-            { "1525266120520",  "D415_DS(3)+Temp(A:0.25/D:15/P:7)" },
-            // Downsample + Spatial + Temporal (+ Hole-Filling)
-            { "1525267168585",  "D415_DS(2)_Spat(A:0.85/D:32/I:3)_Temp(A:0.25/D:15/P:0)" },
-            { "1525089539880",  "D415_DS(2)_Spat(A:0.85/D:32/I:3)_Temp(A:0.25/D:15/P:0)_HoleFill(1)" },
-        };
-
         ppf_test_config test_cfg;
 
         for (auto& ppf_test : ppf_test_cases)
@@ -258,9 +258,83 @@ TEST_CASE("Post-Processing Filters sequence validation", "[software-device][post
 
                 // Compare the resulted frame versus input
                 validate_ppf_results(depth, filtered_depth, test_cfg, i);
-                compare_frame_md(depth, filtered_depth);
             }
         }
     }
 }
 
+TEST_CASE("Post-Processing Filters metadata validation", "[software-device][post-processing-filters]")
+{
+    rs2::context ctx;
+
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    {
+        ppf_test_config test_cfg;
+        for (auto& ppf_test : ppf_test_cases)
+        {
+            CAPTURE(ppf_test.first);
+            CAPTURE(ppf_test.second);
+
+            WARN("PPF test " << ppf_test.first << "[" << ppf_test.second << "]");
+
+            // Load the data from configuration and raw frame files
+            if (!load_test_configuration(ppf_test.first, test_cfg))
+                continue;
+
+            post_processing_filters ppf;
+
+            // Apply the retrieved configuration onto a local post-processing chain of filters
+            REQUIRE_NOTHROW(ppf.configure(test_cfg));
+
+            rs2::software_device dev; // Create software-only device
+            auto depth_sensor = dev.add_sensor("Depth");
+
+            int width = test_cfg.input_res_x;
+            int height = test_cfg.input_res_y;
+            int depth_bpp = 2; //16bit unsigned
+            int frame_number = 1;
+            rs2_intrinsics depth_intrinsics = { width, height,
+                width / 2.f, height / 2.f,                      // Principal point (N/A in this test)
+                test_cfg.focal_length ,test_cfg.focal_length,   // Focal Length
+                RS2_DISTORTION_BROWN_CONRADY ,{ 0,0,0,0,0 } };
+
+            auto depth_stream_profile = depth_sensor.add_video_stream({ RS2_STREAM_DEPTH, 0, 0, width, height, 30, depth_bpp, RS2_FORMAT_Z16, depth_intrinsics });
+
+            // Establish the required chain of filters
+            dev.create_matcher(RS2_MATCHER_DLR_C);
+            rs2::syncer sync;
+
+            depth_sensor.open(depth_stream_profile);
+            depth_sensor.start(sync);
+
+            size_t frames = (test_cfg.frames_sequence_size > 1) ? test_cfg.frames_sequence_size : 1;
+            for (auto i = 0; i < frames; i++)
+            {
+                //set next frames metadata
+                for (auto i = 0; i < rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT; i++)
+                    depth_sensor.set_metadata((rs2_frame_metadata_value)i, rand());
+
+                // Inject input frame
+                depth_sensor.on_video_frame({ test_cfg._input_frames[i].data(), // Frame pixels from capture API
+                    [](void*) {},                   // Custom deleter (if required)
+                    (int)test_cfg.input_res_x *depth_bpp,    // Stride
+                    depth_bpp,                          // Bytes-per-pixels
+                    (rs2_time_t)frame_number + i,      // Timestamp
+                    RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME,   // Clock Domain
+                    frame_number,                       // Frame# for potential sync services
+                    depth_stream_profile });            // Depth stream profile
+
+                rs2::frameset fset = sync.wait_for_frames();
+                REQUIRE(fset);
+                rs2::frame depth = fset.first_or_default(RS2_STREAM_DEPTH);
+                REQUIRE(depth);
+
+                // ... here the actual filters are being applied
+                auto filtered_depth = ppf.process(depth);
+
+                // Compare the resulted frame metadata versus input
+                compare_frame_md(depth, filtered_depth);
+            }
+        }
+    }
+}


### PR DESCRIPTION
-Metadata parsers are now saved in the frame 
-Added metadata support is software frames
-Added test for compering metadata after post processing

Tracked on: DSO-9443