### PR TITLE
Handle offset on UI when graphics driver is not updated

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2981,28 +2981,90 @@ namespace rs2
             {
                 ImGui::OpenPopup(name.c_str());
             }
+
+            if (ImGui::BeginPopupModal(name.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+            {
+                ImGui::Text("RealSense error calling:");
+                ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, regular_blue);
+                ImGui::InputTextMultiline("error", const_cast<char*>(error_message.c_str()),
+                    error_message.size() + 1, { 500,100 }, ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_ReadOnly);
+                ImGui::PopStyleColor();
+
+                if (ImGui::Button("OK", ImVec2(120, 0)))
+                {
+                    if (dont_show_this_error)
+                    {
+                        errors_not_to_show.insert(simplify_error_message(error_message));
+                    }
+                    error_message = "";
+                    ImGui::CloseCurrentPopup();
+                    dont_show_this_error = false;
+                }
+
+                ImGui::SameLine();
+                ImGui::Checkbox("Don't show this error again", &dont_show_this_error);
+
+                ImGui::EndPopup();
+            }
         }
+
+        ImGui::PopStyleColor(3);
+        ImGui::PopStyleVar(2);
+    }
+
+    void rs2::viewer_model::popup_if_ui_not_aligned(ImFont* font_14)
+    {
+        constexpr const char* graphics_updated_driver = "https://downloadcenter.intel.com/download/27266/Graphics-Intel-Graphics-Driver-for-Windows-15-60-?product=80939";
+
+        if (continue_with_ui_not_aligned)
+            return;
+
+        std::string error_message = to_string() <<
+            "The application has detected possible UI alignment issue,            \n" <<
+            "sometimes caused by outdated graphics card drivers.\n" <<
+            "For Intel Integrated Graphics driver \n";
+
+        auto flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+            ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar |
+            ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysVerticalScrollbar;
+
+        ImGui_ScopePushFont(font_14);
+        ImGui::PushStyleColor(ImGuiCol_PopupBg, sensor_bg);
+        ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, white);
+        ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(10, 10));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 1);
+
+        std::string name = to_string() << "  " << textual_icons::exclamation_triangle << " UI Offset Detected";
+
+
+        ImGui::OpenPopup(name.c_str());
+
         if (ImGui::BeginPopupModal(name.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            ImGui::Text("RealSense error calling:");
             ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, regular_blue);
-            ImGui::InputTextMultiline("error", const_cast<char*>(error_message.c_str()),
-                error_message.size() + 1, { 500,100 }, ImGuiInputTextFlags_AutoSelectAll | ImGuiInputTextFlags_ReadOnly);
+            ImGui::Text(const_cast<char*>(error_message.c_str()));
             ImGui::PopStyleColor();
 
-            if (ImGui::Button("OK", ImVec2(120, 0)))
+            ImGui::PushStyleColor(ImGuiCol_Button, transparent);
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, transparent);
+            ImGui::PushStyleColor(ImGuiCol_ButtonActive, transparent);
+            ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
+            ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, white);
+
+            ImGui::SetCursorPos({ 190, 42 });
+            if (ImGui::Button("click here", { 150, 60 }))
             {
-                if (dont_show_this_error)
-                {
-                    errors_not_to_show.insert(simplify_error_message(error_message));
-                }
-                error_message = "";
-                ImGui::CloseCurrentPopup();
-                dont_show_this_error = false;
+                open_url(graphics_updated_driver);
             }
 
-            ImGui::SameLine();
-            ImGui::Checkbox("Don't show this error again", &dont_show_this_error);
+            ImGui::PopStyleColor(5);
+
+            if (ImGui::Button(" Ignore & Continue ", ImVec2(150, 0)))
+            {
+                continue_with_ui_not_aligned = true;
+                ImGui::CloseCurrentPopup();
+            }
 
             ImGui::EndPopup();
         }

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -855,7 +855,7 @@ namespace rs2
 
         void popup_if_error(ImFont* font, std::string& error_message);
 
-		void popup_if_ui_not_aligned(ImFont* font);
+        void popup_if_ui_not_aligned(ImFont* font);
 
         void show_event_log(ImFont* font_14, float x, float y, float w, float h);
 
@@ -907,7 +907,7 @@ namespace rs2
 
         rs2::asynchronous_syncer s;
 
