### PR TITLE
Multi-cam support in Unity wrapper

### DIFF
--- a/wrappers/unity/Assets/RealSenseSDK2.0/Editor/Tests/NewPlayModeTest.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Editor/Tests/NewPlayModeTest.cs
@@ -15,9 +15,8 @@ public class NewPlayModeTest
     {
         var go = new GameObject("RealSenseDevice", typeof(RealSenseDevice));
         Assert.NotNull(go);
-        Assert.NotNull(go.GetComponent<RealSenseDevice>());
 
-        var rs = RealSenseDevice.Instance;
+        var rs = go.GetComponent<RealSenseDevice>();
         Assert.NotNull(rs);
 
         bool started = false;
@@ -39,7 +38,6 @@ public class NewPlayModeTest
         GameObject.Destroy(go);
         yield return null;
         Assert.That(go == null);
-        Assert.IsNull(RealSenseDevice.Instance);
     }
 
     [UnityTest]
@@ -47,6 +45,7 @@ public class NewPlayModeTest
     public IEnumerator TestLiveDepthTexture()
     {
         var go = new GameObject("RealSenseDevice", typeof(RealSenseDevice));
+        var rs = go.GetComponent<RealSenseDevice>();
 
         var depth_go = new GameObject("Depth");
         var depth = depth_go.AddComponent<RealSenseStreamTexture>();
@@ -60,10 +59,10 @@ public class NewPlayModeTest
         Texture depth_tex = null;
         depth.textureBinding.AddListener(t => depth_tex = t);
 
-        yield return new WaitUntil(() => RealSenseDevice.Instance.Streaming);
+        yield return new WaitUntil(() => rs.Streaming);
         Assert.IsNotNull(depth_tex);
 
-        using (var depth_profile = RealSenseDevice.Instance.ActiveProfile.GetStream(Stream.Depth) as VideoStreamProfile)
+        using (var depth_profile = rs.ActiveProfile.GetStream(Stream.Depth) as VideoStreamProfile)
         {
             Assert.AreEqual(depth_tex.width, depth_profile.Width);
             Assert.AreEqual(depth_tex.height, depth_profile.Height);
@@ -79,7 +78,7 @@ public class NewPlayModeTest
     public IEnumerator TestDisabledNoStart()
     {
         var go = new GameObject("RealSenseDevice", typeof(RealSenseDevice));
-        var rs = RealSenseDevice.Instance;
+        var rs = go.GetComponent<RealSenseDevice>();
 
         rs.OnStop += Assert.Fail;
         rs.OnStart += delegate
@@ -92,7 +91,6 @@ public class NewPlayModeTest
         GameObject.Destroy(go);
         yield return null;
         Assert.That(go == null);
-        Assert.IsNull(RealSenseDevice.Instance);
     }
 
     [UnityTest]
@@ -100,7 +98,7 @@ public class NewPlayModeTest
     public IEnumerator TestDisableStop()
     {
         var go = new GameObject("RealSenseDevice", typeof(RealSenseDevice));
-        var rs = RealSenseDevice.Instance;
+        var rs = go.GetComponent<RealSenseDevice>();
 
         bool started = false;
         rs.OnStart += delegate
@@ -130,7 +128,7 @@ public class NewPlayModeTest
     public void TestExtrinsics()
     {
         var go = new GameObject("RealSenseDevice", typeof(RealSenseDevice));
-        var rs = RealSenseDevice.Instance;
+        var rs = go.GetComponent<RealSenseDevice>();
 
         var depth = rs.ActiveProfile.GetStream(Stream.Depth);
         Assert.IsNotNull(depth);
@@ -150,7 +148,7 @@ public class NewPlayModeTest
     public IEnumerator TestRecord()
     {
         var go = new GameObject("RealSenseDevice", typeof(RealSenseDevice));
-        var rs = RealSenseDevice.Instance;
+        var rs = go.GetComponent<RealSenseDevice>();
 
         go.SetActive(false);
 

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseARBackgroundRenderer.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseARBackgroundRenderer.cs
@@ -8,6 +8,21 @@ using UnityEngine.XR;
 
 public class RealSenseARBackgroundRenderer : MonoBehaviour
 {
+    [SerializeField]
+    private RealSenseDevice _realSenseDevice;
+    protected RealSenseDevice realSenseDevice
+    {
+        get
+        {
+            if (_realSenseDevice == null)
+            {
+                _realSenseDevice = FindObjectOfType<RealSenseDevice>();
+            }
+            UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
+            return _realSenseDevice;
+        }
+    }
+
     public Material material;
     private Camera cam;
     private ARBackgroundRenderer bg;
@@ -18,9 +33,9 @@ public class RealSenseARBackgroundRenderer : MonoBehaviour
 
     IEnumerator Start()
     {
-        yield return new WaitUntil(() => RealSenseDevice.Instance.Streaming);
+        yield return new WaitUntil(() => realSenseDevice.Streaming);
 
-        using (var profile = RealSenseDevice.Instance.ActiveProfile.GetStream(Stream.Color) as VideoStreamProfile)
+        using (var profile = realSenseDevice.ActiveProfile.GetStream(Stream.Color) as VideoStreamProfile)
         {
             intrinsics = profile.GetIntrinsics();
         }

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseARBackgroundRenderer.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseARBackgroundRenderer.cs
@@ -10,7 +10,7 @@ public class RealSenseARBackgroundRenderer : MonoBehaviour
 {
     [SerializeField]
     private RealSenseDevice _realSenseDevice;
-    protected RealSenseDevice realSenseDevice
+    public RealSenseDevice realSenseDevice
     {
         get
         {
@@ -20,6 +20,10 @@ public class RealSenseARBackgroundRenderer : MonoBehaviour
             }
             UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
             return _realSenseDevice;
+        }
+        set
+        {
+            _realSenseDevice = value;
         }
     }
 

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseAlignImages.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseAlignImages.cs
@@ -45,7 +45,7 @@ public class RealSenseAlignImages : RealSenseStreamTexture
         texture.Apply();
         textureBinding.Invoke(texture);
 
-        RealSenseDevice.Instance.onNewSampleSet += OnFrameSet;
+        realSenseDevice.onNewSampleSet += OnFrameSet;
     }
 
     private void OnFrameSet(FrameSet frames)

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseDevice.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseDevice.cs
@@ -21,9 +21,7 @@ public class RealSenseDevice : MonoBehaviour
         Multithread,
         UnityThread,
     }
-
-    public static RealSenseDevice Instance { get; private set; }
-
+    
     /// <summary>
     /// Threading mode of operation, Multithreasds or Unitythread
     /// </summary>
@@ -74,10 +72,6 @@ public class RealSenseDevice : MonoBehaviour
 
     void Awake()
     {
-        if (Instance != null && Instance != this)
-            throw new Exception(string.Format("{0} singleton already instanced", this.GetType()));
-        Instance = this;
-
         // m_pipeline = new Pipeline();
         // m_config = DeviceConfiguration.ToPipelineConfig();
         // ActiveProfile = m_config.Resolve(m_pipeline);
@@ -169,8 +163,6 @@ public class RealSenseDevice : MonoBehaviour
         if (m_pipeline != null)
             m_pipeline.Release();
         m_pipeline = null;
-
-        Instance = null;
     }
 
     /// <summary>

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseDeviceInspector.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseDeviceInspector.cs
@@ -6,6 +6,20 @@ using System.Collections;
 
 public class RealSenseDeviceInspector : MonoBehaviour
 {
+    [SerializeField]
+    private RealSenseDevice _realSenseDevice;
+    protected RealSenseDevice realSenseDevice
+    {
+        get
+        {
+            if (_realSenseDevice == null)
+            {
+                _realSenseDevice = FindObjectOfType<RealSenseDevice>();
+            }
+            UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
+            return _realSenseDevice;
+        }
+    }
 
     public bool streaming;
     public Device device;
@@ -20,9 +34,9 @@ public class RealSenseDeviceInspector : MonoBehaviour
 
     private IEnumerator WaitForDevice()
     {
-        yield return new WaitUntil(() => RealSenseDevice.Instance != null);
-        RealSenseDevice.Instance.OnStart += onStartStreaming;
-        RealSenseDevice.Instance.OnStop += onStopStreaming;
+        yield return new WaitUntil(() => realSenseDevice != null);
+        realSenseDevice.OnStart += onStartStreaming;
+        realSenseDevice.OnStop += onStopStreaming;
     }
 
     private void onStopStreaming()

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseDeviceInspector.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseDeviceInspector.cs
@@ -8,7 +8,7 @@ public class RealSenseDeviceInspector : MonoBehaviour
 {
     [SerializeField]
     private RealSenseDevice _realSenseDevice;
-    protected RealSenseDevice realSenseDevice
+    public RealSenseDevice realSenseDevice
     {
         get
         {
@@ -18,6 +18,10 @@ public class RealSenseDeviceInspector : MonoBehaviour
             }
             UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
             return _realSenseDevice;
+        }
+        set
+        {
+            _realSenseDevice = value;
         }
     }
 

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSensePointCloudGenerator.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSensePointCloudGenerator.cs
@@ -13,7 +13,7 @@ public class RealSensePointCloudGenerator : MonoBehaviour
 {
     [SerializeField]
     private RealSenseDevice _realSenseDevice;
-    protected RealSenseDevice realSenseDevice
+    public RealSenseDevice realSenseDevice
     {
         get
         {
@@ -23,6 +23,10 @@ public class RealSensePointCloudGenerator : MonoBehaviour
             }
             UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
             return _realSenseDevice;
+        }
+        set
+        {
+            _realSenseDevice = value;
         }
     }
 

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSensePointCloudGenerator.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSensePointCloudGenerator.cs
@@ -11,6 +11,21 @@ using System.Threading;
 [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
 public class RealSensePointCloudGenerator : MonoBehaviour
 {
+    [SerializeField]
+    private RealSenseDevice _realSenseDevice;
+    protected RealSenseDevice realSenseDevice
+    {
+        get
+        {
+            if (_realSenseDevice == null)
+            {
+                _realSenseDevice = FindObjectOfType<RealSenseDevice>();
+            }
+            UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
+            return _realSenseDevice;
+        }
+    }
+
     public Stream stream = Stream.Color;
     Mesh mesh;
     Texture2D uvmap;
@@ -28,8 +43,8 @@ public class RealSensePointCloudGenerator : MonoBehaviour
 
     void Start()
     {
-        RealSenseDevice.Instance.OnStart += OnStartStreaming;
-        RealSenseDevice.Instance.OnStop += OnStopStreaming;
+        realSenseDevice.OnStart += OnStartStreaming;
+        realSenseDevice.OnStop += OnStopStreaming;
     }
 
     private void OnStartStreaming(PipelineProfile activeProfile)
@@ -95,7 +110,7 @@ public class RealSensePointCloudGenerator : MonoBehaviour
             GetComponent<MeshFilter>().sharedMesh = mesh;
         }
 
-        RealSenseDevice.Instance.onNewSampleSet += OnFrames;
+        realSenseDevice.onNewSampleSet += OnFrames;
     }
 
     void OnDestroy()

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseStreamTexture.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseStreamTexture.cs
@@ -9,16 +9,20 @@ public class RealSenseStreamTexture : MonoBehaviour
 {
     [SerializeField]
     private RealSenseDevice _realSenseDevice;
-    protected RealSenseDevice realSenseDevice
+    public RealSenseDevice realSenseDevice
     {
         get
         {
-            if(_realSenseDevice == null)
+            if (_realSenseDevice == null)
             {
                 _realSenseDevice = FindObjectOfType<RealSenseDevice>();
             }
             UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
             return _realSenseDevice;
+        }
+        set
+        {
+            _realSenseDevice = value;
         }
     }
 

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseStreamTexture.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RealSenseStreamTexture.cs
@@ -7,6 +7,21 @@ using UnityEngine.Events;
 
 public class RealSenseStreamTexture : MonoBehaviour
 {
+    [SerializeField]
+    private RealSenseDevice _realSenseDevice;
+    protected RealSenseDevice realSenseDevice
+    {
+        get
+        {
+            if(_realSenseDevice == null)
+            {
+                _realSenseDevice = FindObjectOfType<RealSenseDevice>();
+            }
+            UnityEngine.Assertions.Assert.IsNotNull(_realSenseDevice);
+            return _realSenseDevice;
+        }
+    }
+
     [System.Serializable]
     public class TextureEvent : UnityEvent<Texture> { }
 
@@ -43,14 +58,14 @@ public class RealSenseStreamTexture : MonoBehaviour
 
     void Start()
     {
-        RealSenseDevice.Instance.OnStart += OnStartStreaming;
-        RealSenseDevice.Instance.OnStop += OnStopStreaming;
+        realSenseDevice.OnStart += OnStartStreaming;
+        realSenseDevice.OnStop += OnStopStreaming;
     }
 
     protected virtual void OnStopStreaming()
     {
-        RealSenseDevice.Instance.onNewSample -= OnNewSampleUnityThread;
-        RealSenseDevice.Instance.onNewSample -= OnNewSampleThreading;
+        realSenseDevice.onNewSample -= OnNewSampleUnityThread;
+        realSenseDevice.onNewSample -= OnNewSampleThreading;
 
         f.Reset();
         data = null;
@@ -80,19 +95,18 @@ public class RealSenseStreamTexture : MonoBehaviour
             texture.Apply();
             textureBinding.Invoke(texture);
         }
-
-        if (RealSenseDevice.Instance.processMode == RealSenseDevice.ProcessMode.UnityThread)
+        if (realSenseDevice.processMode == RealSenseDevice.ProcessMode.UnityThread)
         {
             UnityEngine.Assertions.Assert.AreEqual(threadId, Thread.CurrentThread.ManagedThreadId);
-            RealSenseDevice.Instance.onNewSample += OnNewSampleUnityThread;
+            realSenseDevice.onNewSample += OnNewSampleUnityThread;
         }
         else
-            RealSenseDevice.Instance.onNewSample += OnNewSampleThreading;
+            realSenseDevice.onNewSample += OnNewSampleThreading;
     }
 
     public void OnFrame(Frame f)
     {
-        if (RealSenseDevice.Instance.processMode == RealSenseDevice.ProcessMode.UnityThread)
+        if (realSenseDevice.processMode == RealSenseDevice.ProcessMode.UnityThread)
         {
             UnityEngine.Assertions.Assert.AreEqual(threadId, Thread.CurrentThread.ManagedThreadId);
             OnNewSampleUnityThread(f);


### PR DESCRIPTION
Currently, _RealSenseDevice_ is a singleton. which allow only one device enable in Unity. Remove the singleton instance to enable the feature. Can have more support to select one device in the list and use the serial number to activate it.

![image](https://user-images.githubusercontent.com/40443076/43280059-ae5f72e0-90c4-11e8-953f-05983444b5c4.png)
