### PR TITLE
Fix missing header for major() and minor() functions

### DIFF
--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 #include <linux/usb/video.h>
 #include <linux/uvcvideo.h>
 #include <linux/videodev2.h>


### PR DESCRIPTION
The source `src/uvc-v4l2.cpp` calls `major()` and `minor()` macros, which requires the `sys/sysmacros.h`. This PR fix the missing header.