### PR TITLE
Update CMakeLists.txt and dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
+project(librealsense2 LANGUAGES CXX C)
+
 set(ROS_BUILD_TYPE TRUE)
 
 if(${ROS_BUILD_TYPE})
     find_package(ament_cmake REQUIRED)
 endif()
-
-project(librealsense2 LANGUAGES CXX C)
 
 # include librealsense general configuration
 include(CMake/global_config.cmake)

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,9 @@
 
   <depend>libusb-1.0-dev</depend>
   <depend>linux-headers-generic</depend>
+  <depend>libgl1-mesa-dev</depend>
+  <depend>libglfw3-dev</depend>
+  <depend>libgtk-3-0-dev</depend>
   <depend>libssl-dev</depend>
   <depend>dkms</depend>
   <depend>udev</depend>


### PR DESCRIPTION
Using feedback from the ROS Buildfarm I identified an issue with the CMakeLists.txt: `find_package(ament_cmake REQUIRED)` must be called after `project(librealsense2...)`

After that was resolved there were several further errors during CMake configuration which were due to missing dependencies. I've added keys that do not yet have entries in the rosdep database. I will open PRs for them tomorrow.