### PR TITLE
Public accessor for m_instance field of Sensor class

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Sensor.cs
+++ b/wrappers/csharp/Intel.RealSense/Sensor.cs
@@ -95,6 +95,11 @@ namespace Intel.RealSense
     public class Sensor : IDisposable
     {
         protected readonly IntPtr m_instance;
+        
+        public IntPtr Instance 
+        {
+            get { return m_instance; }
+        }
 
         internal Sensor(IntPtr sensor)
         {


### PR DESCRIPTION
Added public accessor for m_instance field of Sensor class in .NET wrapper to enable operation on native methods that are not available through the wrapper at the moment.