### PR TITLE
Add AVX2-specific preprocessor guards

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -312,6 +312,7 @@ namespace librealsense
 #ifndef ANDROID
     #ifdef __SSSE3__
             static bool do_avx = has_avx();
+    #ifdef __AVX2__
 
             if (do_avx)
             {
@@ -323,6 +324,7 @@ namespace librealsense
                 if (FORMAT == RS2_FORMAT_BGRA8) unpack_yuy2_avx_bgra8(d, s, n);
             }
             else
+    #endif
             {
                 auto src = reinterpret_cast<const __m128i *>(s);
                 auto dst = reinterpret_cast<__m128i *>(d[0]);

--- a/src/image_avx.cpp
+++ b/src/image_avx.cpp
@@ -8,7 +8,7 @@
 //#include "../include/librealsense2/rsutil.h" // For projection/deprojection logic
 
 #ifndef ANDROID
-    #ifdef __SSSE3__
+    #if defined(__SSSE3__) && defined(__AVX2__)
     #include <tmmintrin.h> // For SSE3 intrinsic used in unpack_yuy2_sse
     #include <immintrin.h>
 

--- a/src/image_avx.h
+++ b/src/image_avx.h
@@ -10,7 +10,7 @@
 namespace librealsense
 {
 #ifndef ANDROID
-    #ifdef __SSSE3__
+    #if defined(__SSSE3__) && defined(__AVX2__)
     void unpack_yuy2_avx_y8(byte * const d[], const byte * s, int n);
     void unpack_yuy2_avx_y16(byte * const d[], const byte * s, int n);
     void unpack_yuy2_avx_rgb8(byte * const d[], const byte * s, int n);


### PR DESCRIPTION
This fixes a failed compilation when building for a processor supporting SSSE3, but not AVX (building without `-mavx`). This should address point 2 on Issue #2299.