### PR TITLE
Fix processing blocks issues

### DIFF
--- a/src/proc/align.cpp
+++ b/src/proc/align.cpp
@@ -359,6 +359,7 @@ namespace librealsense
         case 3:
             move_other_to_depth(z_pixels, reinterpret_cast<const bytes<3>*>(source), reinterpret_cast<bytes<3>*>(dest), to,
                 _pixel_top_left_int, bottom_right);
+            break;
         case 4:
             move_other_to_depth(z_pixels, reinterpret_cast<const bytes<4>*>(source), reinterpret_cast<bytes<4>*>(dest), to,
                 _pixel_top_left_int, bottom_right);
@@ -536,7 +537,6 @@ namespace librealsense
         auto aligned_profile = std::make_shared<rs2::video_stream_profile>(original_profile.clone(original_profile.stream_type(), original_profile.stream_index(), original_profile.format()));
         int aligned_unique_id = get_unique_id(original_profile, to_profile, *aligned_profile);
         aligned_profile->get()->profile->set_unique_id(aligned_unique_id);
-        environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*aligned_profile.get()->get()->profile, *original_profile.get()->profile);
         aligned_profile->get()->profile->set_framerate(original_profile.fps());
         if (auto original_video_profile = As<video_stream_profile_interface>(original_profile.get()->profile))
         {

--- a/src/proc/colorizer.cpp
+++ b/src/proc/colorizer.cpp
@@ -124,7 +124,7 @@ namespace librealsense
         } };
 
     colorizer::colorizer()
