### PR TITLE
Export Processing blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(librealsense2 LANGUAGES CXX C)
 
 # include librealsense general configuration
 include(CMake/global_config.cmake)
+    include/librealsense2/hpp/rs_export.hpp
+        include/librealsense2/rs_export.hpp
 
 config_cxx_flags()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,7 @@ project(librealsense2 LANGUAGES CXX C)
 
 # include librealsense general configuration
 include(CMake/global_config.cmake)
-    include/librealsense2/hpp/rs_export.hpp
-        include/librealsense2/rs_export.hpp
+
 
 config_cxx_flags()
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/librealsense2/hpp/rs_types.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/librealsense2/hpp/rs_context.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/librealsense2/hpp/rs_device.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/librealsense2/hpp/rs_export.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/librealsense2/hpp/rs_frame.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/librealsense2/hpp/rs_processing.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/librealsense2/hpp/rs_record_playback.hpp"

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -16,6 +16,7 @@ extern "C" {
 
 #include "rs_types.h"
 #include "rs_sensor.h"
+#include "rs_option.h"
 
 /**
 * Creates Depth-Colorizer processing block that can be used to quickly visualize the depth data

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -72,7 +72,7 @@ rs2_processing_block* rs2_create_processing_block_fptr(rs2_frame_processor_callb
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 * \return            true if adding the option succeeds. false if it fails e.g. an option with this id is already registered
 */
-int rs2_processing_block_register_simple_option(rs2_processing_block* block, int option_id, float min, float max, float step, float def, rs2_error** error);
+int rs2_processing_block_register_simple_option(rs2_processing_block* block, rs2_option option_id, float min, float max, float step, float def, rs2_error** error);
 
 /**
 * This method is used to direct the output from the processing block to some callback or sink object

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -61,6 +61,20 @@ rs2_processing_block* rs2_create_processing_block(rs2_frame_processor_callback* 
 rs2_processing_block* rs2_create_processing_block_fptr(rs2_frame_processor_callback_ptr proc, void * context, rs2_error** error);
 
 /**
+* This method adds a custom option to a custom processing block. This is a simple float that can be accessed via rs2_set_option and rs2_get_option
+* This is an infrastructure function aimed at middleware developers, and also used by provided blocks such as save_to_ply, etc..
+* \param[in] block      Processing block
+* \param[in] option_id  an int ID for referencing the option
+* \param[in] min     the minimum value which will be accepted for this option
+* \param[in] max     the maximum value which will be accepted for this option
+* \param[in] step    the granularity of options which accept discrete values, or zero if the option accepts continuous values
+* \param[in] def     the default value of the option. This will be the initial value.
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \return            true if adding the option succeeds. false if it fails e.g. an option with this id is already registered
+*/
+int rs2_processing_block_register_simple_option(rs2_processing_block* block, int option_id, float min, float max, float step, float def, rs2_error** error);
+
+/**
 * This method is used to direct the output from the processing block to some callback or sink object
 * \param[in] block          Processing block
 * \param[in] on_frame       Callback to be invoked every time the processing block calls frame_ready

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <fstream>
 #include <cmath>
+#include <string>
 #include "rs_processing.hpp"
 
 namespace rs2
@@ -82,8 +83,8 @@ namespace rs2
                 for (int y = 0; y < height - 1; ++y) {
                     auto a = y * width + x, b = y * width + x + 1, c = (y + 1)*width + x, d = (y + 1)*width + x + 1;
                     if (verts[a].z && verts[b].z && verts[c].z && verts[d].z
-                        && abs(verts[a].z - verts[b].z) < threshold && abs(verts[a].z - verts[c].z) < threshold
-                        && abs(verts[b].z - verts[d].z) < threshold && abs(verts[c].z - verts[d].z) < threshold)
+                        && fabs(verts[a].z - verts[b].z) < threshold && fabs(verts[a].z - verts[c].z) < threshold
+                        && fabs(verts[b].z - verts[d].z) < threshold && fabs(verts[c].z - verts[d].z) < threshold)
                     {
                         if (idx_map.count(a) == 0 || idx_map.count(b) == 0 || idx_map.count(c) == 0 ||
                             idx_map.count(d) == 0)

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -7,7 +7,7 @@
 #include <map>
 #include <fstream>
 #include <cmath>
-#include <string>
+#include <sstream>
 #include "rs_processing.hpp"
 
 namespace rs2
@@ -95,9 +95,11 @@ namespace rs2
                 }
             }
 
-            std::ofstream out(fname + std::to_string(p.get_frame_number()) + ".ply");
+            std::stringstream name;
+            name << fname << p.get_frame_number() << ".ply";
+            std::ofstream out(name.str());
             out << "ply\n";
-            out << "format binary_little_endian 1.0\n" /*"format ascii 1.0\n"*/;
+            out << "format binary_little_endian 1.0\n";
             out << "comment pointcloud saved from Realsense Viewer\n";
             out << "element vertex " << new_verts.size() << "\n";
             out << "property float" << sizeof(float) * 8 << " x\n";
@@ -114,7 +116,7 @@ namespace rs2
             out << "end_header\n";
             out.close();
 
-            out.open(fname + std::to_string(p.get_frame_number()) + ".ply", std::ios_base::app | std::ios_base::binary);
+            out.open(name.str(), std::ios_base::app | std::ios_base::binary);
             for (int i = 0; i < new_verts.size(); ++i)
             {
                 // we assume little endian architecture on your device

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -1,0 +1,138 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#ifndef LIBREALSENSE_RS2_EXPORT_HPP
+#define LIBREALSENSE_RS2_EXPORT_HPP
+
+#include <map>
+#include <fstream>
+#include "rs_processing.hpp"
+
+namespace rs2
+{
+    class save_to_ply : public processing_block
+    {
+    public:
+        save_to_ply(std::string filename = "RealSense Pointcloud ", pointcloud pc = pointcloud())
+            : processing_block([this](rs2::frame f, rs2::frame_source& s) { func(f, s); }),
+            _pc(std::move(pc)), fname(filename) {}
+
+    private:
+        void func(rs2::frame data, rs2::frame_source& source)
+        {
+            frame depth, color;
+            if (auto fs = data.as<frameset>()) {
+                depth = fs.first(RS2_STREAM_DEPTH);
+                color = fs.first(RS2_STREAM_COLOR);
+            } else {
+                depth = data.as<depth_frame>();
+            }
+
+            if (!depth) throw std::runtime_error("Need depth data to save PLY");
+            if (!depth.is<points>()) {
+                if (color) _pc.map_to(color);
+                depth = _pc.calculate(depth);
+            }
+
+            export_to_ply(depth, color);
+        }
+
+        void export_to_ply(points p, video_frame color) {
+            auto profile = p.get_profile().as<video_stream_profile>();
+            const auto verts = p.get_vertices();
+            const auto texcoords = p.get_texture_coordinates();
+            std::vector<rs2::vertex> new_verts;
+            std::vector<std::array<uint8_t, 3>> new_tex;
+            std::map<int, int> idx_map;
+
+            new_verts.reserve(p.size());
+            if (color) new_tex.reserve(p.size());
+
+            static const auto min_distance = 1e-6;
+
+            for (size_t i = 0; i < p.size(); ++i) {
+                if (fabs(verts[i].x) >= min_distance || fabs(verts[i].y) >= min_distance ||
+                    fabs(verts[i].z) >= min_distance)
+                {
+                    idx_map[i] = new_verts.size();
+                    new_verts.push_back(verts[i]);
+                    if (color)
+                    {
+                        auto rgb = get_texcolor(color, texcoords[i].u, texcoords[i].v);
+                        new_tex.push_back(rgb);
+                    }
+                }
+            }
+
+            static const auto threshold = 0.05f;
+            auto width = profile.width(), height = profile.height();
+            std::vector<std::array<int, 3>> faces;
+            for (int x = 0; x < width - 1; ++x) {
+                for (int y = 0; y < height - 1; ++y) {
+                    auto a = y * width + x, b = y * width + x + 1, c = (y + 1)*width + x, d = (y + 1)*width + x + 1;
+                    if (verts[a].z && verts[b].z && verts[c].z && verts[d].z
+                        && abs(verts[a].z - verts[b].z) < threshold && abs(verts[a].z - verts[c].z) < threshold
+                        && abs(verts[b].z - verts[d].z) < threshold && abs(verts[c].z - verts[d].z) < threshold)
+                    {
+                        if (idx_map.count(a) == 0 || idx_map.count(b) == 0 || idx_map.count(c) == 0 ||
+                            idx_map.count(d) == 0)
+                            continue;
+                        faces.emplace_back(idx_map[a], idx_map[b], idx_map[d]);
+                        faces.emplace_back(idx_map[d], idx_map[c], idx_map[a]);
+                    }
+                }
+            }
+
+            std::ofstream out(fname + std::to_string(p.get_frame_number()) + ".ply");
+            out << "ply\n";
+            out << "format binary_little_endian 1.0\n" /*"format ascii 1.0\n"*/;
+            out << "comment pointcloud saved from Realsense Viewer\n";
+            out << "element vertex " << new_verts.size() << "\n";
+            out << "property float" << sizeof(float) * 8 << " x\n";
+            out << "property float" << sizeof(float) * 8 << " y\n";
+            out << "property float" << sizeof(float) * 8 << " z\n";
+            if (color)
+            {
+                out << "property uchar red\n";
+                out << "property uchar green\n";
+                out << "property uchar blue\n";
+            }
+            out << "element face " << faces.size() << "\n";
+            out << "property list uchar int vertex_indices\n";
+            out << "end_header\n";
+            out.close();
+
+            out.open(fname, std::ios_base::app | std::ios_base::binary);
+            for (int i = 0; i < new_verts.size(); ++i)
+            {
+                // we assume little endian architecture on your device
+                out.write(reinterpret_cast<const char*>(&(new_verts[i].x)), sizeof(float));
+                out.write(reinterpret_cast<const char*>(&(new_verts[i].y)), sizeof(float));
+                out.write(reinterpret_cast<const char*>(&(new_verts[i].z)), sizeof(float));
+
+                if (color)
+                {
+                    uint8_t x = [0], y = new_tex[i][1], z = new_tex[i][2];
+                    out.write(reinterpret_cast<const char*>(&x), sizeof(uint8_t));
+                    out.write(reinterpret_cast<const char*>(&y), sizeof(uint8_t));
+                    out.write(reinterpret_cast<const char*>(&z), sizeof(uint8_t));
+                }
+            }
+            auto size = faces.size();
+            for (int i = 0; i < size; ++i) {
+                int three = 3;
+                out.write(reinterpret_cast<const char*>(&three), sizeof(uint8_t));
+                out.write(reinterpret_cast<const char*>(&(std::get<0>(faces[i]))), sizeof(int));
+                out.write(reinterpret_cast<const char*>(&(std::get<1>(faces[i]))), sizeof(int));
+                out.write(reinterpret_cast<const char*>(&(std::get<2>(faces[i]))), sizeof(int));
+            }
+        }
+
+        // TODO: get_texcolor, options API
+
+        std::string fname;
+        pointcloud _pc;
+    };
+}
+
+#endif

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <fstream>
+#include <cmath>
 #include "rs_processing.hpp"
 
 namespace rs2

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -175,7 +175,9 @@ namespace rs2
                 for (int i = 0; i < fs.size(); ++i) {
                     frame f = fs[i];
                     auto profile = f.get_profile();
-                    auto s = dev.add_sensor(profile.stream_name() + "Sensor (" + std::to_string(uid) + ")");
+                    std::stringstream sname;
+                    sname << "Sensor (" << uid << ")";
+                    auto s = dev.add_sensor(sname.str());
                     stream_profile software_profile;
 
                     if (auto vf = f.as<video_frame>()) {
@@ -197,7 +199,9 @@ namespace rs2
                 }
 
                 // Recorder needs sensors to already exist when its created
-                recorder rec(fname + std::to_string(data.get_frame_number()) + ".bag", dev);
+                std::stringstream name;
+                name << fname << data.get_frame_number() << ".bag";
+                recorder rec(name.str(), dev);
 
                 for (auto group : sensors) {
                     auto s = std::get<software_sensor>(group);

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -204,11 +204,11 @@ namespace rs2
                 recorder rec(name.str(), dev);
 
                 for (auto group : sensors) {
-                    auto s = std::get<software_sensor>(group);
-                    auto profile = std::get<stream_profile>(group);
+                    auto s = std::get<0>(group);
+                    auto profile = std::get<1>(group);
                     s.open(profile);
                     s.start([](frame) {});
-                    frame f = fs[std::get<int>(group)];
+                    frame f = fs[std::get<2>(group)];
                     if (auto vf = f.as<video_frame>()) {
                         s.on_video_frame({ const_cast<void*>(vf.get_data()), [](void*) {}, vf.get_stride_in_bytes(), vf.get_bytes_per_pixel(),
                                            vf.get_timestamp(), vf.get_frame_timestamp_domain(), static_cast<int>(vf.get_frame_number()), profile });

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -11,11 +11,11 @@
 
 namespace rs2
 {
-    class save_to_ply : public processing_block
+    class save_to_ply : public filter
     {
     public:
         save_to_ply(std::string filename = "RealSense Pointcloud ", pointcloud pc = pointcloud())
-            : processing_block([this](rs2::frame f, rs2::frame_source& s) { func(f, s); }),
+            : filter([this](rs2::frame f, rs2::frame_source& s) { func(f, s); }),
             _pc(std::move(pc)), fname(filename)
         {
             register_simple_option(OPTION_IGNORE_COLOR, option_range{ 0, 1, 0, 1 });
@@ -41,6 +41,7 @@ namespace rs2
             }
 
             export_to_ply(depth, color);
+            source.frame_ready(data); // passthrough filter because processing_block::process doesn't support sinks
         }
 
         void export_to_ply(points p, video_frame color) {
@@ -109,7 +110,7 @@ namespace rs2
             out << "end_header\n";
             out.close();
 
-            out.open(fname, std::ios_base::app | std::ios_base::binary);
+            out.open(fname + std::to_string(p.get_frame_number()) + ".ply", std::ios_base::app | std::ios_base::binary);
             for (int i = 0; i < new_verts.size(); ++i)
             {
                 // we assume little endian architecture on your device

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -8,7 +8,9 @@
 #include <fstream>
 #include <cmath>
 #include <sstream>
+#include <cassert>
 #include "rs_processing.hpp"
+#include "rs_internal.hpp"
 
 namespace rs2
 {
@@ -154,6 +156,77 @@ namespace rs2
 
         std::string fname;
         pointcloud _pc;
+    };
+
+    class save_single_frameset : public filter {
+    public:
+        save_single_frameset(std::string filename = "RealSense Frameset ")
+            : filter([this](frame f, frame_source& s) { save(f, s); }), fname(filename)
+        {}
+
+    private:
+        void save(frame data, frame_source& source, bool do_signal=true)
+        {
+            software_device dev;
+            
+            std::vector<std::tuple<software_sensor, stream_profile, int>> sensors;
+            if (auto fs = data.as<frameset>()) {
+                int uid = 0;
+                for (int i = 0; i < fs.size(); ++i) {
+                    frame f = fs[i];
+                    auto profile = f.get_profile();
+                    auto s = dev.add_sensor(profile.stream_name() + "Sensor (" + std::to_string(uid) + ")");
+                    stream_profile software_profile;
+
+                    if (auto vf = f.as<video_frame>()) {
+                        auto vp = profile.as<video_stream_profile>();
+                        rs2_video_stream stream{ vp.stream_type(), vp.stream_index(), uid++, vp.width(), vp.height(), vp.fps(), vf.get_bytes_per_pixel(), vp.format(), vp.get_intrinsics() };
+                        software_profile = s.add_video_stream(stream);
+                    } else if (f.is<motion_frame>()) {
+                        auto mp = profile.as<motion_stream_profile>();
+                        rs2_motion_stream stream{ mp.stream_type(), mp.stream_index(), uid++, mp.fps(), mp.format(), mp.get_motion_intrinsics() };
+                        software_profile = s.add_motion_stream(stream);
+                    } else if (f.is<pose_frame>()) {
+                        rs2_pose_stream stream{ profile.stream_type(), profile.stream_index(), uid++, profile.fps(), profile.format() };
+                        software_profile = s.add_pose_stream(stream);
+                    } else {
+                        // TODO: How to handle other frame types? (e.g. points)
+                        assert(false);
+                    }
+                    sensors.emplace_back(s, software_profile, i);
+                }
+
+                // Recorder needs sensors to already exist when its created
+                recorder rec(fname + std::to_string(data.get_frame_number()) + ".bag", dev);
+
+                for (auto group : sensors) {
+                    auto s = std::get<software_sensor>(group);
+                    auto profile = std::get<stream_profile>(group);
+                    s.open(profile);
+                    s.start([](frame) {});
+                    frame f = fs[std::get<int>(group)];
+                    if (auto vf = f.as<video_frame>()) {
+                        s.on_video_frame({ const_cast<void*>(vf.get_data()), [](void*) {}, vf.get_stride_in_bytes(), vf.get_bytes_per_pixel(),
+                                           vf.get_timestamp(), vf.get_frame_timestamp_domain(), static_cast<int>(vf.get_frame_number()), profile });
+                    } else if (f.is<motion_frame>()) {
+                        s.on_motion_frame({ const_cast<void*>(f.get_data()), [](void*) {}, f.get_timestamp(),
+                                            f.get_frame_timestamp_domain(), static_cast<int>(f.get_frame_number()), profile });
+                    } else if (f.is<pose_frame>()) {
+                        s.on_pose_frame({ const_cast<void*>(f.get_data()), [](void*) {}, f.get_timestamp(),
+                                          f.get_frame_timestamp_domain(), static_cast<int>(f.get_frame_number()), profile });
+                    }
+                }
+            } else {
+                // single frame
+                auto set = source.allocate_composite_frame({ data });
+                save(set, source, false);
+            }
+
+            if (do_signal)
+                source.frame_ready(data);
+        }
+
+        std::string fname;
     };
 }
 

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -25,7 +25,7 @@ namespace rs2
         }
 
 
-        DECLARE_PB_OPTION(OPTION_IGNORE_COLOR, 1);
+        static const auto OPTION_IGNORE_COLOR = rs2_option(RS2_OPTION_COUNT + 1);
     private:
         void func(frame data, frame_source& source)
         {
@@ -51,7 +51,7 @@ namespace rs2
         }
 
         void export_to_ply(points p, video_frame color) {
-            const bool use_texcoords = color && get_option(OPTION_IGNORE_COLOR);
+            const bool use_texcoords = color && !get_option(OPTION_IGNORE_COLOR);
             const auto verts = p.get_vertices();
             const auto texcoords = p.get_texture_coordinates();
             std::vector<rs2::vertex> new_verts;

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -272,7 +272,7 @@ namespace rs2
         rs2_processing_block* get() const { return _block.get(); }
         
     protected:
-        void register_simple_option(int option_id, option_range range) {
+        void register_simple_option(rs2_option option_id, option_range range) {
             rs2_error * e = nullptr;
             rs2_processing_block_register_simple_option(_block.get(), option_id,
                     range.min, range.max, range.step, range.def, &e);

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -270,7 +270,14 @@ namespace rs2
 
         operator rs2_options*() const { return (rs2_options*)get(); }
         rs2_processing_block* get() const { return _block.get(); }
+        
     protected:
+        void register_simple_option(int option_id, option_range range) {
+            rs2_error * e = nullptr;
+            rs2_processing_block_register_simple_option(_block.get(), option_id,
+                    range.min, range.max, range.step, range.def, &e);
+            error::handle(e);
+        }
         std::shared_ptr<rs2_processing_block> _block;
     };
 
@@ -326,6 +333,13 @@ namespace rs2
     protected:
         frame_queue _queue;
     };
+
+/**
+* This macro can be used in the public portion of a custom processing block's declaration 
+* to name a custom option which will be exposed as a static member of the custom type.
+* the IDs are added after RS2_OPTION_COUNT to avoid colisions with library options.
+*/
+#define DECLARE_PB_OPTION(name, id) static const auto name = rs2_option(RS2_OPTION_COUNT + id)
 
     /**
     * Generating the 3D point cloud base on depth frame also create the mapped texture.

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -334,13 +334,6 @@ namespace rs2
         frame_queue _queue;
     };
 
-/**
-* This macro can be used in the public portion of a custom processing block's declaration 
-* to name a custom option which will be exposed as a static member of the custom type.
-* the IDs are added after RS2_OPTION_COUNT to avoid colisions with library options.
-*/
-#define DECLARE_PB_OPTION(name, id) static const auto name = rs2_option(RS2_OPTION_COUNT + id)
-
     /**
     * Generating the 3D point cloud base on depth frame also create the mapped texture.
     */

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -13,6 +13,7 @@
 #include "hpp/rs_record_playback.hpp"
 #include "hpp/rs_sensor.hpp"
 #include "hpp/rs_pipeline.hpp"
+#include "hpp/rs_export.hpp"
 
 namespace rs2
 {

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -13,7 +13,6 @@
 #include "hpp/rs_record_playback.hpp"
 #include "hpp/rs_sensor.hpp"
 #include "hpp/rs_pipeline.hpp"
-#include "hpp/rs_export.hpp"
 
 namespace rs2
 {

--- a/src/api.h
+++ b/src/api.h
@@ -406,6 +406,7 @@ return __p.invoke(func);\
 
     #define VALIDATE_NOT_NULL(ARG) if(!(ARG)) throw std::runtime_error("null pointer passed for argument \"" #ARG "\"");
     #define VALIDATE_ENUM(ARG) if(!librealsense::is_valid(ARG)) { std::ostringstream ss; ss << "invalid enum value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
+    #define VALIDATE_OPTION(OBJ, OPT_ID) if(!OBJ->options->supports_option(OPT_ID)) { std::ostringstream ss; ss << "object doesn't support option #" << std::to_string(OPT_ID); throw librealsense::invalid_value_exception(ss.str()); }
     #define VALIDATE_RANGE(ARG, MIN, MAX) if((ARG) < (MIN) || (ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
     #define VALIDATE_LE(ARG, MAX) if((ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw std::runtime_error(ss.str()); }
     #define VALIDATE_INTERFACE_NO_THROW(X, T)                                                   \

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -7,11 +7,14 @@
 
 bool librealsense::option_base::is_valid(float value) const
 {
-    if (!std::isnormal(_opt_range.step))
+    if (!std::isnormal(_opt_range.step) && _opt_range.step != 0)
         throw invalid_value_exception(to_string() << "is_valid(...) failed! step is not properly defined. (" << _opt_range.step << ")");
 
     if ((value < _opt_range.min) || (value > _opt_range.max))
         return false;
+
+    if (_opt_range.step == 0)
+        return true;
 
     auto n = (value - _opt_range.min) / _opt_range.step;
     return (fabs(fmod(n, 1)) < std::numeric_limits<float>::min());
@@ -29,6 +32,13 @@ void librealsense::option_base::enable_recording(std::function<void(const option
 void librealsense::option::create_snapshot(std::shared_ptr<option>& snapshot) const
 {
     snapshot = std::make_shared<const_value_option>(get_description(), query());
+}
+
+void librealsense::float_option::set(float value)
+{
+    if (!is_valid(value))
+        throw invalid_value_exception(to_string() << "set(...) failed! " << value << " is not a valid value");
+    _value = value;
 }
 
 void librealsense::uvc_pu_option::set(float value)

--- a/src/option.h
+++ b/src/option.h
@@ -111,26 +111,15 @@ namespace librealsense
                             static_cast<float>(def), }),
             _min(min), _max(max), _step(step), _def(def), _value(value), _desc(desc)
         {
-            static_assert((std::is_arithmetic<T>::value),  "ptr_option class supports arithmetic built-in types only");
+            static_assert((std::is_arithmetic<T>::value), "ptr_option class supports arithmetic built-in types only");
             _on_set = [](float x) {};
         }
 
         void set(float value) override
         {
             T val = static_cast<T>(value);
-            if (!std::isnormal(static_cast<ty>(_step)) && _step != 0)
-                throw invalid_value_exception(to_string() << "set(...) failed! step is not properly defined. (" << _step << ")");
-
-            if ((val < _min) || (val > _max))
-                throw invalid_value_exception(to_string() << "Given value " << val << "is outside valid range!");
-
-            if (_step != 0) {
-                auto n = (val - _min) / _step;
-                if (std::fabs(std::fmod(n, 1)) >= std::numeric_limits<ty>::min()) {
-                    throw invalid_value_exception(to_string() << "Given value" << val << "isn't a valid step!");
-                }
-            }
-
+            if ((_max < val) || (_min > val))
+                throw invalid_value_exception(to_string() << "Given value " << value << "is outside valid range!");
             *_value = val;
             _on_set(value);
         }
@@ -139,12 +128,6 @@ namespace librealsense
         {
             return static_cast<float>(*_value);
         }
-
-//        option_range get_range() const override {
-//            return{
-//                (float)_min, (float)_max,
-//                (float)_step, (float)_def };
-//        }
 
         bool is_enabled() const override { return true; }
 
@@ -174,11 +157,6 @@ namespace librealsense
         std::string _desc;
         std::map<float, std::string> _item_desc;
         std::function<void(float)> _on_set;
-
-        // Makes sure that we check the numeric limits of the type std::fabs will return.
-        // while std::numeric_limits<typename std::result_of<std::fabs(T)>::type> should be simpler, MSVC errors on it.
-        using ty = typename std::conditional<std::is_same<T, long double>::value, long double,
-                            typename std::conditional<std::is_same<T, float>::value, float, double>::type>::type;
     };
 
     class float_option : public option_base

--- a/src/option.h
+++ b/src/option.h
@@ -118,7 +118,7 @@ namespace librealsense
         void set(float value) override
         {
             T val = static_cast<T>(value);
-            if (!std::isnormal<long double>(_step) && _step != 0)
+            if (!std::isnormal(static_cast<ty>(_step)) && _step != 0)
                 throw invalid_value_exception(to_string() << "set(...) failed! step is not properly defined. (" << _step << ")");
 
             if ((val < _min) || (val > _max))
@@ -126,7 +126,7 @@ namespace librealsense
 
             if (_step != 0) {
                 auto n = (val - _min) / _step;
-                if (std::fabs(std::fmod(n, 1)) >= limits::min()) {
+                if (std::fabs(std::fmod(n, 1)) >= std::numeric_limits<ty>::min()) {
                     throw invalid_value_exception(to_string() << "Given value" << val << "isn't a valid step!");
                 }
             }
@@ -177,8 +177,8 @@ namespace librealsense
 
         // Makes sure that we check the numeric limits of the type std::fabs will return.
         // while std::numeric_limits<typename std::result_of<std::fabs(T)>::type> should be simpler, MSVC errors on it.
-        using limits = std::numeric_limits<typename std::conditional<std::is_same<T, long double>::value, long double,
-                            typename std::conditional<std::is_same<T, float>::value, float, double>::type>::type>;
+        using ty = typename std::conditional<std::is_same<T, long double>::value, long double,
+                            typename std::conditional<std::is_same<T, float>::value, float, double>::type>::type;
     };
 
     class float_option : public option_base

--- a/src/option.h
+++ b/src/option.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <vector>
 #include <cmath>
+#include <type_traits>
 
 namespace librealsense
 {
@@ -117,8 +118,19 @@ namespace librealsense
         void set(float value) override
         {
             T val = static_cast<T>(value);
-            if ((_max < val) || (_min > val))
-                throw invalid_value_exception(to_string() << "Given value " << value << " is outside valid range!");
+            if (!std::isnormal<long double>(_step) && _step != 0)
+                throw invalid_value_exception(to_string() << "set(...) failed! step is not properly defined. (" << _step << ")");
+
+            if ((val < _min) || (val > _max))
+                throw invalid_value_exception(to_string() << "Given value " << val << "is outside valid range!");
+
+            if (_step != 0) {
+                auto n = (val - _min) / _step;
+                if (std::fabs(std::fmod(n, 1)) >= limits::min()) {
+                    throw invalid_value_exception(to_string() << "Given value" << val << "isn't a valid step!");
+                }
+            }
+
             *_value = val;
             _on_set(value);
         }
@@ -128,11 +140,11 @@ namespace librealsense
             return static_cast<float>(*_value);
         }
 
-        option_range get_range() const override {
-            return{
-                (float)_min, (float)_max,
-                (float)_step, (float)_def };
-        }
+//        option_range get_range() const override {
+//            return{
+//                (float)_min, (float)_max,
+//                (float)_step, (float)_def };
+//        }
 
         bool is_enabled() const override { return true; }
 
@@ -157,11 +169,30 @@ namespace librealsense
 
         void on_set(std::function<void(float)> on_set) { _on_set = on_set; }
     private:
-        T _min, _max, _step, _def;
+        T _min, _max, _step, _def; // stored separately so that logic can be done in base type
         T* _value;
         std::string _desc;
         std::map<float, std::string> _item_desc;
         std::function<void(float)> _on_set;
+
+        // Makes sure that we check the numeric limits of the type std::fabs will return.
+        // while std::numeric_limits<typename std::result_of<std::fabs(T)>::type> should be simpler, MSVC errors on it.
+        using limits = std::numeric_limits<typename std::conditional<std::is_same<T, long double>::value, long double,
+                            typename std::conditional<std::is_same<T, float>::value, float, double>::type>::type>;
+    };
+
+    class float_option : public option_base
+    {
+    public:
+        float_option(option_range range) : option_base(range), _value(range.def) {}
+
+        void set(float value) override;
+        float query() const override { return _value; }
+        bool is_enabled() const override { return true; }
+        // TODO: expose this outwards
+        const char* get_description() const { return "A simple custom option for a processing block"; }
+    private:
+        float _value;
     };
 
     class uvc_pu_option : public option

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -152,6 +152,7 @@ EXPORTS
     rs2_synthetic_frame_ready
     rs2_create_processing_block
     rs2_create_processing_block_fptr
+    rs2_processing_block_register_simple_option
     rs2_start_processing
     rs2_start_processing_queue
     rs2_start_processing_fptr

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -544,7 +544,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(, sensor)
 int rs2_is_option_read_only(const rs2_options* options, rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_ENUM(option);
+    VALIDATE_OPTION(options, option);
     return options->options->get_option(option).is_read_only();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, options, option)
@@ -552,7 +552,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(0, options, option)
 float rs2_get_option(const rs2_options* options, rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_ENUM(option);
+    VALIDATE_OPTION(options, option);
     return options->options->get_option(option).query();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0.0f, options, option)
@@ -560,7 +560,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(0.0f, options, option)
 void rs2_set_option(const rs2_options* options, rs2_option option, float value, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_ENUM(option);
+    VALIDATE_OPTION(options, option);
     options->options->get_option(option).set(value);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, options, option, value)
@@ -569,7 +569,6 @@ HANDLE_EXCEPTIONS_AND_RETURN(, options, option, value)
 int rs2_supports_option(const rs2_options* options, rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_ENUM(option);
     return options->options->supports_option(option);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, options, option)
@@ -578,7 +577,7 @@ void rs2_get_option_range(const rs2_options* options, rs2_option option,
     float* min, float* max, float* step, float* def, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_ENUM(option);
+    VALIDATE_OPTION(options, option);
     VALIDATE_NOT_NULL(min);
     VALIDATE_NOT_NULL(max);
     VALIDATE_NOT_NULL(step);
@@ -858,7 +857,7 @@ NOEXCEPT_RETURN(, frame)
 const char* rs2_get_option_description(const rs2_options* options, rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_ENUM(option);
+    VALIDATE_OPTION(options, option);
     return options->options->get_option(option).get_description();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, options, option)
@@ -873,7 +872,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(, frame)
 const char* rs2_get_option_value_description(const rs2_options* options, rs2_option option, float value, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_ENUM(option);
+    VALIDATE_OPTION(options, option);
     return options->options->get_option(option).get_value_description(value);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, options, option, value)
@@ -1671,18 +1670,18 @@ rs2_processing_block* rs2_create_processing_block_fptr(rs2_frame_processor_callb
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, proc, context)
 
-int rs2_processing_block_register_simple_option(rs2_processing_block* block, int option_id, float min, float max, float step, float def, rs2_error** error) BEGIN_API_CALL
+int rs2_processing_block_register_simple_option(rs2_processing_block* block, rs2_option option_id, float min, float max, float step, float def, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(block);
     VALIDATE_LE(min, max);
     VALIDATE_RANGE(def, min, max);
     VALIDATE_LE(0, step);
 
-    if (block->options->supports_option(rs2_option(option_id))) return false;
+    if (block->options->supports_option(option_id)) return false;
     std::shared_ptr<option> opt = std::make_shared<float_option>(option_range{ min, max, step, def });
     // TODO: am I supposed to use the extensions API here?
     auto options = dynamic_cast<options_container*>(block->options);
-    options->register_option(rs2_option(option_id), opt);
+    options->register_option(option_id, opt);
     return true;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(false, block, option_id, min, max, step, def)

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1671,6 +1671,22 @@ rs2_processing_block* rs2_create_processing_block_fptr(rs2_frame_processor_callb
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, proc, context)
 
+bool rs2_processing_block_register_simple_option(rs2_processing_block* block, int option_id, float min, float max, float step, float def, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(block);
+    VALIDATE_LE(min, max);
+    VALIDATE_RANGE(def, min, max);
+    VALIDATE_LE(0, step);
+
+    if (block->options->supports_option(rs2_option(option_id))) return false;
+    std::shared_ptr<option> opt = std::make_shared<float_option>(option_range{ min, max, step, def });
+    // TODO: am I supposed to use the extensions API here?
+    auto options = dynamic_cast<options_container*>(block->options);
+    options->register_option(rs2_option(option_id), opt);
+    return true;
+}
+HANDLE_EXCEPTIONS_AND_RETURN(false, block, option_id, min, max, step, def)
+
 rs2_processing_block* rs2_create_sync_processing_block(rs2_error** error) BEGIN_API_CALL
 {
     auto block = std::make_shared<librealsense::syncer_process_unit>();

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1671,7 +1671,7 @@ rs2_processing_block* rs2_create_processing_block_fptr(rs2_frame_processor_callb
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, proc, context)
 
-bool rs2_processing_block_register_simple_option(rs2_processing_block* block, int option_id, float min, float max, float step, float def, rs2_error** error) BEGIN_API_CALL
+int rs2_processing_block_register_simple_option(rs2_processing_block* block, int option_id, float min, float max, float step, float def, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(block);
     VALIDATE_LE(min, max);

--- a/wrappers/matlab/librealsense_mex.cpp
+++ b/wrappers/matlab/librealsense_mex.cpp
@@ -1,6 +1,7 @@
 #include "MatlabParamParser.h"
 #include "Factory.h"
 #include "librealsense2/rs.hpp"
+#include "librealsense2/hpp/rs_export.hpp"
 
 #pragma comment(lib, "libmx.lib")
 #pragma comment(lib, "libmex.lib")
@@ -1119,6 +1120,20 @@ void make_factory(){
             }
         });
         factory->record(save_to_ply_factory);
+    }
+    {
+        ClassFactory save_single_frameset_factory("rs2::save_single_frameset");
+        save_single_frameset_factory.record("new", 1, 0, 1, [](int outc, mxArray* outv[], int inc, const mxArray* inv[])
+        {
+            if (inc == 0) {
+                outv[0] = MatlabParamParser::wrap(rs2::save_single_frameset());
+            }
+            else if (inc == 1) {
+                auto filename = MatlabParamParser::parse<std::string>(inv[0]);
+                outv[0] = MatlabParamParser::wrap(rs2::save_single_frameset(filename));
+            }
+        });
+        factory->record(save_single_frameset_factory);
     }
 
     // rs_context.hpp

--- a/wrappers/matlab/librealsense_mex.cpp
+++ b/wrappers/matlab/librealsense_mex.cpp
@@ -1114,10 +1114,11 @@ void make_factory(){
             }
             else if (inc == 2) {
                 auto filename = MatlabParamParser::parse<std::string>(inv[0]);
-                auto pc = MatlabParamParser::parse<rs2::pointcloud>(inc[1]);
+                auto pc = MatlabParamParser::parse<rs2::pointcloud>(inv[1]);
                 outv[0] = MatlabParamParser::wrap(rs2::save_to_ply(filename, pc));
             }
-        }
+        });
+        factory->record(save_to_ply_factory);
     }
 
     // rs_context.hpp

--- a/wrappers/matlab/librealsense_mex.cpp
+++ b/wrappers/matlab/librealsense_mex.cpp
@@ -1100,6 +1100,26 @@ void make_factory(){
         factory->record(hole_filling_filter_factory);
     }
 
+    // rs_export.hpp
+    {
+        ClassFactory save_to_ply_factory("rs2::save_to_ply");
+        save_to_ply_factory.record("new", 1, 0, 2, [](int outc, mxArray* outv[], int inc, const mxArray* inv[])
+        {
+            if (inc == 0) {
+                outv[0] = MatlabParamParser::wrap(rs2::save_to_ply());
+            }
+            else if (inc == 1) {
+                auto filename = MatlabParamParser::parse<std::string>(inv[0]);
+                outv[0] = MatlabParamParser::wrap(rs2::save_to_ply(filename));
+            }
+            else if (inc == 2) {
+                auto filename = MatlabParamParser::parse<std::string>(inv[0]);
+                auto pc = MatlabParamParser::parse<rs2::pointcloud>(inc[1]);
+                outv[0] = MatlabParamParser::wrap(rs2::save_to_ply(filename, pc));
+            }
+        }
+    }
+
     // rs_context.hpp
     // rs2::event_information                                           [?]
     {

--- a/wrappers/matlab/options.m
+++ b/wrappers/matlab/options.m
@@ -20,39 +20,39 @@ classdef options < handle
         % Functions
         function value = supports_option(this, option)
             narginchk(2, 2);
-            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.option.count}, '', 'option', 2);
+            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'option', 2);
             value = realsense.librealsense_mex('rs2::options', 'supports#rs2_option', this.objectHandle, int64(option));
         end
         function option_description = get_option_description(this, option)
             narginchk(2, 2);
-            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.option.count}, '', 'option', 2);
+            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'option', 2);
             option_description = realsense.librealsense_mex('rs2::options', 'get_option_description', this.objectHandle, int64(option));
         end
         function option_value_description = get_option_value_description(this, option, val)
             narginchk(3, 3);
-            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.option.count}, '', 'option', 2);
+            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'option', 2);
             validateattributes(val, {'numeric'}, {'scalar', 'real'}, '', 'val', 3);
             option_value_description = realsense.librealsense_mex('rs2::options', 'get_option_value_description', this.objectHandle, int64(option), double(val));
         end
         function value = get_option(this, option)
             narginchk(2, 2);
