### PR TITLE
Added functionality of no throw wait_for_frame

### DIFF
--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -93,6 +93,7 @@ EXPORTS
     rs2_delete_frame_queue
     rs2_wait_for_frame
     rs2_poll_for_frame
+    rs2_try_wait_for_frame
     rs2_enqueue_frame
     rs2_flush_queue
 
@@ -224,6 +225,7 @@ EXPORTS
     rs2_pipeline_stop
     rs2_pipeline_wait_for_frames
     rs2_pipeline_poll_for_frames
+    rs2_pipeline_try_wait_for_frames
     rs2_delete_pipeline
     rs2_pipeline_start
     rs2_pipeline_start_with_config

--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -5,6 +5,7 @@ EXPORTS
     rs2_delete_context
     rs2_create_recording_context
     rs2_create_mock_context
+    rs2_create_mock_context_versioned
     rs2_get_time
     rs2_context_add_device
     rs2_context_remove_device

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3169,7 +3169,7 @@ namespace rs2
                 if(viewer.synchronization_enable)
                 {
                     auto index = 0;
-                    while (syncer_queue.poll_for_frame(&frm) && ++index <= syncer_queue.capacity())
+                    while (syncer_queue.try_wait_for_frame(&frm, 30) && ++index <= syncer_queue.capacity())
                     {
                         processing_block.invoke(frm);
                     }
@@ -3184,7 +3184,7 @@ namespace rs2
                     for (auto&& q : frames_queue_local)
                     {
                         frame frm;
-                        if (q.second.poll_for_frame(&frm))
+                        if (q.second.try_wait_for_frame(&frm, 30))
                         {
                             processing_block.invoke(frm);
                         }

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -79,6 +79,18 @@ rs2_context* rs2_create_recording_context(int api_version, const char* filename,
 rs2_context* rs2_create_mock_context(int api_version, const char* filename, const char* section, rs2_error** error);
 
 /**
+* Create librealsense context that given a file will respond to calls exactly as the recording did
+* if the user calls a method that was either not called during recording or violates causality of the recording error will be thrown
+* \param[in] api_version realsense API version as provided by RS2_API_VERSION macro
+* \param[in] filename string representing the name of the file to play back from
+* \param[in] section  string representing the name of the section within existing recording
+* \param[in] min_api_version reject any file that was recorded before this version
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \return            context object, should be released by rs2_delete_context
+*/
+rs2_context* rs2_create_mock_context_versioned(int api_version, const char* filename, const char* section, const char* min_api_version, rs2_error** error);
+
+/**
  * Create software device to enable use librealsense logic without getting data from backend
  * but inject the data from outside
  * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -73,6 +73,22 @@ extern "C" {
     */
     int rs2_pipeline_poll_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, rs2_error ** error);
 
+    /**
+    * Wait until a new set of frames becomes available.
+    * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
+    * The method blocks the calling thread, and fetches the latest unread frames set.
+    * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method should be called
+    * as fast as the device frame rate.
+    * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
+    * may lack memory resources to produce new frames, and the following call to this method shall fail to retrieve new frames, until resources
+    * are retained.
+    * \param[in] pipe           the pipeline
+    * \param[in] timeout_ms     max time in milliseconds to wait until a frame becomes available
+    * \param[out] output_frame  frame handle to be released using rs2_release_frame
+    * \param[out] error         if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return true if new frame was stored to output_frame
+    */
+    int rs2_pipeline_try_wait_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, unsigned int timeout_ms, rs2_error ** error);
 
     /**
     * Delete a pipeline instance.

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -117,6 +117,7 @@ void rs2_delete_frame_queue(rs2_frame_queue* queue);
 /**
 * wait until new frame becomes available in the queue and dequeue it
 * \param[in] queue the frame queue data structure
+* \param[in] timeout_ms   max time in milliseconds to wait until an exception will be thrown
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \return frame handle to be released using rs2_release_frame
 */
@@ -130,6 +131,16 @@ rs2_frame* rs2_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, r
 * \return true if new frame was stored to output_frame
 */
 int rs2_poll_for_frame(rs2_frame_queue* queue, rs2_frame** output_frame, rs2_error** error);
+
+/**
+* wait until new frame becomes available in the queue and dequeue it
+* \param[in] queue          the frame queue data structure
+* \param[in] timeout_ms     max time in milliseconds to wait until a frame becomes available
+* \param[out] output_frame  frame handle to be released using rs2_release_frame
+* \param[out] error         if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \return true if new frame was stored to output_frame
+*/
+int rs2_try_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, rs2_frame** output_frame, rs2_error** error);
 
 /**
 * enqueue new frame into a queue

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -41,11 +41,12 @@ namespace rs2
         * \param[in] filename string of the name of the file
         */
         mock_context(const std::string& filename,
-                     const std::string& section = "")
+                     const std::string& section = "",
+                     const std::string& min_api_version = "0.0.0")
         {
             rs2_error* e = nullptr;
             _context = std::shared_ptr<rs2_context>(
-                rs2_create_mock_context(RS2_API_VERSION, filename.c_str(), section.c_str(), &e),
+                rs2_create_mock_context_versioned(RS2_API_VERSION, filename.c_str(), section.c_str(), min_api_version.c_str(), &e),
                 rs2_delete_context);
             error::handle(e);
         }

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -471,6 +471,20 @@ namespace rs2
             return res > 0;
         }
 
