### PR TITLE
Retrieving public key for debians repo behind firewall and proxy. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_install:
       brew install xctool --HEAD;
       brew install homebrew/core/glfw3;
       brew list libusb || brew install libusb;
-      brew upgrade libusb;
     fi
 
   # Install linux required packages

--- a/doc/distribution_linux.md
+++ b/doc/distribution_linux.md
@@ -3,15 +3,17 @@
 **Intel® RealSense™ SDK 2.0** provides installation packages in [`dpkg`](https://en.wikipedia.org/wiki/Dpkg) format for Ubuntu 16/18 LTS.    
 \* The Realsense [DKMS](https://en.wikipedia.org/wiki/Dynamic_Kernel_Module_Support) kernel drivers package (`librealsense2-dkms`) supports Ubuntu LTS kernels 4.4, 4.10, 4.13 and 4.15\*.
 
-**Note** Kernel 4.16 introduces some non-compatible modification to uvcvideo and media subsystem. We work to support it in future releases, but at this time the support is scoped up to kernel 4.15 and the affected users are requested to downgrade the kernel version.
+**Note** Kernel 4.16 introduced a major change to uvcvideo and media subsystem. While we work to add support v4.16 in future releases,  **librealsense** is verified to run correctly with kernels v4.4-v4.15; the affected users are requested to downgrade the kernel version.
 
 
 >To build the project from sources and prepare/patch the OS manually please follow steps described [here](./installation.md).
 
 
 ## Installing the packages:
-- Register Intel's repository server's public key :  
-`sudo apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-key C8B3A55A6F3EFCDE`  
+- Register the server's public key :  
+`sudo apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C8B3A55A6F3EFCDE`  
+In case the public key still cannot be retrieved, check and specify proxy settings: `export http_proxy="http://<proxy>:<port>"`  
+, and rerun the command. See additional methods in the following [link](https://unix.stackexchange.com/questions/361213/unable-to-add-gpg-key-with-apt-key-behind-a-proxy).  
 
 - Add the server to the list of repositories :  
   Ubuntu 16 LTS:  


### PR DESCRIPTION
Add alternative keyserver with port 80 to retrieve pgp public key behind a Firewall.
Also add instruction to apply proxy settings.
Rectify MacOS CI by removing libusb upgrade request

Change-Id: I4c09ef3f2f39bddcb8fa8706b98629b2e96eb360