### PR TITLE
RGB sensor auto-exposure region of interest

### DIFF
--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -133,6 +133,14 @@ namespace librealsense
         color_ep->register_metadata(RS2_FRAME_METADATA_POWER_LINE_FREQUENCY, make_attribute_parser(&md_rgb_control::power_line_frequency, md_rgb_control_attributes::power_line_frequency_attribute, md_prop_offset));
         color_ep->register_metadata(RS2_FRAME_METADATA_LOW_LIGHT_COMPENSATION, make_attribute_parser(&md_rgb_control::low_light_comp, md_rgb_control_attributes::low_light_comp_attribute, md_prop_offset));
 
+        // Starting with firmware 5.10.9, auto-exposure ROI is available for color sensor
+        if (_fw_version >= firmware_version("5.10.9.0"))
+        {
+            roi_sensor_interface* roi_sensor;
+            if (roi_sensor = dynamic_cast<roi_sensor_interface*>(color_ep.get()))
+                roi_sensor->set_roi_method(std::make_shared<ds5_auto_exposure_roi_method>(*_hw_monitor, ds::fw_cmd::SETRGBAEROI));
+        }
+
         return color_ep;
     }
 

--- a/src/ds5/ds5-color.h
+++ b/src/ds5/ds5-color.h
@@ -30,7 +30,9 @@ namespace librealsense
         std::shared_ptr<lazy<rs2_extrinsics>> _color_extrinsic;
     };
 
-    class ds5_color_sensor : public uvc_sensor, public video_sensor_interface
+    class ds5_color_sensor : public uvc_sensor, 
+                             public video_sensor_interface,
+                             public roi_sensor_base
     {
     public:
         explicit ds5_color_sensor(ds5_color* owner,

--- a/src/ds5/ds5-device.h
+++ b/src/ds5/ds5-device.h
@@ -13,6 +13,19 @@
 
 namespace librealsense
 {
+    class ds5_auto_exposure_roi_method : public region_of_interest_method
+    {
+    public:
+        explicit ds5_auto_exposure_roi_method(const hw_monitor& hwm,
+            ds::fw_cmd cmd = ds::fw_cmd::SETAEROI);
+
+        void set(const region_of_interest& roi) override;
+        region_of_interest get() const override;
+    private:
+        const ds::fw_cmd _cmd;
+        const hw_monitor& _hw_monitor;
+    };
+
     class ds5_device : public virtual device, public debug_interface
     {
     public:

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -111,6 +111,8 @@ namespace librealsense
             GET_EXTRINSICS  = 0x53,     // get extrinsics
             SET_CAM_SYNC    = 0x69,     // set Inter-cam HW sync mode [0-default, 1-master, 2-slave]
             GET_CAM_SYNC    = 0x6A,     // fet Inter-cam HW sync mode
+            SETRGBAEROI     = 0x75,     // set RGB auto-exposure region of interest
+            GETRGBAEROI     = 0x76,     // get RGB auto-exposure region of interest
         };
 
         const int etDepthTableControl = 9; // Identifier of the depth table control

--- a/wrappers/csharp/Intel.RealSense/Sensor.cs
+++ b/wrappers/csharp/Intel.RealSense/Sensor.cs
@@ -92,6 +92,32 @@ namespace Intel.RealSense
         #endregion
     }
 
+    public struct ROI
+    {
+        public int minX, minY, maxX, maxY;
+    }
+
+    public class AutoExposureROI
+    {
+        internal IntPtr m_instance;
+
+        public ROI GetRegionOfInterest()
+        {
+            var result = new ROI();
+            object error;
+            NativeMethods.rs2_get_region_of_interest(m_instance, out result.minX,
+                out result.minY, out result.maxX, out result.maxY, out error);
+            return result;
+        }
+
+        public void SetRegionOfInterest(ROI value)
+        {
+            object error;
+            NativeMethods.rs2_set_region_of_interest(m_instance,
+                value.minX, value.minY, value.maxX, value.maxY, out error);
+        }
+    }
+
     public class Sensor : IDisposable
     {
         protected readonly IntPtr m_instance;
@@ -106,6 +132,19 @@ namespace Intel.RealSense
             //if (sensor == IntPtr.Zero)
             //    throw new ArgumentNullException();
             m_instance = sensor;
+        }
+
+        public AutoExposureROI AutoExposureSettings
+        {
+            get
+            {
+                object error;
+                if (NativeMethods.rs2_is_sensor_extendable_to(m_instance, Extension.Roi, out error) > 0)
+                {
+                    return new AutoExposureROI { m_instance = m_instance };
+                }
+                return null;
+            }
         }
 
         public class CameraInfos


### PR DESCRIPTION
Starting with firmware 5.10.9, users can set custom region of interest for the auto-exposure algorithm of the RGB sensor (similar to existing feature of the stereo module)

Related issues: #1616, #2104