### PR TITLE
Fix build break with libstdc++ versioning enabled

### DIFF
--- a/third-party/realsense-file/rosbag/roscpp_traits/include/ros/message_forward.h
+++ b/third-party/realsense-file/rosbag/roscpp_traits/include/ros/message_forward.h
@@ -30,19 +30,7 @@
 
 // Make sure that either __GLIBCXX__ or _LIBCPP_VERSION is defined.
 #include <cstddef>
-
-// C++ standard section 17.4.3.1/1 states that forward declarations of STL types
-// that aren't specializations involving user defined types results in undefined
-// behavior. Apparently only libc++ has a problem with this and won't compile it.
-#ifndef _LIBCPP_VERSION
-namespace std
-{
-template<typename T> class allocator;
-template<typename T> class shared_ptr;
-}
-#else
 #include <memory>
-#endif
 
 //
 //namespace boost


### PR DESCRIPTION
Stop violating the C++ standard's rules here; instead include the relevant header. This avoids a build break when using a standard library implementation that uses an inline namespace within 'std' for versioning purposes (which includes some configurations of libstdc++ in addition to libc++).