### PR TITLE
Multi-cam sync between Global Shutter devices

### DIFF
--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -360,7 +360,7 @@ namespace librealsense
 
         std::string device_name = (rs400_sku_names.end() != rs400_sku_names.find(group.uvc_devices.front().pid)) ? rs400_sku_names.at(group.uvc_devices.front().pid) : "RS4xx";
         _fw_version = firmware_version(_hw_monitor->get_firmware_version_string(GVD, camera_fw_version_offset));
-        recommended_fw_version = firmware_version("5.9.9.2");
+        recommended_fw_version = firmware_version("5.9.14.0");
         auto serial = _hw_monitor->get_module_serial_string(GVD, module_serial_offset);
 
         auto& depth_ep = get_depth_sensor();

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -446,6 +446,13 @@ namespace librealsense
                 std::make_shared<asic_and_projector_temperature_options>(depth_ep,
                     RS2_OPTION_ASIC_TEMPERATURE));
         }
+
+        if (_fw_version >= firmware_version("5.9.15.1"))
+        {
+            get_depth_sensor().register_option(RS2_OPTION_INTER_CAM_SYNC_MODE,
+                std::make_shared<external_sync_mode>(*_hw_monitor));
+        }
+
         roi_sensor_interface* roi_sensor;
         if (roi_sensor = dynamic_cast<roi_sensor_interface*>(&depth_ep))
             roi_sensor->set_roi_method(std::make_shared<ds5_auto_exposure_roi_method>(*_hw_monitor));

--- a/src/ds5/ds5-rolling-shutter.cpp
+++ b/src/ds5/ds5-rolling-shutter.cpp
@@ -39,7 +39,8 @@ namespace librealsense
             get_depth_sensor().register_pixel_format(pf_rgb888);
         }
 
-        if ((_fw_version >= firmware_version("5.9.13.6")))
+        if ((_fw_version >= firmware_version("5.9.13.6") &&
+             _fw_version < firmware_version("5.9.15.1")))
         {
             get_depth_sensor().register_option(RS2_OPTION_INTER_CAM_SYNC_MODE,
                 std::make_shared<external_sync_mode>(*_hw_monitor));


### PR DESCRIPTION
From firmware 5.9.15.1 global shutter devices (D420, D430, D435) should also offer the option to set Maser / Slave configuration. At the moment this should only synchronize depth to depth, and not affect the color streams. 