### PR TITLE
Removing the creation of usb_interface in recreate_interface method

### DIFF
--- a/src/win/win-usb.cpp
+++ b/src/win/win-usb.cpp
@@ -54,7 +54,6 @@ namespace librealsense
             }
 
             open(_lp_device_path);
-            _usb_interface = std::make_unique<usb_interface>(_device_handle);
         }
 
         void winusb_device::release()


### PR DESCRIPTION
`usb_interface` object is already created in open(...) method