### PR TITLE
[Viewer] Show <Set ROI> button only for sensors that are ROI type

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -636,7 +636,7 @@ namespace rs2
 
             }
 
-            if (!read_only && opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && dev->auto_exposure_enabled && dev->streaming)
+            if (!read_only && opt == RS2_OPTION_ENABLE_AUTO_EXPOSURE && dev->auto_exposure_enabled  && dev->s->is<roi_sensor>() && dev->streaming)
             {
                 ImGui::SameLine(0, 10);
                 std::string button_label = label;


### PR DESCRIPTION
Tracked on: DSO-9738