### PR TITLE
Change the log level to suppress the warning which critically affects…

### DIFF
--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -1104,7 +1104,7 @@ namespace librealsense
                         LOG_WARNING("Failed to read busnum/devnum. Device Path: " << elem);
                     }
 #else
-                    LOG_WARNING("Failed to read busnum/devnum. Device Path: " << elem);
+                    LOG_INFO("Failed to read busnum/devnum. Device Path: " << elem);
 #endif
                     continue;
                 }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -488,7 +488,7 @@ namespace librealsense
 #ifndef RS2_USE_CUDA
                        /* On the Jetson TX, the camera module is CSI & I2C and does not report as this code expects
                        Patch suggested by JetsonHacks: https://github.com/jetsonhacks/buildLibrealsense2TX */
-                        LOG_WARNING("Failed to read busnum/devnum. Device Path: " << path);
+                        LOG_INFO("Failed to read busnum/devnum. Device Path: " << path);
 #endif
                         continue;
                     }


### PR DESCRIPTION
… the system performance, especially for Odroid XU4, UP board, Compute Stick, Aero. Please note these boards have no high-end CPU with great performance. Also, this warning is for IIO hardware control which should be not required.