### PR TITLE
Fix IMU timestamps patch for linux kernels

### DIFF
--- a/scripts/realsense-camera-formats_ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
+++ b/scripts/realsense-camera-formats_ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
@@ -1,9 +1,12 @@
-From 2fb29ac45b298b1dbea7fca174b6e8b7d22e4fb3 Mon Sep 17 00:00:00 2001
-From: administrator <evgeni.raikhel@intel.com>
-Date: Sun, 4 Jun 2017 17:30:59 +0300
-Subject: [PATCH] RS4xx and ZR300 Pixel formats patch
+From ceb29b08b480a2a6a5e9dccf396a284378268037 Mon Sep 17 00:00:00 2001
+From: aangerma <Avishag.Angerman@intel.com>
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
+From: icarpis <itay.carpis@intel.com>
 
-Signed-off-by: administrator <evgeni.raikhel@intel.com>
+Date: Thu, 30 Aug 2018 16:07:01 +0300
+Subject: [PATCH] [PATCH] RS400 ,SR300, RS500 pixel formats
+
+Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 ---
  drivers/media/usb/uvc/Makefile       |  1 +
  drivers/media/usb/uvc/uvc_driver.c   | 55 ++++++++++++++++++++++++++++++++++++
@@ -22,10 +25,10 @@ index c26d12f..d86cf22 100644
  		  uvc_status.o uvc_isight.o uvc_debugfs.o
  ifeq ($(CONFIG_MEDIA_CONTROLLER),y)
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
-index 9b8ac20..9d44f8e 100644
+index cde43b6..54bd175 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -168,6 +168,66 @@ static struct uvc_format_desc uvc_fmts[] = {
+@@ -168,6 +168,103 @@ static struct uvc_format_desc uvc_fmts[] = {
  		.guid		= UVC_GUID_FORMAT_RW10,
  		.fcc		= V4L2_PIX_FMT_SRGGB10P,
  	},
@@ -89,22 +92,51 @@ index 9b8ac20..9d44f8e 100644
 +		.guid		= UVC_GUID_FORMAT_BAYER16,
 +		.fcc		= V4L2_PIX_FMT_SBGGR16,
 +	},
