### PR TITLE
Fixed bugs: DSO-9680, DSO-10411

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3262,10 +3262,10 @@ namespace rs2
                 if(viewer.synchronization_enable)
                 {
                     auto frames = viewer.syncer->try_wait_for_frames();
-                        std::for_each(frames.begin(), frames.end(),[this](rs2::frameset f)
+                        for(auto f:frames)
                         {
                             processing_block.invoke(f);
-                        });
+                        }
                 }
                 else
                 {

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3259,12 +3259,13 @@ namespace rs2
         {
             try
             {
-                frame frm;
                 if(viewer.synchronization_enable)
                 {
-                    frm = viewer.syncer->wait_for_frames();
-                    if(frm)
-                        processing_block.invoke(frm);
+                    auto frames = viewer.syncer->try_wait_for_frames();
+                        std::for_each(frames.begin(), frames.end(),[this](rs2::frameset f)
+                        {
+                            processing_block.invoke(f);
+                        });
                 }
                 else
                 {

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1397,7 +1397,7 @@ namespace rs2
         _pause = false;
     }
 
-    void subdevice_model::play(const std::vector<stream_profile>& profiles, viewer_model& viewer)
+    void subdevice_model::play(const std::vector<stream_profile>& profiles, viewer_model& viewer, std::shared_ptr<rs2::asynchronous_syncer> syncer)
     {
         std::stringstream ss;
         ss << "Starting streaming of ";
@@ -1412,11 +1412,11 @@ namespace rs2
         s->open(profiles);
 
         try {
-            s->start([&](frame f)
+            s->start([&, syncer](frame f)
             {
                 if (viewer.synchronization_enable && (!viewer.is_3d_view || viewer.is_3d_depth_source(f) || viewer.is_3d_texture_source(f)))
                 {
-                    viewer.s.invoke(f);
+                    syncer->invoke(f);
                 }
                 else
                 {
@@ -2799,8 +2799,10 @@ namespace rs2
 
     void device_model::reset()
     {
+        syncer->remove_syncer(dev_syncer);
         subdevices.resize(0);
         _recorder.reset();
+
     }
 
     std::pair<std::string, std::string> get_device_name(const device& dev)
@@ -2825,7 +2827,8 @@ namespace rs2
     }
 
     device_model::device_model(device& dev, std::string& error_message, viewer_model& viewer)
-        : dev(dev)
+        : dev(dev),
+          syncer(viewer.syncer)
     {
         for (auto&& sub : dev.query_sensors())
         {
@@ -2871,6 +2874,8 @@ namespace rs2
     }
     void device_model::play_defaults(viewer_model& viewer)
     {
+        if(!dev_syncer)
+            dev_syncer = viewer.syncer->create_syncer();
         for (auto&& sub : subdevices)
         {
             if (!sub->streaming)
@@ -2888,7 +2893,7 @@ namespace rs2
                 if (profiles.empty())
                     continue;
 
-                sub->play(profiles, viewer);
+                sub->play(profiles, viewer, dev_syncer);
 
                 for (auto&& profile : profiles)
                 {
@@ -3231,7 +3236,23 @@ namespace rs2
             source.frame_ready(std::move(res));
     }
 
+    void post_processing_filters::start()
+    {
+        if (render_thread_active.exchange(true) == false)
+        {
+            viewer.syncer->start();
+            render_thread = std::thread([&](){post_processing_filters::render_loop();});
+        }
+    }
 
+    void post_processing_filters::stop()
+    {
+        if (render_thread_active.exchange(false) == true)
+        {
+            viewer.syncer->stop();
+            render_thread.join();
+        }
+    }
     void post_processing_filters::render_loop()
     {
         while (render_thread_active)
@@ -3241,11 +3262,9 @@ namespace rs2
                 frame frm;
                 if(viewer.synchronization_enable)
                 {
-                    auto index = 0;
-                    while (syncer_queue.try_wait_for_frame(&frm, 30) && ++index <= syncer_queue.capacity())
-                    {
+                    frm = viewer.syncer->wait_for_frames();
+                    if(frm)
                         processing_block.invoke(frm);
-                    }
                 }
                 else
                 {
@@ -5821,7 +5840,10 @@ namespace rs2
                                 auto profiles = sub->get_selected_profiles();
                                 try
                                 {
-                                    sub->play(profiles, viewer);
+                                    if(!dev_syncer)
+                                        dev_syncer = viewer.syncer->create_syncer();
+
+                                    sub->play(profiles, viewer, dev_syncer);
                                 }
                                 catch (const error& e)
                                 {

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -285,6 +285,70 @@ namespace rs2
         std::function<rs2::frame(rs2::frame)> _invoker;
     };
 
+    class syncer_model
+    {
+    public:
+        syncer_model():
+        _active(true){}
+
+        std::shared_ptr<rs2::asynchronous_syncer> create_syncer()
+        {
+            stop();
+            std::lock_guard<std::mutex> lock(_mutex);
+            auto shared_syncer = std::make_shared<rs2::asynchronous_syncer>();
+            rs2::frame_queue q;
+
+           _syncers.push_back({shared_syncer,q});
+           shared_syncer->start(q);
+           start();
+           return shared_syncer;
+        }
+
+        void remove_syncer(std::shared_ptr<rs2::asynchronous_syncer> s)
+        {
+            stop();
+            std::lock_guard<std::mutex> lock(_mutex);
+            _syncers.erase(std::remove_if(_syncers.begin(), _syncers.end(),
+                           [s](std::pair<std::shared_ptr<rs2::asynchronous_syncer>, rs2::frame_queue> pair)
+            {
+                return pair.first.get() == s.get();
+            }), _syncers.end()) ;
+            start();
+        }
+
+        rs2::frameset wait_for_frames()
+        {
+            rs2::frameset result;
+            while(_active)
+            {
+                std::lock_guard<std::mutex> lock(_mutex);
+                for(auto&& s: _syncers)
+                {
+                    if(s.second.try_wait_for_frame(&result,30))
+                        return result;
+                }
+            }
+            return result;
+        }
+
+        void stop()
+        {
+            _active.exchange(false);
+        }
+
+        void start()
+        {
+            _active.exchange(true);
+        }
+
+    private:
+        std::vector<std::pair<std::shared_ptr<rs2::asynchronous_syncer>, rs2::frame_queue>> _syncers;
+        std::mutex _mutex;
+        std::atomic<bool> _active;
+
+    };
+
+
     class subdevice_model
     {
     public:
@@ -301,7 +365,7 @@ namespace rs2
         bool is_selected_combination_supported();
         std::vector<stream_profile> get_selected_profiles();
         void stop(viewer_model& viewer);
-        void play(const std::vector<stream_profile>& profiles, viewer_model& viewer);
+        void play(const std::vector<stream_profile>& profiles, viewer_model& viewer, std::shared_ptr<rs2::asynchronous_syncer>);
         void update(std::string& error_message, notifications_model& model);
         void draw_options(const std::vector<rs2_option>& drawing_order,
                           bool update_read_only_options, std::string& error_message,
@@ -492,6 +556,8 @@ namespace rs2
         void handle_hardware_events(const std::string& serialized_data);
 
         std::vector<std::shared_ptr<subdevice_model>> subdevices;
+        std::shared_ptr<syncer_model> syncer;
+        std::shared_ptr<rs2::asynchronous_syncer> dev_syncer;
         bool is_streaming() const;
         bool metadata_supported = false;
         bool get_curr_advanced_controls = true;
@@ -503,7 +569,6 @@ namespace rs2
         bool _playback_repeat = true;
         bool _should_replay = false;
         bool show_device_info = false;
-
         bool allow_remove = true;
         bool show_depth_only = false;
         bool show_stream_selection = true;
@@ -653,22 +718,10 @@ namespace rs2
         void update_texture(frame f) { pc->map_to(f); }
 
         /* Start the rendering thread in case its disabled */
-        void start()
-        {
-            if (render_thread_active.exchange(true) == false)
-            {
-                render_thread = std::thread(&post_processing_filters::render_loop, this);
-            }
-        }
+        void start();
 
         /* Stop the rendering thread in case its enabled */
-        void stop()
-        {
-            if (render_thread_active.exchange(false) == true)
-            {
-                render_thread.join();
-            }
-        }
+        void stop();
 
         bool is_rendering() const
         {
@@ -697,7 +750,6 @@ namespace rs2
 
         const size_t resulting_queue_max_size;
         std::map<int, rs2::frame_queue> frames_queue;
-        rs2::frame_queue syncer_queue;
         rs2::frame_queue resulting_queue;
 
         std::shared_ptr<pointcloud> get_pc() const { return pc; }
@@ -836,7 +888,7 @@ namespace rs2
             : ppf(*this),
               synchronization_enable(true)
         {
-            s.start(ppf.syncer_queue);
+            syncer = std::make_shared<syncer_model>();
             reset_camera();
             rs2_error* e = nullptr;
             not_model.add_log(to_string() << "librealsense version: " << api_version_to_string(rs2_get_api_version(&e)) << "\n");
@@ -889,7 +941,7 @@ namespace rs2
         std::map<int, int> streams_origin;
         bool fullscreen = false;
         stream_model* selected_stream = nullptr;
-
+        std::shared_ptr<syncer_model> syncer;
         post_processing_filters ppf;
         tm2_model tm2;
 
@@ -916,7 +968,6 @@ namespace rs2
 
         float dim_level = 1.f;
 
-        rs2::asynchronous_syncer s;
 
         bool continue_with_ui_not_aligned = false;
     private:

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -453,7 +453,7 @@ int main(int argv, const char** argc) try
                 {
                     ctx.unload_device(p.file_name());
                 }
-                device_to_remove->syncer->remove_syncer(device_to_remove->dev_syncer);
+                viewer_model.syncer->remove_syncer(device_to_remove->dev_syncer);
                 device_models->erase(std::find_if(begin(*device_models), end(*device_models),
                     [&](const device_model& other) { return get_device_name(other.dev) == get_device_name(device_to_remove->dev); }));
                 device_to_remove = nullptr;

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -52,14 +52,18 @@ void add_playback_device(context& ctx, std::shared_ptr<std::vector<device_model>
                         if (it->_playback_repeat)
                         {
                             //Calling from different since playback callback is from reading thread
-                            std::thread{ [subs, &viewer_model]()
+                            std::thread{ [subs, &viewer_model, it]()
                             {
+                                if(!it->dev_syncer)
+                                    it->dev_syncer = viewer_model.syncer->create_syncer();
+
                                 for (auto&& sub : subs)
                                 {
                                     if (sub->streaming)
                                     {
                                         auto profiles = sub->get_selected_profiles();
-                                        sub->play(profiles, viewer_model);
+
+                                        sub->play(profiles, viewer_model, it->dev_syncer);
                                     }
                                 }
                             } }.detach();
@@ -126,11 +130,6 @@ void refresh_devices(std::mutex& m,
                     viewer_model.not_model.add_notification({ get_device_name(dev).first + " Disconnected\n",
                         0, RS2_LOG_SEVERITY_INFO, RS2_NOTIFICATION_CATEGORY_UNKNOWN_ERROR });
 
-                    viewer_model.ppf.depth_stream_active = false;
-
-                    // Stopping post processing filter rendering thread in case of disconnection
-                    viewer_model.ppf.stop();
-
                     //Remove from devices
                     auto dev_model_itr = std::find_if(begin(*device_models), end(*device_models),
                         [&](const device_model& other) { return get_device_name(other.dev) == get_device_name(dev); });
@@ -140,7 +139,16 @@ void refresh_devices(std::mutex& m,
                         for (auto&& s : dev_model_itr->subdevices)
                             s->streaming = false;
 
+                        dev_model_itr->reset();
                         device_models->erase(dev_model_itr);
+
+                        if(device_models->size() == 0)
+                        {
+                            viewer_model.ppf.depth_stream_active = false;
+
+                            // Stopping post processing filter rendering thread in case of disconnection
+                            viewer_model.ppf.stop();
+                        }
                     }
                     auto dev_name_itr = std::find(begin(device_names), end(device_names), get_device_name(dev));
                     if (dev_name_itr != end(device_names))
@@ -227,6 +235,7 @@ int main(int argv, const char** argc) try
     device_model* device_to_remove = nullptr;
 
     viewer_model viewer_model;
+
     std::vector<device> connected_devs;
     std::mutex m;
 
@@ -444,7 +453,7 @@ int main(int argv, const char** argc) try
                 {
                     ctx.unload_device(p.file_name());
                 }
-
+                device_to_remove->syncer->remove_syncer(device_to_remove->dev_syncer);
                 device_models->erase(std::find_if(begin(*device_models), end(*device_models),
                     [&](const device_model& other) { return get_device_name(other.dev) == get_device_name(device_to_remove->dev); }));
                 device_to_remove = nullptr;
@@ -495,6 +504,7 @@ int main(int argv, const char** argc) try
     }
 
     // Stopping post processing filter rendering thread
+
     viewer_model.ppf.stop();
 
     // Stop all subdevices


### PR DESCRIPTION
The viewer couldn't stream with multiple cameras due to bottleneck in the syncer queue that is shared to all the devices. 
In this PR I added syncer_model class that enable to add syncer per device and manage all the syncers 
each device will have his own syncer instead of one syncer for all the devices.
#2543 #2292