### PR TITLE
Enhancement of box_dimensioner_multicam python exemple

### DIFF
--- a/wrappers/python/examples/box_dimensioner_multicam/realsense_device_manager.py
+++ b/wrappers/python/examples/box_dimensioner_multicam/realsense_device_manager.py
@@ -211,7 +211,8 @@ class DeviceManager:
 		frames = {}
 		for (serial, device) in self._enabled_devices.items():
 			streams = device.pipeline_profile.get_streams()
-			frameset = device.pipeline.wait_for_frames()
+			frameset = rs.composite_frame(rs.frame())
+            device.pipeline.poll_for_frames(frameset)
 			if frameset.size() == len(streams):
 				frames[serial] = {}
 				for stream in streams:


### PR DESCRIPTION
Enhancement of poll_frames() function of the realsense_devices_manager.py which was calling wait_for_frames() instead of poll_for_frames()box_dimensioner_multicam