### PR TITLE
Fix narrowing conversion error for osx clang

### DIFF
--- a/examples/example.hpp
+++ b/examples/example.hpp
@@ -186,7 +186,8 @@ private:
             h > w ? w++ : h++;
         auto new_w = round(window.x / w);
         auto new_h = round(window.y / h);
-        return rect{ w, h, new_w, new_h}; //column count, line count, cell width cell height
+        // column count, line count, cell width cell height
+        return rect{ static_cast<float>(w), static_cast<float>(h), static_cast<float>(new_w), static_cast<float>(new_h) };
     }
 
     std::vector<rect> calc_grid(float2 window, std::vector<rs2::video_frame>& frames)


### PR DESCRIPTION
When I build librealsense on Mac with a default Apple LLVM (Apple LLVM version 8.0.0 (clang-800.0.42.1)), I encounter the following error. 

```
../example.hpp:189:22: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer
      list [-Wc++11-narrowing]
        return rect{ w, h, new_w, new_h}; //column count, line count, cell width cell height
                     ^
```

However, in case of the latest clang from brew (clang version 6.0.1 (tags/RELEASE_601/final)), everything is going fine.

This might be related to the fact that I'm using an old OS, Xcode and clang, but let me give a pull request just in case.
