### PR TITLE
fix race on playback device destruction

### DIFF
--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -43,7 +43,7 @@ playback_sensor::~playback_sensor()
 
 bool playback_sensor::streams_contains_one_frame_or_more()
 {
-    for (auto d : m_dispatchers)
+    for (auto&& d : m_dispatchers)
     {
         if (d.second->empty())
             return false;
@@ -98,7 +98,7 @@ void playback_sensor::close()
 {
     LOG_DEBUG("Close sensor " << m_sensor_id);
     std::vector<device_serializer::stream_identifier> closed_streams;
-    for (auto dispatcher : m_dispatchers)
+    for (auto&& dispatcher : m_dispatchers)
     {
         dispatcher.second->flush();
         for (auto available_profile : m_available_profiles)


### PR DESCRIPTION
**Fix for:**
Jira: [DSO-10749](https://rsjira.intel.com/browse/DSO-10749)

**Potential fix for:**
github: #2472 

There is a race between `playback_sensor::close` and `playbcak_sensor::streams_contains_one_frame_or_more`.
Before the fix, iterating over the dispatchers was done using lvalue pairs.
In some cases, when `streams_contains_one_frame_or_more` is being called during `close`, the dispatcher is released in `streams_contains_one_frame_or_more` instead of being released on `close`.
That prevented from stop/close flow to be executed on the playback device. 