### PR TITLE
Adding Two Dimensional Data Protocols for python wrapper (vtx & tex)

### DIFF
--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -116,6 +116,10 @@ PYBIND11_MODULE(NAME, m) {
             : _ptr(ptr), _itemsize(itemsize), _format(format), _ndim(ndim), _shape(shape), _strides(strides) {}
         BufData(void *ptr, size_t itemsize, const std::string &format, size_t size)
             : BufData(ptr, itemsize, format, 1, std::vector<size_t> { size }, std::vector<size_t> { itemsize }) { }
+        BufData( void *ptr       // Raw pointer
+                , size_t count  // Number of points
+                , size_t dim    // The number of floats inside a point
+        )  : BufData( ptr, sizeof(float), "@f", 2, std::vector<size_t> { count, dim }, std::vector<size_t> { sizeof(float)*dim, sizeof(float) })  { }
     };
 
     py::class_<BufData> BufData_py(m, "BufData", py::buffer_protocol());
@@ -397,6 +401,23 @@ PYBIND11_MODULE(NAME, m) {
     py::class_<rs2::points, rs2::frame> points(m, "points");
     points.def(py::init<>())
         .def(py::init<rs2::frame>())
+        .def("get_vertices_2d", [](rs2::points& self) -> BufData
+        {
+            return BufData(
+                    const_cast<rs2::vertex*>(self.get_vertices())
+                    , self.size()
+                    , 3
+            );
+
+        }, py::keep_alive<0, 1>())
+        .def("get_texture_coordinates_2d", [](rs2::points& self) -> BufData
+        {
+            return BufData(
+                    const_cast<rs2::texture_coordinate*>(self.get_texture_coordinates())
+                    , self.size()
+                    , 2
+            );
+        }, py::keep_alive<0, 1>())
         .def("get_vertices", [](rs2::points& self) -> BufData
     {
         return BufData(const_cast<rs2::vertex*>(self.get_vertices()),


### PR DESCRIPTION
Relating to this issue : 
https://github.com/erleben/pySoRo#adding-two-dimensional-data-protocols

I add two function in the python wrapper to get the vertices and textures coordinate compatible with open3d to do real time visualisation.

### The 2 new functions
```python
points.get_vertices_2d()
points.get_texture_coordinates_2d()
```
### The code to test : 
```python
import pyrealsense2 as rs
import numpy as np
from open3d import *


# Create a pipeline
pipeline = rs.pipeline()

# Create a config and configure the pipeline to stream
#  different resolutions of color and depth streams
config = rs.config()
config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
config.enable_stream(rs.stream.color, 640, 480, rs.format.rgb8, 30)

# Start streaming
profile = pipeline.start(config)


# Streaming loop
try:
    vis = Visualizer()
    vis.create_window("Test")
    pcd = PointCloud()
    while True:
        vis.add_geometry(pcd)
        pcd.clear()
        # Get frameset of color and depth
        frames = pipeline.wait_for_frames()
        color = frames.get_color_frame()
        depth = frames.get_depth_frame()
        if not color or not depth:
            continue
        pc = rs.pointcloud()
        pc.map_to(color)
        points = pc.calculate(depth)
        vtx = np.asanyarray(points.get_vertices_2d())
        pcd.points = Vector3dVector(vtx)
        vis.update_geometry()
        vis.poll_events()
        vis.update_renderer()
finally:
    pipeline.stop()

```