-		bool continue_with_ui_not_aligned = false;
+        bool continue_with_ui_not_aligned = false;
     private:
         struct rgb {
             uint32_t r, g, b;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -855,6 +855,8 @@ namespace rs2
 
         void popup_if_error(ImFont* font, std::string& error_message);
 
+		void popup_if_ui_not_aligned(ImFont* font);
+
         void show_event_log(ImFont* font_14, float x, float y, float w, float h);
 
         void show_3dviewer_header(ImFont* font, rs2::rect stream_rect, bool& paused, std::string& error_message);
@@ -904,6 +906,8 @@ namespace rs2
         float dim_level = 1.f;
 
         rs2::asynchronous_syncer s;
+
+		bool continue_with_ui_not_aligned = false;
     private:
         struct rgb {
             uint32_t r, g, b;

--- a/common/ux-alignment.cpp
+++ b/common/ux-alignment.cpp
@@ -1,0 +1,114 @@
+#include "ux-alignment.h"
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <vector>
+#include <memory>
+
+#ifdef _WIN32
+#undef APIENTRY
+#define GLFW_EXPOSE_NATIVE_WIN32
+#define GLFW_EXPOSE_NATIVE_WGL
+#include <GLFW/glfw3native.h>
+
+#include <Windows.h>
+#endif
+
+#define MAGIC 250
+
+bool is_gui_aligned(GLFWwindow *win)
+{
+#ifdef _WIN32
+    try
+    {
+        auto hwn = glfwGetWin32Window(win);
+        if (hwn == nullptr)
+            return false;
+
+        auto flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
+            ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar |
+            ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoBringToFrontOnFocus;
+
+        ImGui::SetNextWindowPos({ 0, 0 });
+
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0, 0));
+        ImGui::Begin("is_gui_aligned", nullptr, flags);
+
+        auto DrawList = ImGui::GetWindowDrawList();
+        if (DrawList == nullptr)
+            return false;
+
+        DrawList->AddRectFilled({ 0,0 }, { 1,1 }, ImColor(MAGIC / 255.f, 0.f, 0.f, 1.f));
+
+        ImGui::End();
+        ImGui::PopStyleVar();
+
+        ImGui::Render();
+
+        glfwSwapBuffers(win);
+
+        ImGui_ImplGlfw_NewFrame(1.f);
+
+        SetFocus(hwn);
+
+        int width = 1;
+        int height = 1;
+
+        HDC hdc = GetDC(hwn);
+        if (hdc == nullptr)
+            return false;
+
+        std::shared_ptr<HDC> shared_hdc(&hdc, [&](HDC* hdc) {ReleaseDC(hwn, *hdc); DeleteDC(*hdc);});
+
+        HDC hCaptureDC = CreateCompatibleDC(hdc);
+        if (hCaptureDC == nullptr)
+            return false;
+
+        std::shared_ptr<HDC> shared_capture_hdc(&hCaptureDC, [&](HDC* hdc) {ReleaseDC(hwn, *hdc); DeleteDC(*hdc);});
+
+        HBITMAP hCaptureBitmap = CreateCompatibleBitmap(hdc, width, height);
+        if (hCaptureBitmap == nullptr)
+            return false;
+
+        std::shared_ptr<HBITMAP> shared_bmp(&hCaptureBitmap, [&](HBITMAP* bmp) {DeleteObject(bmp);});
+
+        auto original = SelectObject(hCaptureDC, hCaptureBitmap);
+        if (original == nullptr)
+            return false;
+
+        if (!BitBlt(hCaptureDC, 0, 0, width, height, hdc, 0, 0, SRCCOPY | CAPTUREBLT))
+            return false;
+
+        BITMAPINFO bmi = { 0 };
+        bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+        bmi.bmiHeader.biWidth = width;
+        bmi.bmiHeader.biHeight = height;
+        bmi.bmiHeader.biPlanes = 1;
+        bmi.bmiHeader.biBitCount = 32;
+        bmi.bmiHeader.biCompression = BI_RGB;
+
+        std::vector<RGBQUAD> pPixels(width * height);
+
+        auto res = GetDIBits(
+            hCaptureDC,
+            hCaptureBitmap,
+            0,
+            height,
+            pPixels.data(),
+            &bmi,
+            DIB_RGB_COLORS
+        );
+
+        if (res <= 0 || res == ERROR_INVALID_PARAMETER)
+            return false;
+
+        auto ret = pPixels[0].rgbRed == MAGIC;
+        return ret;
+    }
+    catch (...)
+    {
+        return false;
+    }
+#else
+    return true;
+#endif
+}

