### PR TITLE
Fix bug - aligned point cloud is calculated incorrectly 

### DIFF
--- a/src/proc/align.cpp
+++ b/src/proc/align.cpp
@@ -548,7 +548,7 @@ namespace librealsense
                 if (auto aligned_video_profile = As<video_stream_profile_interface>(aligned_profile))
                 {
                     aligned_video_profile->set_dims(to_video_profile->get_width(), to_video_profile->get_height());
-                    auto aligned_intrinsics = original_video_profile->get_intrinsics();
+                    auto aligned_intrinsics = to_video_profile->get_intrinsics();
                     aligned_intrinsics.width = to_video_profile->get_width();
                     aligned_intrinsics.height = to_video_profile->get_height();
                     aligned_video_profile->set_intrinsics([aligned_intrinsics]() { return aligned_intrinsics; });


### PR DESCRIPTION
After alignment frame should save the intrinsic of the frame it is aligned to.

Tracked on: DSO-10045
Related to: #2002 

![image](https://user-images.githubusercontent.com/20966642/44399033-b7885f00-a54e-11e8-9b17-e1dcdc6998f8.png)
