### PR TITLE
Update rodsep keys.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,14 +27,13 @@
 
   <build_depend>pkg-config</build_depend>
 
+  <depend>dkms</depend>
+  <depend>gtk3</depend>
+  <depend>libglfw3-dev</depend>
+  <depend>libssl-dev</depend>
   <depend>libusb-1.0-dev</depend>
   <depend>linux-headers-generic</depend>
-  <depend>libgl1-mesa-dev</depend>
-  <depend>libglfw3-dev</depend>
-  <depend>libglu1-mesa-dev</depend>
-  <depend>libgtk-3-dev</depend>
-  <depend>libssl-dev</depend>
-  <depend>dkms</depend>
+  <depend>opengl</depend>
   <depend>udev</depend>
 
   <export>


### PR DESCRIPTION
All dependencies are upstreamed but the key names didn't match the
ubuntu package names as they usually do.

gtk3 -> libgtk-3-dev
opengl -> libgl1-mesa-dev, libglu1-mesa-dev

Also sorted the dependencies lexically for easier scanning.

References to rsodep
* https://github.com/ros/rosdistro/blob/7227f5296931ec2e22fb6e6c0b27bb0c15d6efa5/rosdep/base.yaml#L4110
* https://github.com/ros/rosdistro/blob/7227f5296931ec2e22fb6e6c0b27bb0c15d6efa5/rosdep/base.yaml#L1212
* https://github.com/ros/rosdistro/blob/7227f5296931ec2e22fb6e6c0b27bb0c15d6efa5/rosdep/base.yaml#L1925