### PR TITLE
disable hid devices enumeration on windows

### DIFF
--- a/src/win/win-hid.cpp
+++ b/src/win/win-hid.cpp
@@ -238,6 +238,7 @@ namespace librealsense
 
         void wmf_hid_device::foreach_hid_device(std::function<void(hid_device_info, CComPtr<ISensor>)> action)
         {
+            return; // HID devices aren't supported on Windows OS
             try
             {
                 CComPtr<ISensorManager> pSensorManager = nullptr;


### PR DESCRIPTION
### Fix - query device function doesn't release memory causing memory leak
github issue: #1899
Jira issue: [DSO-9792](https://rsjira.intel.com/browse/DSO-9792)