+        bool try_wait_for_frames(frameset* f, unsigned int timeout_ms = 5000) const
+        {
+            if (!f)
+            {
+                throw std::invalid_argument("null frameset");
+            }
+            rs2_error* e = nullptr;
+            rs2_frame* frame_ref = nullptr;
+            auto res = rs2_pipeline_try_wait_for_frames(_pipeline.get(), &frame_ref, timeout_ms, &e);
+            error::handle(e);
+            if (res) *f = frameset(frame(frame_ref));
+            return res > 0;
+        }
+
         /**
         * Return the active device and streams profiles, used by the pipeline.
         * The pipeline streams profiles are selected during \c start(). The method returns a valid result only when the pipeline is active -

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -93,7 +93,8 @@ namespace librealsense
     context::context(backend_type type,
                      const char* filename,
                      const char* section,
-                     rs2_recording_mode mode)
+                     rs2_recording_mode mode,
+                     std::string min_api_version)
         : _devices_changed_callback(nullptr, [](rs2_devices_changed_callback*){})
     {
         LOG_DEBUG("Librealsense " << std::string(std::begin(rs2_api_version),std::end(rs2_api_version)));
@@ -107,7 +108,7 @@ namespace librealsense
             _backend = std::make_shared<platform::record_backend>(platform::create_backend(), filename, section, mode);
             break;
         case backend_type::playback:
-            _backend = std::make_shared<platform::playback_backend>(filename, section);
+            _backend = std::make_shared<platform::playback_backend>(filename, section, min_api_version);
 
             break;
         default: throw invalid_value_exception(to_string() << "Undefined backend type " << static_cast<int>(type));
@@ -285,6 +286,13 @@ namespace librealsense
         {
             return rs2_intrinsics {};
         }
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> markers;
+            markers.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            return markers;
+        };
     };
 
     std::shared_ptr<device_interface> platform_camera_info::create(std::shared_ptr<context> ctx,

--- a/src/context.h
+++ b/src/context.h
@@ -112,7 +112,8 @@ namespace librealsense
         explicit context(backend_type type,
             const char* filename = nullptr,
             const char* section = nullptr,
-            rs2_recording_mode mode = RS2_RECORDING_MODE_COUNT);
+            rs2_recording_mode mode = RS2_RECORDING_MODE_COUNT,
+            std::string min_api_version = "0.0.0");
 
         void stop(){_device_watcher->stop();}
         ~context();

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -28,6 +28,23 @@ namespace librealsense
 
     class context;
 
+    typedef enum profile_tag
+    {
+        PROFILE_TAG_ANY = 0,
+        PROFILE_TAG_SUPERSET = 1, // to be included in enable_all
+        PROFILE_TAG_DEFAULT = 2,  // to be included in default pipeline start
+    } profile_tag;
+
+    struct tagged_profile
+    {
+        rs2_stream stream;
+        int stream_index;
+        uint32_t width, height;
+        rs2_format format;
+        uint32_t fps;
+        int tag;
+    };
+
     class stream_interface : public std::enable_shared_from_this<stream_interface>
     {
     public:
@@ -52,8 +69,8 @@ namespace librealsense
         virtual uint32_t get_framerate() const = 0;
         virtual void set_framerate(uint32_t val) = 0;
 
-        virtual bool is_default() const = 0;
-        virtual void make_default() = 0;
+        virtual int get_tag() const = 0;
+        virtual void tag_profile(int tag) = 0;
 
         virtual std::shared_ptr<stream_profile_interface> clone() const = 0;
         virtual rs2_stream_profile* get_c_wrapper() const = 0;
@@ -105,7 +122,7 @@ namespace librealsense
     class sensor_interface : public virtual info_interface, public virtual options_interface
     {
     public:
-        virtual stream_profiles get_stream_profiles() const = 0;
+        virtual stream_profiles get_stream_profiles(int tag = profile_tag::PROFILE_TAG_ANY) const = 0;
         virtual stream_profiles get_active_streams() const = 0;
         virtual void open(const stream_profiles& requests) = 0;
         virtual void close() = 0;
@@ -150,6 +167,9 @@ namespace librealsense
 
         virtual ~device_interface() = default;
 
+        virtual std::vector<tagged_profile> get_profiles_tags() const = 0;
+
+        virtual void tag_profile(stream_profile_interface* profile) const = 0;
     };
 
     class depth_stereo_sensor;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -144,6 +144,7 @@ device::device(std::shared_ptr<context> ctx,
         });
 
         _callback_id = _context->register_internal_device_callback({ cb, [](rs2_devices_changed_callback* p) { p->release(); } });
+        _profiles_tags = lazy<std::vector<tagged_profile>>([this]() { return get_profiles_tags(); });
     }
 }
 
@@ -261,4 +262,20 @@ void librealsense::device::register_stream_to_extrinsic_group(const stream_inter
     }
 }
 
-
+void librealsense::device::tag_profile(stream_profile_interface* profile) const
+{
+    for (auto tag : *_profiles_tags)
+    {
+        auto vp = dynamic_cast<video_stream_profile_interface*>(profile);
+        if (vp)
+        {
+            if ((tag.stream == RS2_STREAM_ANY || vp->get_stream_type() == tag.stream) &&
+                (tag.format == RS2_FORMAT_ANY || vp->get_format() == tag.format) &&
+                (tag.width == -1 || vp->get_width() == tag.width) &&
+                (tag.height == -1 || vp->get_height() == tag.height) &&
+                (tag.fps == -1 || vp->get_framerate() == tag.fps) &&
+                (tag.stream_index == -1 || vp->get_stream_index() == tag.stream_index))
+                profile->tag_profile(tag.tag);
+        }
+    }
+}

--- a/src/device.h
+++ b/src/device.h
@@ -72,6 +72,8 @@ namespace librealsense
             return _is_valid;
         }
 
+        void tag_profile(stream_profile_interface* profile) const override;
+
     protected:
         int add_sensor(std::shared_ptr<sensor_interface> sensor_base);
         int assign_sensor(std::shared_ptr<sensor_interface> sensor_base, uint8_t idx);
@@ -90,5 +92,6 @@ namespace librealsense
         bool _is_valid, _device_changed_notifications;
         mutable std::mutex _device_changed_mtx;
         uint64_t _callback_id;
+        lazy<std::vector<tagged_profile>> _profiles_tags;
     };
 }

--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -171,8 +171,7 @@ namespace librealsense
                     return rs2_intrinsics{};
             });
 
-            if (video->get_width() == 640 && video->get_height() == 480 && video->get_format() == RS2_FORMAT_RGB8 && video->get_framerate() == 30)
-                video->make_default();
+            get_device().tag_profile(video);
         }
 
         return results;

--- a/src/ds5/ds5-device.h
+++ b/src/ds5/ds5-device.h
@@ -32,6 +32,7 @@ namespace librealsense
         void hardware_reset() override;
         void create_snapshot(std::shared_ptr<debug_interface>& snapshot) const override;
         void enable_recording(std::function<void(const debug_interface&)> record_action) override;
+        platform::usb_spec get_usb_spec() const;
 
     protected:
 

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -37,6 +37,25 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor()) {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+        
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // DS5U_S
@@ -52,9 +71,28 @@ namespace librealsense
             ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor()) {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 720, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1152, 1152, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1152, 1152, RS2_FORMAT_Y16, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 720, 720, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1152, 1152, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1152, 1152, RS2_FORMAT_Y16, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
-    // ASR
+    // ASR (D460)
     class rs410_device : public ds5_rolling_shutter,
                          public ds5_active, public ds5_advanced_mode_base
     {
@@ -69,6 +107,25 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor())  {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 0, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 0, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // ASRC
@@ -89,6 +146,25 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor())  {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // PWGT
@@ -104,6 +180,25 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor())  {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // PWG
@@ -118,6 +213,25 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor()) {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // AWG
@@ -133,6 +247,25 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor())  {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // AWGT
@@ -151,6 +284,27 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor())  {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_FISHEYE, -1, 640, 480, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_FISHEYE, -1, 640, 480, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // AWGC
@@ -170,6 +324,24 @@ namespace librealsense
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
 
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     // AWGCT
@@ -190,6 +362,25 @@ namespace librealsense
               ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor()) {}
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
     };
 
     std::shared_ptr<device_interface> ds5_info::create(std::shared_ptr<context> ctx,

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -79,7 +79,7 @@ namespace librealsense
                     assign_stream(_owner->_gpio_streams[p->get_stream_index()-1], p);
                 if (p->get_framerate() == 1000 &&
                     p->get_format() == RS2_FORMAT_MOTION_XYZ32F)
-                    p->make_default();
+                    get_device().tag_profile(p.get());
 
                 //set motion intrinsics
                 if (p->get_stream_type() == RS2_STREAM_ACCEL || p->get_stream_type() == RS2_STREAM_GYRO)
@@ -127,8 +127,7 @@ namespace librealsense
 
                 auto video = dynamic_cast<video_stream_profile_interface*>(p.get());
 
-                if (video->get_width() == 640 && video->get_height() == 480 && video->get_format() == RS2_FORMAT_RAW8 && video->get_framerate() == 30)
-                    video->make_default();
+                get_device().tag_profile(video);
 
                 auto profile = to_profile(p.get());
                 std::weak_ptr<ds5_fisheye_sensor> wp =

--- a/src/ivcam/sr300.h
+++ b/src/ivcam/sr300.h
@@ -158,6 +158,15 @@ namespace librealsense
     class sr300_camera final : public virtual device, public debug_interface
     {
     public:
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            tags.push_back({ RS2_STREAM_COLOR, -1, 1920, 1080, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            return tags;
+        };
+
         class preset_option : public option_base
         {
         public:
@@ -228,9 +237,7 @@ namespace librealsense
                     // Register intrinsics
                     auto video = dynamic_cast<video_stream_profile_interface*>(p.get());
 
-
-                    if (video->get_width() == 1920 && video->get_height() == 1080 && video->get_format() == RS2_FORMAT_RGB8 && video->get_framerate() == 30)
-                        video->make_default();
+                    get_device().tag_profile(video);
 
                     auto profile = to_profile(p.get());
                     std::weak_ptr<sr300_color_sensor> wp =
@@ -286,9 +293,7 @@ namespace librealsense
                     // Register intrinsics
                     auto video = dynamic_cast<video_stream_profile_interface*>(p.get());
 
-
-                    if (video->get_width() == 640 && video->get_height() == 480 && video->get_format() == RS2_FORMAT_Z16 && video->get_framerate() == 30)
-                        video->make_default();
+                    get_device().tag_profile(video);
 
                     auto profile = to_profile(p.get());
                     std::weak_ptr<sr300_depth_sensor> wp =

--- a/src/l500/l500.h
+++ b/src/l500/l500.h
@@ -101,6 +101,15 @@ namespace librealsense
     class l500_device final : public virtual device, public debug_interface
     {
     public:
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            return tags;
+        };
+
         class l500_depth_sensor : public uvc_sensor, public video_sensor_interface, public depth_sensor
         {
         public:
@@ -138,14 +147,8 @@ namespace librealsense
 
                     // Register intrinsics
                     auto video = dynamic_cast<video_stream_profile_interface*>(p.get());
-                    if (video->get_width() == 640 && video->get_height() == 480 && video->get_format() == RS2_FORMAT_Z16 && video->get_framerate() == 30)
-                        video->make_default();
 
-                    if (video->get_width() == 640 && video->get_height() == 480 && video->get_format() == RS2_FORMAT_Y8 && video->get_framerate() == 30)
-                        video->make_default();
-
-                    if (video->get_width() == 640 && video->get_height() == 480 && video->get_format() == RS2_FORMAT_RAW8 && video->get_framerate() == 30)
-                        video->make_default();
+                    get_device().tag_profile(video);
 
                     auto profile = to_profile(p.get());
                     std::weak_ptr<l500_depth_sensor> wp =

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -34,6 +34,16 @@ playback_device::playback_device(std::shared_ptr<context> ctx, std::shared_ptr<d
     register_device_info(m_device_description);
     //Create playback sensor that simulate the recorded sensors
     m_sensors = create_playback_sensors(m_device_description);
+
+    //all of the recorded streams are marked as default
+    for (auto sensor_pair : m_sensors)
+    {
+        auto profiles = sensor_pair.second->get_stream_profiles();
+        for(auto profile : profiles)
+        {
+            tag_profile(profile.get());
+        }
+    }
     register_extrinsics(m_device_description);
 }
 

--- a/src/media/playback/playback_device.h
+++ b/src/media/playback/playback_device.h
@@ -48,6 +48,12 @@ namespace librealsense
         static bool try_extend_snapshot(std::shared_ptr<extension_snapshot>& e, rs2_extension extension_type, void** ext);
         bool is_valid() const override;
 
+        std::vector<tagged_profile> get_profiles_tags() const override { return std::vector<tagged_profile>(); };//no hard-coded default streams for playback
+        void tag_profile(stream_profile_interface* profile) const override 
+        {
+            profile->tag_profile(profile_tag::PROFILE_TAG_DEFAULT | profile_tag::PROFILE_TAG_SUPERSET);
+        }
+
     private:
         void update_time_base(device_serializer::nanoseconds base_timestamp);
         device_serializer::nanoseconds calc_sleep_time(device_serializer::nanoseconds  timestamp) const;

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -40,9 +40,20 @@ playback_sensor::~playback_sensor()
 {
 }
 
-stream_profiles playback_sensor::get_stream_profiles() const
+stream_profiles playback_sensor::get_stream_profiles(int tag) const
 {
     return m_available_profiles;
+    if (tag == profile_tag::PROFILE_TAG_ANY)
+        return m_available_profiles;
+
+    stream_profiles profiles;
+    for (auto p : m_available_profiles)
+    {
+        if (p->get_tag() & tag)
+            profiles.push_back(p);
+    }
+
+    return profiles;
 }
 
 void playback_sensor::open(const stream_profiles& requests)

--- a/src/media/playback/playback_sensor.h
+++ b/src/media/playback/playback_sensor.h
@@ -29,7 +29,7 @@ namespace librealsense
         playback_sensor(const device_interface& parent_device, const device_serializer::sensor_snapshot& sensor_description);
         virtual ~playback_sensor();
 
-        stream_profiles get_stream_profiles() const override;
+        stream_profiles get_stream_profiles(int tag = profile_tag::PROFILE_TAG_ANY) const override;
         void open(const stream_profiles& requests) override;
         void close() override;
         void register_notifications_callback(notifications_callback_ptr callback) override;

--- a/src/media/record/record_device.h
+++ b/src/media/record/record_device.h
@@ -43,6 +43,9 @@ namespace librealsense
         std::pair<uint32_t, rs2_extrinsics> get_extrinsics(const stream_interface& stream) const override;
         bool is_valid() const override;
 
+        std::vector<tagged_profile> get_profiles_tags() const override { return m_device->get_profiles_tags(); };
+        void tag_profile(stream_profile_interface* profile) const override { m_device->tag_profile(profile); }
+
     private:
         template <typename T> void write_device_extension_changes(const T& ext);
         template <rs2_extension E, typename P> bool extend_to_aux(std::shared_ptr<P> p, void** ext);

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -53,9 +53,9 @@ void librealsense::record_sensor::init()
     }
     LOG_DEBUG("Hooked to real sense");
 }
-stream_profiles record_sensor::get_stream_profiles() const
+stream_profiles record_sensor::get_stream_profiles(int tag) const
 {
-    return m_sensor.get_stream_profiles();
+    return m_sensor.get_stream_profiles(tag);
 }
 
 void librealsense::record_sensor::open(const stream_profiles& requests)

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -22,7 +22,7 @@ namespace librealsense
                       sensor_interface& sensor);
         virtual ~record_sensor();
         void init();
-        stream_profiles get_stream_profiles() const override;
+        stream_profiles get_stream_profiles(int tag = profile_tag::PROFILE_TAG_ANY) const override;
         void open(const stream_profiles& requests) override;
         void close() override;
         option& get_option(rs2_option id) override;

--- a/src/media/ros/ros_writer.h
+++ b/src/media/ros/ros_writer.h
@@ -307,7 +307,7 @@ namespace librealsense
         void write_stream_info(nanoseconds timestamp, const sensor_identifier& sensor_id, std::shared_ptr<stream_profile_interface> profile)
         {
             realsense_msgs::StreamInfo stream_info_msg;
-            stream_info_msg.is_recommended = profile->is_default();
+            stream_info_msg.is_recommended = profile->get_tag() & profile_tag::PROFILE_TAG_DEFAULT;
             convert(profile->get_format(), stream_info_msg.encoding);
             stream_info_msg.fps = profile->get_framerate();
             write_message(ros_topic::stream_info_topic({ sensor_id.device_index, sensor_id.sensor_index, profile->get_stream_type(), static_cast<uint32_t>(profile->get_stream_index()) }), timestamp, stream_info_msg);

--- a/src/mock/recorder.cpp
+++ b/src/mock/recorder.cpp
@@ -364,7 +364,25 @@ namespace librealsense
             });
         }
 
-        shared_ptr<recording> recording::load(const char* filename, const char* section, std::shared_ptr<playback_device_watcher> watcher)
+        static bool is_heighr_or_equel_to_min_version(std::string api_version, std::string min_api_version)
+        {
+            const int ver_size = 3;
+            int section_version[ver_size] = { -1, -1, -1 };
+            int min_version[ver_size] = { -1 ,-1 , -1 };
+            std::sscanf(api_version.c_str(), "%d.%d.%d", &section_version[0], &section_version[1], &section_version[2]);
+            std::sscanf(min_api_version.c_str(), "%d.%d.%d", &min_version[0], &min_version[1], &min_version[2]);
+            for (int i = 0; i < ver_size; i++)
+            {
+                if(min_version[i] < 0)
+                    throw runtime_error(to_string() << "Minimum provided version is in wrong format, expexted format: 0.0.0, actual string: " << min_api_version);
+                if (section_version[i] == min_version[i]) continue;
+                if (section_version[i] > min_version[i]) continue;
+                if (section_version[i] < min_version[i]) return false;
+            }
+            return true;
+        }
+
+        shared_ptr<recording> recording::load(const char* filename, const char* section, std::shared_ptr<playback_device_watcher> watcher, std::string min_api_version)
         {
             if (!file_exists(filename))
             {
@@ -403,6 +421,9 @@ namespace librealsense
                 select_api_version.bind(1, section_id);
                 select_api_version.bind(2, API_VERSION_KEY);
                 auto api_version = select_api_version()[0].get_string();
+                if(is_heighr_or_equel_to_min_version(api_version, min_api_version) == false)
+                    throw runtime_error(to_string() << "File version is lower than the minimum required version that was defind by the test, file version: " <<
+                        api_version << " min version: " << min_api_version);
                 LOG_WARNING("Loaded recording from API version " << api_version);
             }
 
@@ -1137,11 +1158,10 @@ namespace librealsense
             return _device_watcher;
         }
 
-        playback_backend::playback_backend(const char* filename, const char* section)
+        playback_backend::playback_backend(const char* filename, const char* section, std::string min_api_version)
             : _device_watcher(new playback_device_watcher(0)),
-            _rec(platform::recording::load(filename, section, _device_watcher))
+            _rec(platform::recording::load(filename, section, _device_watcher, min_api_version))
         {
-
             LOG_DEBUG("Starting section " << section);
         }
 

--- a/src/mock/recorder.h
+++ b/src/mock/recorder.h
@@ -111,7 +111,7 @@ namespace librealsense
 
             double get_time();
             void save(const char* filename, const char* section, bool append = false) const;
-            static std::shared_ptr<recording> load(const char* filename, const char* section, std::shared_ptr<playback_device_watcher> watcher = nullptr);
+            static std::shared_ptr<recording> load(const char* filename, const char* section, std::shared_ptr<playback_device_watcher> watcher = nullptr, std::string min_api_version = "");
 
             int save_blob(const void* ptr, size_t size);
 
@@ -593,7 +593,7 @@ namespace librealsense
             std::shared_ptr<time_service> create_time_service() const override;
             std::shared_ptr<device_watcher> create_device_watcher() const override;
 
-            explicit playback_backend(const char* filename, const char* section);
+            explicit playback_backend(const char* filename, const char* section, std::string min_api_version);
         private:
 
             std::shared_ptr<playback_device_watcher> _device_watcher;

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -577,6 +577,37 @@ namespace librealsense
         return false;
     }
 
+    bool pipeline::try_wait_for_frames(frame_holder* frame, unsigned int timeout_ms)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (!_active_profile)
+        {
+            throw librealsense::wrong_api_call_sequence_exception("wait_for_frames cannot be called before start()");
+        }
+
+        if (_pipeline_process->dequeue(frame, timeout_ms))
+        {
+            return true;
+        }
+
+        //hub returns true even if device already reconnected
+        if (!_hub.is_connected(*_active_profile->get_device()))
+        {
+            try
+            {
+                auto prev_conf = _prev_conf;
+                unsafe_stop();
+                unsafe_start(prev_conf);
+                return _pipeline_process->dequeue(frame, timeout_ms);
+            }
+            catch (const std::exception& e)
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+
     std::shared_ptr<device_interface> pipeline::wait_for_device(const std::chrono::milliseconds& timeout, const std::string& serial)
     {
         // Pipeline's device selection shall be deterministic

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -87,7 +87,7 @@ namespace librealsense
     {
         //empty
     }
-    void pipeline_config::enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int fps)
+    void pipeline_config::enable_stream(rs2_stream stream, int index, uint32_t width, uint32_t height, rs2_format format, uint32_t fps)
     {
         std::lock_guard<std::mutex> lock(_mtx);
         _resolved_profile.reset();
@@ -165,97 +165,77 @@ namespace librealsense
         _resolved_profile.reset();
     }
 
+    std::shared_ptr<pipeline_profile> pipeline_config::resolve(std::shared_ptr<device_interface> dev)
+    {
+        util::config config;
+
+        //if the user requested all streams
+        if (_enable_all_streams)
+        {
+            for (size_t i = 0; i < dev->get_sensors_count(); ++i)
+            {
+                auto&& sub = dev->get_sensor(i);
+                auto profiles = sub.get_stream_profiles(PROFILE_TAG_SUPERSET);
+                config.enable_streams(profiles);
+            }
+            return std::make_shared<pipeline_profile>(dev, config, _device_request.record_output);
+        }
+
+        //If the user did not request anything, give it the default, on playback all recorded streams are marked as default.
+        if (_stream_requests.empty())
+        {
+            auto default_profiles = get_default_configuration(dev);
+            config.enable_streams(default_profiles);
+            return std::make_shared<pipeline_profile>(dev, config, _device_request.record_output);
+        }
+
+        //Enabled requested streams
+        for (auto&& req : _stream_requests)
+        {
+            auto r = req.second;
+            config.enable_stream(r.stream, r.stream_index, r.width, r.height, r.format, r.fps);
+        }
+        return std::make_shared<pipeline_profile>(dev, config, _device_request.record_output);
+    }
+
     std::shared_ptr<pipeline_profile> pipeline_config::resolve(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout)
     {
         std::lock_guard<std::mutex> lock(_mtx);
         _resolved_profile.reset();
+
+        //Resolve the the device that was specified by the user, this call will wait in case the device is not availabe.
         auto requested_device = resolve_device_requests(pipe, timeout);
-
-        std::vector<stream_profile> resolved_profiles;
-
-        //if the user requested all streams, or if the requested device is from file and the user did not request any stream
-        if (_enable_all_streams || (!_device_request.filename.empty() && _stream_requests.empty()))
+        if (requested_device != nullptr)
         {
-            if (!requested_device)
-            {
-                requested_device = pipe->wait_for_device(timeout);
-            }
-
-            util::config config;
-            config.enable_all(util::best_quality);
-            _resolved_profile = std::make_shared<pipeline_profile>(requested_device, config, _device_request.record_output);
+            _resolved_profile = resolve(requested_device);
             return _resolved_profile;
         }
-        else
+
+        //Look for satisfy device in case the user did not specify one.
+        auto devs = pipe->get_context()->query_devices();
+        for (auto dev_info : devs)
         {
-            util::config config;
-
-            //If the user did not request anything, give it the default
-            if (_stream_requests.empty())
+            try
             {
-                if (!requested_device)
-                {
-                    requested_device = pipe->wait_for_device(timeout);
-                }
-
-                auto default_profiles = get_default_configuration(requested_device);
-                for (auto prof : default_profiles)
-                {
-                    auto p = dynamic_cast<video_stream_profile*>(prof.get());
-                    if (!p)
-                    {
-                        LOG_ERROR("prof is not video_stream_profile");
-                        throw std::logic_error("Failed to resolve request. internal error");
-                    }
-                    config.enable_stream(p->get_stream_type(), p->get_stream_index(), p->get_width(), p->get_height(), p->get_format(), p->get_framerate());
-                }
-
-                _resolved_profile = std::make_shared<pipeline_profile>(requested_device, config, _device_request.record_output);
+                auto dev = dev_info->create_device(true);
+                _resolved_profile = resolve(dev);
                 return _resolved_profile;
             }
-            else
+            catch (const std::exception& e)
             {
-                //User enabled some stream, enable only them
-                for(auto&& req : _stream_requests)
-                {
-                    auto r = req.second;
-                    config.enable_stream(r.stream, r.stream_index, r.width, r.height, r.format, r.fps);
-                }
-
-                if (!requested_device)
-                {
-                    //If the users did not request any device, select one for them
-                    auto devs = pipe->get_context()->query_devices();
-                    if (devs.empty())
-                    {
-                        auto dev = pipe->wait_for_device(timeout);
-                        _resolved_profile = std::make_shared<pipeline_profile>(dev, config, _device_request.record_output);
-                        return _resolved_profile;
-                    }
-                    else
-                    {
-                        for (auto dev_info : devs)
-                        {
-                            try
-                            {
-                                auto dev = dev_info->create_device(true);
-                                _resolved_profile = std::make_shared<pipeline_profile>(dev, config, _device_request.record_output);
-                                return _resolved_profile;
-                            }
-                            catch (...) {}
-                        }
-                    }
-
-                    throw std::runtime_error("Failed to resolve request. No device found that satisfies all requirements");
-                }
-                else
-                {
-                    //User specified a device, use it with the requested configuration
-                    _resolved_profile = std::make_shared<pipeline_profile>(requested_device, config, _device_request.record_output);
-                    return _resolved_profile;
-                }
+                LOG_DEBUG("Iterate available devices - config can not be resolved. " << e.what());
             }
         }
+
+        //If no device found wait for one
+        auto dev = pipe->wait_for_device(timeout);
+        if (dev != nullptr)
+        {
+            _resolved_profile = resolve(dev);
+            return _resolved_profile;
+        }
+
+        throw std::runtime_error("Failed to resolve request. No device found that satisfies all requirements");
 
         assert(0); //Unreachable code
     }
@@ -278,6 +258,7 @@ namespace librealsense
         }
         return true;
     }
+
     std::shared_ptr<device_interface> pipeline_config::get_or_add_playback_device(std::shared_ptr<pipeline> pipe, const std::string& file)
     {
         //Check if the file is already loaded to context, and if so return that device
@@ -350,31 +331,8 @@ namespace librealsense
         for (unsigned int i = 0; i < dev->get_sensors_count(); i++)
         {
             auto&& sensor = dev->get_sensor(i);
-            auto profiles = sensor.get_stream_profiles();
-
-            for (auto p : profiles)
-            {
-                if (p->is_default())
-                {
-                    default_profiles.push_back(p);
-                }
-            }
-        }
-
-        // Workaround - default profiles that holds color stream shouldn't supposed to provide infrared either
-        auto color_it = std::find_if(default_profiles.begin(), default_profiles.end(), [](std::shared_ptr<stream_profile_interface> p)
-                        {
-                            return p.get()->get_stream_type() == RS2_STREAM_COLOR;
-                        });
-
-        bool default_profiles_contains_color_stream = color_it != default_profiles.end();
-        if (default_profiles_contains_color_stream)
-        {
-            auto it = std::find_if(default_profiles.begin(), default_profiles.end(), [](std::shared_ptr<stream_profile_interface> p) {return p.get()->get_stream_type() == RS2_STREAM_INFRARED; });
-            if (it != default_profiles.end())
-            {
-                default_profiles.erase(it);
-            }
+            auto profiles = sensor.get_stream_profiles(profile_tag::PROFILE_TAG_DEFAULT);
+            default_profiles.insert(std::end(default_profiles), std::begin(profiles), std::end(profiles));
         }
 
         return default_profiles;

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -52,7 +52,7 @@ namespace librealsense
         std::shared_ptr<pipeline_profile> get_active_profile() const;
         frame_holder wait_for_frames(unsigned int timeout_ms = 5000);
         bool poll_for_frames(frame_holder* frame);
-
+        bool try_wait_for_frames(frame_holder* frame, unsigned int timeout_ms);
         //Non top level API
         std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::hours::max(),
                                                             const std::string& serial = "");

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -80,7 +80,7 @@ namespace librealsense
     {
     public:
         pipeline_config();
-        void enable_stream(rs2_stream stream, int index, int width, int height, rs2_format format, int framerate);
+        void enable_stream(rs2_stream stream, int index, uint32_t width, uint32_t height, rs2_format format, uint32_t framerate);
         void enable_all_stream();
         void enable_device(const std::string& serial);
         void enable_device_from_file(const std::string& file, bool repeat_playback);
@@ -116,6 +116,7 @@ namespace librealsense
         std::shared_ptr<device_interface> get_or_add_playback_device(std::shared_ptr<pipeline> pipe, const std::string& file);
         std::shared_ptr<device_interface> resolve_device_requests(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout);
         stream_profiles get_default_configuration(std::shared_ptr<device_interface> dev);
+        std::shared_ptr<pipeline_profile> resolve(std::shared_ptr<device_interface> dev);
 
         device_request _device_request;
         std::map<std::pair<rs2_stream, int>, util::config::request_type> _stream_requests;

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -919,6 +919,23 @@ int rs2_poll_for_frame(rs2_frame_queue* queue, rs2_frame** output_frame, rs2_err
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, queue, output_frame)
 
+int rs2_try_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, rs2_frame** output_frame, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(queue);
+    VALIDATE_NOT_NULL(output_frame);
+    librealsense::frame_holder fh;
+    if (!queue->queue.dequeue(&fh, timeout_ms))
+    {
+        return false;
+    }
+
+    frame_interface* result = nullptr;
+    std::swap(result, fh.frame);
+    *output_frame = (rs2_frame*)result;
+    return true;
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, queue, output_frame)
+
 void rs2_enqueue_frame(rs2_frame* frame, void* queue) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(frame);
@@ -1369,9 +1386,27 @@ HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
 int rs2_pipeline_poll_for_frames(rs2_pipeline * pipe, rs2_frame** output_frame, rs2_error ** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(pipe);
+    VALIDATE_NOT_NULL(output_frame);
 
     librealsense::frame_holder fh;
     if (pipe->pipe->poll_for_frames(&fh))
+    {
+        frame_interface* result = nullptr;
+        std::swap(result, fh.frame);
+        *output_frame = (rs2_frame*)result;
+        return true;
+    }
+    return false;
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, pipe, output_frame)
+
+int rs2_pipeline_try_wait_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, unsigned int timeout_ms, rs2_error ** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(pipe);
+    VALIDATE_NOT_NULL(output_frame);
+
+    librealsense::frame_holder fh;
+    if (pipe->pipe->try_wait_for_frames(&fh, timeout_ms))
     {
         frame_interface* result = nullptr;
         std::swap(result, fh.frame);

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -416,7 +416,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(, from, width, height)
 int rs2_is_stream_profile_default(const rs2_stream_profile* profile, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(profile);
-    return profile->profile->is_default() ? 1 : 0;
+    return profile->profile->get_tag() & profile_tag::PROFILE_TAG_DEFAULT ? 1 : 0;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, profile)
 
@@ -991,13 +991,23 @@ rs2_context* rs2_create_recording_context(int api_version, const char* filename,
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version, filename, section, mode)
 
+rs2_context* rs2_create_mock_context_versioned(int api_version, const char* filename, const char* section, const char* min_api_version, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(filename);
+    VALIDATE_NOT_NULL(section);
+    verify_version_compatibility(api_version);
+
+    return new rs2_context{ std::make_shared<librealsense::context>(librealsense::backend_type::playback, filename, section, RS2_RECORDING_MODE_COUNT, std::string(min_api_version)) };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version, filename, section)
+
 rs2_context* rs2_create_mock_context(int api_version, const char* filename, const char* section, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(filename);
     VALIDATE_NOT_NULL(section);
     verify_version_compatibility(api_version);
 
-    return new rs2_context{ std::make_shared<librealsense::context>(librealsense::backend_type::playback, filename, section) };
+    return new rs2_context{ std::make_shared<librealsense::context>(librealsense::backend_type::playback, filename, section, RS2_RECORDING_MODE_COUNT) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version, filename, section)
 

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -254,6 +254,22 @@ namespace librealsense
         }
     }
 
+    stream_profiles sensor_base::get_stream_profiles(int tag) const
+    {
+        if (tag == profile_tag::PROFILE_TAG_ANY)
+            return *_profiles;
+
+        stream_profiles results;
+        for (auto p : *_profiles)
+        {
+            auto curr_tag = p->get_tag();
+            if (curr_tag & tag)
+                results.push_back(p);
+        }
+
+        return results;
+    }
+
     stream_profiles uvc_sensor::init_stream_profiles()
     {
         std::unordered_set<std::shared_ptr<video_stream_profile>> results;
@@ -964,7 +980,6 @@ namespace librealsense
     {
         return _hid_device->get_custom_report_data(custom_sensor_name, report_name, report_field);
     }
-
 
     stream_profiles hid_sensor::init_stream_profiles()
     {

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -37,10 +37,7 @@ namespace librealsense
 
         virtual stream_profiles init_stream_profiles() = 0;
 
-        stream_profiles get_stream_profiles() const override
-        {
-            return *_profiles;
-        }
+        stream_profiles get_stream_profiles(int tag = profile_tag::PROFILE_TAG_ANY) const override;
 
         virtual stream_profiles get_active_streams() const override;
         notifications_callback_ptr get_notifications_callback() const override;

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -24,6 +24,13 @@ namespace librealsense
         void set_matcher_type(rs2_matchers matcher);
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> markers;
+            return markers;
+        };
+
     private:
         std::vector<std::shared_ptr<software_sensor>> _software_sensors;
         rs2_matchers _matcher = RS2_MATCHER_DEFAULT;

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -79,14 +79,14 @@ namespace librealsense
         _framerate = val;
     }
 
-    bool stream_profile_base::is_default() const
+    int stream_profile_base::get_tag() const
     {
-        return _is_default;
+        return _tag;
     }
 
-    void stream_profile_base::make_default()
+    void stream_profile_base::tag_profile(int tag)
     {
-        _is_default = true;
+        _tag = tag;
     }
 
     std::shared_ptr<stream_profile_interface> stream_profile_base::clone() const

--- a/src/stream.h
+++ b/src/stream.h
@@ -60,8 +60,8 @@ namespace librealsense
         uint32_t get_framerate() const override;
         void set_framerate(uint32_t val) override;
 
-        bool is_default() const override;
-        void make_default() override;
+        int get_tag() const override;
+        void tag_profile(int tag) override;
 
         int get_unique_id() const override { return _uid; }
         void set_unique_id(int uid) override
@@ -83,7 +83,7 @@ namespace librealsense
         rs2_stream _type = RS2_STREAM_ANY;
         rs2_format _format = RS2_FORMAT_ANY;
         uint32_t _framerate = 0;
-        bool _is_default = false;
+        int _tag = profile_tag::PROFILE_TAG_ANY;
         rs2_stream_profile _c_wrapper;
         rs2_stream_profile* _c_ptr = nullptr;
     };

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -19,7 +19,13 @@ endif()
 
 set(DEPENDENCIES realsense2)
 
-set (unit_tests_sources unit-tests-live.cpp unit-tests-post-processing.cpp unit-tests-post-processing.h unit-tests-main.cpp unit-tests-common.h)
+set (unit_tests_sources
+    unit-tests-live.cpp
+    unit-tests-post-processing.cpp
+    unit-tests-post-processing.h
+    unit-tests-main.cpp
+    unit-tests-common.h
+)
 
 add_executable(live-test ${unit_tests_sources})
 target_link_libraries(live-test ${DEPENDENCIES})

--- a/unit-tests/unit-tests-common.h
+++ b/unit-tests/unit-tests-common.h
@@ -79,7 +79,7 @@ inline bool file_exists(const std::string& filename)
     return f.good();
 }
 
-inline bool make_context(const char* id, rs2::context* ctx)
+inline bool make_context(const char* id, rs2::context* ctx, std::string min_api_version = "0.0.0")
 {
     rs2::log_to_file(RS2_LOG_SEVERITY_DEBUG);
 
@@ -130,14 +130,13 @@ inline bool make_context(const char* id, rs2::context* ctx)
         }
         else if (playback)
         {
-            *ctx = rs2::mock_context(base_filename, section);
+            *ctx = rs2::mock_context(base_filename, section, min_api_version);
         }
         command_line_params::instance()._found_any_section = true;
         return true;
     }
     catch (...)
     {
-
         return false;
     }
 

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -4372,7 +4372,6 @@ TEST_CASE("Pipeline record and playback", "[live][pipeline][using_pipeline][!may
     }
 }
 
-
 TEST_CASE("Pipeline enable bad configuration", "[pipeline][using_pipeline]")
 {
     rs2::context ctx;
@@ -4511,6 +4510,89 @@ TEST_CASE("Syncer sanity with software-device device", "[live][software-device]"
         }
     }
 }
+
+TEST_CASE("Syncer try wait for frames", "[live][software-device]") {
+    rs2::context ctx;
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    {
+        std::shared_ptr<software_device> dev = std::move(std::make_shared<software_device>());
+        auto s = dev->add_sensor("software_sensor");
+
+        const int W = 640, H = 480, BPP = 2;
+        rs2_intrinsics intrinsics{ W, H, 0, 0, 0, 0, RS2_DISTORTION_NONE ,{ 0,0,0,0,0 } };
+        s.add_video_stream({ RS2_STREAM_DEPTH, 0, 0, W, H, 60, BPP, RS2_FORMAT_Z16, intrinsics });
+        s.add_video_stream({ RS2_STREAM_INFRARED, 1, 1, W, H,60, BPP, RS2_FORMAT_Y8, intrinsics });
+        dev->create_matcher(RS2_MATCHER_DI);
+
+        auto profiles = s.get_stream_profiles();
+        syncer sync;
+        s.open(profiles);
+        s.start(sync);
+
+        std::vector<uint8_t> pixels(W * H * BPP, 0);
+        std::weak_ptr<rs2::software_device> weak_dev(dev);
+
+        auto depth = profiles[0];
+        auto ir = profiles[1];
+        std::thread t([&s, weak_dev, pixels, depth, ir]() mutable {
+
+            auto shared_dev = weak_dev.lock();
+            if (shared_dev == nullptr)
+                return;
+            s.on_video_frame({ pixels.data(), [](void*) {}, 0,0,0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 7, depth });
+            s.on_video_frame({ pixels.data(), [](void*) {}, 0,0,0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 5, ir });
+
+            s.on_video_frame({ pixels.data(), [](void*) {},0,0, 0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 8, depth });
+            s.on_video_frame({ pixels.data(), [](void*) {},0,0, 0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 6, ir });
+
+            s.on_video_frame({ pixels.data(), [](void*) {},0,0, 0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 8, ir });
+        });
+        t.detach();
+
+        std::vector<std::vector<std::pair<rs2_stream, int>>> expected =
+        {
+        { { RS2_STREAM_DEPTH , 7 } },
+        { { RS2_STREAM_INFRARED , 5 } },
+        { { RS2_STREAM_INFRARED , 6 } },
+        { { RS2_STREAM_DEPTH , 8 },{ RS2_STREAM_INFRARED , 8 } }
+        };
+
+        std::vector<std::vector<std::pair<rs2_stream, int>>> results;
+        for (auto i = 0; i < expected.size(); i++)
+        {
+            frameset fs;
+            REQUIRE(sync.try_wait_for_frames(&fs,5000));
+            std::vector < std::pair<rs2_stream, int>> curr;
+
+            for (auto f : fs)
+            {
+                curr.push_back({ f.get_profile().stream_type(), f.get_frame_number() });
+            }
+            results.push_back(curr);
+        }
+
+        CAPTURE(results.size());
+        CAPTURE(expected.size());
+        REQUIRE(results.size() == expected.size());
+
+        for (auto i = 0; i < expected.size(); i++)
+        {
+            auto exp = expected[i];
+            auto curr = results[i];
+            CAPTURE(exp.size());
+            CAPTURE(curr.size());
+            REQUIRE(exp.size() == curr.size());
+
+            for (auto j = 0; j < exp.size(); j++)
+            {
+                CAPTURE(exp[j].first);
+                CAPTURE(exp[j].second);
+                REQUIRE(std::find(curr.begin(), curr.end(), exp[j]) != curr.end());
+            }
+        }
+    }
+}
+
 
 TEST_CASE("Syncer clean_inactive_streams by frame number with software-device device", "[live][software-device]") {
     rs2::context ctx;

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -559,11 +559,11 @@ TEST_CASE("Device metadata enumerates correctly", "[live]")
 ////////////////////////////////////////////
 ////// Test basic streaming functionality //
 ////////////////////////////////////////////
-TEST_CASE("Start-Stop stream sequence", "[live]")
+TEST_CASE("Start-Stop stream sequence", "[live][using_pipeline]")
 {
     // Require at least one device to be plugged in
     rs2::context ctx;
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         std::vector<sensor> list;
         REQUIRE_NOTHROW(list = ctx.query_all_sensors());
@@ -2688,11 +2688,11 @@ struct stream_format
     int index;
 };
 
-TEST_CASE("Auto-complete feature works", "[offline][util::config]") {
+TEST_CASE("Auto-complete feature works", "[offline][util::config][using_pipeline]") {
     // dummy device can provide the following profiles:
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         struct Test {
             std::vector<stream_format> given;      // We give these profiles to the config class
@@ -2953,29 +2953,29 @@ void validate(std::vector<std::vector<stream_profile>> frames, std::vector<std::
 }
 
 static const std::map< dev_type, device_profiles> pipeline_default_configurations = {
-/* RS400/PSR*/          { { "0AD1", true}  ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true}},
-/* RS410/ASR*/          { { "0AD2", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true }},
-/* D410/USB2*/          { { "0AD2", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 15, true } },
+/* RS400/PSR*/          { { "0AD1", true}  ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 1 } }, 30, true}},
+/* RS410/ASR*/          { { "0AD2", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 1 } }, 30, true }},
+/* D410/USB2*/          { { "0AD2", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 15, true } },
 /* RS415/ASRC*/         { { "0AD3", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true }},
 /* D415/USB2*/          { { "0AD3", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 640, 480, 0 } }, 15, true } },
