### PR TITLE
fix crash when playback bag file which caused by memory misalignment

### DIFF
--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -75,7 +75,7 @@ namespace librealsense
                 if (_type == *type)
                 {
                     const rs2_metadata_type* value = reinterpret_cast<const rs2_metadata_type*>(pos);
-                    result = *value;
+                    memcpy((void*)&result, (const void*)value, sizeof(*value));
                     return true;
                 }
                 pos += sizeof(rs2_metadata_type);


### PR DESCRIPTION
I rollback the local master/development branch of my forked repo, then synced with upstream's 2.16.3 master/development branch, then updated the remote master/development branch of my forked repo; then created a new work branch from master branch for this PR.

this issue will occurred every-time when playback local bag file.

I/DEBUG   (  165): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
I/DEBUG   (  165): Build fingerprint: 'Android/rk3288_box/rk3288_box:5.1.1/LMY49F/realsense04081912:userdebug/test-keys'
I/DEBUG   (  165): Revision: '0'
I/DEBUG   (  165): ABI: 'arm'
I/DEBUG   (  165): pid: 22682, tid: 22745, name: id.irsa_example  >>> com.android.irsa_example <<<
I/DEBUG   (  165): signal 7 (SIGBUS), code 1 (BUS_ADRALN), fault addr 0xb79dd719
I/DEBUG   (  165):     r0 b79dd715  r1 0000000a  r2 002c0c3e  r3 0000000a
I/DEBUG   (  165):     r4 b77323c0  r5 9f74dc58  r6 0000000a  r7 9f74dae8
I/DEBUG   (  165):     r8 9f74dc60  r9 b7886cd0  sl 9f74db68  fp 9f74ddd0
I/DEBUG   (  165):     ip b79ac908  sp 9f74dad0  lr a2d0b20d  pc a2c6a0be  cpsr 600f0030
I/DEBUG   (  165):
I/DEBUG   (  165): backtrace:
I/DEBUG   (  165):     #00 pc 002150be  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so (librealsense::md_constant_parser::get(librealsense::frame const&) const+97)
I/DEBUG   (  165):     #01 pc 002b620b  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so (librealsense::timestamp_composite_matcher::update_last_arrived(librealsense::frame_holder&, librealsense::matcher*)+58)
I/DEBUG   (  165):     #02 pc 002b41ad  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so (librealsense::composite_matcher::dispatch(librealsense::frame_holder, librealsense::syncronization_environment)+260)
I/DEBUG   (  165):     #03 pc 00223cbf  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so
I/DEBUG   (  165):     #04 pc 00220e79  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so (librealsense::processing_block::invoke(librealsense::frame_holder)+52)
I/DEBUG   (  165):     #05 pc 00260139  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so
I/DEBUG   (  165):     #06 pc 00243383  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so
I/DEBUG   (  165):     #07 pc 00211f1d  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so (dispatcher::dispatcher(unsigned int)::{lambda()#1}::operator()() const+80)
I/DEBUG   (  165):     #08 pc 003dc5cf  /data/app/com.android.irsa_example-1/lib/arm/libirsajni.so
I/DEBUG   (  165):     #09 pc 0001659b  /system/lib/libc.so (__pthread_start(void*)+30)
I/DEBUG   (  165):     #10 pc 000144c3  /system/lib/libc.so (__start_thread+6)
E/WifiStateMachine(  462): [1,294,124,120,606 ms] noteScanstart no scan source uid -1
W/AppOps  (  462): Bad call: specified package media under uid 1000 but it is really 1013
W/libbacktrace(  165): virtual bool Backtrace::VerifyReadWordArgs(uintptr_t, word_t*): invalid pointer 0xaa
W/ActivityManagerService(  462):   Force finishing activity 1 com.android.irsa_example/.MainActivity
D/ActivityManagerService(  462): moveHomeStackTaskToTop: moving TaskRecord{3a1f4de6 #319 A=com.android.launcher3 U=0 sz=1}
I/DEBUG   (  165):
I/DEBUG   (  165): Tombstone written to: /data/tombstones/tombstone_07
I/BootReceiver(  462): Copying /data/tombstones/tombstone_07 to DropBox (SYSTEM_TOMBSTONE)