++	{
++		.name		= "Packed raw data 10-bit",
++		.guid		= UVC_GUID_FORMAT_W10,
++		.fcc		= V4L2_PIX_FMT_W10,
++	},
++	{
++		.name		= "Confidence data (C   )",
++		.guid		= UVC_GUID_FORMAT_CONFIDENCE_MAP,
++		.fcc		= V4L2_PIX_FMT_CONFIDENCE_MAP,
++	},
++	/* FishEye 8-bit monochrome */
++	{
++		.name		= "Raw data 8-bit (RAW8)",
++		.guid		= UVC_GUID_FORMAT_RAW8,
++		.fcc		= V4L2_PIX_FMT_GREY,
++	},
++	/* Legacy/Development formats for backward-compatibility*/
++	{
++		.name		= "Raw data 16-bit (RW16)",
++		.guid		= UVC_GUID_FORMAT_RW16,
++		.fcc		= V4L2_PIX_FMT_RW16,
++	},
++	{
++		.name		= "Frame Grabber (FG  )",
++		.guid		= UVC_GUID_FORMAT_FG,
++		.fcc		= V4L2_PIX_FMT_FG,
++	},
++	{
++		.name		= "SR300 Depth/Confidence (INZC)",
++		.guid		= UVC_GUID_FORMAT_INZC,
++		.fcc		= V4L2_PIX_FMT_INZC,
++	},
++	{
++		.name		= "Relative IR (PAIR)",
++		.guid		= UVC_GUID_FORMAT_PAIR,
++		.fcc		= V4L2_PIX_FMT_PAIR,
++	},
  };
  
  /* ------------------------------------------------------------------------
 diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
-index 7e4d3ee..020dbb7 100644
+index 7e4d3ee..e517d8f 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -115,7 +115,6 @@
- #define UVC_GUID_FORMAT_M420 \
- 	{ 'M',  '4',  '2',  '0', 0x00, 0x00, 0x10, 0x00, \
- 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
--
- #define UVC_GUID_FORMAT_H264 \
- 	{ 'H',  '2',  '6',  '4', 0x00, 0x00, 0x10, 0x00, \
- 	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
-@@ -131,6 +130,43 @@
+@@ -131,6 +131,57 @@
  #define UVC_GUID_FORMAT_RW10 \
  	{ 'R',  'W',  '1',  '0', 0x00, 0x00, 0x10, 0x00, \
  	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
@@ -144,15 +176,29 @@ index 7e4d3ee..020dbb7 100644
 +#define UVC_GUID_FORMAT_BAYER16 \
 +    { 'R',  'W',  '1',  '6', 0x66, 0x1a, 0x42, 0xa2, \
 +     0x90, 0x65, 0xd0, 0x18, 0x14, 0xa8, 0xef, 0x8a}
-+
++#define UVC_GUID_FORMAT_W10 \
++    { 'W',  '1',  '0',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_CONFIDENCE_MAP \
++	{ 'C',  ' ',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_FG \
++	{ 'F',  'G',  ' ',  ' ', 0x00, 0x00, 0x10, 0x00, \
++	0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b, 0x71}
++#define UVC_GUID_FORMAT_INZC \
++	{ 'I',  'N',  'Z',  'C', 0x02, 0xb6, 0x0f, 0x48, \
++	0x97, 0x8c, 0xe4, 0xe8, 0x8a, 0xe8, 0x9b, 0x89}
++#define UVC_GUID_FORMAT_PAIR \
++	{ 'P',  'A',  'I',  'R', 0x36, 0x85, 0x41, 0x48, \
++	0xb6, 0xbf, 0x8f, 0xc6, 0xff, 0xb0, 0x83, 0xa8}
  
  /* ------------------------------------------------------------------------
   * Driver specific constants.
 diff --git a/drivers/media/v4l2-core/v4l2-ioctl.c b/drivers/media/v4l2-core/v4l2-ioctl.c
-index 7486af2..124dd35 100644
+index 51a0fa1..391c2b3 100644
 --- a/drivers/media/v4l2-core/v4l2-ioctl.c
 +++ b/drivers/media/v4l2-core/v4l2-ioctl.c
-@@ -1229,6 +1229,11 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
+@@ -1243,6 +1243,16 @@ static void v4l_fill_fmtdesc(struct v4l2_fmtdesc *fmt)
  	case V4L2_SDR_FMT_CS8:		descr = "Complex S8"; break;
  	case V4L2_SDR_FMT_CS14LE:	descr = "Complex S14LE"; break;
  	case V4L2_SDR_FMT_RU12LE:	descr = "Real U12LE"; break;
@@ -161,14 +207,19 @@ index 7486af2..124dd35 100644
 +	case V4L2_PIX_FMT_Z16:		descr = "16-bit Depth data"; break;
 +	case V4L2_PIX_FMT_RW16:		descr = "16-bit Raw data"; break;
 +	case V4L2_PIX_FMT_INZI:		descr = "32-bit IR:Depth 10:16"; break;
++	case V4L2_PIX_FMT_W10:		descr = "10-bit packed 8888[2222]"; break;
++	case V4L2_PIX_FMT_CONFIDENCE_MAP:	descr = "4-bit per pixel packed"; break;
++	case V4L2_PIX_FMT_FG:		descr = "Frame Grabber (FG  )"; break;
++	case V4L2_PIX_FMT_INZC:		descr = "Planar Depth/Confidence (INZC)"; break;
++	case V4L2_PIX_FMT_PAIR:		descr = "Relative IR (PAIR)"; break;
  
  	default:
  		/* Compressed formats */
 diff --git a/include/uapi/linux/videodev2.h b/include/uapi/linux/videodev2.h
-index 421d274..c41b5c0 100644
+index 724f43e..29bcba5 100644
 --- a/include/uapi/linux/videodev2.h
 +++ b/include/uapi/linux/videodev2.h