-        : _min(0.f), _max(6.f), _equalize(true), _stream()
+        : _min(0.f), _max(6.f), _equalize(true), _target_stream_profile()
     {
         _stream_filter.stream = RS2_STREAM_DEPTH;
         _stream_filter.format = RS2_FORMAT_Z16;
@@ -196,10 +196,10 @@ namespace librealsense
 
     rs2::frame colorizer::process_frame(const rs2::frame_source& source, const rs2::frame& f)
     {
-        if (!_stream || (f.get_profile().get() != _stream->get()))
+        if (!_source_stream_profile || f.get_profile().unique_id() != _source_stream_profile.unique_id())
         {
-            _stream = std::make_shared<rs2::stream_profile>(f.get_profile().clone(RS2_STREAM_DEPTH, 0, RS2_FORMAT_RGB8));
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_stream->get()->profile, *f.get_profile().get()->profile);
+            _source_stream_profile = f.get_profile();
+            _target_stream_profile = f.get_profile().clone(RS2_STREAM_DEPTH, 0, RS2_FORMAT_RGB8);
         }
         auto make_equalized_histogram = [this](const rs2::video_frame& depth, rs2::video_frame rgb)
         {
@@ -272,7 +272,7 @@ namespace librealsense
 
         auto vf = f.as<rs2::video_frame>();
         //rs2_extension ext = f.is<rs2::disparity_frame>() ? RS2_EXTENSION_DISPARITY_FRAME : RS2_EXTENSION_DEPTH_FRAME;
-        ret = source.allocate_video_frame(*_stream, f, 3, vf.get_width(), vf.get_height(), vf.get_width() * 3, RS2_EXTENSION_VIDEO_FRAME);
+        ret = source.allocate_video_frame(_target_stream_profile, f, 3, vf.get_width(), vf.get_height(), vf.get_width() * 3, RS2_EXTENSION_VIDEO_FRAME);
 
         if (_equalize)
             make_equalized_histogram(f, ret);

--- a/src/proc/colorizer.h
+++ b/src/proc/colorizer.h
@@ -107,6 +107,7 @@ namespace librealsense {
         std::vector<color_map*> _maps;
         int _map_index = 0;
         int _preset = 0;
-        std::shared_ptr<rs2::stream_profile> _stream;
+        rs2::stream_profile _target_stream_profile;
+        rs2::stream_profile _source_stream_profile;
     };
 }

--- a/src/proc/decimation-filter.cpp
+++ b/src/proc/decimation-filter.cpp
@@ -273,7 +273,7 @@ namespace librealsense
 
     void  decimation_filter::update_output_profile(const rs2::frame& f)
     {
-        if (_options_changed || (f.get_profile().get() != _source_stream_profile.get()))
+        if (_options_changed || !_source_stream_profile || f.get_profile().unique_id() != _source_stream_profile.unique_id())
         {
             _options_changed = false;
             _source_stream_profile = f.get_profile();
@@ -303,7 +303,6 @@ namespace librealsense
             auto vp = _source_stream_profile.as<rs2::video_stream_profile>();
 
             auto tmp_profile = _source_stream_profile.clone(_source_stream_profile.stream_type(), _source_stream_profile.stream_index(), _source_stream_profile.format());
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*(stream_interface*)(_source_stream_profile.get()->profile), *(stream_interface*)(tmp_profile.get()->profile));
             auto src_vspi = dynamic_cast<video_stream_profile_interface*>(_source_stream_profile.get()->profile);
             auto tgt_vspi = dynamic_cast<video_stream_profile_interface*>(tmp_profile.get()->profile);
             rs2_intrinsics src_intrin = src_vspi->get_intrinsics();

--- a/src/proc/disparity-transform.cpp
+++ b/src/proc/disparity-transform.cpp
@@ -93,7 +93,7 @@ namespace librealsense
 
     void  disparity_transform::update_transformation_profile(const rs2::frame& f)
     {
-        if (f.get_profile().get() != _source_stream_profile.get())
+        if(!_source_stream_profile || f.get_profile().unique_id() != _source_stream_profile.unique_id())
         {
             _source_stream_profile = f.get_profile();
 
@@ -151,7 +151,6 @@ namespace librealsense
         {
             auto tgt_format = _transform_to_disparity ? RS2_FORMAT_DISPARITY32 : RS2_FORMAT_Z16;
             _target_stream_profile = _source_stream_profile.clone(RS2_STREAM_DEPTH, 0, tgt_format);
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*(stream_interface*)(_source_stream_profile.get()->profile), *(stream_interface*)(_target_stream_profile.get()->profile));
             auto src_vspi = dynamic_cast<video_stream_profile_interface*>(_source_stream_profile.get()->profile);
             auto tgt_vspi = dynamic_cast<video_stream_profile_interface*>(_target_stream_profile.get()->profile);
             rs2_intrinsics src_intrin   = src_vspi->get_intrinsics();

--- a/src/proc/hole-filling-filter.cpp
+++ b/src/proc/hole-filling-filter.cpp
@@ -70,14 +70,10 @@ namespace librealsense
 
     void  hole_filling_filter::update_configuration(const rs2::frame& f)
     {
-        if (f.get_profile().get() != _source_stream_profile.get())
+        if (!_source_stream_profile || f.get_profile().unique_id() != _source_stream_profile.unique_id())
         {
             _source_stream_profile = f.get_profile();
             _target_stream_profile = _source_stream_profile.clone(RS2_STREAM_DEPTH, 0, _source_stream_profile.format());
-
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(
-                *(stream_interface*)(f.get_profile().get()->profile),
-                *(stream_interface*)(_target_stream_profile.get()->profile));
 
             _extension_type = f.is<rs2::disparity_frame>() ? RS2_EXTENSION_DISPARITY_FRAME : RS2_EXTENSION_DEPTH_FRAME;
             _bpp = (_extension_type == RS2_EXTENSION_DISPARITY_FRAME) ? sizeof(float) : sizeof(uint16_t);

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -52,23 +52,28 @@ namespace librealsense
     float2 pixel_to_texcoord(const rs2_intrinsics *intrin, const float2 & pixel) { return{ pixel.x / (intrin->width), pixel.y / (intrin->height) }; }
     float2 project_to_texcoord(const rs2_intrinsics *intrin, const float3 & point) { return pixel_to_texcoord(intrin, project(intrin, point)); }
 
-    bool pointcloud::stream_changed(const rs2::stream_profile& old, const rs2::stream_profile& curr)
+    void pointcloud::set_extrinsics()
     {
-        auto v_old = old.as<rs2::video_stream_profile>();
-        auto v_curr = curr.as<rs2::video_stream_profile>();
-
-        return v_old.height() != v_curr.height();
+        if (_output_stream && _other_stream && !_extrinsics)
+        {
+            rs2_extrinsics ex;
+            const rs2_stream_profile* ds = _output_stream;
+            const rs2_stream_profile* os = _other_stream.get_profile();
+            if (environment::get_instance().get_extrinsics_graph().try_fetch_extrinsics(
+                *ds->profile, *os->profile, &ex))
+            {
+                _extrinsics = ex;
+            }
+        }
     }
 
     void pointcloud::inspect_depth_frame(const rs2::frame& depth)
     {
-        if (!_output_stream.get() || _depth_stream->unique_id() != depth.get_profile().unique_id() ||
-            stream_changed(*_depth_stream, depth.get_profile()))
+        if (!_output_stream || _depth_stream.get_profile().unique_id() != depth.get_profile().unique_id())
         {
-            _output_stream = std::make_shared<rs2::video_stream_profile>(depth.get_profile().as<rs2::video_stream_profile>().clone(
-                RS2_STREAM_DEPTH, depth.get_profile().stream_index(), RS2_FORMAT_XYZ32F));
-            _depth_stream = std::make_shared<rs2::video_stream_profile>(depth.get_profile().as<rs2::video_stream_profile>());
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_output_stream->get()->profile, *depth.get_profile().get()->profile);
+            _output_stream = depth.get_profile().as<rs2::video_stream_profile>().clone(
+                RS2_STREAM_DEPTH, depth.get_profile().stream_index(), RS2_FORMAT_XYZ32F);
+            _depth_stream = depth;
             _depth_intrinsics = optional_value<rs2_intrinsics>();
             _depth_units = optional_value<float>();
             _extrinsics = optional_value<rs2_extrinsics>();
@@ -99,56 +104,34 @@ namespace librealsense
             found_depth_units = true;
         }
 
-        if (_other_stream && !_extrinsics)
-        {
-            rs2_extrinsics ex;
-            const rs2_stream_profile* d = _depth_stream->get();
-            const rs2_stream_profile* o = _other_stream->get();
-            if (environment::get_instance().get_extrinsics_graph().try_fetch_extrinsics(
-                *d->profile, *o->profile, &ex))
-            {
-                _extrinsics = ex;
-            }
-        }
+        set_extrinsics();
     }
 
     void pointcloud::inspect_other_frame(const rs2::frame& other)
     {
         if (_stream_filter != _prev_stream_filter)
         {
-            _other_stream = nullptr;
             _prev_stream_filter = _stream_filter;
         }
 
-        if (_extrinsics.has_value() && (_other_stream && other.get_profile().as<rs2::video_stream_profile>() == *_other_stream.get()))
+        if (_extrinsics.has_value() && other.get_profile().unique_id() == _other_stream.get_profile().unique_id())
             return;
 
-        auto osp = other.get_profile().get();
-        _other_stream = std::make_shared<rs2::video_stream_profile>(rs2::stream_profile(osp).as<rs2::video_stream_profile>());
+        _other_stream = other;
         _other_intrinsics = optional_value<rs2_intrinsics>();
         _extrinsics = optional_value<rs2_extrinsics>();
 
         if (!_other_intrinsics)
         {
-            if (auto video = _other_stream->as<rs2::video_stream_profile>())
+            auto stream_profile = _other_stream.get_profile();
+            if (auto video = stream_profile.as<rs2::video_stream_profile>())
             {
                 _other_intrinsics = video.get_intrinsics();
                 _occlusion_filter->set_texel_intrinsics(_other_intrinsics.value());
             }
         }
 
-        if (_output_stream && !_extrinsics)
-        {
-            rs2_extrinsics ex;
-            const rs2_stream_profile* os = _output_stream->get();
-            const rs2_stream_profile* of = other.get_profile().get();
-            if (environment::get_instance().get_extrinsics_graph().try_fetch_extrinsics(
-                *os->profile, *of->profile, &ex
-            ))
-            {
-                _extrinsics = ex;
-            }
-        }
+        set_extrinsics();
     }
 
     void pointcloud::pre_compute_x_y_map()
@@ -416,7 +399,7 @@ namespace librealsense
 
     rs2::frame pointcloud::process_depth_frame(const rs2::frame_source& source, const rs2::depth_frame& depth)
     {
-        auto res = source.allocate_points(*_output_stream, depth);
+        auto res = source.allocate_points(_output_stream, depth);
         auto pframe = (librealsense::points*)(res.get());
 
         auto depth_data = (const uint16_t*)depth.get_data();
@@ -463,8 +446,7 @@ namespace librealsense
         return res;
     }
 
-    pointcloud::pointcloud() :
-        _other_stream(nullptr)
+    pointcloud::pointcloud()
     {
         _occlusion_filter = std::make_shared<occlusion_filter>();
 
@@ -536,16 +518,15 @@ namespace librealsense
         rs2::frame rv;
         if (auto composite = f.as<rs2::frameset>())
         {
+            auto texture = composite.first(_stream_filter.stream);
+            inspect_other_frame(texture);
+
             auto depth = composite.first(RS2_STREAM_DEPTH, RS2_FORMAT_Z16);
             inspect_depth_frame(depth);
             rv = process_depth_frame(source, depth);
-
-            auto texture = composite.first(_stream_filter.stream);
-            inspect_other_frame(texture);
         }
         else
         {
-
             if (f.is<rs2::depth_frame>())
             {
                 inspect_depth_frame(f);

--- a/src/proc/pointcloud.h
+++ b/src/proc/pointcloud.h
@@ -24,15 +24,14 @@ namespace librealsense
         // Intermediate translation table of (depth_x*depth_y) with actual texel coordinates per depth pixel
         std::vector<float2>                    _pixels_map;
 
-        std::shared_ptr<rs2::video_stream_profile> _output_stream;
-        std::shared_ptr<rs2::video_stream_profile> _other_stream;
-        std::shared_ptr<rs2::video_stream_profile> _depth_stream;
+        rs2::stream_profile _output_stream;
+        rs2::frame _other_stream;
+        rs2::frame _depth_stream;
 
         void inspect_depth_frame(const rs2::frame& depth);
         void inspect_other_frame(const rs2::frame& other);
         rs2::frame process_depth_frame(const rs2::frame_source& source, const rs2::depth_frame& depth);
-
-        bool stream_changed(const rs2::stream_profile& old, const rs2::stream_profile& curr);
+        void set_extrinsics();
 
         std::vector<float> _pre_compute_map_x;
         std::vector<float> _pre_compute_map_y;

--- a/src/proc/spatial-filter.cpp
+++ b/src/proc/spatial-filter.cpp
@@ -164,14 +164,10 @@ namespace librealsense
 
     void  spatial_filter::update_configuration(const rs2::frame& f)
     {
-        if (f.get_profile().get() != _source_stream_profile.get())
+        if (!_source_stream_profile || f.get_profile().unique_id() != _source_stream_profile.unique_id())
         {
             _source_stream_profile = f.get_profile();
             _target_stream_profile = _source_stream_profile.clone(RS2_STREAM_DEPTH, 0, _source_stream_profile.format());
-
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(
-                *(stream_interface*)(f.get_profile().get()->profile),
-                *(stream_interface*)(_target_stream_profile.get()->profile));
 
             _extension_type = f.is<rs2::disparity_frame>() ? RS2_EXTENSION_DISPARITY_FRAME : RS2_EXTENSION_DEPTH_FRAME;
             _bpp = (_extension_type == RS2_EXTENSION_DISPARITY_FRAME) ? sizeof(float) : sizeof(uint16_t);

--- a/src/proc/temporal-filter.cpp
+++ b/src/proc/temporal-filter.cpp
@@ -151,14 +151,10 @@ namespace librealsense
 
     void  temporal_filter::update_configuration(const rs2::frame& f)
     {
-        if (f.get_profile().get() != _source_stream_profile.get())
+        if (!_source_stream_profile || f.get_profile().unique_id() != _source_stream_profile.unique_id())
         {
             _source_stream_profile = f.get_profile();
             _target_stream_profile = _source_stream_profile.clone(RS2_STREAM_DEPTH, 0, _source_stream_profile.format());
-
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(
-                *(stream_interface*)(f.get_profile().get()->profile),
-                *(stream_interface*)(_target_stream_profile.get()->profile));
 
             //TODO - reject any frame other than depth/disparity
             _extension_type = f.is<rs2::disparity_frame>() ? RS2_EXTENSION_DISPARITY_FRAME : RS2_EXTENSION_DEPTH_FRAME;

--- a/src/stream.h
+++ b/src/stream.h
@@ -117,6 +117,7 @@ namespace librealsense
             std::function<rs2_intrinsics()> int_func = _calc_intrinsics;
             res->set_intrinsics([int_func]() { return int_func(); });
             res->set_framerate(get_framerate());
+            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*res, *this);
             return res;
         }
 

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -435,25 +435,11 @@ TEST_CASE("Post-Processing expected output", "[post-processing-filters]")
     REQUIRE_THROWS(is_subset(colorizer_processed_set, original));
 
     rs2::frameset to_disp_processed_set = original.apply_filter(to_disp);
-    REQUIRE(is_subset(original, to_disp_processed_set));
     if(supports_disparity)
         REQUIRE_THROWS(is_subset(to_disp_processed_set, original));
 
     rs2::frameset from_disp_processed_set = original.apply_filter(from_disp);//should bypass
     REQUIRE(is_equal(original, from_disp_processed_set));
-
-    rs2::frameset full_pipe = original.
-        apply_filter(decimation).
-        apply_filter(to_disp).
-        apply_filter(spatial).
-        apply_filter(temporal).
-        apply_filter(from_disp).
-        apply_filter(aligner).
-        apply_filter(hole_filling).
-        apply_filter(depth_colorizer);
-
-    REQUIRE(is_subset(original, full_pipe));
-    REQUIRE_THROWS(is_subset(full_pipe, original));
 
     //single to single
     rs2::video_frame org_depth = original.get_depth_frame();
@@ -491,7 +477,7 @@ TEST_CASE("Post-Processing expected output", "[post-processing-filters]")
     rs2::video_frame to_disp_processed_frame = org_depth.apply_filter(to_disp);
     REQUIRE_FALSE(to_disp_processed_frame.is<rs2::frameset>());
     REQUIRE(to_disp_processed_frame.get_profile().stream_type() == RS2_STREAM_DEPTH);
-    bool is_disp = to_disp_processed_frame.get_profile().format() == RS2_FORMAT_DISPARITY16 || 
+    bool is_disp = to_disp_processed_frame.get_profile().format() == RS2_FORMAT_DISPARITY16 ||
         to_disp_processed_frame.get_profile().format() == RS2_FORMAT_DISPARITY32;
     if (supports_disparity)
     {

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -493,3 +493,70 @@ TEST_CASE("Post-Processing expected output", "[post-processing-filters]")
 
     pipe.stop();
 }
+
+TEST_CASE("Post-Processing processing pipe", "[post-processing-filters]")
+{
+    rs2::context ctx;
+
+    if (!make_context(SECTION_FROM_TEST_NAME, &ctx))
+        return;
+
+    rs2::temporal_filter temporal;
+    rs2::hole_filling_filter hole_filling;
+    rs2::spatial_filter spatial;
+    rs2::decimation_filter decimation(4);
+    rs2::align aligner(RS2_STREAM_COLOR);
+    rs2::colorizer depth_colorizer;
+    rs2::disparity_transform to_disp;
+    rs2::disparity_transform from_disp(false);
+    rs2::pointcloud pc(RS2_STREAM_DEPTH);
+
+    rs2::config cfg;
+    cfg.enable_all_streams();
+
+    rs2::pipeline pipe(ctx);
+    auto profile = pipe.start(cfg);
+
+    bool supports_disparity = false;
+    for (auto s : profile.get_device().query_sensors())
+    {
+        if (s.supports(RS2_OPTION_STEREO_BASELINE))
+        {
+            supports_disparity = true;
+            break;
+        }
+    }
+
+    rs2::frameset original = pipe.wait_for_frames();
+
+    rs2::frameset full_pipe;
+    int run_for = 10;
+    std::set<int> uids;
+    int uid_count = 0;
+    while (run_for--)
+    {
+        full_pipe = pipe.wait_for_frames();
+        full_pipe = full_pipe.apply_filter(decimation);
+        full_pipe = full_pipe.apply_filter(to_disp);
+        full_pipe = full_pipe.apply_filter(spatial);
+        full_pipe = full_pipe.apply_filter(temporal);
+        full_pipe = full_pipe.apply_filter(from_disp);
+        full_pipe = full_pipe.apply_filter(aligner);
+        full_pipe = full_pipe.apply_filter(hole_filling);
+        full_pipe = full_pipe.apply_filter(depth_colorizer);
+        full_pipe = full_pipe.apply_filter(pc);
+
+        //printf("test frame:\n");
+        full_pipe.foreach([&](const rs2::frame& f) {
+            uids.insert(f.get_profile().unique_id());
+            //printf("stream: %s, format: %d, uid: %d\n", f.get_profile().stream_name().c_str(), f.get_profile().format(), f.get_profile().unique_id());
+        });
+        if (uid_count == 0)
+            uid_count = uids.size();
+        REQUIRE(uid_count == uids.size());
+    }
+
+    REQUIRE(is_subset(original, full_pipe));
+    REQUIRE_THROWS(is_subset(full_pipe, original));
+    pipe.stop();
+}


### PR DESCRIPTION
Issues:
#2367, [DSO-10532](https://rsjira.intel.com/browse/DSO-10532)

- align processing block: fix missing break that causes an access violation.
- pointcloud processing block: fix empty uv map on first frame by process other frame first.
- pointcloud processing block: fix empty UV map when disparity is enabled by swap disparity and depth frames.
- processing blocks: avoid increment unique ids in the output frames profiles.