### PR TITLE
Call find_package(ament_cmake) after project().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
+project(librealsense2 LANGUAGES CXX C)
+
 set(ROS_BUILD_TYPE TRUE)
 
 if(${ROS_BUILD_TYPE})
     find_package(ament_cmake REQUIRED)
 endif()
-
-project(librealsense2 LANGUAGES CXX C)
 
 # include librealsense general configuration
 include(CMake/global_config.cmake)

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,10 @@
 
   <depend>libusb-1.0-dev</depend>
   <depend>linux-headers-generic</depend>
+  <depend>libgl1-mesa-dev</depend>
+  <depend>libglfw3-dev</depend>
+  <depend>libglu1-mesa-dev</depend>
+  <depend>libgtk-3-dev</depend>
   <depend>libssl-dev</depend>
   <depend>dkms</depend>
   <depend>udev</depend>


### PR DESCRIPTION
To function correctly find_package(ament_cmake) must be called after
project().

Resovles the issue of ament_cmake not being found when building for ROS
2.