-@@ -624,6 +624,12 @@ struct v4l2_pix_format {
+@@ -627,6 +627,18 @@ struct v4l2_pix_format {
  #define V4L2_PIX_FMT_Y8I      v4l2_fourcc('Y', '8', 'I', ' ') /* Greyscale 8-bit L/R interleaved */
  #define V4L2_PIX_FMT_Y12I     v4l2_fourcc('Y', '1', '2', 'I') /* Greyscale 12-bit L/R interleaved */
  #define V4L2_PIX_FMT_Z16      v4l2_fourcc('Z', '1', '6', ' ') /* Depth data 16-bit */
@@ -178,6 +229,12 @@ index 421d274..c41b5c0 100644
 +#define V4L2_PIX_FMT_INVR     v4l2_fourcc('I', 'N', 'V', 'R') /* 16 Depth */
 +#define V4L2_PIX_FMT_INRI     v4l2_fourcc('I', 'N', 'R', 'I') /* 24 Depth/IR 16:8 */
 +#define V4L2_PIX_FMT_RELI     v4l2_fourcc('R', 'E', 'L', 'I') /* 8 IR alternating on off illumination */
++#define V4L2_PIX_FMT_W10      v4l2_fourcc('W', '1', '0', ' ') /* Packed raw data 10-bit */
++#define V4L2_PIX_FMT_CONFIDENCE_MAP  v4l2_fourcc('C', ' ', ' ', ' ') /* Two pixels in one byte */
++/*  Librealsense development*/
++#define V4L2_PIX_FMT_FG	v4l2_fourcc('F', 'G', ' ', ' ') /* Frame Grabber */
++#define V4L2_PIX_FMT_INZC	v4l2_fourcc('I', 'N', 'Z', 'C') /* Planar Depth/Confidence */
++#define V4L2_PIX_FMT_PAIR	v4l2_fourcc('P', 'A', 'I', 'R') /* Relative IR */
  
  /* SDR formats - used only for Software Defined Radio devices */
  #define V4L2_SDR_FMT_CU8          v4l2_fourcc('C', 'U', '0', '8') /* IQ u8 */

--- a/scripts/realsense-hid-ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
@@ -1,5 +1,6 @@
 From 5ef00171f95a150a912f1d14645bcae25df203c9 Mon Sep 17 00:00:00 2001
 From: Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+From: Evgeni Raikhel <evgeni.raikhel@intel.com>
 Date: Tue, 13 Feb 2018 12:06:44 +0200
 Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
 	A symmetric patch for Accelerator was already upstreamed,
@@ -9,13 +10,13 @@ Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
 	of the target kernel version
 
 ---
- drivers/iio/accel/hid-sensor-accel-3d.c |  30 +++-
- drivers/iio/gyro/hid-sensor-gyro-3d.c   |  28 +++-
- include/linux/hid-sensor-ids.h          |   1 +
- 3 file changed, 59 insertions(+), 0 deletions(-)
+ drivers/iio/accel/hid-sensor-accel-3d.c | 30 ++++++++++++++++++++++--------
+ drivers/iio/gyro/hid-sensor-gyro-3d.c   | 28 +++++++++++++++++++++-------
+ include/linux/hid-sensor-ids.h          |  1 +
+ 3 files changed, 44 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/iio/accel/hid-sensor-accel-3d.c b/drivers/iio/accel/hid-sensor-accel-3d.c
-index ab1e238..5de9718 100644
+index ab1e238..15b55a3 100644
 --- a/drivers/iio/accel/hid-sensor-accel-3d.c
 +++ b/drivers/iio/accel/hid-sensor-accel-3d.c
 @@ -42,11 +42,13 @@ struct accel_3d_state {
@@ -83,15 +84,15 @@ index ab1e238..5de9718 100644
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
-+	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		accel_state->timestamp = *(int64_t *)raw_data;
++	case HID_USAGE_SENSOR_TIME_TIMESTAMP: // usec->nsec
++		accel_state->timestamp = (*(int64_t *)raw_data)*1000;
 +		ret = 0;
 +	break;
  	default:
  		break;
  	}
 diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
-index c67ce2a..7ff0dfe 100644
+index c67ce2a..859cdde 100644
 --- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
 +++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
 @@ -42,11 +42,13 @@ struct gyro_3d_state {
@@ -158,8 +159,8 @@ index c67ce2a..7ff0dfe 100644
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
-+	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		gyro_state->timestamp = *(int64_t *)raw_data;
++	case HID_USAGE_SENSOR_TIME_TIMESTAMP:	// usec->nsec
++		gyro_state->timestamp = (*(int64_t *)raw_data)*1000;
 +		ret = 0;
 +	break;
  	default:

--- a/scripts/realsense-hid-ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
@@ -1,5 +1,21 @@
+From 5ef00171f95a150a912f1d14645bcae25df203c9 Mon Sep 17 00:00:00 2001
+From: Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+Date: Tue, 13 Feb 2018 12:06:44 +0200
+Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
+	A symmetric patch for Accelerator was already upstreamed,
+	this patch was skipped from upstream
+	The patch was written by Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+	The version tag has been added to accel module so it will be also replaced regardless
+	of the target kernel version
+
+---
+ drivers/iio/accel/hid-sensor-accel-3d.c |  30 +++-
+ drivers/iio/gyro/hid-sensor-gyro-3d.c   |  28 +++-
+ include/linux/hid-sensor-ids.h          |   1 +
+ 3 file changed, 59 insertions(+), 0 deletions(-)
+
 diff --git a/drivers/iio/accel/hid-sensor-accel-3d.c b/drivers/iio/accel/hid-sensor-accel-3d.c
-index ab1e238..28262c4 100644
+index ab1e238..5de9718 100644
 --- a/drivers/iio/accel/hid-sensor-accel-3d.c
 +++ b/drivers/iio/accel/hid-sensor-accel-3d.c
 @@ -42,11 +42,13 @@ struct accel_3d_state {
@@ -47,14 +63,13 @@ index ab1e238..28262c4 100644
  
  	dev_dbg(&indio_dev->dev, "accel_3d_proc_event\n");
 -	if (atomic_read(&accel_state->common_attributes.data_ready))
--		hid_sensor_push_data(indio_dev,
--				accel_state->accel_val,
--				sizeof(accel_state->accel_val));
 +	if (atomic_read(&accel_state->common_attributes.data_ready)) {
 +		if (!accel_state->timestamp)
 +			accel_state->timestamp = iio_get_time_ns(indio_dev);
 +
-+		hid_sensor_push_data(indio_dev,
+ 		hid_sensor_push_data(indio_dev,
+-				accel_state->accel_val,
+-				sizeof(accel_state->accel_val));
 +				     accel_state->accel_val,
 +				     sizeof(accel_state->accel_val),
 +				     accel_state->timestamp);
@@ -76,7 +91,7 @@ index ab1e238..28262c4 100644
  		break;
  	}
 diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
-index c67ce2a..f45c5a2 100644
+index c67ce2a..7ff0dfe 100644
 --- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
 +++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
 @@ -42,11 +42,13 @@ struct gyro_3d_state {
@@ -92,7 +107,7 @@ index c67ce2a..f45c5a2 100644
  	int value_offset;
 +	int64_t timestamp;
  };
-
+ 
  static const u32 gyro_3d_addresses[GYRO_3D_CHANNEL_MAX] = {
 @@ -87,7 +89,8 @@ static const struct iio_chan_spec gyro_3d_channels[] = {
  		BIT(IIO_CHAN_INFO_SAMP_FREQ) |
@@ -102,11 +117,11 @@ index c67ce2a..f45c5a2 100644
 +	},
 +	IIO_CHAN_SOFT_TIMESTAMP(3)
  };
-
+ 
  /* Adjust channel real bits based on report descriptor */
 @@ -192,11 +195,11 @@ static const struct iio_info gyro_3d_info = {
  };
-
+ 
  /* Function to push data to buffer */
 -static void hid_sensor_push_data(struct iio_dev *indio_dev, const void *data,
 -	int len)
@@ -117,11 +132,11 @@ index c67ce2a..f45c5a2 100644
 -	iio_push_to_buffers(indio_dev, data);
 +	iio_push_to_buffers_with_timestamp(indio_dev, data, timestamp);
  }
-
+ 
  /* Callback handler to send event after all samples are received and captured */
 @@ -208,10 +211,17 @@ static int gyro_3d_proc_event(struct hid_sensor_hub_device *hsdev,
  	struct gyro_3d_state *gyro_state = iio_priv(indio_dev);
-
+ 
  	dev_dbg(&indio_dev->dev, "gyro_3d_proc_event\n");
 -	if (atomic_read(&gyro_state->common_attributes.data_ready))
 +	if (atomic_read(&gyro_state->common_attributes.data_ready)) {
@@ -129,15 +144,14 @@ index c67ce2a..f45c5a2 100644
 +			gyro_state->timestamp = iio_get_time_ns(indio_dev);
 +
  		hid_sensor_push_data(indio_dev,
--				gyro_state->gyro_val,
+ 				gyro_state->gyro_val,
 -				sizeof(gyro_state->gyro_val));
-+				     gyro_state->gyro_val,
-+				     sizeof(gyro_state->gyro_val),
-+				     gyro_state->timestamp);
++				sizeof(gyro_state->gyro_val),
++				gyro_state->timestamp);
 +
 +		gyro_state->timestamp = 0;
 +	}
-
+ 
  	return 0;
  }
 @@ -236,6 +246,10 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
@@ -152,7 +166,7 @@ index c67ce2a..f45c5a2 100644
  		break;
  	}
 diff --git a/include/linux/hid-sensor-ids.h b/include/linux/hid-sensor-ids.h
