### PR TITLE
Fix D435i Frequences selection and idle power consumption

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3029,7 +3029,7 @@ namespace rs2
         if (ImGui::BeginPopupModal(name.c_str(), nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
             ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, regular_blue);
-            ImGui::Text(const_cast<char*>(error_message.c_str()));
+            ImGui::Text("%s", error_message.c_str());
             ImGui::PopStyleColor();
 
             ImGui::PushStyleColor(ImGuiCol_Button, transparent);

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -62,7 +62,7 @@ namespace rs2
 
         void add_on_load_message(const std::string& msg);
 
-		bool is_ui_aligned() { return _is_ui_aligned; }
+        bool is_ui_aligned() { return _is_ui_aligned; }
 
     private:
         void open_window();

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #define RS2_API_MAJOR_VERSION    2
 #define RS2_API_MINOR_VERSION    16
-#define RS2_API_PATCH_VERSION    3
+#define RS2_API_PATCH_VERSION    4
 #define RS2_API_BUILD_VERSION    0
 
 #define STRINGIFY(arg) #arg

--- a/scripts/realsense-hid-ubuntu-bionic-master.patch
+++ b/scripts/realsense-hid-ubuntu-bionic-master.patch
@@ -8,12 +8,27 @@ Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
 	A symmetric patch for Accelerator was already upstreamed,
 	this patch was skipped from upstream
 	The patch was written by Srinivas Pandruvada <srinivas.pandruvada@intel.com>
----
- drivers/iio/gyro/hid-sensor-gyro-3d.c | 28 ++++++++++++++++++++-------
- 1 file changed, 21 insertions(+), 7 deletions(-)
+	Additionally, timestamp management is fixed
 
+---
+ drivers/iio/accel/hid-sensor-accel-3d.c |  1 +
+ drivers/iio/gyro/hid-sensor-gyro-3d.c   | 31 ++++++++++++++++++++++++-------
+ 2 files changed, 25 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/iio/accel/hid-sensor-accel-3d.c b/drivers/iio/accel/hid-sensor-accel-3d.c
+index c066a3b..3346631 100644
+--- a/drivers/iio/accel/hid-sensor-accel-3d.c
++++ b/drivers/iio/accel/hid-sensor-accel-3d.c
+@@ -286,6 +286,7 @@ static int accel_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+ 			hid_sensor_convert_timestamp(
+ 					&accel_state->common_attributes,
+ 					*(int64_t *)raw_data);
++		ret = 0;
+ 	break;
+ 	default:
+ 		break;
 diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
-index f59995a90..e3f2a8357 100644
+index f59995a..98cec98 100644
 --- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
 +++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
 @@ -42,11 +42,13 @@ struct gyro_3d_state {
@@ -76,17 +91,21 @@ index f59995a90..e3f2a8357 100644
  
  	return 0;
  }
-@@ -235,6 +245,10 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+@@ -235,6 +245,13 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
 +	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		gyro_state->timestamp = *(int64_t *)raw_data;
++		gyro_state->timestamp =
++			hid_sensor_convert_timestamp(
++					&gyro_state->common_attributes,
++					*(int64_t *)raw_data);
 +		ret = 0;
 +	break;
  	default:
  		break;
  	}
 -- 
-2.17.0
+2.7.4
+
 

--- a/scripts/realsense-hid-ubuntu-xenial-Ubuntu-hwe-4.13.0-45.50_16.04.1.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-Ubuntu-hwe-4.13.0-45.50_16.04.1.patch
@@ -1,17 +1,32 @@
 From 5ef00171f95a150a912f1d14645bcae25df203c9 Mon Sep 17 00:00:00 2001
 From: Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Date: Tue, 13 Feb 2018 12:06:44 +0200
 Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
 	A symmetric patch for Accelerator was already upstreamed,
 	this patch was skipped from upstream
 	The patch was written by Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+	Additionally, timestamp management is fixed
 
 ---
- drivers/iio/gyro/hid-sensor-gyro-3d.c | 28 +++++++++++++++++++++-------
- 1 file changed, 21 insertions(+), 7 deletions(-)
+ drivers/iio/accel/hid-sensor-accel-3d.c |  1 +
+ drivers/iio/gyro/hid-sensor-gyro-3d.c   | 31 ++++++++++++++++++++++++-------
+ 2 files changed, 25 insertions(+), 7 deletions(-)
 
+diff --git a/drivers/iio/accel/hid-sensor-accel-3d.c b/drivers/iio/accel/hid-sensor-accel-3d.c
+index 2238a26..bbbd268 100644
+--- a/drivers/iio/accel/hid-sensor-accel-3d.c
++++ b/drivers/iio/accel/hid-sensor-accel-3d.c
+@@ -287,6 +287,7 @@ static int accel_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+ 			hid_sensor_convert_timestamp(
+ 					&accel_state->common_attributes,
+ 					*(int64_t *)raw_data);
++		ret = 0;
+ 	break;
+ 	default:
+ 		break;
 diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
