### PR TITLE
Fixed the "must be a scalar" issue

### DIFF
--- a/wrappers/matlab/config.m
+++ b/wrappers/matlab/config.m
@@ -73,14 +73,14 @@ classdef config < handle
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
                         validateattributes(varargin{3}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'width', 4);
                         validateattributes(varargin{4}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'height', 5);
-                        validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.format.count}, '', 'format', 6);
+                        validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 6);
                         which = 'enable_stream#full';
                     end
                 case 7
                     validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
                     validateattributes(varargin{3}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'width', 4);
                     validateattributes(varargin{4}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'height', 5);
-                    validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.format.count}, '', 'format', 6);
+                    validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 6);
                     validateattributes(varargin{6}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'framerate', 7);
                     which = 'enable_stream#full';
             end


### PR DESCRIPTION
`realsense.format.count` cannot be compared with a scalar directly. MATLAB will pop out error message of "Value for <= must be a real scalar". It may cause some issues when a user wants to apply configs on the pipeline.
I changed  `validateattributes` statement in line 76 and 83 in the same manner as the one in line 21. That could solve this issue.