### PR TITLE
The viewer model will move to filters frameset instead of separated frames.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3093,58 +3093,64 @@ namespace rs2
 
     rs2::frame post_processing_filters::apply_filters(rs2::frame f)
     {
-        rs2_stream stream_type = f.get_profile().stream_type();
-        if (stream_type == RS2_STREAM_DEPTH || stream_type == RS2_STREAM_COLOR || stream_type == RS2_STREAM_INFRARED)
+        for (auto&& s : viewer.streams)
         {
-            for (auto&& s : viewer.streams)
+            if (!s.second.dev) continue;
+            auto dev = s.second.dev;
+
+            if (s.second.original_profile.unique_id() == f.get_profile().unique_id())
             {
-                if (!s.second.dev) continue;
-                auto dev = s.second.dev;
-
-                if (s.second.original_profile.unique_id() == f.get_profile().unique_id())
+                if (dev->post_processing_enabled)
                 {
-                    if (dev->post_processing_enabled)
-                    {
-                        auto dec_filter = s.second.dev->decimation_filter;
-                        if (dec_filter->enabled)
-                            f = dec_filter->invoke(f);
+                    auto dec_filter = s.second.dev->decimation_filter;
+                    auto depth_2_disparity = s.second.dev->depth_to_disparity;
+                    auto spatial_filter = s.second.dev->spatial_filter;
+                    auto temp_filter = s.second.dev->temporal_filter;
+                    auto hole_filling = s.second.dev->hole_filling_filter;
+                    auto disparity_2_depth = s.second.dev->disparity_to_depth;
+                   
+                    if (dec_filter && dec_filter->enabled)
+                        f = dec_filter->invoke(f);
 
-                        if (stream_type == RS2_STREAM_DEPTH)
-                        {
-                            auto depth_2_disparity = s.second.dev->depth_to_disparity;
-                            auto spatial_filter = s.second.dev->spatial_filter;
-                            auto temp_filter = s.second.dev->temporal_filter;
-                            auto hole_filling = s.second.dev->hole_filling_filter;
-                            auto disparity_2_depth = s.second.dev->disparity_to_depth;
+                    if (depth_2_disparity && depth_2_disparity->enabled)
+                        f = depth_2_disparity->invoke(f);
 
-                            if (depth_2_disparity->enabled)
-                                f = depth_2_disparity->invoke(f);
+                    if (spatial_filter && spatial_filter->enabled)
+                        f = spatial_filter->invoke(f);
 
-                            if (spatial_filter->enabled)
-                                f = spatial_filter->invoke(f);
+                    if (temp_filter && temp_filter->enabled)
+                        f = temp_filter->invoke(f);
 
-                            if (temp_filter->enabled)
-                                f = temp_filter->invoke(f);
+                    if (disparity_2_depth && disparity_2_depth->enabled)
+                            f = disparity_2_depth->invoke(f);
 
-                            if (disparity_2_depth->enabled)
-                                f = disparity_2_depth->invoke(f);
+                    if (hole_filling && hole_filling->enabled)
+                        f = hole_filling->invoke(f);
 
-                            if (hole_filling->enabled)
-                                f = hole_filling->invoke(f);
-                        }
-
-                        break;
-                    }
+                    break;
                 }
             }
         }
 
         // Override the zero pixel in texture frame with black color for occlusion invalidation
         // TODO - this is a temporal solution to be refactored from the app level into the core library
-        switch (stream_type)
+        std::vector<rs2::frame> frames;
+        if (auto composite = f.as<rs2::frameset>())
         {
-        case RS2_STREAM_COLOR:
+            for (auto&& f : composite)
+                frames.push_back(f);
+        }
+        else
+            frames.push_back(f);
+
+        for (auto&& f : frames)
         {
+            auto stream_type = f.get_profile().stream_type();
+
+            switch (stream_type)
+            {
+            case RS2_STREAM_COLOR:
+            {
                 auto rgb_stream = const_cast<uint8_t*>(static_cast<const uint8_t*>(f.get_data()));
                 memset(rgb_stream, 0, 3);
                 // Alternatively, enable the next two lines to render invalidation with magenta color for inspection
@@ -3160,61 +3166,118 @@ namespace rs2
             break;
             default:
                 break;
+            }
         }
+       
 
         return f;
     }
 
+    void post_processing_filters::map_id(rs2::frame new_frame, rs2::frame old_frame)
+    {
+        if (auto new_set = new_frame.as<rs2::frameset>())
+        {
+            if (auto old_set = old_frame.as<rs2::frameset>())
+            {
+                map_id_frameset_to_frameset(new_set, old_set);
+            }
+            else
+            {
+                map_id_frameset_to_frame(new_set, old_frame);
+            }
+        }
+        else if (auto old_set = old_frame.as<rs2::frameset>())
+        {
+            map_id_frameset_to_frame(old_set, new_frame);
+        }
+        else
+            map_id_frame_to_frame(new_frame, old_frame);
+    }
+
+    void post_processing_filters::map_id_frameset_to_frame(rs2::frameset first, rs2::frame second)
+    {
+        if(auto f = first.first_or_default(second.get_profile().stream_type()))
+        {
+            auto first_uid = f.get_profile().unique_id();
+            auto second_uid = second.get_profile().unique_id();
+
+            viewer.streams_origin[first_uid] = second_uid;
+            viewer.streams_origin[second_uid] = first_uid;
+        }
+    }
+
+    void post_processing_filters::map_id_frameset_to_frameset(rs2::frameset first, rs2::frameset second)
+    {
+        for (auto&& f : first)
+        {
+            auto first_uid = f.get_profile().unique_id();
+            if (auto second_f = second.first_or_default(f.get_profile().stream_type()))
+            {
+                auto second_uid = second_f.get_profile().unique_id();
+
+                viewer.streams_origin[first_uid] = second_uid;
+                viewer.streams_origin[second_uid] = first_uid;
+            }
+        }
+    }
+
+    void rs2::post_processing_filters::map_id_frame_to_frame(rs2::frame first, rs2::frame second)
+    {
+        if (first.get_profile().stream_type() == second.get_profile().stream_type())
+        {
+            auto first_uid = first.get_profile().unique_id();
+            auto second_uid = second.get_profile().unique_id();
+
+            viewer.streams_origin[first_uid] = second_uid;
+            viewer.streams_origin[second_uid] = first_uid;
+        }
+    }
+
+
     std::vector<rs2::frame> post_processing_filters::handle_frame(rs2::frame f)
     {
         std::vector<rs2::frame> res;
+
         auto filtered = apply_filters(f);
-        res.push_back(filtered);
+        map_id(filtered, f);
 
-        auto uid = f.get_profile().unique_id();
-        auto new_uid = filtered.get_profile().unique_id();
-        viewer.streams_origin[uid] = new_uid;
-        viewer.streams_origin[new_uid] = uid;
-
+        if (auto composite = filtered.as<rs2::frameset>())
+        {
+            for (auto&& frame : composite)
+            {
+                res.push_back(frame);
+            }
+        }
+        else
+            res.push_back(filtered);
+           
         if(viewer.is_3d_view)
         {
-            if(viewer.is_3d_depth_source(f))
+            if(auto depth = viewer.get_3d_depth_source(filtered))
             {
-                res.push_back(pc->calculate(filtered));
+                res.push_back(pc->calculate(depth));
             }
-            if(viewer.is_3d_texture_source(f))
+            if(auto texture = viewer.get_3d_texture_source(filtered))
             {
-                update_texture(filtered);
+                update_texture(texture);
             }
         }
 
         return res;
     }
 
+
     void post_processing_filters::process(rs2::frame f, const rs2::frame_source& source)
     {
         points p;
         std::vector<frame> results;
-        frame res;
 
-        if (auto composite = f.as<rs2::frameset>())
-        {
-            for (auto&& f : composite)
-            {
-                auto res = handle_frame(f);
-                results.insert(results.end(), res.begin(), res.end());
-            }
-        }
-        else
-        {
-             auto res = handle_frame(f);
-             results.insert(results.end(), res.begin(), res.end());
-        }
+        auto res = handle_frame(f);
+        
+        auto frame = source.allocate_composite_frame(res);
 
-        res = source.allocate_composite_frame(results);
-
-        if(res)
-            source.frame_ready(std::move(res));
+        if(frame)
+            source.frame_ready(std::move(frame));
     }
 
     void post_processing_filters::start()
@@ -4186,6 +4249,44 @@ namespace rs2
         if (index == selected_tex_source_uid || mapped_index == selected_tex_source_uid || selected_tex_source_uid == -1)
             return true;
         return false;
+    }
+
+    std::vector<frame> rs2::viewer_model::get_frames(frame frame)
+    {
+        std::vector<rs2::frame> res;
+
+        if (auto set = frame.as<frameset>())
+            for (auto&& f : set)
+                res.push_back(f);
+
+        else
+            res.push_back(frame);
+
+        return res;
+    }
+
+    frame viewer_model::get_3d_depth_source(frame f)
+    {
+        auto frames = get_frames(f);
+
+        for (auto&& f : frames)
+        {
+            if (is_3d_depth_source(f))
+                return f;
+        }
+        return nullptr;
+    }
+
+    frame rs2::viewer_model::get_3d_texture_source(frame f)
+    {
+        auto frames = get_frames(f);
+
+        for (auto&& f : frames)
+        {
+            if (is_3d_texture_source(f))
+                return f;
+        }
+        return nullptr;
     }
 
     bool viewer_model::is_3d_depth_source(frame f)

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -762,6 +762,11 @@ namespace rs2
         void process(rs2::frame f, const rs2::frame_source& source);
         std::vector<rs2::frame> handle_frame(rs2::frame f);
 
