### PR TITLE
Avoiding compile errors due to removal of overator() in version 2.16

### DIFF
--- a/wrappers/opencv/grabcuts/rs-grabcuts.cpp
+++ b/wrappers/opencv/grabcuts/rs-grabcuts.cpp
@@ -57,7 +57,7 @@ int main(int argc, char * argv[]) try
         // Colorize depth image with white being near and black being far
         // This will take advantage of histogram equalization done by the colorizer
         colorize.set_option(RS2_OPTION_COLOR_SCHEME, 2);
-        frame bw_depth = colorize(depth);
+        frame bw_depth = depth.apply_filter(colorize);
 
         // Generate "near" mask image:
         auto near = frame_to_mat(bw_depth);

--- a/wrappers/opencv/imshow/rs-imshow.cpp
+++ b/wrappers/opencv/imshow/rs-imshow.cpp
@@ -21,7 +21,7 @@ int main(int argc, char * argv[]) try
     while (waitKey(1) < 0 && cvGetWindowHandle(window_name))
     {
         rs2::frameset data = pipe.wait_for_frames(); // Wait for next set of frames from the camera
-        rs2::frame depth = color_map(data.get_depth_frame());
+        rs2::frame depth = data.get_depth_frame().apply_filter(color_map);
 
         // Query frame size (width and height)
         const int w = depth.as<rs2::video_frame>().get_width();


### PR DESCRIPTION
"processing_block::operator()(frame f) const" was removed in the version 2.16.0.
Therefore, I modified the sample sources to use newly added "frame::apply_filter".
