### PR TITLE
c++ api - remove get_removed_devices method from event_information class

### DIFF
--- a/include/librealsense2/hpp/rs_context.hpp
+++ b/include/librealsense2/hpp/rs_context.hpp
@@ -59,15 +59,6 @@ namespace rs2
             return _added;
         }
 
-        /**
-        * returns a list of all newly removed devices
-        * \return            the list of all newly removed devices
-        */
-        device_list get_removed_devices()  const
-        {
-            return _removed;
-        }
-
     private:
         device_list _removed;
         device_list _added;

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -300,9 +300,7 @@ PYBIND11_MODULE(NAME, m) {
         .def("was_added", &rs2::event_information::was_added, "Check if "
             "specific device was added.", "dev"_a)
         .def("get_new_devices", &rs2::event_information::get_new_devices, "Returns a "
-            "list of all newly connected devices")
-        .def("get_removed_devices", &rs2::event_information::get_removed_devices, "Returns a "
-            "list of all newly removed devices");
+            "list of all newly connected devices");
 
     py::class_<rs2::tm2, rs2::device> tm2(m, "tm2");
     tm2.def(py::init<rs2::device>(), "device"_a)


### PR DESCRIPTION
Jira issue:
[DS5DSO-10869](https://rsjira.intel.com/browse/DSO-10869) - OnDeviceChange provide a removed list which cause crash on enumeration

The current API allows the user to iterate the removed devices list as following:
```
    ctx.set_devices_changed_callback([&](rs2::event_information& info)
    {
        for (auto& d : info.get_removed_devices()) { }
    });
```
This code will always throw exception since iterating the list tries to create the devices in the list.
And since the device is not available, exception is thrown.

The correct way to check if a device was removed is:
```
    ctx.set_devices_changed_callback([&](rs2::event_information& info)
    {
        if (info.was_removed(my_device))
            handle_device_removale();
    });
```