### PR TITLE
export include and libraries for ament build

### DIFF
--- a/CMake/install_config.cmake
+++ b/CMake/install_config.cmake
@@ -53,5 +53,10 @@ endif()
 
 # Set library pkgconfig file for facilitating 3rd party integration
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/config/realsense2.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+       DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
+
+if(${ROS_BUILD_TYPE})
+      ament_export_include_directories(include)
+      ament_export_libraries(${LRS_TARGET})
+endif()


### PR DESCRIPTION
ament_export_libraries is required by other packages which depend on this library. This could make the library available while ament make by using "find_package(librealsense2)"

Signed-off-by: Chris Ye <chris.ye@intel.com>