### PR TITLE
Libuvc fixes

### DIFF
--- a/src/libuvc/libuvc.cpp
+++ b/src/libuvc/libuvc.cpp
@@ -685,6 +685,7 @@ namespace librealsense
                 int unit;
                 int control = rs2_option_to_ctrl_selector(opt, unit);
 
+                value = rs2_value_translate(UVC_SET_CUR, opt, value);
                 set_data_usb( UVC_SET_CUR, control, unit, value);
                 return true;
             }

--- a/src/libuvc/libuvc.cpp
+++ b/src/libuvc/libuvc.cpp
@@ -591,12 +591,92 @@ namespace librealsense
                     throw std::runtime_error("insufficient data writen to USB");
             }
 
+            // Translate between UVC Spec and RS
+            int32_t rs2_value_translate(uvc_req_code action, rs2_option option, int32_t value) const
+            {
+                // Value may be translated according to action/option value
+                int32_t translated_value = value;
+                
+                switch (action)
+                {
+                    case UVC_GET_CUR: // Translating from UVC 1.5 Spec up to RS
+                        if (option == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
+                        {
+                            switch (value)
+                            {
+                                case UVC_AE_MODE_D3_AP:
+                                    translated_value = 1;
+                                    break;
+                                case UVC_AE_MODE_D0_MANUAL:
+                                    translated_value = 0;
+                                    break;
+                                default:
+                                    throw std::runtime_error("Unsupported GET value for RS2_OPTION_ENABLE_AUTO_EXPOSURE");
+                            }
+                        }
+                        break;
+                        
+                    case UVC_SET_CUR: // Translating from RS down to UVC 1.5 Spec
+                        if (option == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
+                        {
+                            switch (value)
+                            {
+                                case 1:
+                                    // Enabling auto exposure
+                                    translated_value = UVC_AE_MODE_D3_AP;
+                                    break;
+                                case 0:
+                                    // Disabling auto exposure
+                                    translated_value = UVC_AE_MODE_D0_MANUAL;
+                                    break;
+                                default:
+                                    throw std::runtime_error("Unsupported SET value for RS2_OPTION_ENABLE_AUTO_EXPOSURE");
+                            }
+                        }
+                        break;
+                        
+                    case UVC_GET_MIN:
+                        if (option == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
+                        {
+                            translated_value = 0; // Hardcoded MIN value
+                        }
+                        break;
+                        
+                    case UVC_GET_MAX:
+                        if (option == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
+                        {
+                            translated_value = 1; // Hardcoded MAX value
+                        }
+                        break;
+                        
+                    case UVC_GET_RES:
+                        if (option == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
+                        {
+                            translated_value = 1; // Hardcoded RES (step) value
+                        }
+                        break;
+                        
+                    case UVC_GET_DEF:
+                        if (option == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
+                        {
+                            translated_value = 1; // Hardcoded DEF value
+                        }
+                        break;
+                        
+                    default:
+                        throw std::runtime_error("Unsupported action translation");
+                }
+                return translated_value;
+            }
+
+            
             bool get_pu(rs2_option opt, int32_t& value) const override
             {
                 int unit;
                 int control = rs2_option_to_ctrl_selector(opt, unit);
 
                 value = get_data_usb( UVC_GET_CUR, control, unit);
+                value = rs2_value_translate(UVC_GET_CUR, opt, value);
                 return true;
             }
 
@@ -613,10 +693,18 @@ namespace librealsense
             {
                 int unit;
                 int control = rs2_option_to_ctrl_selector(option, unit);
+                
                 int min = get_data_usb( UVC_GET_MIN, control, unit);
+                min = rs2_value_translate(UVC_GET_MIN, option, value);
+                
                 int max = get_data_usb( UVC_GET_MAX, control, unit);
+                max = rs2_value_translate(UVC_GET_MAX, option, value);
+                
                 int step = get_data_usb( UVC_GET_RES, control, unit);
+                step = rs2_value_translate(UVC_GET_RES, option, value);
+                
                 int def = get_data_usb( UVC_GET_DEF, control, unit);
+                def = rs2_value_translate(UVC_GET_DEF, option, value);
 
                 control_range result(min, max, step, def);
 

--- a/src/libuvc/libuvc.h
+++ b/src/libuvc/libuvc.h
@@ -20,6 +20,11 @@ extern "C" {
 
 struct libusb_context;
 struct libusb_device_handle;
+    
+#define UVC_AE_MODE_D0_MANUAL   ( 1 << 0 )
+#define UVC_AE_MODE_D1_AUTO     ( 1 << 1 )
+#define UVC_AE_MODE_D2_SP       ( 1 << 2 )
+#define UVC_AE_MODE_D3_AP       ( 1 << 3 )
 
 /** UVC error types, based on libusb errors
  * @ingroup diag

--- a/wrappers/python/examples/python-rs400-advanced-mode-example.py
+++ b/wrappers/python/examples/python-rs400-advanced-mode-example.py
@@ -74,8 +74,11 @@ try:
     as_json_object = json.loads(serialized_string)
 
     # We can also load controls from a json string
+    # For Python 2, the values in 'as_json_object' dict need to be converted from unicode object to utf-8
+    if type(next(iter(as_json_object))) != str:
+        as_json_object = {k.encode('utf-8'): v.encode("utf-8") for k, v in as_json_object.items()}
     # The C++ JSON parser requires double-quotes for the json object so we need
-    #  to replace the single quote of the pythonic json to double-quotes
+    # to replace the single quote of the pythonic json to double-quotes
     json_string = str(as_json_object).replace("'", '\"')
     advnc_mode.load_json(json_string)
 


### PR DESCRIPTION
Added a function that converts UVC auto-exposure mode values to RS compatible 0/1 values. 
The auto exposure modes are introduced in the [UVC specs](http://www.cajunbot.com/wiki/images/8/85/USB_Video_Class_1.1.pdf#page=94). D0 (manual exposure time) is converted to 0, D3 (auto exposure time) is converted to 1.
Previously D3 (as byte array) was converted to integer with value 8, which caused issues as in librealsense auto exposure value is expected to be either 0 or 1.
Fixes: #1587

Additionally, fixed encoding issues in python advanced mode example.