### PR TITLE
Fix the formatting of the viewer's picker display

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2580,7 +2580,7 @@ namespace rs2
             float val{};
             if (texture->try_pick(x, y, &val))
             {
-                ss << ", *p: 0x" << std::hex << val;
+                ss << ", *p: 0x" << std::hex << static_cast<int>(round(val));
             }
 
             if (texture->get_last_frame().is<depth_frame>())


### PR DESCRIPTION
The picker displays pixel values with an "0x" prefix, but the actual
output value is base 10, not hex. Casting the value to an int allows the
formatter to work as intended.