### PR TITLE
Linux Kernel  4.16  support - basic functionality

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2561,11 +2561,15 @@ namespace rs2
             ImGui::End();
             ImGui::PopStyleColor(6);
             ImGui::PopStyleVar(2);
+
         }
     }
 
     void stream_model::show_stream_footer(ImFont* font, const rect &stream_rect, const  mouse_info& mouse)
     {
+        if (show_stream_details) // Evgeni Temporal
+            show_metadata(mouse);
+
         if (stream_rect.contains(mouse.cursor))
         {
             std::stringstream ss;

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2561,15 +2561,11 @@ namespace rs2
             ImGui::End();
             ImGui::PopStyleColor(6);
             ImGui::PopStyleVar(2);
-
         }
     }
 
     void stream_model::show_stream_footer(ImFont* font, const rect &stream_rect, const  mouse_info& mouse)
     {
-        if (show_stream_details) // Evgeni Temporal
-            show_metadata(mouse);
-
         if (stream_rect.contains(mouse.cursor))
         {
             std::stringstream ss;

--- a/examples/capture/rs-capture.cpp
+++ b/examples/capture/rs-capture.cpp
@@ -8,7 +8,7 @@
 // capture depth and color video streams and render them to the screen
 int main(int argc, char * argv[]) try
 {
-    rs2::log_to_console(RS2_LOG_SEVERITY_ERROR);
+    rs2::log_to_console(RS2_LOG_SEVERITY_INFO);
     // Create a simple OpenGL window for rendering:
     window app(1280, 720, "RealSense Capture Example");
     // Declare two textures on the GPU, one for color and one for depth
@@ -19,23 +19,23 @@ int main(int argc, char * argv[]) try
 
     // Declare RealSense pipeline, encapsulating the actual device and sensors
     rs2::pipeline pipe;
+
+    rs2::config cfg;
+
+    cfg.enable_stream(RS2_STREAM_DEPTH, 640, 480, RS2_FORMAT_Z16, 30);
     // Start streaming with default recommended configuration
-    pipe.start();
+    pipe.start(cfg);
 
     while(app) // Application still alive?
     {
         rs2::frameset data = pipe.wait_for_frames(); // Wait for next set of frames from the camera
 
         rs2::frame depth = color_map(data.get_depth_frame()); // Find and colorize the depth data
-        rs2::frame color = data.get_color_frame();            // Find the color data
-
-        // For cameras that don't have RGB sensor, we'll render infrared frames instead of color
-        if (!color)
-            color = data.get_infrared_frame();
+        //rs2::frame color = data.get_color_frame();            // Find the color data
 
         // Render depth on to the first half of the screen and color on to the second
         depth_image.render(depth, { 0,               0, app.width() / 2, app.height() });
-        color_image.render(color, { app.width() / 2, 0, app.width() / 2, app.height() });
+        //color_image.render(color, { app.width() / 2, 0, app.width() / 2, app.height() });
     }
 
     return EXIT_SUCCESS;

--- a/examples/capture/rs-capture.cpp
+++ b/examples/capture/rs-capture.cpp
@@ -28,7 +28,7 @@ int main(int argc, char * argv[]) try
 
     while(app) // Application still alive?
     {
-        rs2::frameset data = pipe.wait_for_frames(); // Wait for next set of frames from the camera
+        rs2::frameset data = pipe.wait_for_frames(0xfffffff); // Wait for next set of frames from the camera
 
         rs2::frame depth = color_map(data.get_depth_frame()); // Find and colorize the depth data
         //rs2::frame color = data.get_color_frame();            // Find the color data

--- a/examples/capture/rs-capture.cpp
+++ b/examples/capture/rs-capture.cpp
@@ -8,7 +8,7 @@
 // capture depth and color video streams and render them to the screen
 int main(int argc, char * argv[]) try
 {
-    rs2::log_to_console(RS2_LOG_SEVERITY_INFO);
+    rs2::log_to_console(RS2_LOG_SEVERITY_ERROR);
     // Create a simple OpenGL window for rendering:
     window app(1280, 720, "RealSense Capture Example");
     // Declare two textures on the GPU, one for color and one for depth
@@ -19,23 +19,23 @@ int main(int argc, char * argv[]) try
 
     // Declare RealSense pipeline, encapsulating the actual device and sensors
     rs2::pipeline pipe;
-
-    rs2::config cfg;
-
-    cfg.enable_stream(RS2_STREAM_DEPTH, 640, 480, RS2_FORMAT_Z16, 30);
     // Start streaming with default recommended configuration
-    pipe.start(cfg);
+    pipe.start();
 
     while(app) // Application still alive?
     {
-        rs2::frameset data = pipe.wait_for_frames(0xfffffff); // Wait for next set of frames from the camera
+        rs2::frameset data = pipe.wait_for_frames(); // Wait for next set of frames from the camera
 
         rs2::frame depth = color_map(data.get_depth_frame()); // Find and colorize the depth data
-        //rs2::frame color = data.get_color_frame();            // Find the color data
+        rs2::frame color = data.get_color_frame();            // Find the color data
+
+        // For cameras that don't have RGB sensor, we'll render infrared frames instead of color
+        if (!color)
+            color = data.get_infrared_frame();
 
         // Render depth on to the first half of the screen and color on to the second
         depth_image.render(depth, { 0,               0, app.width() / 2, app.height() });
-        //color_image.render(color, { app.width() / 2, 0, app.width() / 2, app.height() });
+        color_image.render(color, { app.width() / 2, 0, app.width() / 2, app.height() });
     }
 
     return EXIT_SUCCESS;
@@ -50,6 +50,3 @@ catch (const std::exception& e)
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
 }
-
-
-

--- a/src/backend.h
+++ b/src/backend.h
@@ -171,7 +171,6 @@ namespace librealsense
             const void *    pixels;
             const void *    metadata;
             rs2_time_t      backend_time;
-
         };
 
         typedef std::function<void(stream_profile, frame_object, std::function<void()>)> frame_callback;
@@ -208,6 +207,9 @@ namespace librealsense
             std::string unique_id = "";
             std::string device_path = "";
             usb_spec conn_spec = usb_undefined;
+            uint32_t uvc_capabilities = 0;
+            bool has_metadata_node = false;
+            std::string metadata_node_id = "";
 
             operator std::string()
             {
@@ -218,7 +220,8 @@ namespace librealsense
                     "\nmi- " << mi <<
                     "\nunique_id- " << unique_id <<
                     "\npath- " << device_path <<
-                    "\nsusb specification- " << std::hex << (uint16_t)conn_spec << std::dec;
+                    "\nsusb specification- " << std::hex << (uint16_t)conn_spec << std::dec <<
+                    (has_metadata_node ? ( "\nmetadata node-" + metadata_node_id) : "");
 
                 return s.str();
             }
@@ -227,6 +230,7 @@ namespace librealsense
             {
                 return (std::make_tuple(id, vid, pid, mi, unique_id, device_path) < std::make_tuple(obj.id, obj.vid, obj.pid, obj.mi, obj.unique_id, obj.device_path));
             }
+
         };
 
         inline bool operator==(const uvc_device_info& a,

--- a/src/backend.h
+++ b/src/backend.h
@@ -160,15 +160,6 @@ namespace librealsense
             uint32_t        timestamp;
             uint8_t         source_clock[6];
         };
-
-//        struct uvc_metadata_buf
-//        {
-//            uint64_t    pts;
-//            uint16_t    sof;
-//            uint8_t     length;
-//            uint8_t     flags;
-//            uint8_t*    buf;
-//        };
 #pragma pack(pop)
 
         constexpr uint8_t uvc_header_size = sizeof(uvc_header);

--- a/src/backend.h
+++ b/src/backend.h
@@ -160,6 +160,15 @@ namespace librealsense
             uint32_t        timestamp;
             uint8_t         source_clock[6];
         };
+
+//        struct uvc_metadata_buf
+//        {
+//            uint64_t    pts;
+//            uint16_t    sof;
+//            uint8_t     length;
+//            uint8_t     flags;
+//            uint8_t*    buf;
+//        };
 #pragma pack(pop)
 
         constexpr uint8_t uvc_header_size = sizeof(uvc_header);

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -289,7 +289,6 @@ namespace librealsense
         for (auto&& info : filter_by_mi(all_device_infos, 0)) // Filter just mi=0, DEPTH
             depth_devices.push_back(backend.create_uvc_device(info));
 
-
         std::unique_ptr<frame_timestamp_reader> ds5_timestamp_reader_backup(new ds5_timestamp_reader(backend.create_time_service()));
         auto depth_ep = std::make_shared<ds5_depth_sensor>(this, std::make_shared<platform::multi_pins_uvc_device>(depth_devices),
                                                        std::unique_ptr<frame_timestamp_reader>(new ds5_timestamp_reader_from_metadata(std::move(ds5_timestamp_reader_backup))));

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -505,7 +505,7 @@ namespace librealsense
         depth_ep.register_metadata((rs2_frame_metadata_value)RS2_FRAME_METADATA_WIDTH, make_attribute_parser(&md_configuration::width, md_configuration_attributes::width_attribute, md_prop_offset));
         depth_ep.register_metadata((rs2_frame_metadata_value)RS2_FRAME_METADATA_HEIGHT, make_attribute_parser(&md_configuration::height, md_configuration_attributes::height_attribute, md_prop_offset));
         depth_ep.register_metadata((rs2_frame_metadata_value)RS2_FRAME_METADATA_ACTUAL_FPS,  std::make_shared<ds5_md_attribute_actual_fps> ());
-        
+
         register_info(RS2_CAMERA_INFO_NAME, device_name);
         register_info(RS2_CAMERA_INFO_SERIAL_NUMBER, serial);
         register_info(RS2_CAMERA_INFO_FIRMWARE_VERSION, _fw_version);

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -77,6 +77,7 @@ namespace librealsense
         // DS5 fisheye XU identifiers
         const uint8_t FISHEYE_EXPOSURE = 1;
 
+                                                // subdevice[h] unit[fw], node[h] guid[fw]
         const platform::extension_unit depth_xu = { 0, 3, 2,
         { 0xC9606CCB, 0x594C, 0x4D25,{ 0xaf, 0x47, 0xcc, 0xc4, 0x96, 0x43, 0x59, 0x95 } } };
 

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -201,7 +201,6 @@ namespace librealsense
             }
             else
             {
-                // Evgeni - to check whether this interfere with 4.16. Assuming not
                 _length += MAX_META_DATA_SIZE;
                 _start = static_cast<uint8_t*>(malloc( buf.length + MAX_META_DATA_SIZE));
                 if (!_start) throw linux_backend_exception("User_p allocation failed!");
@@ -263,7 +262,6 @@ namespace librealsense
                     memset((byte*)(get_frame_start()) + metadata_offset, 0, MAX_META_DATA_SIZE);
                 }
 
