### PR TITLE
Handle stop streaming and IR enumaration issues on lib_uvc (RS5-2042)

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -984,7 +984,6 @@ namespace librealsense
                                                                                { requires_processing, &copy_pixels<2>,                               { { RS2_STREAM_DEPTH,          RS2_FORMAT_Z16                    } } } } };
     const native_pixel_format pf_y8_l500                  = { 'GREY', 1, 1, {  { true,                &rotate_270_degrees_clockwise<1>,              { { RS2_STREAM_INFRARED,       RS2_FORMAT_Y8,   rotate_resolution } } },
                                                                                { requires_processing, &copy_pixels<1>,                               { { RS2_STREAM_INFRARED,       RS2_FORMAT_Y8 } } } } };
-
     const native_pixel_format pf_y8                       = { 'GREY', 1, 1, {  { requires_processing, &copy_pixels<1>,                             { { { RS2_STREAM_INFRARED, 1 },  RS2_FORMAT_Y8  } } } } };
     const native_pixel_format pf_y16                      = { 'Y16 ', 1, 2, {  { true,                &unpack_y16_from_y16_10,                     { { { RS2_STREAM_INFRARED, 1 },  RS2_FORMAT_Y16 } } } } };
     const native_pixel_format pf_y8i                      = { 'Y8I ', 1, 2, {  { true,                &unpack_y8_y8_from_y8i,                      { { { RS2_STREAM_INFRARED, 1 },  RS2_FORMAT_Y8  },

--- a/src/libuvc/libuvc.cpp
+++ b/src/libuvc/libuvc.cpp
@@ -346,6 +346,9 @@ namespace librealsense
             void stop_callbacks() override
             {
                 _is_started = false;
+                _stream_ctrls.clear();
+                _profiles.clear();
+                _callbacks.clear();
             }
 
             void close(stream_profile) override


### PR DESCRIPTION
1. Clean the cached data of streams when stop the streaming 
2. Fixed IR enumeration issue on lib_uvc by mapping from HW Fourcc to 'GRAY'