### PR TITLE
Set IMU extrinsic based on mechanical drawings

### DIFF
--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -37,6 +37,7 @@ namespace librealsense
         lazy<ds::imu_intrinsics>        _accel_intrinsics;
         lazy<ds::imu_intrinsics>        _gyro_intrinsics;
         std::shared_ptr<lazy<rs2_extrinsics>> _fisheye_to_imu;
+        std::shared_ptr<lazy<rs2_extrinsics>> _depth_to_imu;
 
         ds::tm1_eeprom        get_tm1_eeprom() const;
         std::vector<uint8_t>  get_tm1_eeprom_raw() const;

--- a/src/environment.h
+++ b/src/environment.h
@@ -18,7 +18,6 @@ namespace librealsense
         void register_extrinsics(const stream_interface& from, const stream_interface& to, rs2_extrinsics extr);
         bool try_fetch_extrinsics(const stream_interface& from, const stream_interface& to, rs2_extrinsics* extr);
 
-
         struct extrinsics_lock
         {
             extrinsics_lock(extrinsics_graph& owner)

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include "image.h"
 #include "image_avx.h"
+#include "types.h"
 
 #ifdef RS2_USE_CUDA
 #include "cuda/cuda-conversion.cuh"
@@ -98,37 +99,43 @@ namespace librealsense
 
 #pragma pack(pop)
 
-    inline void copy_hid_axes(byte * const dest[], const byte * source, double factor)
+    template<rs2_format FORMAT> void copy_hid_axes(byte * const dest[], const byte * source, double factor)
     {
+        using namespace librealsense;
         auto hid = (hid_data*)(source);
 
         // The IMU sensor orientation shall be aligned with depth sensor's coordinate system
         // Note that the implementation follows D435i installation pose and will require refactoring for other designs
         // Reference spec: Bosch BMI055
-        float axes[3] = { static_cast<float>((hid->x) * -factor),
-                         static_cast<float>((hid->y) * factor),
-                         static_cast<float>((hid->z) * -factor) };
-        librealsense::copy(dest[0], axes, sizeof(axes));
+        auto res= float3{ float(hid->x), float(hid->y), float(hid->z)} * float(factor);
+
+        if (RS2_FORMAT_MOTION_XYZ32F==FORMAT)
+        {
+            float3x3 rot = {{-1,0,0},{0,1,0},{0,0,-1}};
+            res=rot*res;
+        }
+
+        librealsense::copy(dest[0], &res, sizeof(float3));
     }
 
     // The Accelerometer input format: signed int 16bit. data units 1LSB=0.001g;
     // Librealsense output format: floating point 32bit. units m/s^2,
-    template<size_t SIZE> void unpack_accel_axes(byte * const dest[], const byte * source, int width, int height)
+    template<rs2_format FORMAT> void unpack_accel_axes(byte * const dest[], const byte * source, int width, int height)
     {
         static constexpr float gravity = 9.80665f;          // Standard Gravitation Acceleration
         static constexpr double accelerator_transform_factor = 0.001*gravity;
 
-        copy_hid_axes(dest, source, accelerator_transform_factor);
+        copy_hid_axes<FORMAT>(dest, source, accelerator_transform_factor);
     }
 
     // The Gyro input format: signed int 16bit. data units 1LSB=0.1deg/sec;
     // Librealsense output format: floating point 32bit. units rad/sec,
-    template<size_t SIZE> void unpack_gyro_axes(byte * const dest[], const byte * source, int width, int height)
+    template<rs2_format FORMAT> void unpack_gyro_axes(byte * const dest[], const byte * source, int width, int height)
     {
         static constexpr double deg2rad = M_PI / 180.;
         static const double gyro_transform_factor = 0.1 * deg2rad;
 
-        copy_hid_axes(dest, source, gyro_transform_factor);
+        copy_hid_axes<FORMAT>(dest, source, gyro_transform_factor);
     }
 
     void unpack_hid_raw_data(byte * const dest[], const byte * source, int width, int height)


### PR DESCRIPTION
Adding a predefined extrinsic for IMU module:
- The IMU data will be transmitted in LRS Coordinate System. (OpenCV-compatible X-right, Y-Down, Z-forward). The rotation from the installation angles to the reference CS will be embedded into data parser.
- The rotation part of IMU->Depth extrinsic will exhibit identity matrix in order to allow for IMU X Extrinsic transformation to work properly.

Tracked on: DSO-11000