### PR TITLE
fix crash caused by memory misalignment

### DIFF
--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -75,7 +75,7 @@ namespace librealsense
                 if (_type == *type)
                 {
                     const rs2_metadata_type* value = reinterpret_cast<const rs2_metadata_type*>(pos);
-                    result = *value;
+                    memcpy((void*)&result, value, sizeof(*value));
                     return true;
                 }
                 pos += sizeof(rs2_metadata_type);

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -75,7 +75,7 @@ namespace librealsense
                 if (_type == *type)
                 {
                     const rs2_metadata_type* value = reinterpret_cast<const rs2_metadata_type*>(pos);
-                    memcpy((void*)&result, value, sizeof(*value));
+                    memcpy((void*)&result, (const void*)value, sizeof(*value));
                     return true;
                 }
                 pos += sizeof(rs2_metadata_type);


### PR DESCRIPTION
this crash only occurred when build type is Release:

/DEBUG   (12405): Build fingerprint: 'Android/rk3288_box/rk3288_box:5.1.1/LMY49F/realsense04081912:userdebug/test-keys'
I/DEBUG   (12405): Revision: '0'
I/DEBUG   (12405): ABI: 'arm'
I/DEBUG   (12405): pid: 13758, tid: 13806, name: el.irsa_example  >>> com.intel.irsa_example <<<
I/DEBUG   (12405): signal 7 (SIGBUS), code 1 (BUS_ADRALN), fault addr 0xb7fcb119
I/DEBUG   (12405):     r0 b7fcb115  r1 0000000a  r2 b6e43dd4  r3 b7fcb1fc
I/DEBUG   (12405):     r4 b806d738  r5 0000000a  r6 0000000a  r7 9f979ae8
I/DEBUG   (12405):     r8 b6e43dd4  r9 00000000  sl 9f979b8c  fp a2f0a9e4
I/DEBUG   (12405):     ip b8008310  sp 9f979ad0  lr a2d570f9  pc a2ccc05a  cpsr 600f0030
I/DEBUG   (12405): 
I/DEBUG   (12405): backtrace:
I/DEBUG   (12405):     #00 pc 0029705a  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so (librealsense::md_constant_parser::get(librealsense::frame const&) const+37)
I/DEBUG   (12405):     #01 pc 003220f7  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so (librealsense::timestamp_composite_matcher::update_last_arrived(librealsense::frame_holder&, librealsense::matcher*)+58)
I/DEBUG   (12405):     #02 pc 00320419  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so (librealsense::composite_matcher::dispatch(librealsense::frame_holder, librealsense::syncronization_environment)+360)
I/DEBUG   (12405):     #03 pc 002a2dab  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so
I/DEBUG   (12405):     #04 pc 002a0525  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so (librealsense::processing_block::invoke(librealsense::frame_holder)+56)
I/DEBUG   (12405):     #05 pc 002d8cbf  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so
I/DEBUG   (12405):     #06 pc 002bd70f  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so
I/DEBUG   (12405):     #07 pc 00294c57  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so (std::__ndk1::function<void (dispatcher::cancellable_timer)>::operator()(dispatcher::cancellable_timer) const+26)
I/DEBUG   (12405):     #08 pc 00294af7  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so (dispatcher::dispatcher(unsigned int)::{lambda()#1}::operator()() const+74)
I/DEBUG   (12405):     #09 pc 00294a81  /data/app/com.intel.irsa_example-1/lib/arm/libirsajni.so (_ZNSt6__ndk114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN10dispatcherC1EjEUlvE_EEEEEPvSA_+22)
I/DEBUG   (12405):     #10 pc 0001659b  /system/lib/libc.so (__pthread_start(void*)+30)
I/DEBUG   (12405):     #11 pc 000144c3  /system/lib/libc.so (__start_thread+6)


 $ arm-linux-androideabi-addr2line -aCfe out/Release/target/armeabi-v7a/build_irsajni/libirsajni.so 0029705a
0x0029705a
librealsense::md_constant_parser::try_get(librealsense::frame const&, long long&) const
/home/adev/librealsense/src/metadata-parser.h:78
