### PR TITLE
Added functionality of no throw wait_for_frame

### DIFF
--- a/CMake/realsense.def
+++ b/CMake/realsense.def
@@ -93,6 +93,7 @@ EXPORTS
     rs2_delete_frame_queue
     rs2_wait_for_frame
     rs2_poll_for_frame
+    rs2_try_wait_for_frame
     rs2_enqueue_frame
     rs2_flush_queue
 
@@ -224,6 +225,7 @@ EXPORTS
     rs2_pipeline_stop
     rs2_pipeline_wait_for_frames
     rs2_pipeline_poll_for_frames
+    rs2_pipeline_try_wait_for_frames
     rs2_delete_pipeline
     rs2_pipeline_start
     rs2_pipeline_start_with_config

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3169,7 +3169,7 @@ namespace rs2
                 if(viewer.synchronization_enable)
                 {
                     auto index = 0;
-                    while (syncer_queue.poll_for_frame(&frm) && ++index <= syncer_queue.capacity())
+                    while (syncer_queue.try_wait_for_frame(&frm, 30) && ++index <= syncer_queue.capacity())
                     {
                         processing_block.invoke(frm);
                     }
@@ -3184,7 +3184,7 @@ namespace rs2
                     for (auto&& q : frames_queue_local)
                     {
                         frame frm;
-                        if (q.second.poll_for_frame(&frm))
+                        if (q.second.try_wait_for_frame(&frm, 30))
                         {
                             processing_block.invoke(frm);
                         }

--- a/include/librealsense2/h/rs_pipeline.h
+++ b/include/librealsense2/h/rs_pipeline.h
@@ -73,6 +73,22 @@ extern "C" {
     */
     int rs2_pipeline_poll_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, rs2_error ** error);
 
+    /**
+    * Wait until a new set of frames becomes available.
+    * The frames set includes time-synchronized frames of each enabled stream in the pipeline.
+    * The method blocks the calling thread, and fetches the latest unread frames set.
+    * Device frames, which were produced while the function wasn't called, are dropped. To avoid frame drops, this method should be called
+    * as fast as the device frame rate.
+    * The application can maintain the frames handles to defer processing. However, if the application maintains too long history, the device
+    * may lack memory resources to produce new frames, and the following call to this method shall fail to retrieve new frames, until resources
+    * are retained.
+    * \param[in] pipe           the pipeline
+    * \param[in] timeout_ms     max time in milliseconds to wait until a frame becomes available
+    * \param[out] output_frame  frame handle to be released using rs2_release_frame
+    * \param[out] error         if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return true if new frame was stored to output_frame
+    */
+    int rs2_pipeline_try_wait_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, unsigned int timeout_ms, rs2_error ** error);
 
     /**
     * Delete a pipeline instance.

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -117,6 +117,7 @@ void rs2_delete_frame_queue(rs2_frame_queue* queue);
 /**
 * wait until new frame becomes available in the queue and dequeue it
 * \param[in] queue the frame queue data structure
+* \param[in] timeout_ms   max time in milliseconds to wait until an exception will be thrown
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \return frame handle to be released using rs2_release_frame
 */
@@ -130,6 +131,16 @@ rs2_frame* rs2_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, r
 * \return true if new frame was stored to output_frame
 */
 int rs2_poll_for_frame(rs2_frame_queue* queue, rs2_frame** output_frame, rs2_error** error);
+
+/**
+* wait until new frame becomes available in the queue and dequeue it
+* \param[in] queue          the frame queue data structure
+* \param[in] timeout_ms     max time in milliseconds to wait until a frame becomes available
+* \param[out] output_frame  frame handle to be released using rs2_release_frame
+* \param[out] error         if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \return true if new frame was stored to output_frame
+*/
+int rs2_try_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, rs2_frame** output_frame, rs2_error** error);
 
 /**
 * enqueue new frame into a queue

--- a/include/librealsense2/hpp/rs_pipeline.hpp
+++ b/include/librealsense2/hpp/rs_pipeline.hpp
@@ -471,6 +471,20 @@ namespace rs2
             return res > 0;
         }
 
+        bool try_wait_for_frames(frameset* f, unsigned int timeout_ms = 5000) const
+        {
+            if (!f)
+            {
+                throw std::invalid_argument("null frameset");
+            }
+            rs2_error* e = nullptr;
+            rs2_frame* frame_ref = nullptr;
+            auto res = rs2_pipeline_try_wait_for_frames(_pipeline.get(), &frame_ref, timeout_ms, &e);
+            error::handle(e);
+            if (res) *f = frameset(frame(frame_ref));
+            return res > 0;
+        }
+
         /**
         * Return the active device and streams profiles, used by the pipeline.
         * The pipeline streams profiles are selected during \c start(). The method returns a valid result only when the pipeline is active -

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -577,6 +577,37 @@ namespace librealsense
         return false;
     }
 
+    bool pipeline::try_wait_for_frames(frame_holder* frame, unsigned int timeout_ms)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (!_active_profile)
+        {
+            throw librealsense::wrong_api_call_sequence_exception("try_wait_for_frames cannot be called before start()");
+        }
+
+        if (_pipeline_process->dequeue(frame, timeout_ms))
+        {
+            return true;
+        }
+
+        //hub returns true even if device already reconnected
+        if (!_hub.is_connected(*_active_profile->get_device()))
+        {
+            try
+            {
+                auto prev_conf = _prev_conf;
+                unsafe_stop();
+                unsafe_start(prev_conf);
+                return _pipeline_process->dequeue(frame, timeout_ms);
+            }
+            catch (const std::exception& e)
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+
     std::shared_ptr<device_interface> pipeline::wait_for_device(const std::chrono::milliseconds& timeout, const std::string& serial)
     {
         // Pipeline's device selection shall be deterministic

--- a/src/pipeline.h
+++ b/src/pipeline.h
@@ -52,7 +52,7 @@ namespace librealsense
         std::shared_ptr<pipeline_profile> get_active_profile() const;
         frame_holder wait_for_frames(unsigned int timeout_ms = 5000);
         bool poll_for_frames(frame_holder* frame);
-
+        bool try_wait_for_frames(frame_holder* frame, unsigned int timeout_ms);
         //Non top level API
         std::shared_ptr<device_interface> wait_for_device(const std::chrono::milliseconds& timeout = std::chrono::hours::max(),
                                                             const std::string& serial = "");

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -919,6 +919,23 @@ int rs2_poll_for_frame(rs2_frame_queue* queue, rs2_frame** output_frame, rs2_err
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, queue, output_frame)
 
+int rs2_try_wait_for_frame(rs2_frame_queue* queue, unsigned int timeout_ms, rs2_frame** output_frame, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(queue);
+    VALIDATE_NOT_NULL(output_frame);
+    librealsense::frame_holder fh;
+    if (!queue->queue.dequeue(&fh, timeout_ms))
+    {
+        return false;
+    }
+
+    frame_interface* result = nullptr;
+    std::swap(result, fh.frame);
+    *output_frame = (rs2_frame*)result;
+    return true;
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, queue, output_frame)
+
 void rs2_enqueue_frame(rs2_frame* frame, void* queue) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(frame);
@@ -1369,9 +1386,27 @@ HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe)
 int rs2_pipeline_poll_for_frames(rs2_pipeline * pipe, rs2_frame** output_frame, rs2_error ** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(pipe);
+    VALIDATE_NOT_NULL(output_frame);
 
     librealsense::frame_holder fh;
     if (pipe->pipe->poll_for_frames(&fh))
+    {
+        frame_interface* result = nullptr;
+        std::swap(result, fh.frame);
+        *output_frame = (rs2_frame*)result;
+        return true;
+    }
+    return false;
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, pipe, output_frame)
+
+int rs2_pipeline_try_wait_for_frames(rs2_pipeline* pipe, rs2_frame** output_frame, unsigned int timeout_ms, rs2_error ** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(pipe);
+    VALIDATE_NOT_NULL(output_frame);
+
+    librealsense::frame_holder fh;
+    if (pipe->pipe->try_wait_for_frames(&fh, timeout_ms))
     {
         frame_interface* result = nullptr;
         std::swap(result, fh.frame);

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -4660,3 +4660,87 @@ TEST_CASE("C API Compilation", "[live]") {
     REQUIRE_NOTHROW(rs2_set_devices_changed_callback(NULL, dev_changed, NULL, &e));
     REQUIRE(e != nullptr);
 }
+
+
+
+TEST_CASE("Syncer try wait for frames", "[live][software-device]") {
+    rs2::context ctx;
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx))
+    {
+        std::shared_ptr<software_device> dev = std::move(std::make_shared<software_device>());
+        auto s = dev->add_sensor("software_sensor");
+
+        const int W = 640, H = 480, BPP = 2;
+        rs2_intrinsics intrinsics{ W, H, 0, 0, 0, 0, RS2_DISTORTION_NONE ,{ 0,0,0,0,0 } };
+        s.add_video_stream({ RS2_STREAM_DEPTH, 0, 0, W, H, 60, BPP, RS2_FORMAT_Z16, intrinsics });
+        s.add_video_stream({ RS2_STREAM_INFRARED, 1, 1, W, H,60, BPP, RS2_FORMAT_Y8, intrinsics });
+        dev->create_matcher(RS2_MATCHER_DI);
+
+        auto profiles = s.get_stream_profiles();
+        syncer sync;
+        s.open(profiles);
+        s.start(sync);
+
+        std::vector<uint8_t> pixels(W * H * BPP, 0);
+        std::weak_ptr<rs2::software_device> weak_dev(dev);
+
+        auto depth = profiles[0];
+        auto ir = profiles[1];
+        std::thread t([&s, weak_dev, pixels, depth, ir]() mutable {
+
+            auto shared_dev = weak_dev.lock();
+            if (shared_dev == nullptr)
+                return;
+            s.on_video_frame({ pixels.data(), [](void*) {}, 0,0,0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 7, depth });
+            s.on_video_frame({ pixels.data(), [](void*) {}, 0,0,0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 5, ir });
+
+            s.on_video_frame({ pixels.data(), [](void*) {},0,0, 0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 8, depth });
+            s.on_video_frame({ pixels.data(), [](void*) {},0,0, 0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 6, ir });
+
+            s.on_video_frame({ pixels.data(), [](void*) {},0,0, 0, RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, 8, ir });
+        });
+        t.detach();
+
+        std::vector<std::vector<std::pair<rs2_stream, int>>> expected =
+        {
+            { { RS2_STREAM_DEPTH , 7 } },
+        { { RS2_STREAM_INFRARED , 5 } },
+        { { RS2_STREAM_INFRARED , 6 } },
+        { { RS2_STREAM_DEPTH , 8 },{ RS2_STREAM_INFRARED , 8 } }
+        };
+
+        std::vector<std::vector<std::pair<rs2_stream, int>>> results;
+        for (auto i = 0; i < expected.size(); i++)
+        {
+            frameset fs;
+            REQUIRE(sync.try_wait_for_frames(&fs, 5000));
+            std::vector < std::pair<rs2_stream, int>> curr;
+
+            for (auto f : fs)
+            {
+                curr.push_back({ f.get_profile().stream_type(), f.get_frame_number() });
+            }
+            results.push_back(curr);
+        }
+
+        CAPTURE(results.size());
+        CAPTURE(expected.size());
+        REQUIRE(results.size() == expected.size());
+
+        for (auto i = 0; i < expected.size(); i++)
+        {
+            auto exp = expected[i];
+            auto curr = results[i];
+            CAPTURE(exp.size());
+            CAPTURE(curr.size());
+            REQUIRE(exp.size() == curr.size());
+
+            for (auto j = 0; j < exp.size(); j++)
+            {
+                CAPTURE(exp[j].first);
+                CAPTURE(exp[j].second);
+                REQUIRE(std::find(curr.begin(), curr.end(), exp[j]) != curr.end());
+            }
+        }
+    }
+}


### PR DESCRIPTION
-Added API of try_wait_for_frame/s to frame_queue, syncer and pipeline.
 The function has the same functionality as wait_for_frame except in case of timeout try_wait_for_frame 
 returns false instead of throwing exception.
-Fixed bug of high CPU utilization in realsense-viewer

Wait for frames | CPU usage | Close delay
-- | -- | --
1 | 23% | Immediate
10 | 20% | Immediate
20 | 15% | Immediate
30 | 10% | Immediate
100 | 10% | Immediate
1000 | 10% | 1 sec

Tracked on: DSO-9381