--- a/common/ux-alignment.cpp
+++ b/common/ux-alignment.cpp
@@ -22,7 +22,7 @@ bool is_gui_aligned(GLFWwindow *win)
     {
         auto hwn = glfwGetWin32Window(win);
         if (hwn == nullptr)
-            return false;
+            return true;
 
         auto flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
             ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar |
@@ -35,7 +35,7 @@ bool is_gui_aligned(GLFWwindow *win)
 
         auto DrawList = ImGui::GetWindowDrawList();
         if (DrawList == nullptr)
-            return false;
+            return true;
 
         DrawList->AddRectFilled({ 0,0 }, { 1,1 }, ImColor(MAGIC / 255.f, 0.f, 0.f, 1.f));
 
@@ -55,28 +55,28 @@ bool is_gui_aligned(GLFWwindow *win)
 
         HDC hdc = GetDC(hwn);
         if (hdc == nullptr)
-            return false;
+            return true;
 
         std::shared_ptr<HDC> shared_hdc(&hdc, [&](HDC* hdc) {ReleaseDC(hwn, *hdc); DeleteDC(*hdc);});
 
         HDC hCaptureDC = CreateCompatibleDC(hdc);
         if (hCaptureDC == nullptr)
-            return false;
+            return true;
 
         std::shared_ptr<HDC> shared_capture_hdc(&hCaptureDC, [&](HDC* hdc) {ReleaseDC(hwn, *hdc); DeleteDC(*hdc);});
 
         HBITMAP hCaptureBitmap = CreateCompatibleBitmap(hdc, width, height);
         if (hCaptureBitmap == nullptr)
-            return false;
+            return true;
 
         std::shared_ptr<HBITMAP> shared_bmp(&hCaptureBitmap, [&](HBITMAP* bmp) {DeleteObject(bmp);});
 
         auto original = SelectObject(hCaptureDC, hCaptureBitmap);
         if (original == nullptr)
-            return false;
+            return true;
 
         if (!BitBlt(hCaptureDC, 0, 0, width, height, hdc, 0, 0, SRCCOPY | CAPTUREBLT))
-            return false;
+            return true;
 
         BITMAPINFO bmi = { 0 };
         bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
@@ -99,14 +99,14 @@ bool is_gui_aligned(GLFWwindow *win)
         );
 
         if (res <= 0 || res == ERROR_INVALID_PARAMETER)
-            return false;
+            return true;
 
         auto ret = pPixels[0].rgbRed == MAGIC;
         return ret;
     }
     catch (...)
     {
-        return false;
+        return true;
     }
 #else
     return true;

--- a/common/ux-alignment.h
+++ b/common/ux-alignment.h
@@ -1,0 +1,9 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#define GLFW_INCLUDE_GLU
+#include <GLFW/glfw3.h>
+ 
+bool is_gui_aligned(GLFWwindow *win);

--- a/common/ux-alignment.h
+++ b/common/ux-alignment.h
@@ -6,4 +6,11 @@
 #define GLFW_INCLUDE_GLU
 #include <GLFW/glfw3.h>
  
+//This function checks whether there is UI misalignment, 
+//sometimes caused by outdated graphics card drivers,
+//it puts a red pixel (1x1 rect) on the top left corner of the window,
+//take a snapshot and check the value of the top left corner pixel
+//if its red - there is no misalignment
+//otherwise - there is misalignment
+
 bool is_gui_aligned(GLFWwindow *win);

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -8,6 +8,8 @@
 // int-rs-splash.hpp contains the PNG image from res/int-rs-splash.png
 #include "res/int-rs-splash.hpp"
 
+#include "ux-alignment.h"
+
 namespace rs2
 {
     void ux_window::open_window()
@@ -144,7 +146,7 @@ namespace rs2
                     }
                 }
             });
-            _first_frame = false;
+            
         }
 
         // If we are just getting started, render the Splash Screen instead of normal UI
@@ -155,6 +157,11 @@ namespace rs2
 
             begin_frame();
 
+			if (_first_frame)
+			{
+				_is_ui_aligned = is_gui_aligned(_win);
+				_first_frame = false;
+			}
             glPushMatrix();
             glViewport(0, 0, _fb_width, _fb_height);
             glClearColor(0.036f, 0.044f, 0.051f, 1.f);

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -62,6 +62,8 @@ namespace rs2
 
         void add_on_load_message(const std::string& msg);
 
+		bool is_ui_aligned() { return _is_ui_aligned; }
+
     private:
         void open_window();
 
@@ -92,5 +94,7 @@ namespace rs2
         bool                     _fullscreen_pressed = false;
         bool                     _fullscreen = false;
         std::string              _title;
+
+		bool                     _is_ui_aligned = false;
     };
 }

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -95,6 +95,6 @@ namespace rs2
         bool                     _fullscreen = false;
         std::string              _title;
 
-		bool                     _is_ui_aligned = false;
+        bool                     _is_ui_aligned = false;
     };
 }