-index f2ee90a..9a3a9db 100644
+index f2ee90a..063aa1f 100644
 --- a/include/linux/hid-sensor-ids.h
 +++ b/include/linux/hid-sensor-ids.h
 @@ -95,6 +95,7 @@
@@ -160,6 +174,8 @@ index f2ee90a..9a3a9db 100644
  #define HID_USAGE_SENSOR_TIME_MINUTE				0x200526
  #define HID_USAGE_SENSOR_TIME_SECOND				0x200527
 +#define HID_USAGE_SENSOR_TIME_TIMESTAMP			0x200529
-
+ 
  /* Units */
  #define HID_USAGE_SENSOR_UNITS_NOT_SPECIFIED			0x00
+-- 
+2.7.4

--- a/scripts/realsense-hid-ubuntu-xenial-hwe-zesty.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-hwe-zesty.patch
@@ -79,7 +79,7 @@ index c67ce2a..7ff0dfe 100644
  		ret = 0;
  	break;
 +	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		gyro_state->timestamp = *(int64_t *)raw_data;
++		gyro_state->timestamp = (*(int64_t *)raw_data)*1000;
 +		ret = 0;
 +	break;
  	default:

--- a/scripts/realsense-hid-ubuntu-xenial-v4.16.patch
+++ b/scripts/realsense-hid-ubuntu-xenial-v4.16.patch
@@ -9,11 +9,11 @@ Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
 	this patch was skipped from upstream
 	The patch was written by Srinivas Pandruvada <srinivas.pandruvada@intel.com>
 ---