-                LOG_INFO("Enqueue buf << "  << _buf.index << " for fd " << fd);
                 if (xioctl(fd, VIDIOC_QBUF, &_buf) < 0)
                     LOG_ERROR("xioctl(VIDIOC_QBUF) failed when requesting new frame! Last-error: " << strerror(errno));
 
@@ -629,8 +627,8 @@ namespace librealsense
             if(!_is_capturing && !_callback)
             {
                 v4l2_fmtdesc pixel_format = {};
-                // TODO - evgeni parse all incoming metadata formats
                 pixel_format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+
                 while (ioctl(_fd, VIDIOC_ENUM_FMT, &pixel_format) == 0)
                 {
                     v4l2_frmsizeenum frame_size = {};
@@ -703,26 +701,7 @@ namespace librealsense
 
                 // Init memory mapped IO
                 request_io_buffers(buffers);
-                /*Evgeni
-                v4l2_requestbuffers req = {};
-                req.count = buffers;
-                req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-                req.memory = _use_memory_map ? V4L2_MEMORY_MMAP : V4L2_MEMORY_USERPTR;
-                if(xioctl(_fd, VIDIOC_REQBUFS, &req) < 0)
-                {
-                    if(errno == EINVAL)
-                        throw linux_backend_exception(_name + " does not support memory mapping");
-                    else
-                        throw linux_backend_exception("xioctl(VIDIOC_REQBUFS) failed");
-                }
-                */
-
                 allocate_io_buffers(buffers);
-                /*Evgeni
-                for(size_t i = 0; i < buffers; ++i)
-                {
-                    _buffers.push_back(std::make_shared<buffer>(_fd, _use_memory_map, i));
-                }*/
 
                 _profile =  profile;
                 _callback = callback;
@@ -790,28 +769,11 @@ namespace librealsense
 
             if (_callback)
             {
+                // Release allocated buffers
                 allocate_io_buffers(0);
-                /*Evgeni
-                for(size_t i = 0; i < _buffers.size(); i++)
-                {
-                    _buffers[i]->detach_buffer();
-                }
-                _buffers.resize(0);*/
 
-                // Close memory mapped IO
+                // Release IO
                 request_io_buffers(0);
-                /* Evgeni
-                struct v4l2_requestbuffers req = {};
-                req.count = 0;
-                req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-                req.memory = _use_memory_map ? V4L2_MEMORY_MMAP : V4L2_MEMORY_USERPTR;
-                if(xioctl(_fd, VIDIOC_REQBUFS, &req) < 0)
-                {
-                    if(errno == EINVAL)
-                        LOG_ERROR(_name + " does not support memory mapping");
-                    else
-                        throw linux_backend_exception("xioctl(VIDIOC_REQBUFS) failed");
-                }*/
 
                 _callback = nullptr;
             }
@@ -844,11 +806,6 @@ namespace librealsense
              {
                  FD_SET(fd, &fds);
              }
-//            FD_SET(_fd, &fds);
-//            FD_SET(_stop_pipe_fd[0], &fds);
-//            FD_SET(_stop_pipe_fd[1], &fds);
-
-            //Evgeni refactored int max_fd = std::max(std::max(_stop_pipe_fd[0], _stop_pipe_fd[1]), _fd);
 
             struct timespec mono_time;
             int ret = clock_gettime(CLOCK_MONOTONIC, &mono_time);
@@ -874,24 +831,13 @@ namespace librealsense
             if(val < 0)
             {
                 stop_data_capture();
-//                _is_capturing = false;
-//                _is_started = false;
-//                signal_stop();
-
-//                _thread->join();
-//                _thread.reset();
-
-//                // Stop streamining
-//                v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-//                if(xioctl(_fd, VIDIOC_STREAMOFF, &type) < 0)
-//                    throw linux_backend_exception("xioctl(VIDIOC_STREAMOFF) failed");
             }
             else
             {
                 std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> urb_sets;
-                if(val > 0) // TODO Refactor required. Evgeni val > 0 originally. shall be positive for backward compatibility
+                //TODO RAII buffers
+                if(val > 0)
                 {
-                    //if(FD_ISSET(_stop_pipe_fd[0], &fds) || FD_ISSET(_stop_pipe_fd[1], &fds))
                     if(_ctl_pipe_fds.end() != std::find_if(_ctl_pipe_fds.begin(),_ctl_pipe_fds.end(),
                                      [&fds](int& val){ return FD_ISSET(val,&fds); }))
                     {
@@ -907,20 +853,9 @@ namespace librealsense
                     }
                     else // Check and acquire data buffers from kernel
                     {
-                        std::stringstream ss;
-                        for (auto& fd : _stream_pipe_fds)
-                        {
-                            if(FD_ISSET(fd, &fds))
-                                ss << fd << ", ";
-                        }
-                        ss << " selected descriptors: " << val;
-                        LOG_INFO("fd signalled: " + ss.str());
-
                         if(FD_ISSET(_fd, &fds))
                         {
                             FD_CLR(_fd,&fds);
-                            //FD_ZERO(&fds);
-                            //FD_SET(_fd, &fds);
                             v4l2_buffer buf = {};
                             buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
                             buf.memory = _use_memory_map ? V4L2_MEMORY_MMAP : V4L2_MEMORY_USERPTR;
@@ -957,14 +892,8 @@ namespace librealsense
                                     void* md_start = nullptr;
                                     uint8_t md_size = 0;
 
-                                    // TODO: Evgeni  Acquire metadata either from kernel appendix or metadata node
+                                    // Get metadata either from kernel appendix or metadata node
                                     acquire_metadata(md_start,md_size,fds,urb_sets);
-
-//                                        if (has_metadata())
-//                                        {
-//                                            md_start = buffer->get_frame_start() + buffer->get_length_frame_only();
-//                                            md_size = (*(uint8_t*)md_start);
-//                                        }
 
                                     LOG_INFO("Frame buf ready, md size: " << (int)md_size << " seq. id: " << buf.sequence);
                                     frame_object fo{ buffer->get_length_frame_only(), md_size,
@@ -973,12 +902,9 @@ namespace librealsense
                                      buffer->attach_buffer(buf);
                                      moved_qbuff = true;
 
-                                     //TODO enqueue next buffers
-                                     //auto fd = _fd;
+                                     //Invoke user callback and enqueue next frame
                                      _callback(_profile, fo,
                                                [urb_sets]() mutable {
-                                         //      [fd, buffer]() mutable {
-                                         // Evgeni buffer->request_next_frame(fd);
                                          for (auto&& kvp : urb_sets)
                                              kvp.first->request_next_frame(kvp.second);
                                      });
@@ -986,7 +912,7 @@ namespace librealsense
                                 else
                                 {
                                     LOG_WARNING("Empty frame has arrived.");
-                                    // TODO: Evgeni  Clear metadata descriptor when empty frame arrives
+                                    // TODO: Clear metadata descriptor when empty frame arrives
                                     void* md_start = nullptr;
                                     uint8_t md_size = 0;
                                     acquire_metadata(md_start,md_size,fds,urb_sets);
@@ -994,7 +920,7 @@ namespace librealsense
                             }
                             else
                             {
-                                LOG_ERROR("Video frame arrived in idle mode."); // TODO - Evgeni verification
+                                LOG_ERROR("Video frame arrived in idle mode."); // TODO - verification
                             }
 
                             if (!moved_qbuff)
@@ -1009,14 +935,13 @@ namespace librealsense
                             void* md_start = nullptr;
                             uint8_t md_size = 0;
 
-                            // TODO: Evgeni  Acquire metadata either from kernel appendix or metadata node
+                            // Clear matadata node
                             acquire_metadata(md_start,md_size,fds,urb_sets);
                         }
                     }
                 }
                 else
                 {
-                    // TODO Evgeni - md descriptor is not reset after DQBUF
                     if(val > 0)
                     {
                         std::stringstream ss;
@@ -1026,9 +951,6 @@ namespace librealsense
                             if(FD_ISSET(fd, &fds))
                             {
                                 ss << fd << ", ";
-                                //FD_CLR(_fd,&fds);
-                                //FD_ZERO(&fds);
-                                //FD_SET(_fd, &fds);
                                 if (_stream_pipe_fds.end() != std::find(_stream_pipe_fds.begin(), _stream_pipe_fds.end(), fd))
                                 {
                                     v4l2_buffer buf = {};
@@ -1070,79 +992,27 @@ namespace librealsense
         {
             if (has_metadata())
             {
-                // std::assert(0!=datasets.size()); Verify Evgeni !!
-                auto buffer = datasets[0].first;
-                md_start = buffer->get_frame_start() + buffer->get_length_frame_only();
-                md_size = (*(uint8_t*)md_start);
+                if (datasets.size())
+                {
+                    auto buffer = datasets[0].first;
+                    md_start = buffer->get_frame_start() + buffer->get_length_frame_only();
+                    md_size = (*(uint8_t*)md_start);
+                }
+                else
+                    LOG_ERROR("Metadata was requested with no valid file descriptors");
             }
         }
-
-//        void v4l_uvc_device::capture_frame(fd_set &cur_fds)       // retrieve frame from kernel and dispatch user-callback
-//        {
-
-//        }
 
         void v4l_uvc_device::set_power_state(power_state state)
         {
             if (state == D0 && _state == D3)
             {
                 map_device_descriptor();
-                /* Evgeni
-                _fd = open(_name.c_str(), O_RDWR | O_NONBLOCK, 0);
-                if(_fd < 0)
-                    throw linux_backend_exception(to_string() << "Cannot open '" << _name);
-
-                if (pipe(_stop_pipe_fd) < 0)
-                    throw linux_backend_exception("v4l_uvc_device: Cannot create pipe!");
-
-                v4l2_capability cap = {};
-                if(xioctl(_fd, VIDIOC_QUERYCAP, &cap) < 0)
-                {
-                    if(errno == EINVAL)
-                        throw linux_backend_exception(_name + " is no V4L2 device");
-                    else
-                        throw linux_backend_exception("xioctl(VIDIOC_QUERYCAP) failed");
-                }
-                if(!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE))
-                    throw linux_backend_exception(_name + " is no video capture device");
-
-                if(!(cap.capabilities & V4L2_CAP_STREAMING))
-                    throw linux_backend_exception(_name + " does not support streaming I/O");
-
-                // Select video input, video standard and tune here.
-                v4l2_cropcap cropcap = {};
-                cropcap.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-                if(xioctl(_fd, VIDIOC_CROPCAP, &cropcap) == 0)
-                {
-                    v4l2_crop crop = {};
-                    crop.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-                    crop.c = cropcap.defrect; // reset to default
-                    if(xioctl(_fd, VIDIOC_S_CROP, &crop) < 0)
-                    {
-                        switch (errno)
-                        {
-                        case EINVAL: break; // Cropping not supported
-                        default: break; // Errors ignored
-                        }
-                    }
-                } else {} // Errors ignored
-                */
             }
             if (state == D3 && _state == D0)
             {
                 close(_profile);
                 unmap_device_descriptor();
-                // evgeni
-//                if(::close(_fd) < 0)
-//                    throw linux_backend_exception("v4l_uvc_device: close(_fd) failed");
-
-//                if(::close(_stop_pipe_fd[0]) < 0)
-//                   throw linux_backend_exception("v4l_uvc_device: close(_stop_pipe_fd[0]) failed");
-//                if(::close(_stop_pipe_fd[1]) < 0)
-//                   throw linux_backend_exception("v4l_uvc_device: close(_stop_pipe_fd[1]) failed");
-
-//                _fd = 0;
-//                _stop_pipe_fd[0] = _stop_pipe_fd[1] = 0;
             }
             _state = state;
         }
@@ -1769,12 +1639,12 @@ namespace librealsense
                 auto buffer = _md_buffers[buf.index];
                 LOG_INFO("Metadata buf id :" << buf.index << " was polled, seq id: " << buf.sequence <<  " bytes used: " << buf.bytesused << " flags: "
                          << std::hex << buf.flags << std::dec);
-                //std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> urb_sets;
+
                 datasets.emplace_back(std::make_pair(buffer,_md_fd));
 
                 if (_is_started)
                 {
-                    // TODO Evgeni
+                    // TODO Handle incomplete metadata buffer
                     /*if((buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE) &&
                             buf.bytesused > 0)
                     {
@@ -1797,13 +1667,6 @@ namespace librealsense
                             // The first 10 bytes of metadata buffer are generated by host driver
                             md_size = buf.bytesused - uvc_md_start_offset;
 
-        //                    std::stringstream ss;
-        //                    uint8_t *ptr = (uint8_t*)md_start;
-        //                    for (int i=0; i< buf.bytesused; i++)
-        //                        ss << std::hex << (int)ptr[i] << " ";
-        //                    LOG_INFO("Metadata buffer received, size " << std::dec << (int)md_size
-        //                             << " data: " << ss.str());
-
                             uvc_meta_buffer md_buf{};
                             uvc_header md_hdr{};
                             memcpy(&md_buf,md_start,buf.bytesused);
@@ -1819,10 +1682,8 @@ namespace librealsense
                                      << " stc: " << *(uint32_t*)(&md_hdr.source_clock[0])
                                      << " sof: " << *(uint16_t*)(&md_hdr.source_clock[4]));
                                      //<< " data: " << ss.str());
-        //                    frame_object fo{ buffer->get_length_frame_only(), md_si<< " uvc stc: " << (uint32_t)(&md_hdr.source_clock[0])ze,
-        //                        buffer->get_frame_start(), md_start, timestamp };
 
-                             buffer->attach_buffer(buf);
+                            buffer->attach_buffer(buf);
                              moved_qbuff = true;
                         }
                         else
@@ -1837,7 +1698,7 @@ namespace librealsense
                 }
                 else
                 {
-                    LOG_ERROR("Metadata frame arrived in idle mode."); // TODO - Evgeni verification
+                    LOG_WARNING("Metadata frame arrived in idle mode.");
                 }
 
                 if (!moved_qbuff)
@@ -1870,7 +1731,7 @@ namespace librealsense
                       [](const uvc_device_info& lhs, const uvc_device_info& rhs){ return lhs.id < rhs.id; });
 
             // Discriminate video and metadata nodes
-            // under the assumption that for each metadata node n there is a origin streaming node with index (n-1)
+            // under the assumption that for each metadata node with index N there is a origin streaming node with index (N-1)
             std::vector<uvc_device_info> results;
             for (auto&& cur_node : uvc_nodes)
             {

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -342,11 +342,16 @@ namespace librealsense
             return cap.device_caps;
         }
 
+        void stream_ctl_on(int fd, v4l2_buf_type type=V4L2_BUF_TYPE_VIDEO_CAPTURE)
+        {
+            if(xioctl(fd, VIDIOC_STREAMON, &type) < 0)
+                throw linux_backend_exception(to_string() << "xioctl(VIDIOC_STREAMON) failed for buf_type=" << type);
+        }
+
         void stream_off(int fd, v4l2_buf_type type=V4L2_BUF_TYPE_VIDEO_CAPTURE)
         {
-            //v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
             if(xioctl(fd, VIDIOC_STREAMOFF, &type) < 0)
-                throw linux_backend_exception("xioctl(VIDIOC_STREAMOFF) failed");
+                throw linux_backend_exception(to_string() << "xioctl(VIDIOC_STREAMOFF) failed for buf_type=" << type);
         }
 
         void req_io_buff(int fd, uint32_t count, std::string dev_name,
@@ -612,6 +617,9 @@ namespace librealsense
         v4l_uvc_device::~v4l_uvc_device()
         {
             _is_capturing = false;
+            _fds.clear();
+            _stream_pipe_fds.clear();
+            _ctl_pipe_fds.clear();
             if (_thread) _thread->join();
         }
 
@@ -731,20 +739,35 @@ namespace librealsense
                 _error_handler = error_handler;
 
                 // Start capturing
-                start_data_capture();
+                prepare_capture_buffers();
+                // Synchronise stream requests for meta and video data.
+                streamon();
 
                 _is_capturing = true;
                 _thread = std::unique_ptr<std::thread>(new std::thread([this](){ capture_loop(); }));
             }
         }
 
-        void v4l_uvc_device::start_data_capture()
+        void v4l_uvc_device::prepare_capture_buffers()
         {
             for (auto&& buf : _buffers) buf->prepare_for_streaming(_fd);
 
-            v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-            if(xioctl(_fd, VIDIOC_STREAMON, &type) < 0)
-                throw linux_backend_exception("xioctl(VIDIOC_STREAMON) failed");
+//            v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+//            if(xioctl(_fd, VIDIOC_STREAMON, &type) < 0)
+//                throw linux_backend_exception("xioctl(VIDIOC_STREAMON) failed");
+        }
+
+        void v4l_uvc_device::stop_data_capture()
+        {
+            _is_capturing = false;
+            _is_started = false;
+            signal_stop();
+
+            _thread->join();
+            _thread.reset();
+
+            // Stop streamining
+            streamoff();
         }
 
         void v4l_uvc_device::start_callbacks()
@@ -761,18 +784,7 @@ namespace librealsense
         {
             if(_is_capturing)
             {
-                _is_capturing = false;
-                _is_started = false;
-                signal_stop();
-
-                _thread->join();
-                _thread.reset();
-
-                // Stop streamining
-                streamoff();
-//                v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-//                if(xioctl(_fd, VIDIOC_STREAMOFF, &type) < 0)
-//                    throw linux_backend_exception("xioctl(VIDIOC_STREAMOFF) failed");
+                stop_data_capture();
             }
 
             if (_callback)
@@ -825,29 +837,33 @@ namespace librealsense
 
         void v4l_uvc_device::poll()
         {
-            fd_set fds{};
-            FD_ZERO(&fds);
-            FD_SET(_fd, &fds);
-            FD_SET(_stop_pipe_fd[0], &fds);
-            FD_SET(_stop_pipe_fd[1], &fds);
+             fd_set fds{};
+             FD_ZERO(&fds);
+             for (auto fd : _fds)
+             {
+                 FD_SET(fd, &fds);
+             }
+//            FD_SET(_fd, &fds);
+//            FD_SET(_stop_pipe_fd[0], &fds);
+//            FD_SET(_stop_pipe_fd[1], &fds);
 
-            int max_fd = std::max(std::max(_stop_pipe_fd[0], _stop_pipe_fd[1]), _fd);
+            //Evgeni refactored int max_fd = std::max(std::max(_stop_pipe_fd[0], _stop_pipe_fd[1]), _fd);
 
             struct timespec mono_time;
-            int r = clock_gettime(CLOCK_MONOTONIC, &mono_time);
-            if (r) throw linux_backend_exception("could not query time!");
+            int ret = clock_gettime(CLOCK_MONOTONIC, &mono_time);
+            if (ret) throw linux_backend_exception("could not query time!");
 
             struct timeval expiration_time = { mono_time.tv_sec + 5, mono_time.tv_nsec / 1000 };
             int val = 0;
             do {
                 struct timeval remaining;
-                r = clock_gettime(CLOCK_MONOTONIC, &mono_time);
-                if (r) throw linux_backend_exception("could not query time!");
+                ret = clock_gettime(CLOCK_MONOTONIC, &mono_time);
+                if (ret) throw linux_backend_exception("could not query time!");
 
                 struct timeval current_time = { mono_time.tv_sec, mono_time.tv_nsec / 1000 };
                 timersub(&expiration_time, &current_time, &remaining);
                 if (timercmp(&current_time, &expiration_time, <)) {
-                    val = select(max_fd + 1, &fds, NULL, NULL, &remaining);
+                    val = select(_max_fd + 1, &fds, NULL, NULL, &remaining);
                 }
                 else {
                     val = 0;
@@ -856,108 +872,180 @@ namespace librealsense
 
             if(val < 0)
             {
-                _is_capturing = false;
-                _is_started = false;
-                signal_stop();
+                stop_data_capture();
+//                _is_capturing = false;
+//                _is_started = false;
+//                signal_stop();
 
-                _thread->join();
-                _thread.reset();
+//                _thread->join();
+//                _thread.reset();
 
-                // Stop streamining
-                v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-                if(xioctl(_fd, VIDIOC_STREAMOFF, &type) < 0)
-                    throw linux_backend_exception("xioctl(VIDIOC_STREAMOFF) failed");
+//                // Stop streamining
+//                v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+//                if(xioctl(_fd, VIDIOC_STREAMOFF, &type) < 0)
+//                    throw linux_backend_exception("xioctl(VIDIOC_STREAMOFF) failed");
             }
-            else if(val > 0)
+            else
             {
-                if(FD_ISSET(_stop_pipe_fd[0], &fds) || FD_ISSET(_stop_pipe_fd[1], &fds))
+                if(val == 2) // Evgeni val > 0 originally. shall be positive for backward compat
                 {
-                    if(!_is_capturing)
+                    //if(FD_ISSET(_stop_pipe_fd[0], &fds) || FD_ISSET(_stop_pipe_fd[1], &fds))
+                    if(_ctl_pipe_fds.end() != std::find_if(_ctl_pipe_fds.begin(),_ctl_pipe_fds.end(),
+                                     [&fds](int& val){ return FD_ISSET(val,&fds); }))
                     {
-                        LOG_INFO("Stream finished");
-                        return;
-                    }
-                }
-                else if(FD_ISSET(_fd, &fds))
-                {
-                    FD_ZERO(&fds);
-                    FD_SET(_fd, &fds);
-                    v4l2_buffer buf = {};
-                    buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-                    buf.memory = _use_memory_map ? V4L2_MEMORY_MMAP : V4L2_MEMORY_USERPTR;
-                    if(xioctl(_fd, VIDIOC_DQBUF, &buf) < 0)
-                    {
-                        if(errno == EAGAIN)
+                        if(!_is_capturing)
+                        {
+                            LOG_INFO("Stream finished");
                             return;
-
-                        throw linux_backend_exception("xioctl(VIDIOC_DQBUF) failed");
-                    }
-
-                    bool moved_qbuff = false;
-                    auto buffer = _buffers[buf.index];
-
-                    if (_is_started)
-                    {
-                        if((buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE) &&
-                                buf.bytesused > 0)
-                        {
-                            auto percentage = (100 * buf.bytesused) / buffer->get_full_length();
-                            std::stringstream s;
-                            s << "Incomplete frame detected!\nSize " << buf.bytesused
-                              << " out of " << buffer->get_full_length() << " bytes (" << percentage << "%)";
-                            librealsense::notification n = { RS2_NOTIFICATION_CATEGORY_FRAME_CORRUPTED, 0, RS2_LOG_SEVERITY_WARN, s.str()};
-
-                            _error_handler(n);
-                        }
-                        else if (buf.bytesused > 0)
-                        {
-                            void* md_start = nullptr;
-                            uint8_t md_size = 0;
-                            if (has_metadata())
-                            {
-                                md_start = buffer->get_frame_start() + buffer->get_length_frame_only();
-                                md_size = (*(uint8_t*)md_start);
-                            }
-
-                            auto timestamp = (double)buf.timestamp.tv_sec*1000.f + (double)buf.timestamp.tv_usec/1000.f;
-                            timestamp = monotonic_to_realtime(timestamp);
-
-                            frame_object fo{ buffer->get_length_frame_only(), md_size,
-                                buffer->get_frame_start(), md_start, timestamp };
-
-                             buffer->attach_buffer(buf);
-                             moved_qbuff = true;
-                             auto fd = _fd;
-                             _callback(_profile, fo,
-                                       [fd, buffer]() mutable {
-                                 buffer->request_next_frame(fd);
-                             });
                         }
                         else
                         {
-                            LOG_WARNING("Empty frame has arrived.");
+                            LOG_INFO("Control pipe fd was signalled ");
                         }
                     }
-
-                    if (!moved_qbuff)
+                    else // Check and acquire data buffers from kernel
                     {
-                        if (xioctl(_fd, VIDIOC_QBUF, &buf) < 0)
-                            throw linux_backend_exception("xioctl(VIDIOC_QBUF) failed");
+                        //for (auto fd in _stream_pipe_fds)
+                        {
+                            std::stringstream ss;
+                            for (auto fd =0; fd <_max_fd; fd++)
+                            {
+                                if(FD_ISSET(fd, &fds))
+                                    ss << fd << ", ";
+                            }
+                            ss << " select value is " << val;
+                            LOG_INFO("fd signalled: " + ss.str());
+
+                            if(FD_ISSET(_fd, &fds))
+                            {
+                                //FD_ZERO(&fds);
+                                //FD_SET(_fd, &fds);
+                                v4l2_buffer buf = {};
+                                buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+                                buf.memory = _use_memory_map ? V4L2_MEMORY_MMAP : V4L2_MEMORY_USERPTR;
+                                if(xioctl(_fd, VIDIOC_DQBUF, &buf) < 0)
+                                {
+                                    if(errno == EAGAIN)
+                                        return;
+
+                                    throw linux_backend_exception(to_string() << "xioctl(VIDIOC_DQBUF) failed for fd: " << _fd);
+                                }
+
+                                bool moved_qbuff = false;
+                                auto buffer = _buffers[buf.index];
+                                std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> urb_sets;
+                                urb_sets.emplace_back(std::make_pair(buffer,_fd));
+
+                                if (_is_started)
+                                {
+                                    if((buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE) &&
+                                            buf.bytesused > 0)
+                                    {
+                                        auto percentage = (100 * buf.bytesused) / buffer->get_full_length();
+                                        std::stringstream s;
+                                        s << "Incomplete frame detected!\nSize " << buf.bytesused
+                                          << " out of " << buffer->get_full_length() << " bytes (" << percentage << "%)";
+                                        librealsense::notification n = { RS2_NOTIFICATION_CATEGORY_FRAME_CORRUPTED, 0, RS2_LOG_SEVERITY_WARN, s.str()};
+
+                                        _error_handler(n);
+                                    }
+                                    else if (buf.bytesused > 0)
+                                    {
+                                        auto timestamp = (double)buf.timestamp.tv_sec*1000.f + (double)buf.timestamp.tv_usec/1000.f;
+                                        timestamp = monotonic_to_realtime(timestamp);
+
+                                        void* md_start = nullptr;
+                                        uint8_t md_size = 0;
+
+                                        // TODO: Evgeni  Acquire metadata either from kernel appendix or metadata node
+                                        acquire_metadata(md_start,md_size,urb_sets);
+
+//                                        if (has_metadata())
+//                                        {
+//                                            md_start = buffer->get_frame_start() + buffer->get_length_frame_only();
+//                                            md_size = (*(uint8_t*)md_start);
+//                                        }
+
+                                        frame_object fo{ buffer->get_length_frame_only(), md_size,
+                                            buffer->get_frame_start(), md_start, timestamp };
+
+                                         buffer->attach_buffer(buf);
+                                         moved_qbuff = true;
+
+                                         //TODO enqueue next buffers
+                                         //auto fd = _fd;
+                                         _callback(_profile, fo,
+                                                   [urb_sets]() mutable {
+                                             //      [fd, buffer]() mutable {
+                                             // Evgeni buffer->request_next_frame(fd);
+                                             for (auto&& kvp : urb_sets)
+                                                 kvp.first->request_next_frame(kvp.second);
+                                         });
+                                    }
+                                    else
+                                    {
+                                        LOG_WARNING("Empty frame has arrived.");
+                                    }
+                                }
+                                else
+                                {
+                                    LOG_ERROR("Video frame arrived in idle mode."); // TODO - Evgeni verification
+                                }
+
+                                if (!moved_qbuff)
+                                {
+                                    if (xioctl(_fd, VIDIOC_QBUF, &buf) < 0)
+                                        throw linux_backend_exception("xioctl(VIDIOC_QBUF) failed");
+                                }
+                            }
+                            else
+                            {
+                                throw linux_backend_exception("FD_ISSET returned false");
+                            }
+                        }
                     }
                 }
                 else
                 {
-                    throw linux_backend_exception("FD_ISSET returned false");
+                    if(val > 0)
+                    {
+                        std::stringstream ss;
+                        ss << " select value!=2 : " << val << " signalled descriptors: ";
+                        for (auto fd =0; fd <_max_fd; fd++)
+                        {
+                            if(FD_ISSET(fd, &fds))
+                                ss << fd << ", ";
+                        }
+                        LOG_INFO(ss.str());
+                    }
+
+                    if (val==0)
+                    {
+                        LOG_WARNING("Frames didn't arrived within 5 seconds");
+                        librealsense::notification n = {RS2_NOTIFICATION_CATEGORY_FRAMES_TIMEOUT, 0, RS2_LOG_SEVERITY_WARN,  "Frames didn't arrived within 5 seconds"};
+
+                        _error_handler(n);
+                    }
                 }
             }
-            else
-            {
-                LOG_WARNING("Frames didn't arrived within 5 seconds");
-                librealsense::notification n = {RS2_NOTIFICATION_CATEGORY_FRAMES_TIMEOUT, 0, RS2_LOG_SEVERITY_WARN,  "Frames didn't arrived within 5 seconds"};
+        }
 
-                _error_handler(n);
+        void v4l_uvc_device::acquire_metadata(void *&md_start,uint8_t& md_size,
+                                              std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> &datasets)
+        {
+            if (has_metadata())
+            {
+                // std::assert(0!=datasets.size()); Verify Evgeni !!
+                auto buffer = datasets[0].first;
+                md_start = buffer->get_frame_start() + buffer->get_length_frame_only();
+                md_size = (*(uint8_t*)md_start);
             }
         }
+
+//        void v4l_uvc_device::capture_frame(fd_set &cur_fds)       // retrieve frame from kernel and dispatch user-callback
+//        {
+
+//        }
 
         void v4l_uvc_device::set_power_state(power_state state)
         {
@@ -1329,6 +1417,11 @@ namespace librealsense
             return !_use_memory_map;
         }
 
+        void v4l_uvc_device::streamon() const
+        {
+            stream_ctl_on(_fd);
+        }
+
         void v4l_uvc_device::streamoff() const
         {
             stream_off(_fd);
@@ -1364,10 +1457,19 @@ namespace librealsense
         {
             _fd = open(_name.c_str(), O_RDWR | O_NONBLOCK, 0);
             if(_fd < 0)
-                throw linux_backend_exception(to_string() << "Cannot open '" << _name);
+                throw linux_backend_exception(to_string() <<__FUNCTION__ << " Cannot open '" << _name);
 
             if (pipe(_stop_pipe_fd) < 0)
-                throw linux_backend_exception("v4l_uvc_device: Cannot create pipe!");
+                throw linux_backend_exception(to_string() <<__FUNCTION__ << " Cannot create pipe!");
+
+            if (_fds.size())
+                throw linux_backend_exception(to_string() <<__FUNCTION__ << " Device descriptor is already allocated");
+
+            _stream_pipe_fds.push_back(_fd);
+            _ctl_pipe_fds.push_back(_stop_pipe_fd[0]);
+            _ctl_pipe_fds.push_back(_stop_pipe_fd[1]);
+            _fds.insert(_fds.end(),{_fd,_stop_pipe_fd[0],_stop_pipe_fd[1]});
+            _max_fd = *std::max_element(_fds.begin(),_fds.end());
 
             v4l2_capability cap = {};
             if(xioctl(_fd, VIDIOC_QUERYCAP, &cap) < 0)
@@ -1414,6 +1516,9 @@ namespace librealsense
 
             _fd = 0;
             _stop_pipe_fd[0] = _stop_pipe_fd[1] = 0;
+            _fds.clear();
+            _stream_pipe_fds.clear();
+            _ctl_pipe_fds.clear();
         }
 
         void v4l_uvc_device::set_format(stream_profile profile)
@@ -1452,6 +1557,16 @@ namespace librealsense
 //            v4l_uvc_device::close();
 //            // Closing the metadata node
 //        }
+
+        void v4l_uvc_meta_device::streamon() const
+        {
+            // Metadata stream shall be configured first to allow sync with video node
+            stream_ctl_on(_md_fd,V4L2_BUF_TYPE_META_CAPTURE);
+
+            // Invoke UVC streaming request
+            v4l_uvc_device::streamon();
+
+        }
 
         void v4l_uvc_meta_device::streamoff() const
         {
@@ -1503,6 +1618,12 @@ namespace librealsense
 
             if (pipe(_md_stop_pipe_fd) < 0)
                 throw linux_backend_exception("v4l_uvc_meta_device: Cannot create pipe!");
+
+            _stream_pipe_fds.push_back(_md_fd);
+            _ctl_pipe_fds.push_back(_md_stop_pipe_fd[0]);
+            _ctl_pipe_fds.push_back(_md_stop_pipe_fd[1]);
+            _fds.insert(_fds.end(),{_md_fd,_md_stop_pipe_fd[0],_md_stop_pipe_fd[1]});
+            _max_fd = *std::max_element(_fds.begin(),_fds.end());
 
             v4l2_capability cap = {};
             if(xioctl(_md_fd, VIDIOC_QUERYCAP, &cap) < 0)
@@ -1559,17 +1680,97 @@ namespace librealsense
                 throw linux_backend_exception(_md_name + " ioctl(VIDIOC_S_FMT) for metadata node failed");
         }
 
-        void v4l_uvc_meta_device::start_data_capture()
+        void v4l_uvc_meta_device::prepare_capture_buffers()
         {
             // Meta node to be initialized first to enforce initial sync
             for (auto&& buf : _md_buffers) buf->prepare_for_streaming(_md_fd);
 
-            v4l2_buf_type type = V4L2_BUF_TYPE_META_CAPTURE;
-            if(xioctl(_md_fd, VIDIOC_STREAMON, &type) < 0)
-                throw linux_backend_exception(_md_name + " xioctl(VIDIOC_STREAMON) failed");
-
             // Request streaming for video node
-            v4l_uvc_device::start_data_capture();
+            v4l_uvc_device::prepare_capture_buffers();
+
+//            v4l2_buf_type type = V4L2_BUF_TYPE_META_CAPTURE;
+//            if(xioctl(_md_fd, VIDIOC_STREAMON, &type) < 0)
+//                throw linux_backend_exception(_md_name + " xioctl(VIDIOC_STREAMON) failed");
+
+        }
+
+        void v4l_uvc_meta_device::acquire_metadata(void *&md_start,uint8_t& md_size,
+                                                   std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> &datasets)
+        {
+
+            md_size = 0;
+            md_start = nullptr;
+
+            v4l2_buffer buf = {};
+            buf.type = V4L2_BUF_TYPE_META_CAPTURE;
+            buf.memory = _use_memory_map ? V4L2_MEMORY_MMAP : V4L2_MEMORY_USERPTR;
+            if(xioctl(_md_fd, VIDIOC_DQBUF, &buf) < 0)
+            {
+                if(errno == EAGAIN)
+                    return;
+
+                throw linux_backend_exception(to_string() << "xioctl(VIDIOC_DQBUF) failed for metadata fd: " << _md_fd);
+            }
+
+            bool moved_qbuff = false;
+            auto buffer = _md_buffers[buf.index];
+            //std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> urb_sets;
+            datasets.emplace_back(std::make_pair(buffer,_md_fd));
+
+            if (_is_started)
+            {
+                // TODO Evgeni
+                /*if((buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE) &&
+                        buf.bytesused > 0)
+                {
+                    auto percentage = (100 * buf.bytesused) / buffer->get_full_length();
+                    std::stringstream s;
+                    s << "Incomplete frame detected!\nSize " << buf.bytesused
+                      << " out of " << buffer->get_full_length() << " bytes (" << percentage << "%)";
+                    librealsense::notification n = { RS2_NOTIFICATION_CATEGORY_FRAME_CORRUPTED, 0, RS2_LOG_SEVERITY_WARN, s.str()};
+
+                    _error_handler(n);
+                }
+                else*/ if (buf.bytesused > 0)
+                {
+
+                    // TODO: Evgeni  Acquire metadata either from kernel appendix or metadata node
+
+                    md_start = buffer->get_frame_start() + buffer->get_length_frame_only();
+                    // TODO verify metadata <=255
+                    md_size = buffer->get_length_frame_only();
+
+//                    frame_object fo{ buffer->get_length_frame_only(), md_size,
+//                        buffer->get_frame_start(), md_start, timestamp };
+
+                     buffer->attach_buffer(buf);
+                     moved_qbuff = true;
+
+                     //TODO enqueue next buffers
+                     //auto fd = _fd;
+//                     _callback(_profile, fo,
+//                               [urb_sets]() mutable {
+//                         //      [fd, buffer]() mutable {
+//                         // Evgeni buffer->request_next_frame(fd);
+//                         for (auto&& kvp : urb_sets)
+//                             kvp.first->request_next_frame(kvp.second);
+//                     });
+                }
+                else
+                {
+                    LOG_WARNING("Empty frame has arrived.");
+                }
+            }
+            else
+            {
+                LOG_ERROR("Metadata frame arrived in idle mode."); // TODO - Evgeni verification
+            }
+
+            if (!moved_qbuff)
+            {
+                if (xioctl(_md_fd, VIDIOC_QBUF, &buf) < 0)
+                    throw linux_backend_exception("xioctl(VIDIOC_QBUF) failed");
+            }
         }
 
         std::shared_ptr<uvc_device> v4l_backend::create_uvc_device(uvc_device_info info) const

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -46,7 +46,6 @@
 // Metadata streaming nodes are available with kernels 4.16+
 #ifdef V4L2_META_FMT_UVC
 constexpr bool metadata_node = true;
-#pragma message ( "\nibrealsense notification: V4L2_META_FMT_UVC was found, metadata node will be enabled")
 #else
 #pragma message ( "\nLibrealsense notification: V4L2_META_FMT_UVC was not defined, adding metadata constructs")
 
@@ -68,9 +67,9 @@ constexpr bool metadata_node = false;
 
 // Use local definition of buf type to resolve for kernel versions
 constexpr auto LOCAL_V4L2_BUF_TYPE_META_CAPTURE = (v4l2_buf_type)(13);
-// uvcvideo.h
+
 #pragma pack(push, 1)
-// The struct definition is identical to one defined in kernel 4.16 headers, and is provided to allow for cross-kernel compilation
+// The struct definition is identical to uvc_meta_buf defined uvcvideo.h/ kernel 4.16 headers, and is provided to allow for cross-kernel compilation
 struct uvc_meta_buffer {
     __u64 ns;               // system timestamp of the payload in nanoseconds
     __u16 sof;              // USB Frame Number
@@ -79,9 +78,6 @@ struct uvc_meta_buffer {
     __u8* buf;              //device-specific metadata payload data
 };
 #pragma pack(pop)
-
-// uvc_meta_buf definition shall be kernel or locally defined
-//typedef std::conditional<std::is_class<uvc_meta_buf>::value, uvc_meta_buf, uvc_meta_buf_local>::type uvc_meta_buffer;
 
 
 namespace librealsense

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -45,10 +45,38 @@
 
 // Metadata streaming nodes are available with kernels 4.16+
 #ifndef V4L2_CAP_META_CAPTURE
-//#define V4L2_CAP_META_CAPTURE   0x00800000     // The device supports the Metadata Interface capture interface.
 constexpr bool metadata_node = true;
 #else
 constexpr bool metadata_node = false;
+
+// Providing missing parts from videodev2.h
+#define V4L2_META_FMT_UVC    v4l2_fourcc('U', 'V', 'C', 'H') /* UVC Payload Header */
+#define V4L2_CAP_META_CAPTURE		0x00800000  /* Is a metadata capture device */
+
+// uvcvideo.h
+/**
+ * struct uvc_meta_buf - metadata buffer building block
+ * @ns		- system timestamp of the payload in nanoseconds
+ * @sof		- USB Frame Number
+ * @length	- length of the payload header
+ * @flags	- payload header flags
+ * @buf		- optional device-specific header data
+ *
+ * UVC metadata nodes fill buffers with possibly multiple instances of this
+ * struct. The first two fields are added by the driver, they can be used for
+ * clock synchronisation. The rest is an exact copy of a UVC payload header.
+ * Only complete objects with complete buffers are included. Therefore it's
+ * always sizeof(meta->ts) + sizeof(meta->sof) + meta->length bytes large.
+ */
+#pragma pack(push, 1)
+struct uvc_meta_buf {
+    __u64 ns;               // system timestamp of the payload in nanoseconds
+    __u16 sof;
+    __u8 length;
+    __u8 flags;
+    __u8* buf;
+};
+#pragma pack(pop)
 #endif
 
 namespace librealsense

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -201,7 +201,7 @@ namespace librealsense
             virtual void prepare_capture_buffers();
             virtual void stop_data_capture();
             //virtual void capture_frame(fd_set &cur_fds);       // retrieve frame from kernel and dispatch user-callback
-            virtual void acquire_metadata(void *&md_start,uint8_t& md_size,
+            virtual void acquire_metadata(void *&md_start,uint8_t& md_size, fd_set &fds,
                                           std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> &datasets);
 
 
@@ -241,7 +241,7 @@ namespace librealsense
                     std::function<void(const uvc_device_info&,
                                        const std::string&)> action);
 
-            v4l_uvc_meta_device(const uvc_device_info& info, bool use_memory_map = true);
+            v4l_uvc_meta_device(const uvc_device_info& info, bool use_memory_map = false);
 
             ~v4l_uvc_meta_device();
 
@@ -291,7 +291,7 @@ namespace librealsense
             void unmap_device_descriptor();
             void set_format(stream_profile profile);
             void prepare_capture_buffers();
-            virtual void acquire_metadata(void *&md_start,uint8_t& md_size,
+            virtual void acquire_metadata(void *&md_start,uint8_t& md_size, fd_set &fds,
                                           std::vector<std::pair< std::shared_ptr<platform::buffer>,int>> &datasets);
 
             int _md_fd = -1;


### PR DESCRIPTION
Metadata device enumeration and binding to corresponding video device.
Metadata node configuration, data polling and dispatch.
Add alternative definitions for metadata blocks to allow build for kernels prior to 4.16
Parsing of basic UVC metadata payload (UVC timestamp)
Tracked on: DSO-9160