+        void map_id(rs2::frame new_frame, rs2::frame old_frame);
+        void map_id_frameset_to_frame(rs2::frameset first, rs2::frame second);
+        void map_id_frameset_to_frameset(rs2::frameset first, rs2::frameset second);
+        void map_id_frame_to_frame(rs2::frame first, rs2::frame second);
+
         rs2::frame apply_filters(rs2::frame f);
         rs2::frame last_tex_frame;
         rs2::processing_block processing_block;
@@ -903,8 +908,12 @@ namespace rs2
 
         void begin_stream(std::shared_ptr<subdevice_model> d, rs2::stream_profile p);
 
-        bool is_3d_texture_source(frame f);
+        std::vector<frame> get_frames(frame set);
+        frame get_3d_depth_source(frame f);
+        frame get_3d_texture_source(frame f);
+
         bool is_3d_depth_source(frame f);
+        bool is_3d_texture_source(frame f);
 
         texture_buffer* upload_frame(frame&& f);
 

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -320,7 +320,19 @@ namespace rs2
         */
         points calculate(frame depth)
         {
-            return process(depth);
+            auto res = process(depth);
+            if (res.as<points>())
+                return res;
+
+            if (auto set = res.as <frameset>())
+            {
+                for (auto f : set)
+                {
+                    if(f.as<points>())
+                        return f;
+                }
+            }
+            throw std::runtime_error("Error occured during execution of the processing block! See the log for more info");
         }
         /**
         * Map the point cloud to other frame.

--- a/src/hw-monitor.cpp
+++ b/src/hw-monitor.cpp
@@ -156,20 +156,17 @@ namespace librealsense
             << "." << static_cast<int>(fws[1]) << "." << static_cast<int>(fws[0]);
     }
 
-    std::string hw_monitor::get_module_serial_string(uint8_t gvd_cmd, uint32_t offset) const
+    std::string hw_monitor::get_module_serial_string(uint8_t gvd_cmd, uint32_t offset, int size) const
     {
         std::vector<unsigned char> gvd(HW_MONITOR_BUFFER_SIZE);
         get_gvd(gvd.size(), gvd.data(), gvd_cmd);
         unsigned char ss[8];
         librealsense::copy(ss, gvd.data() + offset, 8);
         std::stringstream formattedBuffer;
-        formattedBuffer << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(ss[0]) <<
-            std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(ss[1]) <<
-            std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(ss[2]) <<
-            std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(ss[3]) <<
-            std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(ss[4]) <<
-            std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(ss[5]);
-
+        for (auto i = 0;i < size;i++)
+        {
+            formattedBuffer << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(ss[i]);
+        }
         return formattedBuffer.str();
     }
 

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -166,7 +166,7 @@ namespace librealsense
         std::vector<uint8_t> send(command cmd) const;
         void get_gvd(size_t sz, unsigned char* gvd, uint8_t gvd_cmd) const;
         std::string get_firmware_version_string(int gvd_cmd, uint32_t offset) const;
-        std::string get_module_serial_string(uint8_t gvd_cmd, uint32_t offset) const;
+        std::string get_module_serial_string(uint8_t gvd_cmd, uint32_t offset, int size = 6) const;
         bool is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const;
     };
 }

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -32,7 +32,8 @@ namespace librealsense
         enum gvd_fields
         {
             fw_version_offset = 12,
-            module_serial_offset = 56
+            module_serial_offset = 56,
+            module_serial_size = 8
         };
 
         bool try_fetch_usb_device(std::vector<platform::usb_device_info>& devices,

--- a/src/l500/l500.cpp
+++ b/src/l500/l500.cpp
@@ -92,7 +92,7 @@ namespace librealsense
 //#endif
         *_calib_table_raw;  //work around to bug on fw
         auto fw_version = _hw_monitor->get_firmware_version_string(GVD, fw_version_offset);
-        auto serial = _hw_monitor->get_module_serial_string(GVD, module_serial_offset);
+        auto serial = _hw_monitor->get_module_serial_string(GVD, module_serial_offset, module_serial_size);
 
         auto pid = group.uvc_devices.front().pid;
         auto pid_hex_str = hexify(pid >> 8) + hexify(static_cast<uint8_t>(pid));


### PR DESCRIPTION
Some filters need to get synced frames as frameset and all the filters handle the frameset separation and consolidation, thus the viewer should move to the filters framesets.