### PR TITLE
Adjust IMU rates to spec

### DIFF
--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -622,11 +622,7 @@ namespace librealsense
         std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get()};
         std::vector<stream_interface*> mm_streams = { _fisheye_stream.get(),
         _accel_stream.get(),
-        _gyro_stream.get(),
-        _gpio_streams[0].get(),
-        _gpio_streams[1].get(),
-        _gpio_streams[2].get(),
-        _gpio_streams[3].get()};
+        _gyro_stream.get()};
 
         if (frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
         {
@@ -663,11 +659,7 @@ namespace librealsense
         std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get() };
         std::vector<stream_interface*> mm_streams = { _fisheye_stream.get(),
             _accel_stream.get(),
-            _gyro_stream.get(),
-            _gpio_streams[0].get(),
-            _gpio_streams[1].get(),
-            _gpio_streams[2].get(),
-            _gpio_streams[3].get()};
+            _gyro_stream.get()};
 
         if (!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
         {
@@ -694,11 +686,7 @@ namespace librealsense
         std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get(), _color_stream.get() };
         std::vector<stream_interface*> mm_streams = { _fisheye_stream.get(),
             _accel_stream.get(),
-            _gyro_stream.get(),
-            _gpio_streams[0].get(),
-            _gpio_streams[1].get(),
-            _gpio_streams[2].get(),
-            _gpio_streams[3].get()};
+            _gyro_stream.get()};
 
         if (frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
         {
@@ -714,8 +702,6 @@ namespace librealsense
         std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get(), _color_stream.get() };
         // TODO - A proper matcher for High-FPS sensor is required
         std::vector<stream_interface*> mm_streams = { _accel_stream.get(), _gyro_stream.get()};
-        for (auto i=0; i<4; i++)
-            mm_streams.emplace_back(_gpio_streams[i].get());
 
         if (frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
         {
@@ -730,9 +716,6 @@ namespace librealsense
     {
         // TODO - A proper matcher for High-FPS sensor is required
         std::vector<stream_interface*> mm_streams = { _accel_stream.get(), _gyro_stream.get()};
-        for (auto i=0; i<4; i++)
-            mm_streams.emplace_back(_gpio_streams[i].get());
         return matcher_factory::create(RS2_MATCHER_DEFAULT, mm_streams);
     }
-
 }

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -45,20 +45,14 @@ namespace librealsense
 
         // Bandwidth parameters from BOSCH BMI 055 spec. used by D435i
         std::vector<std::pair<std::string, stream_profile>> sensor_name_and_hid_profiles =
-            {{"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 100,  RS2_FORMAT_MOTION_RAW}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_RAW}},
+            {{"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_RAW}},
              {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 400,  RS2_FORMAT_MOTION_RAW}},
-             {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 100,  RS2_FORMAT_MOTION_XYZ32F}},
              {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_XYZ32F}},
              {"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 400,  RS2_FORMAT_MOTION_XYZ32F}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 63,  RS2_FORMAT_MOTION_RAW}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 125,  RS2_FORMAT_MOTION_RAW}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 250,  RS2_FORMAT_MOTION_RAW}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 500,  RS2_FORMAT_MOTION_RAW}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 63,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 125,  RS2_FORMAT_MOTION_XYZ32F}},
              {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 250,  RS2_FORMAT_MOTION_XYZ32F}},
-             {"accel_3d", {RS2_STREAM_ACCEL, 0, 1, 1, 500,  RS2_FORMAT_MOTION_XYZ32F}},
              {"HID Sensor Class Device: Gyroscope",     { RS2_STREAM_GYRO,  0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
              {"HID Sensor Class Device: Accelerometer", { RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}},
              {"HID Sensor Class Device: Custom",        { RS2_STREAM_ACCEL, 0, 1, 1, 1000, RS2_FORMAT_MOTION_XYZ32F}}};
@@ -66,17 +60,13 @@ namespace librealsense
         // The frequency selector is vendor and model-specific
         std::map<rs2_stream, std::map<unsigned, unsigned>> fps_and_sampling_frequency_per_rs2_stream =
                                                          {{RS2_STREAM_ACCEL, {{63,   1},
-                                                                              {125,  2},
-                                                                              {250,  3},
-                                                                              {500,  5}}},
-                                                          {RS2_STREAM_GYRO,  {{100,  1},
-                                                                              {200,  2},
+                                                                              {250,  3}}},
+                                                          {RS2_STREAM_GYRO,  {{200,  2},
                                                                               {400,  4}}}};
 
     protected:
         std::shared_ptr<stream_interface> _fisheye_stream;
         std::shared_ptr<stream_interface> _accel_stream;
         std::shared_ptr<stream_interface> _gyro_stream;
-        std::shared_ptr<stream_interface> _gpio_streams[4];
     };
 }

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -60,6 +60,9 @@ else() # Some other windows version
 endif()
 
 pybind11_add_module(pybackend2 SHARED ${RAW_RS_CPP} ${RAW_RS_HPP})
+if(USE_EXTERNAL_USB)
+    add_dependencies(pybackend2 libusb)
+endif()
 target_link_libraries(pybackend2 PRIVATE ${LIBUSB1_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(pybackend2 PROPERTIES
                         VERSION     ${REALSENSE_VERSION_STRING}


### PR DESCRIPTION

Camera | Parameter | Properties
-- | -- | --
Intel® RealSense™ Depth   Camera D435i (D430 + BMI055) | Degrees of Freedom | 6
Acceleration Range | ±4g
Accelerometer Sample   Rate | 62.5, 250,  (Hz)
Gyroscope Range | ±1000 deg/s
Gyroscope Sample Rate | 200, 400 (Hz)

Remove GPIO interfaces

Tracked on: DSO-10942