### PR TITLE
[matlab] update frameset.m to reflect mexfile

### DIFF
--- a/wrappers/matlab/frameset.m
+++ b/wrappers/matlab/frameset.m
@@ -38,8 +38,8 @@ classdef frameset < realsense.frame
             end
             infrared_frame = realsense.video_frame(ret);
         end
-        function size = get_size(this)
-            size = realsense.librealsense_mex('rs2::frameset', 'get_size', this.objectHandle);
+        function frameset_size = size(this)
+            frameset_size = realsense.librealsense_mex('rs2::frameset', 'size', this.objectHandle);
         end
         % TODO: iterator protocol?
     end


### PR DESCRIPTION
librealsense_mex.cpp implemented frameset.size like the c++ wrapper while frameset.m implemented get_size. Now they both implement frameset.size