-            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.option.count}, '', 'option', 2);
+            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'option', 2);
             value = realsense.librealsense_mex('rs2::options', 'get_option', this.objectHandle, int64(option));
         end
         function option_range = get_option_range(this, option)
             narginchk(2, 2);
-            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.option.count}, '', 'option', 2);
+            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'option', 2);
             option_range = realsense.librealsense_mex('rs2::options', 'get_option_range', this.objectHandle, int64(option));
         end
         function set_option(this, option, val)
             narginchk(3, 3);
-            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.option.count}, '', 'option', 2);
+            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'option', 2);
             validateattributes(val, {'numeric'}, {'scalar', 'real'}, '', 'val', 3);
             realsense.librealsense_mex('rs2::options', 'set_option', this.objectHandle, int64(option), double(val));
         end
         function value = is_option_read_only(this, option)
             narginchk(2, 2);
-            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.option.count}, '', 'option', 2);
+            validateattributes(option, {'realsense.option', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'option', 2);
             value = realsense.librealsense_mex('rs2::options', 'is_option_read_only', this.objectHandle, int64(option));
         end
     end

--- a/wrappers/matlab/save_single_frameset.m
+++ b/wrappers/matlab/save_single_frameset.m
@@ -1,0 +1,18 @@
+% Wraps librealsense2 save_to_ply class
+classdef save_single_frameset < realsense.processing_block
+    methods
+        % Constructor
+        function this = save_single_frameset(filename)
+            switch nargin
+                case 0
+                    out = realsense.librealsense_mex('rs2::save_single_frameset', 'new');
+                case 1
+                    validateattributes(filename, {'char', 'string'}, {'scalartext'});
+                    out = realsense.librealsense_mex('rs2::save_single_frameset', 'new', filename);
+            end
+            this = this@realsense.processing_block(out);
+        end
+        
+        % Destructor (uses base class destructor)
+    end
+end

--- a/wrappers/matlab/save_to_ply.m
+++ b/wrappers/matlab/save_to_ply.m
@@ -1,0 +1,25 @@
+% Wraps librealsense2 save_to_ply class
+classdef save_to_ply < realsense.processing_block
+    properties (Constant=true)
+        option_ignore_color = realsense.option.count + 1;
+    end
+    methods
+        % Constructor
+        function this = save_to_ply(filename, pc)
+            switch nargin
+                case 0
+                    out = realsense.librealsense_mex('rs2::save_to_ply', 'new');
+                case 1
+                    validateattributes(filename, {'char', 'string'}, {'scalartext'});
+                    out = realsense.librealsense_mex('rs2::save_to_ply', 'new', filename);
+                case 2
+                    validateattributes(filename, {'char', 'string'}, {'scalartext'});
+                    validateattributes(pc, {'realsense.pointcloud'}, {'scalar'});
+                    out = realsense.librealsense_mex('rs2::save_to_ply', 'new', filename, pc.objectHandle);
+            end
+            this = this@realsense.processing_block(out);
+        end
+        
+        % Destructor (uses base class destructor)
+    end
+end

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -20,6 +20,7 @@ Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 
 #include "../include/librealsense2/rs.h"
 #include "../include/librealsense2/rs.hpp"
+#include "../include/librealsense2/hpp/rs_export.hpp"
 #include "../include/librealsense2/rs_advanced_mode.hpp"
 #include "../include/librealsense2/rsutil.h"
 #define NAME pyrealsense2
@@ -575,6 +576,9 @@ PYBIND11_MODULE(NAME, m) {
     py::class_<rs2::save_to_ply, rs2::filter> save_to_ply(m, "save_to_ply");
     save_to_ply.def(py::init<std::string, rs2::pointcloud>(), "filename"_a = "RealSense Pointcloud ", "pc"_a = rs2::pointcloud())
                .def_readonly_static("option_ignore_color", &rs2::save_to_ply::OPTION_IGNORE_COLOR);
+
+    py::class_<rs2::save_single_frameset, rs2::filter> save_single_frameset(m, "save_single_frameset");
+    save_single_frameset.def(py::init<std::string>(), "filename"_a = "RealSense Frameset ");
 
     /* rs2_record_playback.hpp */
     py::class_<rs2::playback, rs2::device> playback(m, "playback");

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -192,7 +192,6 @@ PYBIND11_MODULE(NAME, m) {
         .def_property(BIND_RAW_ARRAY_PROPERTY(rs2_motion_device_intrinsic, bias_variances, float, 3));
 
     /* rs2_types.hpp */
-
     py::class_<rs2::option_range> option_range(m, "option_range");
     option_range.def_readwrite("min", &rs2::option_range::min)
         .def_readwrite("max", &rs2::option_range::max)
@@ -312,7 +311,6 @@ PYBIND11_MODULE(NAME, m) {
 
 
     /* rs2_frame.hpp */
-
     auto get_frame_data = [](const rs2::frame& self) ->  BufData
     {
         if (auto vf = self.as<rs2::video_frame>()) {
@@ -573,6 +571,11 @@ PYBIND11_MODULE(NAME, m) {
     py::class_<rs2::disparity_transform, rs2::filter> disparity_transform(m, "disparity_transform");
     disparity_transform.def(py::init<bool>(), "transform_to_disparity"_a=true);
 
+    /* rs_export.hpp */
+    py::class_<rs2::save_to_ply, rs2::processing_block> save_to_ply(m, "save_to_ply");
+    save_to_ply.def(py::init<std::string, rs2::pointcloud>(), "filename"_a = "RealSense Pointcloud ", "pc"_a = rs2::pointcloud())
+               .def_readonly_static("option_ignore_color", &rs2::save_to_ply::OPTION_IGNORE_COLOR);
+
     /* rs2_record_playback.hpp */
     py::class_<rs2::playback, rs2::device> playback(m, "playback");
     playback.def(py::init<rs2::device>(), "device"_a)
@@ -713,8 +716,6 @@ PYBIND11_MODULE(NAME, m) {
         .def("__nonzero__", &rs2::depth_sensor::operator bool);
 
     /* rs2_pipeline.hpp */
-
-
     py::class_<rs2::pipeline> pipeline(m, "pipeline");
     pipeline.def(py::init([](rs2::context ctx) { return rs2::pipeline(ctx); }))
         .def(py::init([]() { return rs2::pipeline(rs2::context()); }))
@@ -746,7 +747,6 @@ PYBIND11_MODULE(NAME, m) {
 
     py::implicitly_convertible<rs2::pipeline, pipeline_wrapper>();
 
-    /* rs2_pipeline.hpp */
     py::class_<rs2::pipeline_profile> pipeline_profile(m, "pipeline_profile");
     pipeline_profile.def(py::init<>())
         .def("get_streams", &rs2::pipeline_profile::get_streams)

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -572,7 +572,7 @@ PYBIND11_MODULE(NAME, m) {
     disparity_transform.def(py::init<bool>(), "transform_to_disparity"_a=true);
 
     /* rs_export.hpp */
-    py::class_<rs2::save_to_ply, rs2::processing_block> save_to_ply(m, "save_to_ply");
+    py::class_<rs2::save_to_ply, rs2::filter> save_to_ply(m, "save_to_ply");
     save_to_ply.def(py::init<std::string, rs2::pointcloud>(), "filename"_a = "RealSense Pointcloud ", "pc"_a = rs2::pointcloud())
                .def_readonly_static("option_ignore_color", &rs2::save_to_ply::OPTION_IGNORE_COLOR);
 


### PR DESCRIPTION
Implements save_to_ply functionality as a processing block sink.
The old flow (rs2::points::export_to_ply) is still in the code.

Current uses of save_to_ply within the codebase have not been migrated yet.

Additionally, implements another processing block to save a single frameset as a rosbag