### PR TITLE
unity - copy specific dlls from the build folder to the unity folder

### DIFF
--- a/wrappers/csharp/Intel.RealSense/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/CMakeLists.txt
@@ -28,8 +28,12 @@ csharp_set_designer_cs_properties(
 if(BUILD_UNITY_BINDINGS)
 	add_custom_command(TARGET ${PROJECT_NAME}
 			   POST_BUILD
-			   COMMAND XCOPY /y /s "$(OutDir)*.dll" "${CMAKE_BINARY_WIN_DIR}\\wrappers\\unity\\Assets\\RealSenseSDK2.0\\Plugins\\"
-			   COMMENT "Copy DLLs to Unity plugins folder")
+			   COMMAND XCOPY /y /s "$(OutDir)Intel.RealSense.dll" "${CMAKE_BINARY_WIN_DIR}\\wrappers\\unity\\Assets\\RealSenseSDK2.0\\Plugins\\"
+			   COMMENT "Copy Intel.RealSense.dll to Unity plugins folder")
+	add_custom_command(TARGET ${PROJECT_NAME}
+			   POST_BUILD
+			   COMMAND XCOPY /y /s "$(OutDir)realsense2.dll" "${CMAKE_BINARY_WIN_DIR}\\wrappers\\unity\\Assets\\RealSenseSDK2.0\\Plugins\\"
+			   COMMENT "Copy realsense2.dll to Unity plugins folder")
 			   
 	find_program (UNITY_PATH Unity\\Editor\\Unity.exe)
 	if(EXISTS ${UNITY_PATH})


### PR DESCRIPTION
Fix issues: #2396, #2453
As part of the CI mscorelib.dll is copied to the build folder, this dll is later copied by a post build event to the unity folder and that cause compilation issues in unity.
In this fix the post build event copies only the specific required dlls.