### PR TITLE
Fix more Matlab bugs

### DIFF
--- a/wrappers/matlab/librealsense_mex.vcxproj
+++ b/wrappers/matlab/librealsense_mex.vcxproj
@@ -33,7 +33,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -70,9 +70,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetExt>.mexw64</TargetExt>
+    <OutDir>$(SolutionDir)$(Configuration)\+realsense\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <TargetExt>.mexw64</TargetExt>
+    <OutDir>$(SolutionDir)$(Configuration)\+realsense\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetExt>.mexw64</TargetExt>
@@ -80,7 +82,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetExt>.mexw64</TargetExt>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\+realsense\</OutDir>
+    <OutDir>$(SolutionDir)$(Configuration)\+realsense\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -93,7 +95,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>C:\MATLAB\R2017a\extern\lib\win64\microsoft;C:\MATLAB\R2017b\extern\lib\win64\microsoft;$(ProjectDir)..\..\build\third-party\realsense-file\$(Configuration);$(ProjectDir)..\..\build\$(Configuration);$(ProjectDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\MATLAB\R2017a\extern\lib\win64\microsoft;C:\MATLAB\R2017b\extern\lib\win64\microsoft;$(OutDir)..\..\third-party\libtm\libtm\src\$(Configuration);$(OutDir)..\..\third-party\realsense-file\$(Configuration);$(OutDir)..\..\libusb_install\lib;$(OutDir)..;$(ProjectDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libmx.lib;libmex.lib;libmat.lib;realsense2.lib;realsense-file.lib;tm.lib;usb.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>librealsense_mex.def</ModuleDefinitionFile>
     </Link>
@@ -110,13 +112,14 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\..\include\;C:\MATLAB\R2017b\extern\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\include\;C:\MATLAB\R2017a\extern\include\;C:\MATLAB\R2017b\extern\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libmx.lib;libmex.lib;libmat.lib;realsense.lib;tm.lib;usb.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libmx.lib;libmex.lib;libmat.lib;realsense2.lib;realsense-file.lib;tm.lib;usb.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Link>
       <ModuleDefinitionFile>librealsense_mex.def</ModuleDefinitionFile>
+      <AdditionalLibraryDirectories>C:\MATLAB\R2017a\extern\lib\win64\microsoft;C:\MATLAB\R2017b\extern\lib\win64\microsoft;$(OutDir)..\..\third-party\libtm\libtm\src\$(Configuration);$(OutDir)..\..\third-party\realsense-file\$(Configuration);$(OutDir)..\..\libusb_install\lib;$(OutDir)..;$(ProjectDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -127,11 +130,14 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\..\include\;C:\MATLAB\R2017b\extern\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\include\;C:\MATLAB\R2017a\extern\include\;C:\MATLAB\R2017b\extern\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>libmx.lib;libmex.lib;libmat.lib;realsense2.lib;realsense-file.lib;tm.lib;usb.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>librealsense_mex.def</ModuleDefinitionFile>
+      <AdditionalLibraryDirectories>C:\MATLAB\R2017a\extern\lib\win64\microsoft;C:\MATLAB\R2017b\extern\lib\win64\microsoft;$(OutDir)..\..\third-party\libtm\libtm\src\$(Configuration);$(OutDir)..\..\third-party\realsense-file\$(Configuration);$(OutDir)..\..\libusb_install\lib;$(OutDir)..;$(ProjectDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -149,7 +155,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\MATLAB\R2017a\extern\lib\win64\microsoft;C:\MATLAB\R2017b\extern\lib\win64\microsoft;$(ProjectDir)..\..\build\third-party\realsense-file\$(Configuration);$(ProjectDir)..\..\build\$(Configuration);$(ProjectDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\MATLAB\R2017a\extern\lib\win64\microsoft;C:\MATLAB\R2017b\extern\lib\win64\microsoft;$(OutDir)..\..\third-party\libtm\libtm\src\$(Configuration);$(OutDir)..\..\third-party\realsense-file\$(Configuration);$(OutDir)..\..\libusb_install\lib;$(OutDir)..;$(ProjectDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libmx.lib;libmex.lib;libmat.lib;realsense2.lib;realsense-file.lib;tm.lib;usb.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>librealsense_mex.def</ModuleDefinitionFile>
     </Link>

--- a/wrappers/matlab/readme.md
+++ b/wrappers/matlab/readme.md
@@ -7,7 +7,7 @@ To get started controlling the RealSense Cameras with Matlab® in Windows 10, we
 
 ## Getting Started
 ### Building from Source
-1. Download the Git repository and run CMake, specifying the x64 toolchain and static linkage (`-DBUILD_SHARED_LIBS:BOOL=OFF`).
+1. Download the Git repository and run CMake, specifying the x64 toolchain and static linkage (`-DBUILD_SHARED_LIBS:BOOL=OFF`). Additionally, make sure you compile the optional TM2 libraries (-DBUILD_WITH_TM2:BOOL=ON)
 2. Open Visual Studio and import the project file located [here](./librealsense_mex.vcxproj).
 3. Make sure that the project settings are consistent with the instructions listed in this web page for [Compiling Mex File with Visual Studio](https://www.ini.uzh.ch/~ppyk/BasicsOfInstrumentation/matlab_help/matlab_external/compiling-mex-files-with-the-microsoft-visual-c-ide.html) and your system. For more information on Matlab settings, you can also refer to this [Matlab example project](http://coachk.cs.ucf.edu/GPGPU/Compiling_a_MEX_file_with_Visual_Studio2.htm).
 4. Make sure that in the project's settings `Target Platform Version` and `Platform Toolset` match the values set for the `realsense2` target.

--- a/wrappers/matlab/stream_profile.m
+++ b/wrappers/matlab/stream_profile.m
@@ -58,11 +58,11 @@ classdef stream_profile < handle
             out = realsense.librealsense_mex('rs2::stream_profile', 'as', this.objectHandle, type);
             switch type
                 case 'stream_profile'
-                    profile = realsense.stream_profile(out);
+                    profile = realsense.stream_profile(out{:});
                 case 'video_stream_profile'
-                    profile = realsense.video_stream_profile(out);
+                    profile = realsense.video_stream_profile(out{:});
                 case 'motion_stream_profile'
-                    profile = realsense.motion_stream_profile(out);
+                    profile = realsense.motion_stream_profile(out{:});
             end
         end
         function name = stream_name(this)

--- a/wrappers/matlab/types.h
+++ b/wrappers/matlab/types.h
@@ -149,17 +149,19 @@ template<typename T> struct MatlabParamParser::mx_wrapper_fns<T, typename std::e
     static T parse(const mxArray* cell)
     {
         using internal_t = typename type_traits<T>::rs2_internal_t;
-        return traits_trampoline::from_internal<T>(mx_wrapper_fns<internal_t*>::parse(cell));
+        // since stream_profiles embed the raw pointer directly, we need to add on the extra level of indirection expected by from_internal.
+        auto internal_p = mx_wrapper_fns<internal_t>::parse(cell);
+        return traits_trampoline::from_internal<T>(&internal_p);
     }
     static mxArray* wrap(T&& val)
     {
         auto cells = mxCreateCellMatrix(1, 2);
         auto handle_cell = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
-        auto handle_ptr = static_cast<uint64_t*>(mxGetData(cells));
+        auto handle_ptr = static_cast<uint64_t*>(mxGetData(handle_cell));
         *handle_ptr = reinterpret_cast<uint64_t>(typename type_traits<T>::rs2_internal_t(val));
 
         auto own_cell = mxCreateNumericMatrix(1, 1, mxUINT64_CLASS, mxREAL);
-        auto own_ptr = static_cast<uint64_t*>(mxGetData(cells));
+        auto own_ptr = static_cast<uint64_t*>(mxGetData(own_cell));
         // if its cloned, give the wrapper ownership of the stream_profile
         if (val.is_cloned())
         {
@@ -201,6 +203,8 @@ template<typename T> struct MatlabParamParser::mx_wrapper_fns<T, typename std::e
     {
         auto inptr = mx_wrapper_fns<typename type_traits<T>::rs2_internal_t>::parse(cell);
         rs2_frame_add_ref(inptr, nullptr);
+        // Can the jump through rs2::frame happen automatically? e.g. is rs2::points(rs2_frame* inptr) equivalent to rs2::points(rs2::frame(rs2_frame* inptr))?
+        // If not, might have to use trampolining like stream_profile
         return T(inptr);
     }
     static void destroy(const mxArray* cell)

--- a/wrappers/matlab/types.h
+++ b/wrappers/matlab/types.h
@@ -133,7 +133,7 @@ template<> mxArray* MatlabParamParser::mx_wrapper_fns<rs2::device_list>::wrap(rs
         auto idx_cell = mxCreateNumericMatrix(1, 1, idx_wrap_t::value::value, mxREAL);
         *static_cast<idx_wrap_t::type*>(mxGetData(idx_cell)) = static_cast<idx_wrap_t::type>(i);
         mxSetCell(cells, 0, dl_cell);
-        mxSetCell(cells, 1, dl_cell);
+        mxSetCell(cells, 1, idx_cell);
         mxSetCell(vec, i, cells);
     }
 


### PR DESCRIPTION
Address issues #2539 and #2541.
Additionally add tm2 dependencies to the Matlab Visual Studio Project to fix local compilation and mention this in the readme.