### PR TITLE
Android run fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if(ANDROID_NDK_TOOLCHAIN_INCLUDED)
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_BSD_SOURCE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pedantic -g -Wno-missing-field-initializers")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar")
-
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie")
     message(STATUS "Prepare RealSense SDK for Android OS (${ANDROID_NDK_ABI_NAME})")
 endif()
 

--- a/doc/android/AndroidJavaApp.md
+++ b/doc/android/AndroidJavaApp.md
@@ -47,6 +47,7 @@ Click on `Run` and choose `Run 'app'`. Choose your Android device and click on t
 16. Open the Terminal Emulator application and type below lines in order to move to Super User mode and change the USB permissions.
 ```shell
 su
+setenforce 0
 lsusb
 chmod 0777 /dev/bus/usb/<Bus number>/<Dev Number>
 ```

--- a/doc/android/AndroidNativeSamples.md
+++ b/doc/android/AndroidNativeSamples.md
@@ -14,7 +14,7 @@ This document describes how to build the Intel® RealSense™ SDK 2.0 including 
 7. Open Terminal on the host machine, navigate to *librealsense* root directory and type the following lines:
 ```shell
 mkdir build && cd build
-cmake .. -DANDROID_ABI=<Application Binary Interface> -DCMAKE_TOOLCHAIN_FILE=<Path to NDK folder>/build/cmake/android.toolchain.cmake -DFORCE_LIBUVC=TRUE
+cmake .. -DANDROID_ABI=<Application Binary Interface> -DCMAKE_TOOLCHAIN_FILE=<Path to NDK folder>/build/cmake/android.toolchain.cmake -DFORCE_LIBUVC=TRUE -DBUILD_SHARED_LIBS=false
 make
 ```
 
@@ -23,7 +23,6 @@ make
 8. When compilation done type the following lines to store the binaries at the same location to easily copy them to your Android device.
 ```shell
 mkdir lrs_binaries && cd lrs_binaries
-cp ../librealsense2.so ./
 cp ../examples/C/color/rs-color ./
 cp ../examples/C/depth/rs-depth ./
 cp ../examples/C/distance/rs-distance ./

--- a/doc/android/native-lib.cpp_
+++ b/doc/android/native-lib.cpp_
@@ -8,7 +8,6 @@
 #include "librealsense/include/librealsense2/hpp/rs_pipeline.hpp"
 #include "librealsense/include/librealsense2/hpp/rs_internal.hpp"
 
-
 static rs2::context ctx;
 static std::atomic<bool> streaming(false);
 static std::thread frame_thread;
@@ -21,23 +20,26 @@ Java_com_example_realsense_1app_MainActivity_startStreaming(JNIEnv *env, jobject
             return;
 
         const char* nativeClassName = env->GetStringUTFChars(className, 0);
-        jclass handlerClass = env->FindClass(nativeClassName);
-        env->ReleaseStringUTFChars(className, nativeClassName);
-        if (handlerClass == NULL) {
+        jclass localClass = env->FindClass(nativeClassName);
+        if (localClass == NULL) {
             throw std::runtime_error("FindClass(...) failed!");
         }
+
+        jclass handlerClass = reinterpret_cast<jclass>(env->NewGlobalRef(localClass));
+        env->ReleaseStringUTFChars(className, nativeClassName);
 
         jmethodID onFrame = env->GetStaticMethodID(handlerClass, "onFrame",
                                                    "(Ljava/lang/Object;II)V");
         if (onFrame == NULL) {
+            env->DeleteGlobalRef(handlerClass);
             throw std::runtime_error("GetStaticMethodID(...) failed!");
         }
 
         auto list = ctx.query_devices();
         if (0 == list.size()) {
+            env->DeleteGlobalRef(handlerClass);
             throw std::runtime_error("No RealSense devices where found!");
         }
-
 
         JavaVM* vm;
         env->GetJavaVM(&vm);
@@ -76,6 +78,7 @@ Java_com_example_realsense_1app_MainActivity_startStreaming(JNIEnv *env, jobject
             {}
 
             env->DeleteLocalRef(arr);
+            env->DeleteGlobalRef(handlerClass);
             vm->DetachCurrentThread();
         });
     }
@@ -93,9 +96,9 @@ Java_com_example_realsense_1app_MainActivity_stopStreaming(JNIEnv *env, jobject 
         if (!streaming)
             return;
 
-            streaming = false;
-            if (frame_thread.joinable())
-                frame_thread.join();
+        streaming = false;
+        if (frame_thread.joinable())
+            frame_thread.join();
 
     }
     catch (const std::exception& ex)


### PR DESCRIPTION
- Added PIE linker flags (when compiled in terminal as in the tutorial, file couldn't run because  of "Only position independent executables (PIE) are supported" error);
- Fixed local reference issue in the example code for the tutorial (as suggested by @aarun2211 and @bilalbinrais );
- In the .md files:  -DBUILD_SHARED_LIBS=false solves "librealsense2.so not found" error.

Fixes: #2008 #2075