-index c67ce2a..7ff0dfe 100644
+index c67ce2a..7ffa8d6 100644
 --- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
 +++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
 @@ -42,11 +42,13 @@ struct gyro_3d_state {
@@ -27,7 +42,7 @@ index c67ce2a..7ff0dfe 100644
  	int value_offset;
 +	int64_t timestamp;
  };
-
+ 
  static const u32 gyro_3d_addresses[GYRO_3D_CHANNEL_MAX] = {
 @@ -87,7 +89,8 @@ static const struct iio_chan_spec gyro_3d_channels[] = {
  		BIT(IIO_CHAN_INFO_SAMP_FREQ) |
@@ -37,11 +52,11 @@ index c67ce2a..7ff0dfe 100644
 +	},
 +	IIO_CHAN_SOFT_TIMESTAMP(3)
  };
-
+ 
  /* Adjust channel real bits based on report descriptor */
 @@ -192,11 +195,11 @@ static const struct iio_info gyro_3d_info = {
  };
-
+ 
  /* Function to push data to buffer */
 -static void hid_sensor_push_data(struct iio_dev *indio_dev, const void *data,
 -	int len)
@@ -52,11 +67,11 @@ index c67ce2a..7ff0dfe 100644
 -	iio_push_to_buffers(indio_dev, data);
 +	iio_push_to_buffers_with_timestamp(indio_dev, data, timestamp);
  }
-
+ 
  /* Callback handler to send event after all samples are received and captured */
 @@ -208,10 +211,17 @@ static int gyro_3d_proc_event(struct hid_sensor_hub_device *hsdev,
  	struct gyro_3d_state *gyro_state = iio_priv(indio_dev);
-
+ 
  	dev_dbg(&indio_dev->dev, "gyro_3d_proc_event\n");
 -	if (atomic_read(&gyro_state->common_attributes.data_ready))
 +	if (atomic_read(&gyro_state->common_attributes.data_ready)) {
@@ -74,17 +89,20 @@ index c67ce2a..7ff0dfe 100644
 
  	return 0;
  }
-@@ -236,6 +246,10 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+@@ -236,6 +246,13 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
 +	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		gyro_state->timestamp = *(int64_t *)raw_data;
++		gyro_state->timestamp =
++			hid_sensor_convert_timestamp(
++					&gyro_state->common_attributes,
++					*(int64_t *)raw_data);
 +		ret = 0;
 +	break;
  	default:
  		break;
  	}
---
+-- 
 2.7.4
 

--- a/scripts/realsense-hid-ubuntu-xenial-hwe.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-hwe.patch
@@ -4,16 +4,31 @@ From: Evgeni <evgeni.raikhel@intel.com>
 Date: Sun, 13 May 2018 10:49:26 -0400
 
 Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
-         Ubuntu 18.04 Bionic Beaver with KErnel 4.15
+         Ubuntu 18.04 Bionic Beaver with Kernel 4.15
 	A symmetric patch for Accelerator was already upstreamed,
 	this patch was skipped from upstream
 	The patch was written by Srinivas Pandruvada <srinivas.pandruvada@intel.com>
----
- drivers/iio/gyro/hid-sensor-gyro-3d.c | 28 ++++++++++++++++++++-------
- 1 file changed, 21 insertions(+), 7 deletions(-)
+	Additionally, timestamp management is fixed
 
+---
+ drivers/iio/accel/hid-sensor-accel-3d.c |  1 +
+ drivers/iio/gyro/hid-sensor-gyro-3d.c   | 31 ++++++++++++++++++++++++-------
+ 2 files changed, 25 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/iio/accel/hid-sensor-accel-3d.c b/drivers/iio/accel/hid-sensor-accel-3d.c
+index c066a3b..3346631 100644
+--- a/drivers/iio/accel/hid-sensor-accel-3d.c
++++ b/drivers/iio/accel/hid-sensor-accel-3d.c
+@@ -286,6 +286,7 @@ static int accel_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+ 			hid_sensor_convert_timestamp(
+ 					&accel_state->common_attributes,
+ 					*(int64_t *)raw_data);
++		ret = 0;
+ 	break;
+ 	default:
+ 		break;
 diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
-index f59995a90..e3f2a8357 100644
+index f59995a..98cec98 100644
 --- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
 +++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
 @@ -42,11 +42,13 @@ struct gyro_3d_state {
@@ -76,17 +91,21 @@ index f59995a90..e3f2a8357 100644
  
  	return 0;
  }
-@@ -235,6 +245,10 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+@@ -235,6 +245,13 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
 +	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		gyro_state->timestamp = *(int64_t *)raw_data;
