### PR TITLE
Include SSSE3 intrinsics unconditionally to fix compilation with CUDA.

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -8,8 +8,9 @@
 
 #ifdef RS2_USE_CUDA
 #include "cuda/cuda-conversion.cuh"
-#elif __SSSE3__
-#include <tmmintrin.h> // For SSE3 intrinsic used in unpack_yuy2_sse
+#endif
+#ifdef __SSSE3__
+#include <tmmintrin.h> // For SSSE3 intrinsics
 #endif
 
 #if defined (ANDROID) || (defined (__linux__) && !defined (__x86_64__))

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -14,8 +14,9 @@
 
 #ifdef RS2_USE_CUDA
 #include "../cuda/cuda-pointcloud.cuh"
-#elif __SSSE3__
-#include <tmmintrin.h> // For SSE3 intrinsic used in unpack_yuy2_sse
+#endif
+#ifdef __SSSE3__
+#include <tmmintrin.h> // For SSSE3 intrinsics
 #endif
 
 


### PR DESCRIPTION
This fixes a compilation bug under Gentoo Linux (GCC 7.3.0) when building with CUDA support. The error is that intrinsics such as `__m128i` in `image.cpp` functions `unpack_rw10_from_rw8` and `unpack_y8_from_rw10` are missing due to `<tmmintrin.h>` not being included when CUDA is enabled.

The solution is that `<tmmintrin.h>` header needs to be included regardless of CUDA headers.