### PR TITLE
Video4Linux uvcvideo buffers overlow handling

### DIFF
--- a/scripts/0001-Debug-ioctl-fmt-desc.patch
+++ b/scripts/0001-Debug-ioctl-fmt-desc.patch
@@ -1,0 +1,28 @@
+From 72064c30574df63d52c3d0baeb9f9b585064f548 Mon Sep 17 00:00:00 2001
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+Date: Thu, 30 Aug 2018 17:29:13 +0300
+Subject: [PATCH] Debug ioctl fmt desc
+
+The patch is useful to profile kernel calls invocation after applying kernel patches
+
+---
+ drivers/media/v4l2-core/v4l2-ioctl.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
+index cab63bb..e8b6590 100644
+--- a/drivers/media/v4l2-core/v4l2-ioctl.c
++++ b/drivers/media/v4l2-core/v4l2-ioctl.c
+@@ -1105,6 +1105,9 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+ 	const char *descr = NULL;
+ 	u32 flags = 0;
+ 
++	printk(KERN_DEBUG "LRS dbg: read format description for pixel_format: %x\n",
++					fmt->pixelformat);
++
+ 	/*
+ 	 * We depart from the normal coding style here since the descriptions
+ 	 * should be aligned so it is easy to see which descriptions will be
+-- 
+2.7.4
+

--- a/scripts/patch-realsense-ubuntu-lts.sh
+++ b/scripts/patch-realsense-ubuntu-lts.sh
@@ -40,6 +40,7 @@ then
 fi
 kernel_branch=$(choose_kernel_branch ${LINUX_BRANCH} ${ubuntu_codename})
 kernel_name="ubuntu-${ubuntu_codename}-$kernel_branch"
+echo -e "\e[32mCreate patches workspace in \e[93m${kernel_name} \e[32mfolder\n\e[0m"
 
 #Distribution-specific packages
 if [ ${ubuntu_codename} == "bionic" ];
@@ -92,6 +93,10 @@ else
 	patch -p1 < ../scripts/realsense-hid-ubuntu-${ubuntu_codename}-${kernel_branch}.patch
 	echo -e "\e[32mApplying realsense-powerlinefrequency-fix patch\e[0m"
 	patch -p1 < ../scripts/realsense-powerlinefrequency-control-fix.patch
+	# Applying 3rd-party patch that affects USB2 behavior
+	# See reference https://patchwork.kernel.org/patch/9907707/
+	echo -e "\e[32mRetrofit uvc bug fix enabled with 4.18+\e[0m"
+	patch -p1 < ../scripts/v1-media-uvcvideo-mark-buffer-error-where-overflow.patch
 fi
 
 # Copy configuration

--- a/scripts/patch-utils.sh
+++ b/scripts/patch-utils.sh
@@ -116,7 +116,7 @@ function try_module_insert {
 	backup_available=1
 	dependent_modules=""
 
-	printf "\e[32mReplacing\e[93m\e[1m%s \e[32m:\n\e[0m" ${module_name}
+	printf "\e[32mReplacing \e[93m\e[1m%s \e[32m:\n\e[0m" ${module_name}
 
 	#Check if the module is loaded, and if does - are there dependent kernel modules.
 	#Unload those first, then unload the requsted module and proceed with replacement

--- a/scripts/realsense-camera-formats_ubuntu-xenial-Ubuntu-hwe-4.13.0-45.50_16.04.1.patch
+++ b/scripts/realsense-camera-formats_ubuntu-xenial-Ubuntu-hwe-4.13.0-45.50_16.04.1.patch
@@ -1,22 +1,22 @@
-From e80ed73e9489d7833dbdd3e24d11c0e01d9c4ffd Mon Sep 17 00:00:00 2001
+From 40c5c21a9613165904cca37f5d15632b442987bc Mon Sep 17 00:00:00 2001
 From: Evgeni Raikhel <evgeni.raikhel@intel.com>
 From: icarpis <itay.carpis@intel.com>
-Date: Sun, 18 Mar 2018 11:04:42 +0200
+Date: Thu, 30 Aug 2018 16:07:01 +0300
 Subject: [PATCH] realsense formats patch for kernel 4.13
 
 Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c   | 37 ++++++++++++++++++++++++++++++++++++
- drivers/media/usb/uvc/uvcvideo.h     | 22 +++++++++++++++++++++
- drivers/media/v4l2-core/v4l2-ioctl.c |  3 +++
- include/uapi/linux/videodev2.h       |  3 +++
- 4 files changed, 65 insertions(+)
+ drivers/media/usb/uvc/uvc_driver.c   | 52 ++++++++++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++++++++
+ drivers/media/v4l2-core/v4l2-ioctl.c |  8 +++++-
+ include/uapi/linux/videodev2.h       |  8 ++++++
+ 4 files changed, 101 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
-index 70842c5..0f43de2 100644
+index 70842c5..2c92aa0 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -203,6 +203,43 @@ static struct uvc_format_desc uvc_fmts[] = {
+@@ -203,6 +203,58 @@ static struct uvc_format_desc uvc_fmts[] = {
  		.guid		= UVC_GUID_FORMAT_INZI,
  		.fcc		= V4L2_PIX_FMT_INZI,
  	},
@@ -46,7 +46,7 @@ index 70842c5..0f43de2 100644
 +		.guid		= UVC_GUID_FORMAT_RAW8,
 +		.fcc		= V4L2_PIX_FMT_GREY,
 +	},
-+	/* Legacy formats for backward-compatibility*/
++	/* Legacy/Development formats for backward-compatibility*/
 +	{
 +		.name		= "Raw data 16-bit (RW16)",
 +		.guid		= UVC_GUID_FORMAT_RW16,
@@ -57,14 +57,29 @@ index 70842c5..0f43de2 100644
 +		.guid		= UVC_GUID_FORMAT_BAYER16,
 +		.fcc		= V4L2_PIX_FMT_SBGGR16,
 +	},