++		gyro_state->timestamp =
++			hid_sensor_convert_timestamp(
++					&gyro_state->common_attributes,
++					*(int64_t *)raw_data);
 +		ret = 0;
 +	break;
  	default:
  		break;
  	}
 -- 
-2.17.0
+2.7.4
+
 

--- a/scripts/realsense-hid-ubuntu-xenial-master.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-master.patch
@@ -1,3 +1,18 @@
+From 5ef00171f95a150a912f1d14645bcae25df203c9 Mon Sep 17 00:00:00 2001
+From: Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+Date: Tue, 13 Feb 2018 12:06:44 +0200
+Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
+	A symmetric patch for Accelerator was already upstreamed,
+	this patch was skipped from upstream
+	The patch was written by Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+	Additionally, timestamp management is fixed
+
+---
+ drivers/iio/gyro/hid-sensor-gyro-3d.c | 28 ++++++++++++++++++++-------
+ drivers/iio/gyro/hid-sensor-accel-3d.c | 28 ++++++++++++++++++++-------
+ 2 file changed, 56 insertions(+), 14 deletions(-)
+ 
 diff --git a/drivers/iio/accel/hid-sensor-accel-3d.c b/drivers/iio/accel/hid-sensor-accel-3d.c
 index ab1e238..28262c4 100644
 --- a/drivers/iio/accel/hid-sensor-accel-3d.c

--- a/scripts/realsense-hid-ubuntu-xenial-master.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-master.patch
@@ -68,8 +68,8 @@ index ab1e238..28262c4 100644
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
-+	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		accel_state->timestamp = *(int64_t *)raw_data;
++	case HID_USAGE_SENSOR_TIME_TIMESTAMP:	// usec->nsec
++		accel_state->timestamp = (*(int64_t *)raw_data)*1000;
 +		ret = 0;
 +	break;
  	default:
@@ -144,8 +144,8 @@ index c67ce2a..f45c5a2 100644
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
-+	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		gyro_state->timestamp = *(int64_t *)raw_data;
++	case HID_USAGE_SENSOR_TIME_TIMESTAMP: // usec->nsec
++		gyro_state->timestamp = (*(int64_t *)raw_data)*1000;
 +		ret = 0;
 +	break;
  	default:

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -42,36 +42,36 @@ namespace librealsense
         std::vector<uint8_t>  get_tm1_eeprom_raw() const;
 
         lazy<std::vector<uint8_t>>      _fisheye_calibration_table_raw;
-        //std::shared_ptr<lazy<rs2_extrinsics>> _depth_to_fisheye;
 
-        // Bandwidth parameters from BOSCH BMI 055 spec'
+        // Bandwidth parameters from BOSCH BMI 055 spec. used by D435i
         std::vector<std::pair<std::string, stream_profile>> sensor_name_and_hid_profiles =
-            {{"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_RAW}},
+            {{"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 100,  RS2_FORMAT_MOTION_RAW}},
+             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_RAW}},
              {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 400,  RS2_FORMAT_MOTION_RAW}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_RAW}},
+             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 100,  RS2_FORMAT_MOTION_XYZ32F}},
              {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_XYZ32F}},
              {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 400,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 63,  RS2_FORMAT_MOTION_RAW}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 125,  RS2_FORMAT_MOTION_RAW}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 250,  RS2_FORMAT_MOTION_RAW}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 500,  RS2_FORMAT_MOTION_RAW}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_RAW}},
