### PR TITLE
Fixing typo of openCV compilation commands

### DIFF
--- a/doc/stepbystep/getting_started_with_openCV.md
+++ b/doc/stepbystep/getting_started_with_openCV.md
@@ -57,7 +57,7 @@ int main()
 Compile and run the application from terminal using the following command line:
 
 ```shell
-g++ -std=c++11 BGR_sample.cpp -lrealsense2 –lopencv_core -lopencv_highgui -o BGR && ./BGR
+g++ -std=c++11 BGR_sample.cpp -lrealsense2 -lopencv_core -lopencv_highgui -o BGR && ./BGR
 ```
 
 **Result:**
@@ -127,7 +127,7 @@ int main()
 Compile and run the program from the terminal, with the following command:
 
 ```shell
-g++ -std=c++11 IR_sample.cpp -lrealsense2 -lopencv_core -lopencv_imgproc -o ir && ./ir
+g++ -std=c++11 IR_sample.cpp -lrealsense2 -lopencv_core -lopencv_imgproc -lopencv_highgui -o ir && ./ir
 ```
 
 **Result :**


### PR DESCRIPTION
Fixing typo and missing option of compilation commands of the openCV examples.