-/* RS430/AWG*/          { { "0AD4", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 } }, 30, true }},
-/* RS430_MM/AWGT*/      { { "0AD5", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true }},
-/* RS420/PWG*/          { { "0AF6", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true }},
-/* RS420_MM/PWGT*/      { { "0AFE", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true }},
-/* RS410_MM/ASRT*/      { { "0AFF", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
-/* RS400_MM/PSR*/       { { "0B00", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
+/* RS430/AWG*/          { { "0AD4", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 1280, 720, 1 } }, 30, true }},
+/* RS430_MM/AWGT*/      { { "0AD5", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 1280, 720, 1 } }, 30, true }},
+/* RS420/PWG*/          { { "0AF6", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 1280, 720, 1 } }, 30, true }},
+/* RS420_MM/PWGT*/      { { "0AFE", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 1280, 720, 1 } }, 30, true }},
+/* RS410_MM/ASRT*/      { { "0AFF", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 1 } }, 30, true } },
+/* RS400_MM/PSR*/       { { "0B00", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 1 } }, 30, true } },
 /* RS430_MM_RGB/AWGTC*/ { { "0B01", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true }},
-/* RS405/DS5U*/         { { "0B03", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true }},
+/* RS405/D460/DS5U*/    { { "0B03", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 1280, 720, 1 } }, 30, true }},
 /* RS435_RGB/AWGC*/     { { "0B07", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 1280, 720, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true }},
 /* D435/USB2*/          { { "0B07", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 640, 480, 0 } }, 15, true } },
 /* SR300*/              { { "0AA5", true } ,{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1920, 1080, 0 } }, 30, true } },
 };
 