- drivers/iio/gyro/hid-sensor-gyro-3d.c | 28 ++++++++++++++++++++-------
- 1 file changed, 21 insertions(+), 7 deletions(-)
+ drivers/iio/gyro/hid-sensor-gyro-3d.c | 30 +++++++++++++++++++++++-------
+ 1 file changed, 23 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
-index f59995a90..e3f2a8357 100644
+index f59995a..a4a5e9c 100644
 --- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
 +++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
 @@ -42,11 +42,13 @@ struct gyro_3d_state {
@@ -76,17 +76,19 @@ index f59995a90..e3f2a8357 100644
  
  	return 0;
  }
-@@ -235,6 +245,10 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+@@ -235,6 +245,12 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
  						*(u32 *)raw_data;
  		ret = 0;
  	break;
 +	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
-+		gyro_state->timestamp = *(int64_t *)raw_data;
-+		ret = 0;
++		gyro_state->timestamp =
++			hid_sensor_convert_timestamp(
++					&gyro_state->common_attributes,
++					*(int64_t *)raw_data);
 +	break;
  	default:
  		break;
  	}
 -- 
-2.17.0
+2.7.4
 

--- a/scripts/realsense-metadata-ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
+++ b/scripts/realsense-metadata-ubuntu-xenial-Ubuntu-hwe-4.8.0-58.63_16.04.1.patch
@@ -1,21 +1,22 @@
 From 6a837242353bf4f8d3ee19e6ff06983f345a7412 Mon Sep 17 00:00:00 2001
 From: Elad Zucker <eladx.zucker@intel.com>
 From: icarpis <itay.carpis@intel.com>
