### PR TITLE
Handle assertion on playback_device caused by race condition between the start of two

### DIFF
--- a/src/media/playback/playback_device.h
+++ b/src/media/playback/playback_device.h
@@ -57,7 +57,7 @@ namespace librealsense
 
     private:
         void update_time_base(device_serializer::nanoseconds base_timestamp);
-        device_serializer::nanoseconds calc_sleep_time(device_serializer::nanoseconds  timestamp) const;
+        device_serializer::nanoseconds calc_sleep_time(device_serializer::nanoseconds  timestamp);
         void start();
         void stop_internal();
         void try_looping();

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -140,7 +140,7 @@ void playback_sensor::start(frame_callback_ptr callback)
 void playback_sensor::stop(bool invoke_required)
 {
     LOG_DEBUG("Stop sensor " << m_sensor_id);
-
+    std::lock_guard<std::mutex> l(m_mutex);
     if (m_is_started == true)
     {
         m_is_started = false;
@@ -148,7 +148,6 @@ void playback_sensor::stop(bool invoke_required)
         {
             dispatcher.second->stop();
         }
-        std::lock_guard<std::mutex> l(m_mutex);
         m_user_callback.reset();
         stopped(m_sensor_id, invoke_required);
     }

--- a/src/media/playback/playback_sensor.h
+++ b/src/media/playback/playback_sensor.h
@@ -104,7 +104,6 @@ namespace librealsense
 
                     frame_interface* pframe = nullptr;
                     std::swap((*pf).frame, pframe);
-                    std::lock_guard<std::mutex> l(m_mutex);
 
                     m_user_callback->on_frame((rs2_frame*)pframe);
                     update_last_pushed_frame();


### PR DESCRIPTION
Handle assertion on playback_device caused by race condition between the start of two streams in this case we need to restart the m_base_timestamp again instead assertion.