### PR TITLE
Addressing GitHub #2178 / DSO-10235 - playback twice

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -356,7 +356,8 @@ namespace librealsense
 
         for (auto&& item : playback_devices)
         {
-            list.push_back(item.second.lock());
+            if (auto dev = item.second.lock())
+                list.push_back(dev);
         }
 
         return list;


### PR DESCRIPTION
Follow-up on #2178:
The following code now works: 
```cpp
        rs2::pipeline pipe;

	{
		rs2::config config;
		config.enable_device_from_file( "file1.bag" );
		pipe.start( config );
		pipe.stop();
	}

	{
		rs2::config config;
		config.enable_device_from_file( "file2.bag" );
		pipe.start( config );
		pipe.stop();
	}
```