-Date: Mon, 25 Sep 2017 11:36:52 +0300
+From: aangerma <Avishag.Angerman@intel.com>
+Date: Thu, 30 Aug 2018 16:07:01 +0300
 Subject: [PATCH] added support for uvc metadata
 
 Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>
 ---
- drivers/media/usb/uvc/uvc_driver.c | 126 +++++++++++++++++++++++++++++++++++++
- drivers/media/usb/uvc/uvc_video.c  |  19 ++++--
- drivers/media/usb/uvc/uvcvideo.h   |   4 +-
+ drivers/media/usb/uvc/uvc_driver.c      | 259 ++++++++++++++++++++++++++++++++
+ drivers/media/usb/uvc/uvc_video.c       |  20 ++-
+ drivers/media/usb/uvc/uvcvideo.h        |  55 ++++++-
  3 files changed, 142 insertions(+), 7 deletions(-)
 
 diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
 index 04bf350..5fd10f0 100644
 --- a/drivers/media/usb/uvc/uvc_driver.c
 +++ b/drivers/media/usb/uvc/uvc_driver.c
-@@ -2699,6 +2699,159 @@ static struct usb_device_id uvc_ids[] = {
+@@ -2699,6 +2699,186 @@ static struct usb_device_id uvc_ids[] = {
  	  .bInterfaceSubClass	= 1,
  	  .bInterfaceProtocol	= 0,
  	  .driver_info		= UVC_QUIRK_FORCE_Y8 },
@@ -172,6 +173,33 @@ index 04bf350..5fd10f0 100644
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,
 +	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D410/USB2 Depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b15,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D415/USB2 Depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b16,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	/* Intel D435/USB2 Depth camera */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor			= 0x8086,
++	  .idProduct		= 0x0b17,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_15) },
@@ -179,7 +207,7 @@ diff --git a/drivers/media/usb/uvc/uvc_video.c b/drivers/media/usb/uvc/uvc_video
 index f3c1c85..f69d749 100644
 --- a/drivers/media/usb/uvc/uvc_video.c
 +++ b/drivers/media/usb/uvc/uvc_video.c
