### PR TITLE
Fix box_dimensioner_multicam python example

### DIFF
--- a/wrappers/python/examples/box_dimensioner_multicam/realsense_device_manager.py
+++ b/wrappers/python/examples/box_dimensioner_multicam/realsense_device_manager.py
@@ -197,28 +197,27 @@ class DeviceManager:
 
     def poll_frames(self):
         """
-        Poll for frames from the enabled Intel RealSense devices.
+        Poll for frames from the enabled Intel RealSense devices. This will return at least one frame from each device. 
         If temporal post processing is enabled, the depth stream is averaged over a certain amount of frames
-
+        
         Parameters:
         -----------
-
         """
         frames = {}
-        for (serial, device) in self._enabled_devices.items():
-            streams = device.pipeline_profile.get_streams()
-            frameset = rs.composite_frame(rs.frame())
-            device.pipeline.poll_for_frames(frameset)
-            if frameset.size() == len(streams):
-                frames[serial] = {}
-                for stream in streams:
-                    if (rs.stream.infrared == stream.stream_type()):
-                        frame = frameset.get_infrared_frame(stream.stream_index())
-                        key_ = (stream.stream_type(), stream.stream_index())
-                    else:
-                        frame = frameset.first_or_default(stream.stream_type())
-                        key_ = stream.stream_type()
-                    frames[serial][key_] = frame
+        while len(frames) < len(self._enabled_devices.items()) :
+            for (serial, device) in self._enabled_devices.items():
+                streams = device.pipeline_profile.get_streams()
+                frameset = device.pipeline.poll_for_frames() #frameset will be a pyrealsense2.composite_frame object
+                if frameset.size() == len(streams):
+                    frames[serial] = {}
+                    for stream in streams:
+                        if (rs.stream.infrared == stream.stream_type()):
+                            frame = frameset.get_infrared_frame(stream.stream_index())
+                            key_ = (stream.stream_type(), stream.stream_index())
+                        else:
+                            frame = frameset.first_or_default(stream.stream_type())
+                            key_ = stream.stream_type()
+                        frames[serial][key_] = frame
 
         return frames
 


### PR DESCRIPTION
This PR updates box_dimensioner_multicam example to work with the latest pyrealsense2 api.


wappers/python/examples/box_dimensioner_multicam example does not work in v2.16.5

The error is:
Traceback (most recent call last):
  File "box_dimensioner_multicam_demo.py", line 143, in <module>
    run_demo()
  File "box_dimensioner_multicam_demo.py", line 52, in run_demo
    frames = device_manager.poll_frames()
  File "C:\work\projects\librealsense\wrappers\python\examples\box_dimensioner_multicam\realsense_device_manager.py", line 211, in poll_frames
    device.pipeline.poll_for_frames(frameset)
TypeError: poll_for_frames(): incompatible function arguments. The following argument types are supported:
    1. (self: pyrealsense2.pipeline) -> pyrealsense2.composite_frame

Invoked with: <pyrealsense2.pipeline object at 0x0000025294D13DF8>, <pyrealsense2.composite_frame object at 0x0000025294D13F80