### PR TITLE
Realsense-viewer - disable sync by default

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -886,7 +886,7 @@ namespace rs2
 
         viewer_model()
             : ppf(*this),
-              synchronization_enable(true)
+              synchronization_enable(false)
         {
             syncer = std::make_shared<syncer_model>();
             reset_camera();


### PR DESCRIPTION
To better support D435i and T265 devices