-TEST_CASE("Pipeline wait_for_frames", "[live]") {
+TEST_CASE("Pipeline wait_for_frames", "[live][pipeline][using_pipeline]") {
 
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         rs2::device dev;
         rs2::pipeline pipe(ctx);
@@ -3037,11 +3037,11 @@ TEST_CASE("Pipeline wait_for_frames", "[live]") {
     }
 }
 
-TEST_CASE("Pipeline poll_for_frames", "[live]")
+TEST_CASE("Pipeline poll_for_frames", "[live][pipeline][using_pipeline]")
 {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -3106,19 +3106,19 @@ TEST_CASE("Pipeline poll_for_frames", "[live]")
 }
 
 static const std::map<dev_type, device_profiles> pipeline_custom_configurations = {
-    /* RS400/PSR*/      { {"0AD1", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
-    /* RS410/ASR*/      { {"0AD2", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
-    /* D410/USB2*/      { {"0AD2", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 480, 270, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 480, 270, 0 } }, 30, true } },
+    /* RS400/PSR*/      { {"0AD1", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+    /* RS410/ASR*/      { {"0AD2", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+    /* D410/USB2*/      { {"0AD2", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 480, 270, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 480, 270, 1 } }, 30, true } },
     /* RS415/ASRC*/     { {"0AD3", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
     /* D415/USB2*/      { {"0AD3", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 480, 270, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 424, 240, 0 } }, 30, true } },
     /* RS430/AWG*/      { {"0AD4", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 640, 480, 1 } }, 30, true } },
-    /* RS430_MM/AWGT*/  { {"0AD5", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
-    /* RS420/PWG*/      { {"0AF6", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
-    /* RS420_MM/PWGT*/  { {"0AFE", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
-    /* RS410_MM/ASRT*/  { {"0AFF", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
-    /* RS400_MM/PSR*/   { {"0B00", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
+    /* RS430_MM/AWGT*/  { {"0AD5", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 640, 480, 1 } }, 30, true } },
+    /* RS420/PWG*/      { {"0AF6", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 640, 480, 1 } }, 30, true } },
+    /* RS420_MM/PWGT*/  { {"0AFE", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_Y8, 640, 480, 1 } }, 30, true } },
+    /* RS410_MM/ASRT*/  { {"0AFF", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
+    /* RS400_MM/PSR*/   { {"0B00", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 1 } }, 30, true } },
     /* RS430_MC/AWGTC*/ { {"0B01", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
-    /* RS405/DS5U*/     { {"0B03", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
+    /* RS405/D460/DS5U*/{ {"0B03", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_INFRARED, RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
     /* RS435_RGB/AWGC*/ { {"0B07", true },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 640, 480, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1280, 720, 0 } }, 30, true } },
     /* D435/USB2*/      { {"0B07", false },{ { { RS2_STREAM_DEPTH, RS2_FORMAT_Z16, 480, 270, 0 },{ RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 424, 240, 0 } }, 30, true } },
 
@@ -3130,76 +3130,76 @@ static const std::map<dev_type, device_profiles> pipeline_custom_configurations 
                                      { RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 1920, 1080, 0 } }, 30, true } },
 };
 
-TEST_CASE("Pipeline enable stream", "[live]") {
+TEST_CASE("Pipeline enable stream", "[live][pipeline][using_pipeline]") {
 
     auto dev_requests = pipeline_custom_configurations;
 
     rs2::context ctx;
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (!make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
+        return;
+
+    auto list = ctx.query_devices();
+    REQUIRE(list.size());
+
+    rs2::device dev;
+    rs2::pipeline pipe(ctx);
+    rs2::config cfg;
+    rs2::pipeline_profile profile;
+    REQUIRE_NOTHROW(profile = cfg.resolve(pipe));
+    REQUIRE(profile);
+    REQUIRE_NOTHROW(dev = profile.get_device());
+    REQUIRE(dev);
+    disable_sensitive_options_for(dev);
+    dev_type PID = get_PID(dev);
+    CAPTURE(PID.first);
+    CAPTURE(PID.second);
+
+    if (dev_requests.end() == dev_requests.find(PID))
     {
-        auto list = ctx.query_devices();
-        REQUIRE(list.size());
+        WARN("Skipping test - the Device-Under-Test profile is not defined for PID " << PID.first << (PID.second ? " USB3" : " USB2"));
+    }
+    else
+    {
+        REQUIRE(dev_requests[PID].streams.size() > 0);
 
-        rs2::device dev;
-        rs2::pipeline pipe(ctx);
-        rs2::config cfg;
-        rs2::pipeline_profile profile;
-        REQUIRE_NOTHROW(profile = cfg.resolve(pipe));
+        for (auto req : pipeline_custom_configurations.at(PID).streams)
+            REQUIRE_NOTHROW(cfg.enable_stream(req.stream, req.index, req.width, req.height, req.format, dev_requests[PID].fps));
+
+        REQUIRE_NOTHROW(profile = pipe.start(cfg));
         REQUIRE(profile);
-        REQUIRE_NOTHROW(dev = profile.get_device());
-        REQUIRE(dev);
-        disable_sensitive_options_for(dev);
-        dev_type PID = get_PID(dev);
-        CAPTURE(PID.first);
-        CAPTURE(PID.second);
+        REQUIRE(std::string(profile.get_device().get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)) == dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+        std::vector<std::vector<stream_profile>> frames;
+        std::vector<std::vector<double>> timestamps;
 
-        if (dev_requests.end() == dev_requests.find(PID))
+        for (auto i = 0; i < 30; i++)
+            REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
+
+        auto actual_fps = dev_requests[PID].fps;
+
+        while (frames.size() < 100)
         {
-            WARN("Skipping test - the Device-Under-Test profile is not defined for PID " << PID.first << (PID.second ? " USB3" : " USB2"));
-        }
-        else
-        {
-            REQUIRE(dev_requests[PID].streams.size() > 0);
+            frameset frame;
+            REQUIRE_NOTHROW(frame = pipe.wait_for_frames(5000));
+            std::vector<stream_profile> frames_set;
+            std::vector<double> ts;
 
-            for (auto req : pipeline_custom_configurations.at(PID).streams)
-                REQUIRE_NOTHROW(cfg.enable_stream(req.stream, req.index, req.width, req.height, req.format, dev_requests[PID].fps));
-
-            REQUIRE_NOTHROW(profile = pipe.start(cfg));
-            REQUIRE(profile);
-            REQUIRE(std::string(profile.get_device().get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)) == dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
-            std::vector<std::vector<stream_profile>> frames;
-            std::vector<std::vector<double>> timestamps;
-
-            for (auto i = 0; i < 30; i++)
-                REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
-
-            auto actual_fps = dev_requests[PID].fps;
-
-            while (frames.size() < 100)
+            for (auto f : frame)
             {
-                frameset frame;
-                REQUIRE_NOTHROW(frame = pipe.wait_for_frames(5000));
-                std::vector<stream_profile> frames_set;
-                std::vector<double> ts;
-
-                for (auto f : frame)
+                if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                 {
-                    if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
-                    {
-                        auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
-                        if (val < actual_fps)
-                            actual_fps = val;
-                    }
-                    frames_set.push_back(f.get_profile());
-                    ts.push_back(f.get_timestamp());
+                    auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                    if (val < actual_fps)
+                        actual_fps = val;
                 }
-                frames.push_back(frames_set);
-                timestamps.push_back(ts);
+                frames_set.push_back(f.get_profile());
+                ts.push_back(f.get_timestamp());
             }
-
-            REQUIRE_NOTHROW(pipe.stop());
-            validate(frames, timestamps, dev_requests[PID], actual_fps);
+            frames.push_back(frames_set);
+            timestamps.push_back(ts);
         }
+
+        REQUIRE_NOTHROW(pipe.stop());
+        validate(frames, timestamps, dev_requests[PID], actual_fps);
     }
 }
 
@@ -3227,13 +3227,13 @@ static const std::map<dev_type, device_profiles> pipeline_autocomplete_configura
                                      { RS2_STREAM_COLOR, RS2_FORMAT_RGB8, 0, 0, 0 } }, 30, true } },
 };
 
-TEST_CASE("Pipeline enable stream auto complete", "[live]")
+TEST_CASE("Pipeline enable stream auto complete", "[live][pipeline][using_pipeline]")
 {
     auto configurations = pipeline_autocomplete_configurations;
 
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -3302,14 +3302,14 @@ TEST_CASE("Pipeline enable stream auto complete", "[live]")
     }
 }
 
-TEST_CASE("Pipeline disable_all", "[live]") {
+TEST_CASE("Pipeline disable_all", "[live][pipeline][using_pipeline]") {
 
     auto not_default_configurations = pipeline_custom_configurations;
     auto default_configurations = pipeline_default_configurations;
 
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -3380,13 +3380,13 @@ TEST_CASE("Pipeline disable_all", "[live]") {
     }
 }
 
-TEST_CASE("Pipeline disable stream", "[live]") {
+TEST_CASE("Pipeline disable stream", "[live][pipeline][using_pipeline]") {
 
     auto configurations = pipeline_custom_configurations;
 
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -3459,12 +3459,12 @@ TEST_CASE("Pipeline disable stream", "[live]") {
     }
 }
 // The test relies on default profiles that may alter
-TEST_CASE("Pipeline with specific device", "[live]")
+TEST_CASE("Pipeline with specific device", "[live][pipeline][using_pipeline]")
 {
 
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -3521,13 +3521,13 @@ bool operator==(std::vector<profile> streams1, std::vector<profile> streams2)
     return equals;
 }
 
-TEST_CASE("Pipeline start stop", "[live]") {
+TEST_CASE("Pipeline start stop", "[live][pipeline][using_pipeline]") {
 
     auto configurations = pipeline_custom_configurations;
 
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -3663,11 +3663,11 @@ static const std::map<dev_type, device_profiles> pipeline_configurations_for_ext
                                      { RS2_STREAM_COLOR,    RS2_FORMAT_RGB8, 640, 480, 0 } }, 30, true } },
                         };
 
-TEST_CASE("Pipeline get selection", "[live]") {
+TEST_CASE("Pipeline get selection", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
     auto configurations = pipeline_configurations_for_extrinsic;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -3933,10 +3933,10 @@ TEST_CASE("All suggested profiles can be opened", "[live][!mayfail]") {
     }
 }
 
-TEST_CASE("Pipeline config enable resolve start flow", "[live]") {
+TEST_CASE("Pipeline config enable resolve start flow", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         auto list = ctx.query_devices();
         REQUIRE(list.size());
@@ -4001,10 +4001,10 @@ TEST_CASE("Pipeline config enable resolve start flow", "[live]") {
     }
 }
 
-TEST_CASE("Pipeline - multicam scenario with specific devices", "[live][multicam]") {
+TEST_CASE("Pipeline - multicam scenario with specific devices", "[live][multicam][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
 
         auto list = ctx.query_devices();
@@ -4123,10 +4123,10 @@ TEST_CASE("Pipeline - multicam scenario with specific devices", "[live][multicam
     }
 }
 
-TEST_CASE("Empty Pipeline Profile", "[live]") {
+TEST_CASE("Empty Pipeline Profile", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         REQUIRE_NOTHROW(rs2::pipeline_profile p);
         rs2::pipeline_profile prof;
@@ -4201,10 +4201,10 @@ void require_pipeline_profile_same(const rs2::pipeline_profile& profile1, const 
         throw std::runtime_error(std::string("Profiles contain different streams"));
     }
 }
-TEST_CASE("Pipeline empty Config", "[live]") {
+TEST_CASE("Pipeline empty Config", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         REQUIRE_NOTHROW(rs2::config c);
         //Empty config
@@ -4221,10 +4221,10 @@ TEST_CASE("Pipeline empty Config", "[live]") {
     }
 }
 
-TEST_CASE("Pipeline 2 Configs", "[live]") {
+TEST_CASE("Pipeline 2 Configs", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         rs2::pipeline p(ctx);
         REQUIRE_NOTHROW(rs2::config c1);
@@ -4249,10 +4249,10 @@ TEST_CASE("Pipeline 2 Configs", "[live]") {
     }
 }
 
-TEST_CASE("Pipeline start after resolve uses the same profile", "[live]") {
+TEST_CASE("Pipeline start after resolve uses the same profile", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         rs2::pipeline pipe(ctx);
         rs2::config cfg;
@@ -4268,9 +4268,9 @@ TEST_CASE("Pipeline start after resolve uses the same profile", "[live]") {
     }
 }
 
-TEST_CASE("Pipeline start ignores previous config if it was changed", "[live]") {
+TEST_CASE("Pipeline start ignores previous config if it was changed", "[live][pipeline][using_pipeline][!mayfail]") {
     rs2::context ctx;
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         rs2::pipeline pipe(ctx);
         rs2::config cfg;
@@ -4284,10 +4284,11 @@ TEST_CASE("Pipeline start ignores previous config if it was changed", "[live]") 
         REQUIRE_THROWS(require_pipeline_profile_same(profile_from_cfg, profile_from_start));
     }
 }
-TEST_CASE("Pipeline Config disable all is a nop with empty config", "[live]") {
+
+TEST_CASE("Pipeline Config disable all is a nop with empty config", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         rs2::pipeline p(ctx);
         rs2::config c1;
@@ -4303,10 +4304,10 @@ TEST_CASE("Pipeline Config disable all is a nop with empty config", "[live]") {
         REQUIRE_NOTHROW(require_pipeline_profile_same(profile1, profile2));
     }
 }
-TEST_CASE("Pipeline Config disable each stream is nop on empty config", "[live]") {
+TEST_CASE("Pipeline Config disable each stream is nop on empty config", "[live][pipeline][using_pipeline]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         rs2::pipeline p(ctx);
         rs2::config c1;
@@ -4326,10 +4327,10 @@ TEST_CASE("Pipeline Config disable each stream is nop on empty config", "[live]"
     }
 }
 
-TEST_CASE("Pipeline record and playback", "[live]") {
+TEST_CASE("Pipeline record and playback", "[live][pipeline][using_pipeline][!mayfail]") {
     rs2::context ctx;
 
-    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
     {
         const std::string filename = get_folder_path(special_folder::temp_folder) + "test_file.bag";
         //Scoping the below code to make sure no one holds the device
@@ -4371,6 +4372,51 @@ TEST_CASE("Pipeline record and playback", "[live]") {
     }
 }
 
+
+TEST_CASE("Pipeline enable bad configuration", "[pipeline][using_pipeline]")
+{
+    rs2::context ctx;
+    if (!make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
+        return;
+
+    pipeline pipe(ctx);
+    rs2::config cfg;
+
+    cfg.enable_stream(rs2_stream::RS2_STREAM_COLOR, 1000);
+    REQUIRE_THROWS(pipe.start(cfg));
+}
+
+TEST_CASE("Pipeline stream enable hierarchy", "[pipeline]")
+{
+    rs2::context ctx;
+    if (!make_context(SECTION_FROM_TEST_NAME, &ctx, "2.13.0"))
+        return;
+
+    pipeline pipe(ctx);
+    rs2::config cfg;
+    std::vector<stream_profile> default_streams = pipe.start(cfg).get_streams();
+    pipe.stop();
+
+    cfg.enable_all_streams();
+    std::vector<stream_profile> all_streams = pipe.start(cfg).get_streams();
+    pipe.stop();
+
+    cfg.disable_all_streams();
+    cfg.enable_stream(rs2_stream::RS2_STREAM_DEPTH);
+    std::vector<stream_profile> wildcards_streams = pipe.start(cfg).get_streams();
+    pipe.stop();
+
+    for (auto d : default_streams)
+    {
+        auto it = std::find(begin(all_streams), end(all_streams), d);
+        REQUIRE(it != std::end(all_streams));
+    }
+    for (auto w : wildcards_streams)
+    {
+        auto it = std::find(begin(all_streams), end(all_streams), w);
+        REQUIRE(it != std::end(all_streams));
+    }
+}
 
 TEST_CASE("Syncer sanity with software-device device", "[live][software-device]") {
     rs2::context ctx;

--- a/wrappers/csharp/Intel.RealSense/NativeMethods.cs
+++ b/wrappers/csharp/Intel.RealSense/NativeMethods.cs
@@ -676,7 +676,7 @@ namespace Intel.RealSense
 
 
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr rs2_create_mock_context(int api_version, [MarshalAs(UnmanagedType.LPStr)] string filename, [MarshalAs(UnmanagedType.LPStr)] string section, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Helpers.ErrorMarshaler))] out object error);
+        internal static extern IntPtr rs2_create_mock_context(int api_version, [MarshalAs(UnmanagedType.LPStr)] string filename, [MarshalAs(UnmanagedType.LPStr)] string section, [MarshalAs(UnmanagedType.LPStr)] string min_api_version, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(Helpers.ErrorMarshaler))] out object error);
 
 
         #endregion


### PR DESCRIPTION
-Added API of try_wait_for_frame/s to frame_queue, syncer and pipeline.
 The function has the same functionality as wait_for_frame except in case of timeout try_wait_for_frame 
 returns false instead of throwing exception.
-Fixed bug of high CPU utilization in realsense-viewer

Wait for frames | CPU usage | Close delay
-- | -- | --
1 | 23% | Immediate
10 | 20% | Immediate
20 | 15% | Immediate
30 | 10% | Immediate
100 | 10% | Immediate
1000 | 10% | 1 sec

Tracked on: DSO-9381