### PR TITLE
Add optional configuration in CMake for test-data location

### DIFF
--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -43,13 +43,17 @@ install(
     ${CMAKE_INSTALL_PREFIX}/bin
 )
 
-#Windows OS will host the files under %TEMP% location
-#Unix-like machines will host the tests files under /temp/ directory
-if (WIN32)
-    set(Deployment_Location "$ENV{TEMP}\\")
-else() # Data shall be preserved between reboots. For Linux distributions/ ANDROID_NDK_TOOLCHAIN_INCLUDED/APPLE
-    #set(Deployment_Location /var/tmp/) The standard confoiguration currently fails on CI
-    set(Deployment_Location /tmp/)
+if(TESTDATA_LOCATION)
+    set(Deployment_Location ${TESTDATA_LOCATION})
+else()
+    #Windows OS will host the files under %TEMP% location
+    #Unix-like machines will host the tests files under /tmp/ directory
+    if (WIN32)
+        set(Deployment_Location "$ENV{TEMP}\\")
+    else() # Data shall be preserved between reboots. For Linux distributions/ ANDROID_NDK_TOOLCHAIN_INCLUDED/APPLE
+        #set(Deployment_Location /var/tmp/) The standard configuration currently fails on CI
+        set(Deployment_Location /tmp/)
+    endif()
 endif()
 
 add_custom_command(TARGET live-test POST_BUILD


### PR DESCRIPTION
Hi. 140MB+ test data provided for `BUILD_UNIT_TESTS` really help us testing code but due to the files location is pinned to systems' temporary directory (`%TEMP%` for Windows and `/tmp` for others), we need to re-download them every time we reboot machines.

 - It's great for CI but not happy for developers using laptop for development like me.
 - In some networks, fetching *.raw files inside CMake somehow take too much time, so it'd be appreciated if we can point to local cache dir.

This pull-req introduces optional parameter `TESTDATA_LOCATION` to point to cache location for `unit-tests`.