### PR TITLE
Fix Openni2 build failed on linux (update to C99 standard)

### DIFF
--- a/wrappers/openni2/CMakeLists.txt
+++ b/wrappers/openni2/CMakeLists.txt
@@ -6,7 +6,12 @@ set(OPENNI2_DIR "c:/Program Files/OpenNI2" CACHE FILEPATH "OpenNI2 SDK directory
 set(REALSENSE2_DIR "c:/Program Files (x86)/Intel RealSense SDK 2.0" CACHE FILEPATH "RealSense2 SDK directory")
 
 # INCLUDE DIR
-include_directories (${OPENNI2_DIR}/Include)
+if (UNIX)
+    include_directories (${OPENNI2_DIR})
+else ()
+    include_directories (${OPENNI2_DIR}/Include)
+endif ()
+
 include_directories (${REALSENSE2_DIR}/include)
 include_directories (src)
 

--- a/wrappers/openni2/README.md
+++ b/wrappers/openni2/README.md
@@ -20,12 +20,13 @@ Download [OpenNI2 SDK](https://structure.io/openni)
 Download [RealSense2 SDK](https://github.com/IntelRealSense/librealsense/releases)
 
 Run CMake on driver and configure SDK's:
-* OPENNI2_DIR
+* OPENNI2_DIR (For linux, the path may be "/usr/include/openni2")
 * REALSENSE2_DIR
 
 Generate project files and compile driver
 
-Copy rs2driver.dll and realsense2.dll to OPENNI2_DIR/Samples/Bin/OpenNI2/Drivers/
+For windows,copy rs2driver.dll and realsense2.dll to OPENNI2_DIR/Samples/Bin/OpenNI2/Drivers/
+For windows,copy librs2driver.so and librealsense2.so to OPENNI2_DIR/Samples/Bin/OpenNI2/Drivers/
 
 Launch any OpenNI2 example (SimpleRead SimpleViewer NiViewer) located at OPENNI2_DIR/Samples/Bin/
 

--- a/wrappers/openni2/README.md
+++ b/wrappers/openni2/README.md
@@ -25,8 +25,8 @@ Run CMake on driver and configure SDK's:
 
 Generate project files and compile driver
 
-For windows,copy rs2driver.dll and realsense2.dll to OPENNI2_DIR/Samples/Bin/OpenNI2/Drivers/
-For windows,copy librs2driver.so and librealsense2.so to OPENNI2_DIR/Samples/Bin/OpenNI2/Drivers/
+For Windows, copy rs2driver.dll and realsense2.dll to OPENNI2_DIR/Samples/Bin/OpenNI2/Drivers/
+For Linux, copy librs2driver.so and librealsense2.so to OPENNI2_DIR/Samples/Bin/OpenNI2/Drivers/
 
 Launch any OpenNI2 example (SimpleRead SimpleViewer NiViewer) located at OPENNI2_DIR/Samples/Bin/
 

--- a/wrappers/openni2/src/Rs2Base.h
+++ b/wrappers/openni2/src/Rs2Base.h
@@ -36,9 +36,9 @@
 	#define RS2_ASSERT assert
 #endif
 
-#define rsTraceError(format, ...) printf("[RS2] ERROR at FILE %s LINE %d FUNC %s\n\t" format "\n", __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
-#define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
-#define rsLogDebug(format, ...) printf("[RS2] " format "\n", __VA_ARGS__)
+#define rsTraceError(format, ...) printf("[RS2] ERROR at FILE %s LINE %d FUNC %s\n\t" format "\n", __FILE__, __LINE__, __FUNCTION__, ##  __VA_ARGS__)
+#define rsTraceFunc(format, ...) printf("[RS2] %s " format "\n", __FUNCTION__, ##  __VA_ARGS__)
+#define rsLogDebug(format, ...) printf("[RS2] " format "\n", ## __VA_ARGS__)
 
 namespace oni { namespace driver {
 


### PR DESCRIPTION
### original bug

* original source code is use g++ 7.3.0 will build failed. Because in c99 __FUNCTION__ marco should not use string concatenate.
* __VA_ARGS__ Variadic  marco may be empty. So it need to add "##" to fix.
```
[ 14%] Building CXX object CMakeFiles/rs2driver.dir/src/Rs2Stream.cpp.o
In file included from /home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.h:3:0,
                 from /home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Device.h:3,
                 from /home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Driver.h:3,
                 from /home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:1:
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp: In member function ‘OniStatus oni::driver::Rs2Stream::initialize(oni::driver::Rs2Device*, rs2_sensor*, int, int, std::vector<oni::driver::Rs2StreamProfileInfo>*)’:
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:50: error: expected ‘)’ before ‘__FUNCTION__’
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                  ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:31:2: note: in expansion of macro ‘rsTraceFunc’
  rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, sensorId, streamId);
  ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:91: warning: too many arguments for format [-Wformat-extra-args]
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                                                           ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:31:2: note: in expansion of macro ‘rsTraceFunc’
  rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, sensorId, streamId);
  ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp: In member function ‘void oni::driver::Rs2Stream::shutdown()’:
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:50: error: expected ‘)’ before ‘__FUNCTION__’
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                  ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:55:18: note: in expansion of macro ‘rsTraceFunc’
  if (m_sensor) { rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, m_sensorId, m_streamId); }
                  ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:91: warning: too many arguments for format [-Wformat-extra-args]
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                                                           ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:55:18: note: in expansion of macro ‘rsTraceFunc’
  if (m_sensor) { rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, m_sensorId, m_streamId); }
                  ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp: In member function ‘virtual OniStatus oni::driver::Rs2Stream::start()’:
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:50: error: expected ‘)’ before ‘__FUNCTION__’
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                  ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:74:3: note: in expansion of macro ‘rsTraceFunc’
   rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, m_sensorId, m_streamId);
   ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:91: warning: too many arguments for format [-Wformat-extra-args]
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                                                           ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:74:3: note: in expansion of macro ‘rsTraceFunc’
   rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, m_sensorId, m_streamId);
   ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp: In member function ‘virtual void oni::driver::Rs2Stream::stop()’:
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:50: error: expected ‘)’ before ‘__FUNCTION__’
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                  ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:86:3: note: in expansion of macro ‘rsTraceFunc’
   rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, m_sensorId, m_streamId);
   ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:40:91: warning: too many arguments for format [-Wformat-extra-args]
 #define rsTraceFunc(format, ...) printf("[RS2] " __FUNCTION__ " " format "\n", __VA_ARGS__)
                                                                                           ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:86:3: note: in expansion of macro ‘rsTraceFunc’
   rsTraceFunc("type=%d sensorId=%d streamId=%d", (int)m_rsType, m_sensorId, m_streamId);
   ^~~~~~~~~~~
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp: In member function ‘virtual OniStatus oni::driver::Rs2Stream::convertDepthToColorCoordinates(oni::driver::StreamBase*, int, int, OniDepthPixel, int*, int*)’:
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Base.h:39:145: error: expected primary-expression before ‘)’ token
 raceError(format, ...) printf("[RS2] ERROR at FILE %s LINE %d FUNC %s\n\t" format "\n", __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
                                                                                                                                      ^
/home/tommycc/work/librealsense/wrappers/openni2/src/Rs2Stream.cpp:114:3: note: in expansion of macro ‘rsTraceError’
   rsTraceError("Invalid colorStream");
   ^~~~~~~~~~~~
CMakeFiles/rs2driver.dir/build.make:86: recipe for target 'CMakeFiles/rs2driver.dir/src/Rs2Stream.cpp.o' failed
make[2]: *** [CMakeFiles/rs2driver.dir/src/Rs2Stream.cpp.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/rs2driver.dir/all' failed
make[1]: *** [CMakeFiles/rs2driver.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2

```
### update
For __FUNCTION__ marco, it must not use string concatenate I follow [GNU GCC Function Names as Strings](https://gcc.gnu.org/onlinedocs/gcc/Function-Names.html) use %s format to fix.
For __VA_ARGS__ variadic macro, I follow [GNU GCC Variadic Macros](https://gcc.gnu.org/onlinedocs/cpp/Variadic-Macros.html) to fix it.

