### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/tools/rosbag-inspector/CMakeLists.txt
+++ b/tools/rosbag-inspector/CMakeLists.txt
@@ -5,6 +5,7 @@ project(RealsenseToolsRosbagInspector)
 
 # Save the command line compile commands in the build output
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+set(BUILD_GRAPHICAL_EXAMPLES 1)
 
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)


### PR DESCRIPTION
Explicitly set BUILD_GRAPHICAL_EXAMPLES to 1; otherwise, it is 0 if the SDK is installed using the binary (at least on Windows), and rs-rosbag-inspector project is not built.