--- a/tools/depth-quality/CMakeLists.txt
+++ b/tools/depth-quality/CMakeLists.txt
@@ -48,8 +48,8 @@ endif()
             ../../third-party/imgui/imgui_impl_glfw.cpp
             ../../third-party/imgui/imgui-fonts-karla.hpp
             ../../third-party/imgui/imgui-fonts-fontawesome.hpp
-			../../common/ux-alignment.cpp
-			../../common/ux-alignment.h
+            ../../common/ux-alignment.cpp
+            ../../common/ux-alignment.h
         )
 
     if(WIN32)

--- a/tools/depth-quality/CMakeLists.txt
+++ b/tools/depth-quality/CMakeLists.txt
@@ -48,6 +48,8 @@ endif()
             ../../third-party/imgui/imgui_impl_glfw.cpp
             ../../third-party/imgui/imgui-fonts-karla.hpp
             ../../third-party/imgui/imgui-fonts-fontawesome.hpp
+			../../common/ux-alignment.cpp
+			../../common/ux-alignment.h
         )
 
     if(WIN32)

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -434,10 +434,10 @@ namespace rs2
 
         void tool_model::render(ux_window& win)
         {
-			if (!win.is_ui_aligned())
-			{
-				_viewer_model.popup_if_ui_not_aligned(win.get_font());
-			}
+            if (!win.is_ui_aligned())
+            {
+                _viewer_model.popup_if_ui_not_aligned(win.get_font());
+            }
             rect viewer_rect = { _viewer_model.panel_width,
                 _viewer_model.panel_y, win.width() -
                 _viewer_model.panel_width,

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -434,6 +434,10 @@ namespace rs2
 
         void tool_model::render(ux_window& win)
         {
+			if (!win.is_ui_aligned())
+			{
+				_viewer_model.popup_if_ui_not_aligned(win.get_font());
+			}
             rect viewer_rect = { _viewer_model.panel_width,
                 _viewer_model.panel_y, win.width() -
                 _viewer_model.panel_width,

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -45,13 +45,15 @@ endif()
             ../../common/model-views.cpp
             ../../common/ux-window.h
             ../../common/ux-window.cpp
+			../../common/ux-alignment.cpp
+			../../common/ux-alignment.h
         )
 
     # config-ui
     if(WIN32)
         add_executable(realsense-viewer WIN32
                 ${RS_VIEWER_CPP} ${CMAKE_CURRENT_SOURCE_DIR}/res/resource.h
-                ${RS_VIEWER_CPP} ${CMAKE_CURRENT_SOURCE_DIR}/res/realsense-viewer.rc
+                ${CMAKE_CURRENT_SOURCE_DIR}/res/realsense-viewer.rc
                 ../../common/windows-app-bootstrap.cpp)
 
         source_group("3rd Party" FILES
@@ -67,8 +69,7 @@ endif()
 
         include_directories(realsense-viewer ../../third-party/imgui ../../common ../../third-party ${CMAKE_CURRENT_SOURCE_DIR}/res/)
     else()
-        add_executable(realsense-viewer
-                ${RS_VIEWER_CPP})
+        add_executable(realsense-viewer ${RS_VIEWER_CPP})
         include_directories(realsense-viewer ../../third-party/imgui ../../common ../../third-party)
     endif()
 

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -45,8 +45,8 @@ endif()
             ../../common/model-views.cpp
             ../../common/ux-window.h
             ../../common/ux-window.cpp
-			../../common/ux-alignment.cpp
-			../../common/ux-alignment.h
+            ../../common/ux-alignment.cpp
+            ../../common/ux-alignment.h
         )
 
     # config-ui

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -273,7 +273,7 @@ int main(int argv, const char** argc) try
     // Closing the window
     while (window)
     {
-		if (!window.is_ui_aligned())
+        if (!window.is_ui_aligned())
 		{
 			viewer_model.popup_if_ui_not_aligned(window.get_font());
 		}

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -273,6 +273,10 @@ int main(int argv, const char** argc) try
     // Closing the window
     while (window)
     {
+		if (!window.is_ui_aligned())
+		{
+			viewer_model.popup_if_ui_not_aligned(window.get_font());
+		}
         refresh_devices(m, ctx, devices_connection_changes, connected_devs, device_names, device_models, viewer_model, error_message);
 
         bool update_read_only_options = update_readonly_options_timer;


### PR DESCRIPTION
When graphics driver is not up to date there is sometimes misalignment in the viewer UI:
![image](https://user-images.githubusercontent.com/22448952/47083126-675d0e80-d218-11e8-9d97-22879257695b.png)

In this PR I added code that detects this situation, notifies the user and suggests a link to the updated driver:
![image](https://user-images.githubusercontent.com/22448952/47083393-1699e580-d219-11e8-8815-84fc4e81b781.png)