+             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 63,  RS2_FORMAT_MOTION_XYZ32F}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 125,  RS2_FORMAT_MOTION_XYZ32F}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 250,  RS2_FORMAT_MOTION_XYZ32F}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 500,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
-             {"HID Sensor Class Device: Gyroscope",     { RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}} ,
+             {"HID Sensor Class Device: Gyroscope",     { RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
              {"HID Sensor Class Device: Accelerometer", { RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
              {"HID Sensor Class Device: Custom",        { RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}}};
 
+        // The frequency selector is vendor and model-specific
         std::map<rs2_stream, std::map<unsigned, unsigned>> fps_and_sampling_frequency_per_rs2_stream =
-                                                         {{RS2_STREAM_ACCEL, {{125,  1},
-                                                                              {250,  2},
-                                                                              {500,  5},
-                                                                              {1000, 10}}},
-                                                          {RS2_STREAM_GYRO,  {{200,  1},
-                                                                              {400,  4},
-                                                                              {1000, 10}}}};
+                                                         {{RS2_STREAM_ACCEL, {{63,   1},
+                                                                              {125,  2},
+                                                                              {250,  3},
+                                                                              {500,  5}}},
+                                                          {RS2_STREAM_GYRO,  {{100,  1},
+                                                                              {200,  2},
+                                                                              {400,  4}}}};
 
     protected:
         std::shared_ptr<stream_interface> _fisheye_stream;

--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -165,8 +165,8 @@ namespace librealsense
         if(has_metadata(mode, fo.metadata, fo.metadata_size))
         {
             auto timestamp = *((uint64_t*)((const uint8_t*)fo.metadata));
-            // TODO The FW timestamps for HID are converted to Nanosec in Linux kernel. This may produce conflicts with MS API.
-            return static_cast<rs2_time_t>(timestamp) * 0.00001;//TIMESTAMP_USEC_TO_MSEC; TODO -Evgeni - replace with Nikolai
+            // The FW timestamps for HID are converted to Nanosec in Linux kernel. This may produce conflicts with MS API.
+            return static_cast<rs2_time_t>(timestamp) * TIMESTAMP_NSEC_TO_MSEC;
         }
 
         if (!started)
@@ -228,6 +228,7 @@ namespace librealsense
         static const uint8_t timestamp_offset = 17;
 
         auto timestamp = *((uint64_t*)((const uint8_t*)fo.pixels + timestamp_offset));
+        // TODO - verify units with custom report
         return static_cast<rs2_time_t>(timestamp) * TIMESTAMP_USEC_TO_MSEC;
     }
 

--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -165,7 +165,8 @@ namespace librealsense
         if(has_metadata(mode, fo.metadata, fo.metadata_size))
         {
             auto timestamp = *((uint64_t*)((const uint8_t*)fo.metadata));
-            return static_cast<rs2_time_t>(timestamp) * TIMESTAMP_USEC_TO_MSEC;
+            // TODO The FW timestamps for HID are converted to Nanosec in Linux kernel. This may produce conflicts with MS API.
+            return static_cast<rs2_time_t>(timestamp) * 0.00001;//TIMESTAMP_USEC_TO_MSEC; TODO -Evgeni - replace with Nikolai
         }
 
         if (!started)

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -362,9 +362,6 @@ namespace librealsense
             if (fd < 0)
                 throw linux_backend_exception("Failed to open report!");
 
-            if (!_is_capturing)
-                enable(true);
-
             std::vector<uint8_t> buffer;
             buffer.resize(MAX_INPUT);
             auto read_size = read(fd, buffer.data(), buffer.size());
@@ -435,6 +432,17 @@ namespace librealsense
             }
             custom_device_file << input_data;
             custom_device_file.close();
+
+            // Work-around for the HID custom driver failing to release resources,
+            // preventing the device to enter idle U3 mode
+            // reading out the value will refresh the device tree in kernel
+//            if (!state)
+//            {
+//                std::string feat_val("default");
+//                if(!(std::ifstream(_custom_device_path + "/feature-0-200309/feature-0-200309-value") >> feat_val))
+//                    throw linux_backend_exception("Failed to read feat_val");
+//                std::cout << "Feat value is " << feat_val << std::endl;
+//            }
         }
 
         void hid_custom_sensor::signal_stop()

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -918,7 +918,7 @@ namespace librealsense
         void v4l_hid_device::open(const std::vector<hid_profile>& hid_profiles)
         {
             _hid_profiles = hid_profiles;
-            for (auto& device_info : _hid_device_infos)
+             for (auto& device_info : _hid_device_infos)
              {
                 try
                 {

--- a/src/types.h
+++ b/src/types.h
@@ -48,6 +48,7 @@ namespace librealsense
 {
     #define UNKNOWN_VALUE "UNKNOWN"
     const double TIMESTAMP_USEC_TO_MSEC = 0.001;
+    const double TIMESTAMP_NSEC_TO_MSEC = 0.000001;
 
     ///////////////////////////////////
     // Utility types for general use //

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -283,9 +283,9 @@ int main(int argv, const char** argc) try
     while (window)
     {
         if (!window.is_ui_aligned())
-		{
-			viewer_model.popup_if_ui_not_aligned(window.get_font());
-		}
+        {
+            viewer_model.popup_if_ui_not_aligned(window.get_font());
+        }
         refresh_devices(m, ctx, devices_connection_changes, connected_devs, device_names, device_models, viewer_model, error_message);
 
         bool update_read_only_options = update_readonly_options_timer;


### PR DESCRIPTION
Fix HID power in idle state
 - Prevent hid custom device activation on read report to query  host only.
 - Add placeholder for patch that will refresh the kernel tree internally in case "enable_sensor" is not working properly with hid_custom device.

Update IMU frequencies selections:
 - Rectify Linux kernel patches with regards to IMU IIO timestamps.
        Kernel 4.4  - in-place scale
        Kernel 4.13/4.15 - employ hid report exponent for gyro, as implemented for accel_3d.
- Fix hid iio timestamp parsing routine 
Fix tabulation and warning.

Promote to version 2.16.4

Tracked on: DSO-10736 
Tracked on: DSO-10807