-@@ -1228,8 +1228,13 @@ static void uvc_video_decode_bulk(struct urb *urb, struct uvc_streaming *stream,
+@@ -1228,8 +1229,13 @@ static void uvc_video_decode_bulk(struct urb *urb, struct uvc_streaming *stream,
  		do {
  			ret = uvc_video_decode_start(stream, buf, mem, len);
  			if (ret == -EAGAIN)
@@ -195,7 +223,7 @@ index f3c1c85..f69d749 100644
  		} while (ret == -EAGAIN);
 
  		/* If an error occurred skip the rest of the payload. */
-@@ -1261,9 +1266,13 @@ static void uvc_video_decode_bulk(struct urb *urb, struct uvc_streaming *stream,
+@@ -1261,9 +1267,13 @@ static void uvc_video_decode_bulk(struct urb *urb, struct uvc_streaming *stream,
  		if (!stream->bulk.skip_payload && buf != NULL) {
  			uvc_video_decode_end(stream, buf, stream->bulk.header,
  				stream->bulk.payload_size);
@@ -216,7 +244,7 @@ diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
 index 3d6cc62..e24b763 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -155,8 +155,7 @@
+@@ -143,8 +194,7 @@
  /* Maximum number of packets per URB. */
  #define UVC_MAX_PACKETS		32
  /* Maximum status buffer size in bytes of interrupt URB. */
@@ -226,7 +254,7 @@ index 3d6cc62..e24b763 100644
  #define UVC_CTRL_CONTROL_TIMEOUT	300
  #define UVC_CTRL_STREAMING_TIMEOUT	5000
 
-@@ -176,6 +175,7 @@
+@@ -164,6 +214,7 @@
  #define UVC_QUIRK_RESTRICT_FRAME_RATE	0x00000200
  #define UVC_QUIRK_RESTORE_CTRLS_ON_INIT	0x00000400
  #define UVC_QUIRK_FORCE_Y8		0x00000800

--- a/scripts/realsense-metadata-ubuntu-xenial-v4.16.patch
+++ b/scripts/realsense-metadata-ubuntu-xenial-v4.16.patch
@@ -86,7 +86,7 @@ index fd387bf..3219519 100644
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,
-+	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	  .driver_info		= UVC_QUIRK_META(V4L2_META_FMT_D4XX) },
 +	/* Intel D420/PWG depth camera */
 +	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
 +				| USB_DEVICE_ID_MATCH_INT_INFO,
@@ -185,7 +185,7 @@ index fd387bf..3219519 100644
 +	  .bInterfaceClass	= USB_CLASS_VIDEO,
 +	  .bInterfaceSubClass	= 1,
 +	  .bInterfaceProtocol	= 0,
-+	  .driver_info		= UVC_QUIRK_APPEND_UVC_HEADER },
++	  .driver_info		= UVC_QUIRK_META(V4L2_META_FMT_D4XX) },
  	/* Generic USB Video Class */
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_UNDEFINED) },
  	{ USB_INTERFACE_INFO(USB_CLASS_VIDEO, 1, UVC_PC_PROTOCOL_15) },

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -713,6 +713,8 @@ namespace librealsense
         std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get(), _color_stream.get() };
         // TODO - A proper matcher for High-FPS sensor is required
         std::vector<stream_interface*> mm_streams = { _accel_stream.get(), _gyro_stream.get()};
+        for (auto i=0; i<4; i++)
+            mm_streams.emplace_back(_gpio_streams[i].get());
 
         if (frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
         {
@@ -727,6 +729,8 @@ namespace librealsense
     {
         // TODO - A proper matcher for High-FPS sensor is required
         std::vector<stream_interface*> mm_streams = { _accel_stream.get(), _gyro_stream.get()};
+        for (auto i=0; i<4; i++)
+            mm_streams.emplace_back(_gpio_streams[i].get());
         return matcher_factory::create(RS2_MATCHER_DEFAULT, mm_streams);
     }
 

--- a/src/option.h
+++ b/src/option.h
@@ -118,7 +118,7 @@ namespace librealsense
         {
             T val = static_cast<T>(value);
             if ((_max < val) || (_min > val))
-                throw invalid_value_exception(to_string() << "Given value " << value << "is outside valid range!");
+                throw invalid_value_exception(to_string() << "Given value " << value << " is outside valid range!");
             *_value = val;
             _on_set(value);
         }

--- a/src/proc/processing-blocks-factory.cpp
+++ b/src/proc/processing-blocks-factory.cpp
@@ -1,15 +1,13 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
-#pragma once
-
 #include "processing-blocks-factory.h"
 #include "sse/sse-align.h"
 #include "cuda/cuda-align.h"
- 
+
 namespace librealsense
 {
-#ifdef RS2_USE_CUDA  
+#ifdef RS2_USE_CUDA
     std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)                                                               
     { 
         return std::make_shared<librealsense::align_cuda>(align_to);
@@ -26,6 +24,5 @@ namespace librealsense
         return std::make_shared<librealsense::align>(align_to);
     }
 #endif // __SSSE3__
-#endif // RS2_USE_CUDA   
+#endif // RS2_USE_CUDA
 }
- 


### PR DESCRIPTION
[v4l] - Apply IMU TS conversion units patch for kernels 4.8, 4.10 and 4.16. rectify Metadata quirk name for D435i
[v4l] - Add development/obsolete LRS format to remove false kernel reports

Enable default syncer for IMU GPIO interface.

Tracked On: DSO-10889