### PR TITLE
Fixing Accel data in Windows

### DIFF
--- a/src/win/win-hid.cpp
+++ b/src/win/win-hid.cpp
@@ -119,17 +119,46 @@ namespace librealsense
                 CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE2, &var));
                 auto customTimestampHigh = var.ulVal;
 
-                // Raw X
-                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE3, &var));
-                auto rawX = var.iVal;
+                /* Retrieve sensor type - Sensor types are more specific groupings than sensor categories. Sensor type IDs are GUIDs that are defined in Sensors.h */
 
-                // Raw Y
-                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE4, &var));
-                auto rawY = var.iVal;
+                SENSOR_TYPE_ID type{};
 
-                // Raw Z
-                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE5, &var));
-                auto rawZ = var.iVal;
+                CHECK_HR(pSensor->GetType(&type));
+
+                double rawX, rawY, rawZ;
+
+
+                if (type == SENSOR_TYPE_ACCELEROMETER_3D)
+                {
+                    CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_ACCELERATION_X_G, &var));
+                    rawX = var.dblVal;
+
+                    CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_ACCELERATION_Y_G, &var));
+                    rawY = var.dblVal;
+
+                    CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_ACCELERATION_Z_G, &var));
+                    rawZ = var.dblVal;
+
+                    static constexpr double accelerator_transform_factor = 1000.0;
+
+                    rawX *= accelerator_transform_factor;
+                    rawY *= accelerator_transform_factor;
+                    rawZ *= accelerator_transform_factor;
+                }
+                else
+                {
+                    // Raw X
+                    CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE3, &var));
+                    rawX = var.iVal;
+
+                    // Raw Y
+                    CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE4, &var));
+                    rawY = var.iVal;
+
+                    // Raw Z
+                    CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE5, &var));
+                    rawZ = var.iVal;
+                }
 
                 PropVariantClear(&var);
 


### PR DESCRIPTION
For the D435i on Windows 10, the reported accelerometer readings were unreasonably high. 
This patch solves this problem (tested that the resulting values are equivalent to Linux counterparts) by using `SENSOR_DATA_TYPE_ACCELERATION_*_G` and normalizing to units expected by `sensor.cpp`. 

Addresses DSO-11041