++	{
++		.name		= "Frame Grabber (FG  )",
++		.guid		= UVC_GUID_FORMAT_FG,
++		.fcc		= V4L2_PIX_FMT_FG,
++	},
++	{
++		.name		= "SR300 Depth/Confidence (INZC)",
++		.guid		= UVC_GUID_FORMAT_INZC,
++		.fcc		= V4L2_PIX_FMT_INZC,
++	},
++	{
++		.name		= "Relative IR (PAIR)",
++		.guid		= UVC_GUID_FORMAT_PAIR,
++		.fcc		= V4L2_PIX_FMT_PAIR,
++	},
  };
 
  /* ------------------------------------------------------------------------
 diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
-index 15e415e..d7b62a2 100644
+index 15e415e..1ade6ee 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -152,6 +152,28 @@
+@@ -152,6 +152,40 @@
  #define UVC_GUID_FORMAT_INVI \
  	{ 'I',  'N',  'V',  'I', 0xdb, 0x57, 0x49, 0x5e, \
  	 0x8e, 0x3f, 0xf4, 0x79, 0x53, 0x2b, 0x94, 0x6f}
@@ -83,45 +98,66 @@ index 15e415e..d7b62a2 100644
 +#define UVC_GUID_FORMAT_CONFIDENCE_MAP \
 +	{ 'C',  ' ',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
 +	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
-+/* Legacy formats */
++/* Legacy/Development formats */
 +#define UVC_GUID_FORMAT_RW16 \
 +	{ 'R',  'W',  '1',  '6', 0x00, 0x00, 0x10, 0x00, \
 +	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
 +#define UVC_GUID_FORMAT_BAYER16 \
 +	{ 'R',  'W',  '1',  '6', 0x66, 0x1a, 0x42, 0xa2, \
 +	0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
-
++#define UVC_GUID_FORMAT_BAYER16 \
++	{ 'R',  'W',  '1',  '6', 0x66, 0x1a, 0x42, 0xa2, \
++	0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
++#define UVC_GUID_FORMAT_FG \
++	{ 'F',  'G',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_INZC \
++	{ 'I',  'N',  'Z',  'C', 0x02, 0xb6, 0x0f, 0x48, \
++	0x97, 0x8c, 0xe4, 0xe8, 0x8a, 0xe8, 0x9b, 0x89}
++#define UVC_GUID_FORMAT_PAIR \
++	{ 'P',  'A',  'I',  'R', 0x36, 0x85, 0x41, 0x48, \
++	0xb6, 0xbf, 0x8f, 0xc6, 0xff, 0xb0, 0x83, 0xa8}
+ 
  /* ------------------------------------------------------------------------
   * Driver specific constants.
 diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
-index cab63bb..85935a9 100644
+index cab63bb..f9fcf13 100644
 --- a/drivers/media/v4l2-core/v4l2-ioctl.c
 +++ b/drivers/media/v4l2-core/v4l2-ioctl.c
-@@ -1239,6 +1239,10 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+@@ -1239,7 +1239,13 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
  	case V4L2_TCH_FMT_TU08:		descr = "8-bit unsigned touch data"; break;
  	case V4L2_META_FMT_VSP1_HGO:	descr = "R-Car VSP1 1-D Histogram"; break;
  	case V4L2_META_FMT_VSP1_HGT:	descr = "R-Car VSP1 2-D Histogram"; break;
-+	/* Librealsense formats*/
+-
++	/* Librealsense Legacy/Development formats*/
 +	case V4L2_PIX_FMT_RW16:		descr = "16-bit Raw data"; break;
 +	case V4L2_PIX_FMT_W10:		descr = "10-bit packed 8888[2222]"; break;
-+	case V4L2_PIX_FMT_CONFIDENCE_MAP:		descr = "4-bit per pixel packed into 8 bit"; break;
-
++	case V4L2_PIX_FMT_CONFIDENCE_MAP:	descr = "4-bit per pixel packed"; break;
++	case V4L2_PIX_FMT_FG:		descr = "Frame Grabber (FG  )"; break;
++	case V4L2_PIX_FMT_INZC:		descr = "Planar Depth/Confidence (INZC)"; break;
++	case V4L2_PIX_FMT_PAIR:		descr = "Relative IR (PAIR)"; break;
  	default:
  		/* Compressed formats */
+ 		flags = V4L2_FMT_FLAG_COMPRESSED;
 diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
-index 45cf735..0bcd206 100644
+index 45cf735..6944a02 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -662,6 +662,9 @@ struct v4l2_pix_format {
+@@ -662,6 +662,14 @@ struct v4l2_pix_format {
  #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
  #define V4L2_PIX_FMT_MT21C    v4l2_fourcc('M', 'T', '2', '1') /* Mediatek compressed block mode  */
  #define V4L2_PIX_FMT_INZI     v4l2_fourcc('I', 'N', 'Z', 'I') /* Intel Planar Greyscale 10-bit and Depth 16-bit */
 +#define V4L2_PIX_FMT_RW16	v4l2_fourcc('R', 'W', '1', '6') /* Raw data 16-bit */
 +#define V4L2_PIX_FMT_W10	v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
 +#define V4L2_PIX_FMT_CONFIDENCE_MAP  v4l2_fourcc('C', ' ', ' ', ' ') /* Two pixels in one byte */
-
++
++/*  Librealsense development*/
++#define V4L2_PIX_FMT_FG	v4l2_fourcc('F', 'G', ' ', ' ') /* Frame Grabber */
++#define V4L2_PIX_FMT_INZC	v4l2_fourcc('I', 'N', 'Z', 'C') /* Planar Depth/Confidence */
++#define V4L2_PIX_FMT_PAIR	v4l2_fourcc('P', 'A', 'I', 'R') /* Relative IR */
+ 
  /* SDR formats - used only for Software Defined Radio devices */
  #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */
---
+-- 
 2.7.4
 

--- a/scripts/realsense-camera-formats_ubuntu-xenial-hwe-zesty.patch
+++ b/scripts/realsense-camera-formats_ubuntu-xenial-hwe-zesty.patch
@@ -1,20 +1,22 @@
 From ceb29b08b480a2a6a5e9dccf396a284378268037 Mon Sep 17 00:00:00 2001
 From: aangerma <Avishag.Angerman@intel.com>
-Date: Wed, 22 Aug 2018 13:08:03 +0300
-Subject: [PATCH] C
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+From: icarpis <itay.carpis@intel.com>
+Date: Thu, 30 Aug 2018 16:07:01 +0300
+Subject: [PATCH] Register realsense development formats. Kernel 4.10
 
 ---
- drivers/media/usb/uvc/uvc_driver.c   | 55 ++++++++++++++++++++++++++++++++++++
- drivers/media/usb/uvc/uvcvideo.h     | 33 ++++++++++++++++++++++
- drivers/media/v4l2-core/v4l2-ioctl.c |  5 +++-
- include/uapi/linux/videodev2.h       |  6 +++-
- 4 files changed, 97 insertions(+), 2 deletions(-)
+ drivers/media/usb/uvc/uvc_driver.c   | 82 ++++++++++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvcvideo.h     | 42 ++++++++++++++++++
+ drivers/media/v4l2-core/v4l2-ioctl.c |  8 +++-
+ include/uapi/linux/videodev2.h       | 11 ++++-
+ 4 files changed, 141 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
-index 04bf350..5df98e5 100644
+index 04bf350..bb8fefb 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -188,6 +188,61 @@ static struct uvc_format_desc uvc_fmts[] = {
+@@ -188,6 +188,88 @@ static struct uvc_format_desc uvc_fmts[] = {
  		.guid		= UVC_GUID_FORMAT_GR16,
  		.fcc		= V4L2_PIX_FMT_SGRBG16,
  	},
@@ -73,14 +75,41 @@ index 04bf350..5df98e5 100644
 +		.guid		= UVC_GUID_FORMAT_CONFIDENCE_MAP,
 +		.fcc		= V4L2_PIX_FMT_CONFIDENCE_MAP,
 +	},
++	/* FishEye 8-bit monochrome */
++	{
++		.name		= "Raw data 8-bit (RAW8)",
++		.guid		= UVC_GUID_FORMAT_RAW8,
++		.fcc		= V4L2_PIX_FMT_GREY,
++	},
++	/* Legacy/Development formats for backward-compatibility*/
++	{
++		.name		= "Raw data 16-bit (RW16)",
++		.guid		= UVC_GUID_FORMAT_RW16,
++		.fcc		= V4L2_PIX_FMT_RW16,
++	},
++	{
++		.name		= "Frame Grabber (FG  )",
++		.guid		= UVC_GUID_FORMAT_FG,
++		.fcc		= V4L2_PIX_FMT_FG,
++	},
++	{
++		.name		= "SR300 Depth/Confidence (INZC)",
++		.guid		= UVC_GUID_FORMAT_INZC,
++		.fcc		= V4L2_PIX_FMT_INZC,
++	},
++	{
++		.name		= "Relative IR (PAIR)",
++		.guid		= UVC_GUID_FORMAT_PAIR,
++		.fcc		= V4L2_PIX_FMT_PAIR,
++	},
  };
  
  /* ------------------------------------------------------------------------
 diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
-index 3d6cc62..575c1ea 100644
+index 3d6cc62..6ffdc0e 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -143,6 +143,39 @@
+@@ -143,6 +143,48 @@
  #define UVC_GUID_FORMAT_RW10 \
  	{ 'R',  'W',  '1',  '0', 0x00, 0x00, 0x10, 0x00, \
  	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
@@ -117,14 +146,23 @@ index 3d6cc62..575c1ea 100644
 +#define UVC_GUID_FORMAT_CONFIDENCE_MAP \
 +	{ 'C',  ' ',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
 +	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_FG \
++	{ 'F',  'G',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_INZC \
++	{ 'I',  'N',  'Z',  'C', 0x02, 0xb6, 0x0f, 0x48, \
++	0x97, 0x8c, 0xe4, 0xe8, 0x8a, 0xe8, 0x9b, 0x89}
++#define UVC_GUID_FORMAT_PAIR \
++	{ 'P',  'A',  'I',  'R', 0x36, 0x85, 0x41, 0x48, \
++	0xb6, 0xbf, 0x8f, 0xc6, 0xff, 0xb0, 0x83, 0xa8}
  
  /* ------------------------------------------------------------------------
   * Driver specific constants.
 diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
-index 0c3f238..09fbc6d 100644
+index 0c3f238..5347286 100644
 --- a/drivers/media/v4l2-core/v4l2-ioctl.c
 +++ b/drivers/media/v4l2-core/v4l2-ioctl.c
-@@ -1217,7 +1217,10 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+@@ -1217,7 +1217,13 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
  	case V4L2_TCH_FMT_DELTA_TD08:	descr = "8-bit signed deltas"; break;
  	case V4L2_TCH_FMT_TU16:		descr = "16-bit unsigned touch data"; break;
  	case V4L2_TCH_FMT_TU08:		descr = "8-bit unsigned touch data"; break;
@@ -132,15 +170,18 @@ index 0c3f238..09fbc6d 100644
 +	case V4L2_PIX_FMT_RW16:		descr = "16-bit Raw data"; break;
 +	case V4L2_PIX_FMT_INZI:		descr = "32-bit IR:Depth 10:16"; break;
 +	case V4L2_PIX_FMT_W10:		descr = "10-bit packed 8888[2222]"; break;
-+	case V4L2_PIX_FMT_CONFIDENCE_MAP:		descr = "4-bit per pixel packed into 8 bit"; break;
++	case V4L2_PIX_FMT_CONFIDENCE_MAP:	descr = "4-bit per pixel packed"; break;
++	case V4L2_PIX_FMT_FG:		descr = "Frame Grabber (FG  )"; break;
++	case V4L2_PIX_FMT_INZC:		descr = "Planar Depth/Confidence (INZC)"; break;
++	case V4L2_PIX_FMT_PAIR:		descr = "Relative IR (PAIR)"; break;
  	default:
  		/* Compressed formats */
  		flags = V4L2_FMT_FLAG_COMPRESSED;
 diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
-index 45184a2..48c3592 100644
+index 45184a2..e7f6029 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -661,7 +661,11 @@ struct v4l2_pix_format {
+@@ -661,7 +661,16 @@ struct v4l2_pix_format {
  #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
  #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
  #define V4L2_PIX_FMT_MT21C    v4l2_fourcc('M', 'T', '2', '1') /* Mediatek compressed block mode  */
@@ -150,6 +191,11 @@ index 45184a2..48c3592 100644
 +#define V4L2_PIX_FMT_INZI	v4l2_fourcc('I', 'N', 'Z', 'I') /* 24 Depth/IR 16:8 */
 +#define V4L2_PIX_FMT_W10      v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
 +#define V4L2_PIX_FMT_CONFIDENCE_MAP  v4l2_fourcc('C', ' ', ' ', ' ') /* Two pixels in one byte */
++
++/*  Librealsense development*/
++#define V4L2_PIX_FMT_FG	v4l2_fourcc('F', 'G', ' ', ' ') /* Frame Grabber */
++#define V4L2_PIX_FMT_INZC	v4l2_fourcc('I', 'N', 'Z', 'C') /* Planar Depth/Confidence */
++#define V4L2_PIX_FMT_PAIR	v4l2_fourcc('P', 'A', 'I', 'R') /* Relative IR */
  /* SDR formats - used only for Software Defined Radio devices */
  #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */
  #define V4L2_SDR_FMT_CU16LE       v4l2_fourcc('C', 'U', '1', '6') /* IQ u16le */

--- a/scripts/realsense-camera-formats_ubuntu-xenial-hwe.patch
+++ b/scripts/realsense-camera-formats_ubuntu-xenial-hwe.patch
@@ -1,20 +1,20 @@
-From ee8d2d09ab3492665a8ca5fb7fb6727a279392b2 Mon Sep 17 00:00:00 2001
+From 7013990ed22d6ab5884b2cf8647332c37586f3b6 Mon Sep 17 00:00:00 2001
 From: Evgeni <evgeni.raikhel@intel.com>
 From: icarpis <itay.carpis@intel.com>
-Date: Sun, 13 May 2018 10:37:44 -0400
-Subject: [PATCH] Streaming formats for Ubuntu 18.04 (Bionic Beaver), Kernel 4.15
+Date: Sun, 2 Sep 2018 13:12:14 +0300
+Subject: [PATCH] Streaming formats for Ubuntu  Kernel 4.15
 
 Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 ---
  drivers/media/usb/uvc/Makefile       |  1 +
- drivers/media/usb/uvc/uvc_driver.c   | 37 ++++++++++++++++++++++++++++
- drivers/media/usb/uvc/uvcvideo.h     | 22 +++++++++++++++++
- drivers/media/v4l2-core/v4l2-ioctl.c |  3 +++
- include/uapi/linux/videodev2.h       |  3 +++
- 5 files changed, 66 insertions(+)
+ drivers/media/usb/uvc/uvc_driver.c   | 52 ++++++++++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvcvideo.h     | 34 +++++++++++++++++++++++
+ drivers/media/v4l2-core/v4l2-ioctl.c |  8 +++++-
+ include/uapi/linux/videodev2.h       |  8 ++++++
+ 5 files changed, 102 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/Makefile b/drivers/media/usb/uvc/Makefile
-index a4fe5b5d5..cb5ee0955 100644
+index a4fe5b5..cb5ee09 100644
 --- a/drivers/media/usb/uvc/Makefile
 +++ b/drivers/media/usb/uvc/Makefile
 @@ -1,4 +1,5 @@
@@ -24,10 +24,10 @@ index a4fe5b5d5..cb5ee0955 100644
  		  uvc_status.o uvc_isight.o uvc_debugfs.o
  ifeq ($(CONFIG_MEDIA_CONTROLLER),y)
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
-index 28b91b7d7..f50a2b148 100644
+index 28b91b7..a262064 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -203,6 +203,43 @@ static struct uvc_format_desc uvc_fmts[] = {
+@@ -203,6 +203,58 @@ static struct uvc_format_desc uvc_fmts[] = {
  		.guid		= UVC_GUID_FORMAT_INZI,
  		.fcc		= V4L2_PIX_FMT_INZI,
  	},
@@ -57,7 +57,7 @@ index 28b91b7d7..f50a2b148 100644
 +		.guid		= UVC_GUID_FORMAT_RAW8,
 +		.fcc		= V4L2_PIX_FMT_GREY,
 +	},
-+	/* Legacy formats for backward-compatibility*/
++	/* Legacy/Development formats for backward-compatibility*/
 +	{
 +		.name		= "Raw data 16-bit (RW16)",
 +		.guid		= UVC_GUID_FORMAT_RW16,
@@ -68,14 +68,29 @@ index 28b91b7d7..f50a2b148 100644
 +		.guid		= UVC_GUID_FORMAT_BAYER16,
 +		.fcc		= V4L2_PIX_FMT_SBGGR16,
 +	},
++	{
++		.name		= "Frame Grabber (FG  )",
++		.guid		= UVC_GUID_FORMAT_FG,
++		.fcc		= V4L2_PIX_FMT_FG,
++	},
++	{
++		.name		= "SR300 Depth/Confidence (INZC)",
++		.guid		= UVC_GUID_FORMAT_INZC,
++		.fcc		= V4L2_PIX_FMT_INZC,
++	},
++	{
++		.name		= "Relative IR (PAIR)",
++		.guid		= UVC_GUID_FORMAT_PAIR,
++		.fcc		= V4L2_PIX_FMT_PAIR,
++	},
  };
-
+ 
  /* ------------------------------------------------------------------------
 diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
-index 05398784d..8c99aabef 100644
+index 0539878..401882d 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -153,6 +153,28 @@
+@@ -153,6 +153,40 @@
  #define UVC_GUID_FORMAT_INVI \
  	{ 'I',  'N',  'V',  'I', 0xdb, 0x57, 0x49, 0x5e, \
  	 0x8e, 0x3f, 0xf4, 0x79, 0x53, 0x2b, 0x94, 0x6f}
@@ -94,43 +109,66 @@ index 05398784d..8c99aabef 100644
 +#define UVC_GUID_FORMAT_CONFIDENCE_MAP \
 +	{ 'C',  ' ',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
 +	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
-+/* Legacy formats */
++/* Legacy/Development formats */
 +#define UVC_GUID_FORMAT_RW16 \
 +	{ 'R',  'W',  '1',  '6', 0x00, 0x00, 0x10, 0x00, \
 +	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
 +#define UVC_GUID_FORMAT_BAYER16 \
 +	{ 'R',  'W',  '1',  '6', 0x66, 0x1a, 0x42, 0xa2, \
 +	0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
-
++#define UVC_GUID_FORMAT_BAYER16 \
++	{ 'R',  'W',  '1',  '6', 0x66, 0x1a, 0x42, 0xa2, \
++	0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
++#define UVC_GUID_FORMAT_FG \
++	{ 'F',  'G',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_INZC \
++	{ 'I',  'N',  'Z',  'C', 0x02, 0xb6, 0x0f, 0x48, \
++	0x97, 0x8c, 0xe4, 0xe8, 0x8a, 0xe8, 0x9b, 0x89}
++#define UVC_GUID_FORMAT_PAIR \
++	{ 'P',  'A',  'I',  'R', 0x36, 0x85, 0x41, 0x48, \
++	0xb6, 0xbf, 0x8f, 0xc6, 0xff, 0xb0, 0x83, 0xa8}
+ 
  /* ------------------------------------------------------------------------
   * Driver specific constants.
 diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
-index 89e0878ce..c422d70a2 100644
+index 89e0878..b584ff1 100644
 --- a/drivers/media/v4l2-core/v4l2-ioctl.c
 +++ b/drivers/media/v4l2-core/v4l2-ioctl.c
-@@ -1246,6 +1246,9 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+@@ -1246,7 +1246,13 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
  	case V4L2_TCH_FMT_TU08:		descr = "8-bit unsigned touch data"; break;
  	case V4L2_META_FMT_VSP1_HGO:	descr = "R-Car VSP1 1-D Histogram"; break;
  	case V4L2_META_FMT_VSP1_HGT:	descr = "R-Car VSP1 2-D Histogram"; break;
-+	/* Librealsense formats*/
+-
++	/* Librealsense Legacy/Development formats*/
 +	case V4L2_PIX_FMT_RW16:		descr = "16-bit Raw data"; break;
 +	case V4L2_PIX_FMT_W10:		descr = "10-bit packed 8888[2222]"; break;
-
++	case V4L2_PIX_FMT_CONFIDENCE_MAP:	descr = "4-bit per pixel packed"; break;
++	case V4L2_PIX_FMT_FG:		descr = "Frame Grabber (FG  )"; break;
++	case V4L2_PIX_FMT_INZC:		descr = "Planar Depth/Confidence (INZC)"; break;
++	case V4L2_PIX_FMT_PAIR:		descr = "Relative IR (PAIR)"; break;
  	default:
  		/* Compressed formats */
+ 		flags = V4L2_FMT_FLAG_COMPRESSED;
 diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
-index 1c095b5a9..3e20f2b8a 100644
+index 1c095b5..959bf0b 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -668,6 +668,9 @@ struct v4l2_pix_format {
+@@ -668,6 +668,14 @@ struct v4l2_pix_format {
  #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
  #define V4L2_PIX_FMT_MT21C    v4l2_fourcc('M', 'T', '2', '1') /* Mediatek compressed block mode  */
  #define V4L2_PIX_FMT_INZI     v4l2_fourcc('I', 'N', 'Z', 'I') /* Intel Planar Greyscale 10-bit and Depth 16-bit */
-+#define V4L2_PIX_FMT_RW16     v4l2_fourcc('R', 'W', '1', '6') /* Raw data 16-bit */
-+#define V4L2_PIX_FMT_W10      v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
-+#define V4L2_PIX_FMT_CONFIDENCE_MAP	v4l2_fourcc('C', ' ', ' ', ' ') /* Two pixels in one byte */
-
++#define V4L2_PIX_FMT_RW16	v4l2_fourcc('R', 'W', '1', '6') /* Raw data 16-bit */
++#define V4L2_PIX_FMT_W10	v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
++#define V4L2_PIX_FMT_CONFIDENCE_MAP  v4l2_fourcc('C', ' ', ' ', ' ') /* Two pixels in one byte */
++
++/*  Librealsense development*/
++#define V4L2_PIX_FMT_FG	v4l2_fourcc('F', 'G', ' ', ' ') /* Frame Grabber */
++#define V4L2_PIX_FMT_INZC	v4l2_fourcc('I', 'N', 'Z', 'C') /* Planar Depth/Confidence */
++#define V4L2_PIX_FMT_PAIR	v4l2_fourcc('P', 'A', 'I', 'R') /* Relative IR */
+ 
  /* SDR formats - used only for Software Defined Radio devices */
  #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */
---
-2.17.0
+-- 
+2.7.4
+

--- a/scripts/realsense-camera-formats_ubuntu-xenial-master.patch
+++ b/scripts/realsense-camera-formats_ubuntu-xenial-master.patch
@@ -2,9 +2,11 @@ From e5d0e1f6e3a35ea469d41aaeccecc69bcda5d37f Mon Sep 17 00:00:00 2001
 From: aangerma <Avishag.Angerman@intel.com>
 From: icarpis <itay.carpis@intel.com>
 From: administrator <evgeni.raikhel@intel.com>
-Date: Mon, 30 Oct 2017 10:14:04 +0200
+Date: Thu, 30 Aug 2018 16:07:01 +0300
 
-Subject: [PATCH] RS4xx, ZR300, RS5 Pixel formats patch
+Subject: [PATCH] RS4xx, ZR300, RS5 Pixel formats for kernel 4.4
+Also include development formats
+
 Date: Wed, 22 Aug 2018 10:02:43 +0300
 
 
@@ -26,10 +28,10 @@ index c26d12f..d86cf22 100644
  		  uvc_status.o uvc_isight.o uvc_debugfs.o
  ifeq ($(CONFIG_MEDIA_CONTROLLER),y)
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
-index 4a07535..4888495 100644
+index 4a07535..ac186a7 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -168,6 +168,76 @@ static struct uvc_format_desc uvc_fmts[] = {
+@@ -168,6 +168,92 @@ static struct uvc_format_desc uvc_fmts[] = {
  		.guid		= UVC_GUID_FORMAT_RW10,
  		.fcc		= V4L2_PIX_FMT_SRGGB10P,
  	},
@@ -103,22 +105,30 @@ index 4a07535..4888495 100644
 +		.guid		= UVC_GUID_FORMAT_CONFIDENCE_MAP,
 +		.fcc		= V4L2_PIX_FMT_CONFIDENCE_MAP,
 +	},
++	/* Legacy/Development formats for backward-compatibility*/
++	{
++		.name		= "Frame Grabber (FG  )",
++		.guid		= UVC_GUID_FORMAT_FG,
++		.fcc		= V4L2_PIX_FMT_FG,
++	},
++	{
++		.name		= "SR300 Depth/Confidence (INZC)",
++		.guid		= UVC_GUID_FORMAT_INZC,
++		.fcc		= V4L2_PIX_FMT_INZC,
++	},
++	{
++		.name		= "Relative IR (PAIR)",
++		.guid		= UVC_GUID_FORMAT_PAIR,
++		.fcc		= V4L2_PIX_FMT_PAIR,
++	},
  };
  
  /* ------------------------------------------------------------------------
 diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
-index 7e4d3ee..96d9f2b 100644
+index 7e4d3ee..24904e2 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -115,7 +115,6 @@
- #define UVC_GUID_FORMAT_M420 \
- 	{ 'M',  '4',  '2',  '0', 0x00, 0x00, 0x10, 0x00, \
- 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
--
- #define UVC_GUID_FORMAT_H264 \
- 	{ 'H',  '2',  '6',  '4', 0x00, 0x00, 0x10, 0x00, \
- 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
-@@ -131,6 +130,48 @@
+@@ -131,6 +131,57 @@
  #define UVC_GUID_FORMAT_RW10 \
  	{ 'R',  'W',  '1',  '0', 0x00, 0x00, 0x10, 0x00, \
  	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
@@ -164,14 +174,23 @@ index 7e4d3ee..96d9f2b 100644
 +#define UVC_GUID_FORMAT_CONFIDENCE_MAP \
 +	{ 'C',  ' ',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
 +	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_FG \
++	{ 'F',  'G',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_INZC \
++	{ 'I',  'N',  'Z',  'C', 0x02, 0xb6, 0x0f, 0x48, \
++	0x97, 0x8c, 0xe4, 0xe8, 0x8a, 0xe8, 0x9b, 0x89}
++#define UVC_GUID_FORMAT_PAIR \
++	{ 'P',  'A',  'I',  'R', 0x36, 0x85, 0x41, 0x48, \
++	0xb6, 0xbf, 0x8f, 0xc6, 0xff, 0xb0, 0x83, 0xa8}
  
  /* ------------------------------------------------------------------------
   * Driver specific constants.
 diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
-index 5e2a7e5..7c2714b 100644
+index 5e2a7e5..7ac69b3 100644
 --- a/drivers/media/v4l2-core/v4l2-ioctl.c
 +++ b/drivers/media/v4l2-core/v4l2-ioctl.c
-@@ -1229,6 +1229,13 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+@@ -1229,6 +1229,16 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
  	case V4L2_SDR_FMT_CS8:		descr = "Complex S8"; break;
  	case V4L2_SDR_FMT_CS14LE:	descr = "Complex S14LE"; break;
  	case V4L2_SDR_FMT_RU12LE:	descr = "Real U12LE"; break;
@@ -181,19 +200,21 @@ index 5e2a7e5..7c2714b 100644
 +	case V4L2_PIX_FMT_RW16:		descr = "16-bit Raw data"; break;
 +	case V4L2_PIX_FMT_INZI:		descr = "32-bit IR:Depth 10:16"; break;
 +	case V4L2_PIX_FMT_W10:		descr = "10-bit packed 8888[2222]"; break;
-+	case V4L2_PIX_FMT_CONFIDENCE_MAP:		descr = "4-bit per pixel packed into 8 bit"; break;
++	case V4L2_PIX_FMT_CONFIDENCE_MAP:	descr = "4-bit per pixel packed"; break;
++	case V4L2_PIX_FMT_FG:		descr = "Frame Grabber (FG  )"; break;
++	case V4L2_PIX_FMT_INZC:		descr = "Planar Depth/Confidence (INZC)"; break;
++	case V4L2_PIX_FMT_PAIR:		descr = "Relative IR (PAIR)"; break;
  
  	default:
  		/* Compressed formats */
 diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
-index 421d274..89f20fa 100644
+index 421d274..c17b625 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -624,7 +624,14 @@ struct v4l2_pix_format {
+@@ -624,6 +624,18 @@ struct v4l2_pix_format {
  #define V4L2_PIX_FMT_Y8I      v4l2_fourcc('Y', '8', 'I', ' ') /* Greyscale 8-bit L/R interleaved */
  #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
  #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
--
 +#define V4L2_PIX_FMT_Y16      v4l2_fourcc('Y', '1', '6', ' ') /* Greyscale 16-bit */
 +#define V4L2_PIX_FMT_RW16     v4l2_fourcc('R', 'W', '1', '6') /* Raw data 16-bit */
 +#define V4L2_PIX_FMT_INZI     v4l2_fourcc('I', 'N', 'Z', 'I') /* 24 Depth/IR 16:8 */
@@ -202,9 +223,13 @@ index 421d274..89f20fa 100644
 +#define V4L2_PIX_FMT_RELI     v4l2_fourcc('R', 'E', 'L', 'I') /* 8 IR alternating on off illumination */
 +#define V4L2_PIX_FMT_W10      v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
 +#define V4L2_PIX_FMT_CONFIDENCE_MAP  v4l2_fourcc('C', ' ', ' ', ' ') /* Two pixels in one byte */
++/*  Librealsense development*/
++#define V4L2_PIX_FMT_FG			v4l2_fourcc('F', 'G', ' ', ' ') /* Frame Grabber */
++#define V4L2_PIX_FMT_INZC		v4l2_fourcc('I', 'N', 'Z', 'C') /* Planar Depth/Confidence */
++#define V4L2_PIX_FMT_PAIR		v4l2_fourcc('P', 'A', 'I', 'R') /* Relative IR */
+ 
  /* SDR formats - used only for Software Defined Radio devices */
  #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */
- #define V4L2_SDR_FMT_CU16LE       v4l2_fourcc('C', 'U', '1', '6') /* IQ u16le */
 -- 
 2.7.4
 

--- a/scripts/v1-media-uvcvideo-mark-buffer-error-where-overflow.patch
+++ b/scripts/v1-media-uvcvideo-mark-buffer-error-where-overflow.patch
@@ -1,0 +1,104 @@
+From patchwork Fri Aug 18 07:17:56 2017
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Baoyou Xie <baoyou.xie@linaro.org>
+X-Patchwork-Id: 9907707
+Return-Path: <linux-media-owner@kernel.org>
+Received: from mail.wl.linuxfoundation.org (pdx-wl-mail.web.codeaurora.org
+	[172.30.200.125])
+	by pdx-korg-patchwork.web.codeaurora.org (Postfix) with ESMTP id
+	645E5600CC for <patchwork-linux-media@patchwork.kernel.org>;
+	Fri, 18 Aug 2017 07:19:03 +0000 (UTC)
+Received: from mail.wl.linuxfoundation.org (localhost [127.0.0.1])
+	by mail.wl.linuxfoundation.org (Postfix) with ESMTP id 5630F28C5C
+	for <patchwork-linux-media@patchwork.kernel.org>;
+	Fri, 18 Aug 2017 07:19:03 +0000 (UTC)
+Received: by mail.wl.linuxfoundation.org (Postfix, from userid 486)
+	id 4A6AC28C60; Fri, 18 Aug 2017 07:19:03 +0000 (UTC)
+X-Spam-Checker-Version: SpamAssassin 3.3.1 (2010-03-16) on
+	pdx-wl-mail.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-7.0 required=2.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID, DKIM_VALID_AU, HK_RANDOM_FROM,
+	RCVD_IN_DNSWL_HI autolearn=ham version=3.3.1
+Received: from vger.kernel.org (vger.kernel.org [209.132.180.67])
+	by mail.wl.linuxfoundation.org (Postfix) with ESMTP id D7C2928C5C
+	for <patchwork-linux-media@patchwork.kernel.org>;
+	Fri, 18 Aug 2017 07:19:02 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+	id S1750927AbdHRHTB (ORCPT
+	<rfc822;patchwork-linux-media@patchwork.kernel.org>);
+	Fri, 18 Aug 2017 03:19:01 -0400
+Received: from mail-pg0-f50.google.com ([74.125.83.50]:36934 "EHLO
+	mail-pg0-f50.google.com" rhost-flags-OK-OK-OK-OK) by vger.kernel.org
+	with ESMTP id S1750709AbdHRHTA (ORCPT
+	<rfc822;linux-media@vger.kernel.org>);
+	Fri, 18 Aug 2017 03:19:00 -0400
+Received: by mail-pg0-f50.google.com with SMTP id y129so58821257pgy.4
+	for <linux-media@vger.kernel.org>;
+	Fri, 18 Aug 2017 00:19:00 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=linaro.org; s=google;
+	h=from:to:cc:subject:date:message-id;
+	bh=WZma9/FVx+4ujRq49xwt1lLa1OfmilkWR60UbzRTIL0=;
+	b=YoRZ76KVuuXVQrMuA/vhxIiw2HvI8Vy6Txb8afLSbiuMh/fWMnydcN7xJm6NDagD4z
+	VkNuaw2xDs8U5l08+XTUevzDQzHIJqap3bDHqEnVjmStkIw10QaI7u52p5sMliGx0LBI
+	2MYF5Z/cpAIzZg+XvITM3Za8ijI4wWkscBvro=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+	d=1e100.net; s=20161025;
+	h=x-gm-message-state:from:to:cc:subject:date:message-id;
+	bh=WZma9/FVx+4ujRq49xwt1lLa1OfmilkWR60UbzRTIL0=;
+	b=R6efZM1vaCo0t1KFMAykCBppRIE8EHIccZtKsUHtzwMWKQ0S2Sc+dFh3M1fzKXV8yz
+	gtbSToIHs2B7mJapngaOSxdaHfov1hmQGgxtpY0PAhtW5HSIJ+tAdM65727Oza+NPdGb
+	GoTlqMFBgsoCxtAvnxIV9KAq+zzTDzBL7PaddxPgrqpoaPAoBbSMJUXsZTuQhbtKN92c
+	PCLWU73WEf2oEfeLSPX/6PcnHMvi8BpZpvgsqa2FX81FiqedSEEd8BNR1HezWR0brQ3P
+	cNZ4M6GKV0PcQ0iUsjT3YLKDQlXP4qbngiChXvtlsR24Z/L9crOM8UzQEr+lAhxN0y1w
+	zyYA==
+X-Gm-Message-State: AHYfb5hJAfDErEeU6B2CbkOin/j1+YvYrUVNp8mq4THFLkn7Ps4fCTDj
+	2u2MR44dWdjM3DUnHGlVcg==
+X-Received: by 10.99.174.11 with SMTP id q11mr5932467pgf.111.1503040739992;
+	Fri, 18 Aug 2017 00:18:59 -0700 (PDT)
+Received: from localhost.localdomain ([104.237.91.15])
+	by smtp.gmail.com with ESMTPSA id
+	v9sm1359746pgb.30.2017.08.18.00.18.53
+	(version=TLS1_2 cipher=ECDHE-RSA-AES128-SHA bits=128/128);
+	Fri, 18 Aug 2017 00:18:59 -0700 (PDT)
+From: Baoyou Xie <baoyou.xie@linaro.org>
+To: laurent.pinchart@ideasonboard.com, mchehab@kernel.org
+Cc: linux-media@vger.kernel.org, linux-kernel@vger.kernel.org,
+	shawnguo@kernel.org, baoyou.xie@gmail.com, baoyou.xie@zte.com.cn,
+	jun.nie@linaro.org, broonie@kernel.org, arnd@arndb.de,
+	Baoyou Xie <baoyou.xie@linaro.org>
+Subject: [PATCH v1] [media] uvcvideo: mark buffer error where overflow
+Date: Fri, 18 Aug 2017 15:17:56 +0800
+Message-Id: <1503040676-28802-1-git-send-email-baoyou.xie@linaro.org>
+X-Mailer: git-send-email 2.7.4
+Sender: linux-media-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-media.vger.kernel.org>
+X-Mailing-List: linux-media@vger.kernel.org
+X-Virus-Scanned: ClamAV using ClamSMTP
+
+Some cameras post inaccurate frame where next frame data overlap
+it. this results in screen flicker, and it need to be prevented.
+
+So this patch marks the buffer error to discard the frame where
+buffer overflow.
+
+Signed-off-by: Baoyou Xie <baoyou.xie@linaro.org>
+---
+ drivers/media/usb/uvc/uvc_video.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_video.c b/drivers/media/usb/uvc/uvc_video.c
+index fb86d6a..81a3530 100644
+--- a/drivers/media/usb/uvc/uvc_video.c
++++ b/drivers/media/usb/uvc/uvc_video.c
+@@ -1077,6 +1077,7 @@ static void uvc_video_decode_data(struct uvc_streaming *stream,
+ 	/* Complete the current frame if the buffer size was exceeded. */
+ 	if (len > maxlen) {
+ 		uvc_trace(UVC_TRACE_FRAME, "Frame complete (overflow).\n");
++		buf->error = 1;
+ 		buf->state = UVC_BUF_STATE_READY;
+ 	}
+ }


### PR DESCRIPTION
Prevent uploading corrupted/invalid frame buffers from kernel (v4l) to user space.
Based on kernel patch [issued by 3rd party](https://lkml.org/lkml/2017/9/6/775)

Applicable during the first frame received from the camera that often is not managed properly by v4l kernel sub-system. The patch has a side-effect causing the driver to  invalidate video buffers if they're not properly marked with EOF but only by FID bit. In that case the buffer actual size exceed the data mentioned in the payload header, triggering internal error and removing otherwise valid video buffer.

In addition the PR:
- adds development formats ("FG  " , "PAIR" , "INZC" ) to kernel patch to silence false alarms.
- fixes overflow with "C   " format description in ioctl.c

Tracked On: DSO-10234