### PR TITLE
Support for D435 intrinsic calibration

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -580,7 +580,7 @@ namespace rs2
                                 if (value >= 0)
                                     value = (loffset < roffset) ? value - loffset : value + roffset;
                                 else
-                                    value = (loffset < roffset) ? value + loffset : value - roffset; 
+                                    value = (loffset < roffset) ? value + loffset : value - roffset;
                                 value = (value < range.min) ? range.min : value;
                                 value = (value > range.max) ? range.max : value;
                                 model.add_log(to_string() << "Setting " << opt << " to " << value);
@@ -5248,7 +5248,7 @@ namespace rs2
         }
     }
 
-    // Load viewer configuration for stereo module (depth/infrared streams) only 
+    // Load viewer configuration for stereo module (depth/infrared streams) only
     void device_model::load_viewer_configurations(const std::string& json_str)
     {
         json j = json::parse(json_str);

--- a/examples/callback/rs-callback.cpp
+++ b/examples/callback/rs-callback.cpp
@@ -42,7 +42,7 @@ int main(int argc, char * argv[]) try
     // Start streaming through the callback with default recommended configuration
     // The default video configuration contains Depth and Color streams
     // If a device is capable to stream IMU data, both Gyro and Accelerometer are enabled by default
-    // 
+    //
     rs2::pipeline_profile profiles = pipe.start(callback);
 
     // Collect the enabled streams names

--- a/examples/capture/rs-capture.cpp
+++ b/examples/capture/rs-capture.cpp
@@ -22,7 +22,7 @@ int main(int argc, char * argv[]) try
 
     // Start streaming with default recommended configuration
     // The default video configuration contains Depth and Color streams
-    // If a device is capable to stream IMU data, both Gyro and Accelerometer are enabled by default 
+    // If a device is capable to stream IMU data, both Gyro and Accelerometer are enabled by default
     pipe.start();
 
     while (app) // Application still alive?

--- a/examples/example.hpp
+++ b/examples/example.hpp
@@ -562,7 +562,7 @@ private:
         }
 
         return rv;
-    } 
+    }
 };
 
 // Struct for managing rotation of pointcloud view

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -168,7 +168,7 @@ namespace rs2
         void save(frame data, frame_source& source, bool do_signal=true)
         {
             software_device dev;
-            
+
             std::vector<std::tuple<software_sensor, stream_profile, int>> sensors;
             if (auto fs = data.as<frameset>()) {
                 int uid = 0;

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -927,7 +927,7 @@ namespace rs2
             else
             {
                 foreach([&f, index](const frame& frm) {
-                    if (frm.get_profile().stream_type() == RS2_STREAM_INFRARED && 
+                    if (frm.get_profile().stream_type() == RS2_STREAM_INFRARED &&
                         frm.get_profile().stream_index() == index) f = frm;
                 });
             }

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -270,7 +270,7 @@ namespace rs2
 
         operator rs2_options*() const { return (rs2_options*)get(); }
         rs2_processing_block* get() const { return _block.get(); }
-        
+
     protected:
         void register_simple_option(rs2_option option_id, option_range range) {
             rs2_error * e = nullptr;
@@ -689,7 +689,7 @@ namespace rs2
         * \param[in] smooth_alpha - defines the weight of the current pixel for smoothing is bounded within [25..100]%
         * \param[in] smooth_delta - defines the depth gradient below which the smoothing will occur as number of depth levels
         * \param[in] magnitude - number of filter iterations.
-        * \param[in] hole_fill - an in-place heuristic symmetric hole-filling mode applied horizontally during the filter passes. 
+        * \param[in] hole_fill - an in-place heuristic symmetric hole-filling mode applied horizontally during the filter passes.
         *                           Intended to rectify minor artefacts with minimal performance impact
         */
         spatial_filter(float smooth_alpha, float smooth_delta, float magnitude, float hole_fill) : filter(init(), 1)

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -51,7 +51,7 @@ namespace librealsense
         const auto texcoords = get_texture_coordinates();
         std::vector<float3> new_vertices;
         std::vector<std::tuple<uint8_t, uint8_t, uint8_t>> new_tex;
-        std::map<int, int> index2reducedIndex;
+        std::map<size_t, size_t> index2reducedIndex;
 
         new_vertices.reserve(get_vertex_count());
         new_tex.reserve(get_vertex_count());
@@ -72,7 +72,7 @@ namespace librealsense
         const auto threshold = 0.05f;
         auto width = video_stream_profile->get_width();
         std::vector<std::tuple<int, int, int>> faces;
-        for (int x = 0; x < width - 1; ++x) {
+        for (size_t x = 0; x < width - 1; ++x) {
             for (int y = 0; y < video_stream_profile->get_height() - 1; ++y) {
                 auto a = y * width + x, b = y * width + x + 1, c = (y + 1)*width + x, d = (y + 1)*width + x + 1;
                 if (vertices[a].z && vertices[b].z && vertices[c].z && vertices[d].z

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -51,7 +51,7 @@ namespace librealsense
         const auto texcoords = get_texture_coordinates();
         std::vector<float3> new_vertices;
         std::vector<std::tuple<uint8_t, uint8_t, uint8_t>> new_tex;
-        std::map<size_t, size_t> index2reducedIndex;
+        std::map<int, int> index2reducedIndex;
 
         new_vertices.reserve(get_vertex_count());
         new_tex.reserve(get_vertex_count());
@@ -72,7 +72,7 @@ namespace librealsense
         const auto threshold = 0.05f;
         auto width = video_stream_profile->get_width();
         std::vector<std::tuple<int, int, int>> faces;
-        for (size_t x = 0; x < width - 1; ++x) {
+        for (int x = 0; x < width - 1; ++x) {
             for (int y = 0; y < video_stream_profile->get_height() - 1; ++y) {
                 auto a = y * width + x, b = y * width + x + 1, c = (y + 1)*width + x, d = (y + 1)*width + x + 1;
                 if (vertices[a].z && vertices[b].z && vertices[c].z && vertices[d].z

--- a/src/backend.h
+++ b/src/backend.h
@@ -671,7 +671,7 @@ namespace librealsense
             virtual std::shared_ptr<time_service> create_time_service() const = 0;
 
             virtual std::shared_ptr<device_watcher> create_device_watcher() const = 0;
-            
+
             virtual std::string get_device_serial(uint16_t device_vid, uint16_t device_pid, const std::string& device_uid) const
             {
                 std::string empty_str;

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -172,7 +172,7 @@ namespace librealsense
         hid_ep->register_pixel_format(pf_accel_axes);
         hid_ep->register_pixel_format(pf_gyro_axes);
 
-        uint16_t pid = static_cast<uint16_t>(std::stoul(all_hid_infos.front().pid, nullptr, 16));
+        uint16_t pid = static_cast<uint16_t>(strtoul(all_hid_infos.front().pid.data(), nullptr, 16));
 
         if ((camera_fw_version >= firmware_version(custom_sensor_fw_ver)) && (!val_in_range(pid, { ds::RS400_IMU_PID, ds::RS435I_PID })))
         {

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -143,10 +143,6 @@ namespace librealsense
 
     rs2_motion_device_intrinsic ds5_motion::get_motion_intrinsics(rs2_stream stream) const
     {
-        // Evgeni
-        //if ((stream == RS2_STREAM_ACCEL) || (stream == RS2_STREAM_GYRO))
-        //    return create_motion_intrinsics(get_intrinsic(stream));
-
         if (stream == RS2_STREAM_ACCEL)
             return create_motion_intrinsics(*_accel_intrinsic);
 
@@ -155,47 +151,6 @@ namespace librealsense
 
         throw std::runtime_error(to_string() << "Motion Intrinsics unknown for stream " << rs2_stream_to_string(stream) << "!");
     }
-
-    //std::vector<uint8_t> ds5_motion::get_imu_eeprom_raw() const
-    //{
-    //    const int offset = 0;
-    //    const int size = ds::eeprom_imu_table_size;
-    //    command cmd(ds::MMER, offset, size);
-    //    return _hw_monitor->send(cmd);
-    //}
-
-    ////template<class T>
-    ////const T* check_calib(const std::vector<uint8_t>& raw_data)
-    //auto ds5_motion::get_imu_eeprom()
-    //{
-    //    // Read the calibration table format, and act accordingly
-    //    auto header = reinterpret_cast<const ds::table_header*>(*_imu_eeprom_raw);
-    //    switch (header->version)
-    //    {
-    //    case 1:
-    //        auto tm1_calib_tbl = ds::check_calib<ds::tm1_eeprom>(*_imu_eeprom_raw);
-    //        return *tm1_calib_tbl;
-    //    case 2:
-    //        auto dm_v2_calib_tbl = ds::check_calib<ds::dm_v2_eeprom>(*_imu_eeprom_raw);
-    //        return *dm_v2_calib_tbl;
-    //    default:
-    //        std::runtime_error(to_string() << "Motion Intrinsics unresolved, type: " << header->version <<  " !");
-    //    }
-    //}
-
-    //std::vector<uint8_t> ds5_motion::get_tm1_eeprom_raw() const
-    //{
-    //    const int offset = 0;
-    //    const int size = ds::tm1_eeprom_size;
-    //    command cmd(ds::MMER, offset, size);
-    //    return _hw_monitor->send(cmd);
-    //}
-
-    //ds::tm1_eeprom ds5_motion::get_tm1_eeprom() const
-    //{
-    //    auto table = ds::check_calib<ds::tm1_eeprom>(*_tm1_eeprom_raw);
-    //    return *table;
-    //}
 
     std::shared_ptr<hid_sensor> ds5_motion::create_hid_device(std::shared_ptr<context> ctx,
                                                                 const std::vector<platform::hid_device_info>& all_hid_infos,
@@ -286,16 +241,10 @@ namespace librealsense
     {
         using namespace ds;
 
-        //_tm1_eeprom_raw = [this]() { return get_tm1_eeprom_raw(); };
-        //_imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
-        //_tm1_eeprom = [this]() { return *_imu_eeprom_raw; };
-
         _mm_calib = std::make_shared<mm_calib_handler>(_hw_monitor);
 
         _accel_intrinsic = [this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); };
         _gyro_intrinsic = [this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); };
-        //_accel_intrinsic = [this]() { return (*_tm1_eeprom).calibration_table.imu_calib_table.accel_intrinsics; };
-        //_gyro_intrinsic = [this](){ return (*_tm1_eeprom).calibration_table.imu_calib_table.gyro_intrinsics; };
 
         std::string motion_module_fw_version = "";
         if (_fw_version >= firmware_version("5.5.8.0"))
@@ -375,9 +324,6 @@ namespace librealsense
 
         _fisheye_calibration_table_raw = [this]()
         {
-            // Evgeni TODO
-            //uint8_t* fe_calib_ptr = reinterpret_cast<uint8_t*>(&(*_tm1_eeprom).calibration_table.calib_model.fe_calibration);
-            //return std::vector<uint8_t>(fe_calib_ptr, fe_calib_ptr+ fisheye_calibration_table_size);
             return _mm_calib->get_fisheye_calib_raw();
         };
 
@@ -476,25 +422,6 @@ namespace librealsense
         return _hw_monitor->send(cmd);
     }
 
-    //auto mm_calib_handler::get_imu_eeprom()
-    //{
-    //    // Read the calibration table format, and act accordingly
-    //    //auto header = reinterpret_cast<const ds::table_header*>(*_imu_eeprom_raw);
-    //    auto data = *_imu_eeprom_raw;
-    //    auto header = reinterpret_cast<ds::table_header*>(&data);
-    //    switch (header->version)
-    //    {
-    //    case 1:
-    //        auto tm1_calib_tbl = ds::check_calib<ds::tm1_eeprom>(*_imu_eeprom_raw);
-    //        return tm1_calib_tbl;
-    //    case 2:
-    //        auto dm_v2_calib_tbl = ds::check_calib<ds::dm_v2_eeprom>(*_imu_eeprom_raw);
-    //        return dm_v2_calib_tbl;
-    //    default:
-    //        std::runtime_error(to_string() << "Motion Intrinsics unresolved, type: " << header->version << " !");
-    //    }
-    //}
-
     ds::imu_intrinsic mm_calib_handler::get_intrinsic(rs2_stream stream)
     {
 
@@ -512,12 +439,4 @@ namespace librealsense
         uint8_t* fe_calib_ptr = reinterpret_cast<uint8_t*>(&fe_calib_table);
         return std::vector<uint8_t>(fe_calib_ptr, fe_calib_ptr+ ds::fisheye_calibration_table_size);
     }
-
-    //const std::vector<uint8_t>& mm_calib_handler::get_fisheye_calib()
-    //{
-    //    // TODO Evgeni
-    //    ds::tm1_eeprom a;
-    //    return a.calibration_table.calib_model.fe_calibration;
-    //    //auto fe_calib = (*_tm1_eeprom).calibration_table.calib_model.fe_calibration;
-    //}
 }

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -270,7 +270,7 @@ namespace librealsense
             }
             catch (const std::exception &exc)
             {
-                LOG_ERROR("IMU Extrinsic table " << exc.what());
+                LOG_INFO("IMU EEPROM extrinsic is not available" << exc.what());
                 throw;
             }
         });
@@ -306,8 +306,8 @@ namespace librealsense
                     }
                 };
             }
-            catch (...){
-                std::cout << "No depth->imu extrinsic" << std::endl;
+            catch (const std::exception& ex){
+                LOG_INFO("Motion Module extrinsic calibration  is not available, report: " << ex.what());
             }
 
             try
@@ -322,7 +322,7 @@ namespace librealsense
             }
             catch (const std::exception& ex)
             {
-                LOG_INFO("Motion Module calibration is not available, report: " << ex.what());
+                LOG_INFO("Motion Module intrinsic calibration is not available, report: " << ex.what());
 
                 // transform IMU axes if supported
                 hid_ep->register_on_before_frame_callback(align_imu_axes);

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -7,6 +7,159 @@
 
 namespace librealsense
 {
+    class mm_calib_parser
+    {
+    public:
+        virtual rs2_extrinsics get_extrinsic_to(rs2_stream) = 0;    // Extrinsics are referenced to the Depth stream, except for TM1
+        virtual ds::imu_intrinsic get_intrinsic(rs2_stream) = 0;    // With extrinsic from FE<->IMU only
+        //const std::vector<uint8_t>& get_raw_data()  = 0;
+    };
+
+    class tm1_imu_calib_parser : public mm_calib_parser
+    {
+    public:
+        tm1_imu_calib_parser(const std::vector<uint8_t>& raw_data)
+        {
+            calib_table = *(ds::check_calib<ds::tm1_eeprom>(raw_data));
+        };
+        tm1_imu_calib_parser(const tm1_imu_calib_parser&);
+        ~tm1_imu_calib_parser(){};
+
+        rs2_extrinsics get_extrinsic_to(rs2_stream stream)
+        {
+            if (!(RS2_STREAM_ACCEL == stream) && !(RS2_STREAM_GYRO == stream) && !(RS2_STREAM_FISHEYE == stream))
+                std::runtime_error(to_string() << "TM1 Calibration does not provide extrinsic for : " << rs2_stream_to_string(stream) << " !");
+
+            auto fe_calib = calib_table.calibration_table.calib_model.fe_calibration;
+
+            auto rot = fe_calib.fisheye_to_imu.rotation;
+            auto trans = fe_calib.fisheye_to_imu.translation;
+
+            pose ex = { { rot(0,0), rot(1,0),rot(2,0),rot(0,1), rot(1,1),rot(2,1),rot(0,2), rot(1,2),rot(2,2) },
+            { trans[0], trans[1], trans[2] } };
+
+            if (RS2_STREAM_FISHEYE == stream)
+                return inverse(from_pose(ex));
+            else
+                return from_pose(ex);
+        };
+
+        ds::imu_intrinsic get_intrinsic(rs2_stream stream)
+        {
+            ds::imu_intrinsics in_intr;
+            switch (stream)
+            {
+            case RS2_STREAM_ACCEL:
+                in_intr = calib_table.calibration_table.imu_calib_table.accel_intrinsics; break;
+            case RS2_STREAM_GYRO:
+                in_intr = calib_table.calibration_table.imu_calib_table.gyro_intrinsics; break;
+            default:
+                std::runtime_error(to_string() << "TM1 IMU Calibration does not support intrinsic for : " << rs2_stream_to_string(stream) << " !");
+            }
+            ds::imu_intrinsic out_intr{};
+            for (auto i = 0; i < 3; i++)
+            {
+                out_intr.sensitivity(i,i)  = in_intr.bias[i];
+                out_intr.bias[i]            = in_intr.bias[i];
+            }
+            return out_intr;
+        }
+
+    private:
+        ds::tm1_eeprom  calib_table;
+    };
+
+    class dm_v2_imu_calib_parser : public mm_calib_parser
+    {
+    public:
+        dm_v2_imu_calib_parser(const std::vector<uint8_t>& raw_data)
+        {
+            calib_table = *(ds::check_calib<ds::dm_v2_eeprom>(raw_data));
+        };
+        dm_v2_imu_calib_parser(const dm_v2_imu_calib_parser&);
+        ~dm_v2_imu_calib_parser() {};
+
+        rs2_extrinsics get_extrinsic_to(rs2_stream stream)
+        {
+            if (!(RS2_STREAM_ACCEL == stream) && !(RS2_STREAM_GYRO == stream))
+                std::runtime_error(to_string() << "TM1 Calibration does not provide extrinsic for : " << rs2_stream_to_string(stream) << " !");
+
+            // The extrinsic is stored as array of floats / little-endian
+            rs2_extrinsics extr;
+            librealsense::copy(&extr, &calib_table.module_info.dm_v2_calib_table.depth_to_imu, sizeof(rs2_extrinsics));
+            return extr;
+        };
+
+        ds::imu_intrinsic get_intrinsic(rs2_stream stream)
+        {
+            ds::dm_v2_imu_intrinsic in_intr;
+            switch (stream)
+            {
+                case RS2_STREAM_ACCEL:
+                    in_intr = calib_table.module_info.dm_v2_calib_table.accel_intrinsic; break;
+                case RS2_STREAM_GYRO:
+                    in_intr = calib_table.module_info.dm_v2_calib_table.gyro_intrinsic; break;
+                default:
+                    std::runtime_error(to_string() << "Depth Module V2 does not provide intrinsic for stream type : " << rs2_stream_to_string(stream) << " !");
+            }
+            
+            //ds::imu_intrinsic out_intr{ in_intr.sensitivity, in_intr.bias, {0,0,0}, {0,0,0} };
+            return { in_intr.sensitivity, in_intr.bias, {0,0,0}, {0,0,0} };
+        }
+
+    private:
+        ds::dm_v2_eeprom  calib_table;
+    };
+
+
+    class mm_calib_handler
+    {
+    public:
+        mm_calib_handler(std::shared_ptr<hw_monitor> hw_monitor) :
+            _hw_monitor(hw_monitor)
+        {
+            _imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
+            _calib_parser = [this]() {
+                auto calib_header = reinterpret_cast<const ds::table_header*>((*_imu_eeprom_raw).data());
+                std::shared_ptr<mm_calib_parser> prs = nullptr;
+                switch (calib_header->version)
+                {
+                    case 1:
+                        prs = std::make_shared<tm1_imu_calib_parser>(*_imu_eeprom_raw);
+                    case 2:
+                        prs = std::make_shared<dm_v2_imu_calib_parser>(*_imu_eeprom_raw);
+                    default:
+                        std::runtime_error(to_string() << "Motion Intrinsics unresolved, type: " << calib_header->version <<  " !");
+                }
+                return prs;
+            };
+        };
+        mm_calib_handler(const mm_calib_handler&);
+        ~mm_calib_handler() {};
+
+        ds::imu_intrinsic get_intrinsic(rs2_stream);
+        rs2_extrinsics get_extrinsic(rs2_stream);       // The extrinsic defined as Depth->Stream rigid-body transfom.
+        const std::vector<uint8_t> get_fisheye_calib_raw();
+        //const std::vector<uint8_t>& get_fisheye_calib();
+
+    private:
+        std::shared_ptr<hw_monitor> _hw_monitor;
+        lazy< std::shared_ptr<mm_calib_parser>> _calib_parser;
+        lazy<std::vector<uint8_t>>      _imu_eeprom_raw;
+        std::vector<uint8_t>            get_imu_eeprom_raw() const;
+        lazy<std::vector<uint8_t>>      _fisheye_calibration_table_raw;
+        /*optional_value<uint8_t> _fisheye_device_idx;
+        optional_value<uint8_t> _motion_module_device_idx;*/
+        //lazy<std::vector<uint8_t>>      _tm1_eeprom_raw;
+        //lazy<ds::tm1_eeprom>            _tm1_eeprom;
+        //lazy<ds::eeprom_imu_table>      _imu_eeprom;
+        //std::shared_ptr<lazy<rs2_extrinsics>> _fisheye_to_imu;
+        //std::shared_ptr<lazy<rs2_extrinsics>> _depth_to_imu;
+        //ds::tm1_eeprom                get_tm1_eeprom() const;
+        //std::vector<uint8_t>          get_tm1_eeprom_raw() const;
+        //auto                            get_imu_eeprom();
+    };
+
     class ds5_motion : public virtual ds5_device
     {
     public:
@@ -22,6 +175,9 @@ namespace librealsense
         std::shared_ptr<auto_exposure_mechanism> register_auto_exposure_options(uvc_sensor* uvc_ep,
                                                                                 const platform::extension_unit* fisheye_xu);
 
+        //const std::vector<uint8_t>&   get_fisheye_raw_calib(void) const { return _mm_calib->get_fisheye_raw(); };
+        //ds::imu_intrinsic get_intrinsic(rs2_stream stream) const { return _mm_calib.get_intrinsic(stream); };
+
     private:
 
         friend class ds5_fisheye_sensor;
@@ -32,17 +188,25 @@ namespace librealsense
         optional_value<uint8_t> _fisheye_device_idx;
         optional_value<uint8_t> _motion_module_device_idx;
 
-        lazy<std::vector<uint8_t>>      _tm1_eeprom_raw;
-        lazy<ds::tm1_eeprom>            _tm1_eeprom;
-        lazy<ds::imu_intrinsics>        _accel_intrinsics;
-        lazy<ds::imu_intrinsics>        _gyro_intrinsics;
-        std::shared_ptr<lazy<rs2_extrinsics>> _fisheye_to_imu;
-        std::shared_ptr<lazy<rs2_extrinsics>> _depth_to_imu;
-
-        ds::tm1_eeprom        get_tm1_eeprom() const;
-        std::vector<uint8_t>  get_tm1_eeprom_raw() const;
-
-        lazy<std::vector<uint8_t>>      _fisheye_calibration_table_raw;
+        //mutable mm_calib_handler                    _mm_calib;
+        std::shared_ptr<mm_calib_handler>        _mm_calib;
+        lazy<ds::imu_intrinsic>                 _accel_intrinsic;
+        lazy<ds::imu_intrinsic>                 _gyro_intrinsic;
+        lazy<std::vector<uint8_t>>              _fisheye_calibration_table_raw;
+        std::shared_ptr<lazy<rs2_extrinsics>>   _depth_to_imu;
+        
+        ////lazy<std::vector<uint8_t>>      _tm1_eeprom_raw;
+        //lazy<std::vector<uint8_t>>      _imu_eeprom_raw;
+        //lazy<ds::tm1_eeprom>            _tm1_eeprom;
+        ////lazy<ds::eeprom_imu_table>      _imu_eeprom;
+        
+        //std::shared_ptr<lazy<rs2_extrinsics>> _fisheye_to_imu;
+        
+        //ds::tm1_eeprom                get_tm1_eeprom() const;
+        //std::vector<uint8_t>          get_tm1_eeprom_raw() const;
+        /*std::vector<uint8_t>            get_imu_eeprom_raw() const;
+        auto                            get_imu_eeprom();*/
+        
 
 #ifdef _WIN32
         // Bandwidth parameters from BOSCH BMI 055 spec'

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -5,7 +5,6 @@
 
 #include "ds5-device.h"
 #include <fstream>
-#include <iostream>
 
 namespace librealsense
 {

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -219,7 +219,7 @@ namespace librealsense
                                                             {RS2_STREAM_GYRO, {{200,  500},
                                                                                {400,  250}}}};
 
-#else                                                                  
+#else
         // Bandwidth parameters from BOSCH BMI 055 spec'
         std::vector<std::pair<std::string, stream_profile>> sensor_name_and_hid_profiles =
         {{"gyro_3d",  {RS2_STREAM_GYRO,  0, 1, 1, 200,  RS2_FORMAT_MOTION_XYZ32F}},

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -12,7 +12,6 @@ namespace librealsense
     public:
         virtual rs2_extrinsics get_extrinsic_to(rs2_stream) = 0;    // Extrinsics are referenced to the Depth stream, except for TM1
         virtual ds::imu_intrinsic get_intrinsic(rs2_stream) = 0;    // With extrinsic from FE<->IMU only
-        //const std::vector<uint8_t>& get_raw_data()  = 0;
     };
 
     class tm1_imu_calib_parser : public mm_calib_parser
@@ -102,8 +101,7 @@ namespace librealsense
                 default:
                     std::runtime_error(to_string() << "Depth Module V2 does not provide intrinsic for stream type : " << rs2_stream_to_string(stream) << " !");
             }
-            
-            //ds::imu_intrinsic out_intr{ in_intr.sensitivity, in_intr.bias, {0,0,0}, {0,0,0} };
+
             return { in_intr.sensitivity, in_intr.bias, {0,0,0}, {0,0,0} };
         }
 
@@ -140,7 +138,6 @@ namespace librealsense
         ds::imu_intrinsic get_intrinsic(rs2_stream);
         rs2_extrinsics get_extrinsic(rs2_stream);       // The extrinsic defined as Depth->Stream rigid-body transfom.
         const std::vector<uint8_t> get_fisheye_calib_raw();
-        //const std::vector<uint8_t>& get_fisheye_calib();
 
     private:
         std::shared_ptr<hw_monitor> _hw_monitor;
@@ -148,16 +145,6 @@ namespace librealsense
         lazy<std::vector<uint8_t>>      _imu_eeprom_raw;
         std::vector<uint8_t>            get_imu_eeprom_raw() const;
         lazy<std::vector<uint8_t>>      _fisheye_calibration_table_raw;
-        /*optional_value<uint8_t> _fisheye_device_idx;
-        optional_value<uint8_t> _motion_module_device_idx;*/
-        //lazy<std::vector<uint8_t>>      _tm1_eeprom_raw;
-        //lazy<ds::tm1_eeprom>            _tm1_eeprom;
-        //lazy<ds::eeprom_imu_table>      _imu_eeprom;
-        //std::shared_ptr<lazy<rs2_extrinsics>> _fisheye_to_imu;
-        //std::shared_ptr<lazy<rs2_extrinsics>> _depth_to_imu;
-        //ds::tm1_eeprom                get_tm1_eeprom() const;
-        //std::vector<uint8_t>          get_tm1_eeprom_raw() const;
-        //auto                            get_imu_eeprom();
     };
 
     class ds5_motion : public virtual ds5_device
@@ -175,9 +162,6 @@ namespace librealsense
         std::shared_ptr<auto_exposure_mechanism> register_auto_exposure_options(uvc_sensor* uvc_ep,
                                                                                 const platform::extension_unit* fisheye_xu);
 
-        //const std::vector<uint8_t>&   get_fisheye_raw_calib(void) const { return _mm_calib->get_fisheye_raw(); };
-        //ds::imu_intrinsic get_intrinsic(rs2_stream stream) const { return _mm_calib.get_intrinsic(stream); };
-
     private:
 
         friend class ds5_fisheye_sensor;
@@ -188,25 +172,11 @@ namespace librealsense
         optional_value<uint8_t> _fisheye_device_idx;
         optional_value<uint8_t> _motion_module_device_idx;
 
-        //mutable mm_calib_handler                    _mm_calib;
         std::shared_ptr<mm_calib_handler>        _mm_calib;
         lazy<ds::imu_intrinsic>                 _accel_intrinsic;
         lazy<ds::imu_intrinsic>                 _gyro_intrinsic;
         lazy<std::vector<uint8_t>>              _fisheye_calibration_table_raw;
         std::shared_ptr<lazy<rs2_extrinsics>>   _depth_to_imu;
-        
-        ////lazy<std::vector<uint8_t>>      _tm1_eeprom_raw;
-        //lazy<std::vector<uint8_t>>      _imu_eeprom_raw;
-        //lazy<ds::tm1_eeprom>            _tm1_eeprom;
-        ////lazy<ds::eeprom_imu_table>      _imu_eeprom;
-        
-        //std::shared_ptr<lazy<rs2_extrinsics>> _fisheye_to_imu;
-        
-        //ds::tm1_eeprom                get_tm1_eeprom() const;
-        //std::vector<uint8_t>          get_tm1_eeprom_raw() const;
-        /*std::vector<uint8_t>            get_imu_eeprom_raw() const;
-        auto                            get_imu_eeprom();*/
-        
 
 #ifdef _WIN32
         // Bandwidth parameters from BOSCH BMI 055 spec'

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -175,8 +175,8 @@ namespace librealsense
     }
 
     enable_motion_correction::enable_motion_correction(sensor_base* mm_ep,
-                                                       const ds::imu_intrinsics& accel,
-                                                       const ds::imu_intrinsics& gyro,
+                                                       const ds::imu_intrinsic& accel,
+                                                       const ds::imu_intrinsic& gyro,
                                                        const option_range& opt_range)
         : option_base(opt_range), _is_enabled(true), _accel(accel), _gyro(gyro)
     {
@@ -187,7 +187,8 @@ namespace librealsense
             {
                 auto xyz = (float*)(fr->get_frame_data());
 
-                if (stream == RS2_STREAM_ACCEL)
+                // Evgeni TODO
+               /* if (stream == RS2_STREAM_ACCEL)
                 {
                     for (int i = 0; i < 3; i++)
                         xyz[i] = xyz[i] * _accel.scale[i] - _accel.bias[i];
@@ -197,7 +198,7 @@ namespace librealsense
                 {
                     for (int i = 0; i < 3; i++)
                         xyz[i] = xyz[i] * _gyro.scale[i] - _gyro.bias[i];
-                }
+                }*/
             }
         });
     }

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -177,30 +177,37 @@ namespace librealsense
     enable_motion_correction::enable_motion_correction(sensor_base* mm_ep,
                                                        const ds::imu_intrinsic& accel,
                                                        const ds::imu_intrinsic& gyro,
+                                                       //const rs2_extrinsics& depth_to_imu,
+                                                       std::shared_ptr<librealsense::lazy<rs2_extrinsics>> depth_to_imu,
+                                                       on_before_frame_callback frame_callback,
                                                        const option_range& opt_range)
-        : option_base(opt_range), _is_enabled(true), _accel(accel), _gyro(gyro)
+        : option_base(opt_range), _is_enabled(true), _accel(accel), _gyro(gyro)//, _depth_to_imu(depth_to_imu->)
     {
         mm_ep->register_on_before_frame_callback(
-                    [this](rs2_stream stream, frame_interface* fr, callback_invocation_holder callback)
-        {
-            if (_is_enabled.load() && fr->get_stream()->get_format() == RS2_FORMAT_MOTION_XYZ32F)
+            [this, frame_callback](rs2_stream stream, frame_interface* fr, callback_invocation_holder callback)
             {
-                auto xyz = (float*)(fr->get_frame_data());
-
-                // Evgeni TODO
-               /* if (stream == RS2_STREAM_ACCEL)
+                if (_is_enabled.load() && fr->get_stream()->get_format() == RS2_FORMAT_MOTION_XYZ32F)
                 {
-                    for (int i = 0; i < 3; i++)
-                        xyz[i] = xyz[i] * _accel.scale[i] - _accel.bias[i];
+                    auto xyz = (float*)(fr->get_frame_data());
+
+                    // Evgeni TODO
+                    /*if (stream == RS2_STREAM_ACCEL)
+                    {
+                        for (int i = 0; i < 3; i++)
+                            xyz[i] = xyz[i] * _accel.scale[i] - _accel.bias[i];
+                    }
+
+                    if (stream == RS2_STREAM_GYRO)
+                    {
+                        for (int i = 0; i < 3; i++)
+                            xyz[i] = xyz[i] * _gyro.scale[i] - _gyro.bias[i];
+                    }*/
                 }
 
-                if (stream == RS2_STREAM_GYRO)
-                {
-                    for (int i = 0; i < 3; i++)
-                        xyz[i] = xyz[i] * _gyro.scale[i] - _gyro.bias[i];
-                }*/
-            }
-        });
+                // Align IMU axes to the established Coordinates System
+                if (frame_callback)
+                    frame_callback(stream, fr, std::move(callback));
+            });
     }
 
     void enable_auto_exposure_option::set(float value)

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -71,12 +71,16 @@ namespace librealsense
         enable_motion_correction(sensor_base* mm_ep,
                                  const ds::imu_intrinsic& accel,
                                  const ds::imu_intrinsic& gyro,
+                                 //const rs2_extrinsics& depth_to_imu,
+                                 std::shared_ptr<librealsense::lazy<rs2_extrinsics>> depth_to_imu,
+                                 on_before_frame_callback frame_callback,
                                  const option_range& opt_range);
 
     private:
         std::atomic<bool>   _is_enabled;
         ds::imu_intrinsic   _accel;
         ds::imu_intrinsic   _gyro;
+        rs2_extrinsics      _depth_to_imu;
     };
 
     class enable_auto_exposure_option : public option_base

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -243,8 +243,8 @@ namespace librealsense
         virtual float query() const override;
         virtual option_range get_range() const override;
         virtual bool is_enabled() const override { return true; }
-        virtual const char* get_description() const override 
-        { 
+        virtual const char* get_description() const override
+        {
             return "Emitter On/Off Mode: 0:disabled(default), 1:enabled(emitter toggles between on and off). Can only be set before streaming";
         }
         virtual void enable_recording(std::function<void(const option &)> record_action) {_record_action = record_action;}

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -69,14 +69,14 @@ namespace librealsense
         }
 
         enable_motion_correction(sensor_base* mm_ep,
-                                 const ds::imu_intrinsics& accel,
-                                 const ds::imu_intrinsics& gyro,
+                                 const ds::imu_intrinsic& accel,
+                                 const ds::imu_intrinsic& gyro,
                                  const option_range& opt_range);
 
     private:
-        std::atomic<bool>  _is_enabled;
-        ds::imu_intrinsics _accel;
-        ds::imu_intrinsics _gyro;
+        std::atomic<bool>   _is_enabled;
+        ds::imu_intrinsic   _accel;
+        ds::imu_intrinsic   _gyro;
     };
 
     class enable_auto_exposure_option : public option_base

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -71,7 +71,6 @@ namespace librealsense
         enable_motion_correction(sensor_base* mm_ep,
                                  const ds::imu_intrinsic& accel,
                                  const ds::imu_intrinsic& gyro,
-                                 //const rs2_extrinsics& depth_to_imu,
                                  std::shared_ptr<librealsense::lazy<rs2_extrinsics>> depth_to_imu,
                                  on_before_frame_callback frame_callback,
                                  const option_range& opt_range);

--- a/src/ds5/ds5-private.cpp
+++ b/src/ds5/ds5-private.cpp
@@ -68,7 +68,7 @@ namespace librealsense
                 intrinsics.model = RS2_DISTORTION_BROWN_CONRADY;
                 memset(intrinsics.coeffs, 0, sizeof(intrinsics.coeffs));  // All coefficients are zeroed since rectified depth is defined as CS origin
 
-                // In case of the special 848x100 resolution adjust the intrinsics 
+                // In case of the special 848x100 resolution adjust the intrinsics
                 if (width == 848 && height == 100)
                 {
                     intrinsics.height = 100;
@@ -85,7 +85,7 @@ namespace librealsense
                 rs2_intrinsics intrinsics;
                 intrinsics.width = width;
                 intrinsics.height = height;
-                
+
                 auto rect_params = static_cast<const float4>(table->rect_params[resolution]);
                 // DS5U - assume ideal intrinsic params
                 if ((rect_params.x == rect_params.y) && (rect_params.z == rect_params.w))

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -282,10 +282,20 @@ namespace librealsense
             float3              translation;
         };
 
+        // TODO Evgeni - remove this as obsolete -need to check recorder/playback
         struct imu_intrinsics
         {
             float bias[3];
             float scale[3];
+        };
+
+        // Note that the intrinsic definition follows rs2_motion_device_intrinsic with different data layout
+        struct imu_intrinsic
+        {
+            float3x3    sensitivity;
+            float3      bias;
+            float3      noise_variances;  /**< Variance of noise for X, Y, and Z axis */
+            float3      bias_variances;   /**< Variance of bias for X, Y, and Z axis */
         };
 
         struct fisheye_calibration_table
@@ -365,6 +375,48 @@ namespace librealsense
 
         constexpr size_t tm1_eeprom_size = sizeof(tm1_eeprom);
 
+        struct dm_v2_imu_intrinsic
+        {
+            float3x3            sensitivity;
+            float3              bias;
+        };
+
+        struct dm_v2_calibration_table
+        {
+            table_header            header;
+            extrinsics_table        depth_to_imu;       // The extrinsic parameters of IMU persented in Depth sensor's CS
+            dm_v2_imu_intrinsic     accel_intrinsic;
+            dm_v2_imu_intrinsic     gyro_intrinsic;
+            uint8_t                 reserved[96];
+        };
+
+        constexpr size_t dm_v2_calibration_table_size = sizeof(dm_v2_calibration_table);
+
+        struct dm_v2_calib_info
+        {
+            table_header            header;
+            dm_v2_calibration_table dm_v2_calib_table;
+            tm1_serial_num_table    serial_num_table;
+        };
+
+        constexpr size_t dm_v2_calib_info_size = sizeof(dm_v2_calib_info);
+
+        // Depth Module V2 IMU EEPROM ver 0.52
+        struct dm_v2_eeprom
+        {
+            table_header            header;
+            dm_v2_calib_info        module_info;
+        };
+
+        constexpr size_t dm_v2_eeprom_size = sizeof(dm_v2_eeprom);
+
+        union eeprom_imu_table {
+            tm1_eeprom      tm1_table;
+            dm_v2_eeprom    dm_v2_table;
+        };
+
+        constexpr size_t eeprom_imu_table_size = sizeof(eeprom_imu_table);
+
         struct depth_table_control
         {
             uint32_t depth_units;
@@ -395,15 +447,29 @@ namespace librealsense
         };
 
 
-        inline rs2_motion_device_intrinsic create_motion_intrinsics(imu_intrinsics data)
+        inline rs2_motion_device_intrinsic create_motion_intrinsics(imu_intrinsic data)
         {
             rs2_motion_device_intrinsic result;
-            memset(&result, 0, sizeof(result));
+            //float3x3    sensitivity;
+            //float3      bias;
+            //float3      noise_variances;  /**< Variance of noise for X, Y, and Z axis */
+            //float3      bias_variances;   /**< Variance of bias for X, Y, and Z axis */
+            // Evgeni
+            for (int i = 0; i < 3; i++)
+            {
+                for (int j = 0; j < 3; j++)
+                    result.data[i][j] = data.sensitivity(i,j);
+
+                result.bias_variances[i] = data.bias_variances[i];
+                result.noise_variances[i] = data.noise_variances[i];
+            }
+            
+            /*memset(&result, 0, sizeof(result));
             for (int i = 0; i < 3; i++)
             {
                 result.data[i][3] = data.bias[i];
                 result.data[i][i] = data.scale[i];
-            }
+            }*/
             return result;
         }
 

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -282,7 +282,6 @@ namespace librealsense
             float3              translation;
         };
 
-        // TODO Evgeni - remove this as obsolete -need to check recorder/playback
         struct imu_intrinsics
         {
             float bias[3];
@@ -384,10 +383,13 @@ namespace librealsense
         struct dm_v2_calibration_table
         {
             table_header            header;
+            uint8_t                 extrinsic_valid;
+            uint8_t                 intrinsic_valid;
+            uint8_t                 reserved[2];
             extrinsics_table        depth_to_imu;       // The extrinsic parameters of IMU persented in Depth sensor's CS
             dm_v2_imu_intrinsic     accel_intrinsic;
             dm_v2_imu_intrinsic     gyro_intrinsic;
-            uint8_t                 reserved[96];
+            uint8_t                 reserved1[96];
         };
 
         constexpr size_t dm_v2_calibration_table_size = sizeof(dm_v2_calibration_table);
@@ -450,11 +452,7 @@ namespace librealsense
         inline rs2_motion_device_intrinsic create_motion_intrinsics(imu_intrinsic data)
         {
             rs2_motion_device_intrinsic result;
-            //float3x3    sensitivity;
-            //float3      bias;
-            //float3      noise_variances;  /**< Variance of noise for X, Y, and Z axis */
-            //float3      bias_variances;   /**< Variance of bias for X, Y, and Z axis */
-            // Evgeni
+            
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 3; j++)
@@ -463,13 +461,6 @@ namespace librealsense
                 result.bias_variances[i] = data.bias_variances[i];
                 result.noise_variances[i] = data.noise_variances[i];
             }
-            
-            /*memset(&result, 0, sizeof(result));
-            for (int i = 0; i < 3; i++)
-            {
-                result.data[i][3] = data.bias[i];
-                result.data[i][i] = data.scale[i];
-            }*/
             return result;
         }
 

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -452,7 +452,7 @@ namespace librealsense
         inline rs2_motion_device_intrinsic create_motion_intrinsics(imu_intrinsic data)
         {
             rs2_motion_device_intrinsic result;
-            
+
             for (int i = 0; i < 3; i++)
             {
                 for (int j = 0; j < 3; j++)
@@ -463,8 +463,6 @@ namespace librealsense
             }
             return result;
         }
-
-
 
 #pragma pack(pop)
 

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -419,6 +419,12 @@ namespace librealsense
 
         constexpr size_t eeprom_imu_table_size = sizeof(eeprom_imu_table);
 
+        enum imu_eeprom_id : uint16_t
+        {
+            dm_v2_eeprom_id     = 0x0101,   // The pack alignment is Big-endian
+            tm1_eeprom_id       = 0x0002
+        };
+
         struct depth_table_control
         {
             uint32_t depth_units;

--- a/src/ds5/ds5-rolling-shutter.cpp
+++ b/src/ds5/ds5-rolling-shutter.cpp
@@ -39,7 +39,6 @@ namespace librealsense
             get_depth_sensor().register_pixel_format(pf_rgb888);
         }
 
-  
         get_depth_sensor().unregister_option(RS2_OPTION_EMITTER_ON_OFF);
 
         if ((_fw_version >= firmware_version("5.9.13.6") &&

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1,8 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
 
-#define _USE_MATH_DEFINES
-#include <cmath>
 #include "image.h"
 #include "image_avx.h"
 #include "types.h"
@@ -104,16 +102,7 @@ namespace librealsense
         using namespace librealsense;
         auto hid = (hid_data*)(source);
 
-        // The IMU sensor orientation shall be aligned with depth sensor's coordinate system
-        // Note that the implementation follows D435i installation pose and will require refactoring for other designs
-        // Reference spec: Bosch BMI055
         auto res= float3{ float(hid->x), float(hid->y), float(hid->z)} * float(factor);
-
-        if (RS2_FORMAT_MOTION_XYZ32F==FORMAT)
-        {
-            float3x3 rot = {{-1,0,0},{0,1,0},{0,0,-1}};
-            res=rot*res;
-        }
 
         librealsense::copy(dest[0], &res, sizeof(float3));
     }
@@ -132,8 +121,7 @@ namespace librealsense
     // Librealsense output format: floating point 32bit. units rad/sec,
     template<rs2_format FORMAT> void unpack_gyro_axes(byte * const dest[], const byte * source, int width, int height)
     {
-        static constexpr double deg2rad = M_PI / 180.;
-        static const double gyro_transform_factor = 0.1 * deg2rad;
+        static const double gyro_transform_factor = deg2rad(0.1);
 
         copy_hid_axes<FORMAT>(dest, source, gyro_transform_factor);
     }

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -681,8 +681,8 @@ namespace librealsense
             std::fstream sysfs_stream(path);
             if (!sysfs_stream.is_open())
             {
-                 throw linux_backend_exception(to_string() << "The specified sysfs entry "
-                            << path << " is not valid");
+                LOG_DEBUG("The specified sysfs entry "  << path << " is not valid");
+                 return res;
             }
 
             try

--- a/src/pipeline/aggregator.cpp
+++ b/src/pipeline/aggregator.cpp
@@ -51,7 +51,7 @@ namespace librealsense
                 {
                     sync_set.push_back(s.second.clone());
                     // send only the synchronized frames to the user callback
-                    if (std::find(_streams_to_sync_ids.begin(), _streams_to_sync_ids.end(), 
+                    if (std::find(_streams_to_sync_ids.begin(), _streams_to_sync_ids.end(),
                         s.second->get_stream()->get_unique_id()) != _streams_to_sync_ids.end())
                         async_set.push_back(s.second.clone());
                 }

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -314,5 +314,5 @@ namespace librealsense
             }
             return false;
         }
-    } 
+    }
 }

--- a/src/pipeline/resolver.h
+++ b/src/pipeline/resolver.h
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <cmath>
 #include <set>
-#include <iostream>
 #include "sensor.h"
 #include "types.h"
 #include "stream.h"

--- a/src/proc/align.cpp
+++ b/src/proc/align.cpp
@@ -180,7 +180,7 @@ namespace librealsense
         //process composite frame only if it contains both a depth frame and the requested texture frame
         bool has_tex = false, has_depth = false;
         set.foreach([this, &has_tex](const rs2::frame& frame) { if (frame.get_profile().stream_type() == _to_stream_type) has_tex = true; });
-        set.foreach([&has_depth](const rs2::frame& frame) 
+        set.foreach([&has_depth](const rs2::frame& frame)
             { if (frame.get_profile().stream_type() == RS2_STREAM_DEPTH && frame.get_profile().format() == RS2_FORMAT_Z16) has_depth = true; });
         if (!has_tex || !has_depth)
             return false;

--- a/src/proc/colorizer.cpp
+++ b/src/proc/colorizer.cpp
@@ -276,7 +276,7 @@ namespace librealsense
 
         if (_equalize)
             make_equalized_histogram(f, ret);
-        else 
+        else
             make_value_cropped_frame(f, ret);
 
         return ret;

--- a/src/proc/processing-blocks-factory.cpp
+++ b/src/proc/processing-blocks-factory.cpp
@@ -8,10 +8,10 @@
 namespace librealsense
 {
 #ifdef RS2_USE_CUDA
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)                                                               
-    { 
+    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
+    {
         return std::make_shared<librealsense::align_cuda>(align_to);
-    } 
+    }
 #else
 #ifdef __SSSE3__
     std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)

--- a/src/proc/rates_printer.h
+++ b/src/proc/rates_printer.h
@@ -4,7 +4,6 @@
 #pragma once
 #include "synthetic-stream.h"
 #include <iomanip>
-#include <iostream>
 #include <map>
 
 namespace librealsense

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -96,7 +96,7 @@ namespace librealsense
         // in case the input frame is a frameset, create an output frameset from the input frameset and the processed frame by the following heuristic:
         // if one of the input frames has the same stream type and format as the processed frame,
         //     remove the input frame from the output frameset (i.e. temporal filter), otherwise kepp the input frame (i.e. colorizer).
-        // the only exception is in case one of the input frames is z16 or disparity and the result frame is disparity or z16 respectively, 
+        // the only exception is in case one of the input frames is z16 or disparity and the result frame is disparity or z16 respectively,
         // in this case the the input frmae will be removed.
 
         if (results.empty())

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -22,7 +22,7 @@ EXPORTS
     rs2_delete_sensor_list
     rs2_create_sensor
     rs2_delete_sensor
-    
+
     rs2_get_extrinsics
     rs2_register_extrinsics
     rs2_get_motion_intrinsics
@@ -76,7 +76,7 @@ EXPORTS
     rs2_get_option_description
     rs2_get_option_value_description
     rs2_is_option_read_only
-    
+
     rs2_set_region_of_interest
     rs2_get_region_of_interest
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1499,7 +1499,7 @@ rs2_pipeline_profile* rs2_pipeline_start_with_config_and_callback_cpp(rs2_pipeli
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(callback);
 
-    return new rs2_pipeline_profile{ pipe->pipeline->start(config->config, 
+    return new rs2_pipeline_profile{ pipe->pipeline->start(config->config,
         { callback, [](rs2_frame_callback* p) { p->release(); } }) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe, config, callback)

--- a/src/types.h
+++ b/src/types.h
@@ -24,6 +24,8 @@
 #include <condition_variable>
 #include <functional>
 #include <utility>                          // For std::forward
+
+
 #include "backend.h"
 #include "concurrency.h"
 #if BUILD_EASYLOGGINGPP
@@ -37,6 +39,13 @@ const int RS2_USER_QUEUE_SIZE = 128;
 #ifndef DBL_EPSILON
 const double DBL_EPSILON = 2.2204460492503131e-016;  // smallest such that 1.0+DBL_EPSILON != 1.0
 #endif
+
+// Usage of non-standard C++ PI derivatives is prohibitive, use local definitions
+static const double pi = std::acos(-1);
+static const double d2r = pi / 180;
+static const double r2d = 180 / pi;
+template<typename T> T deg2rad(T val) { return T(val * d2r); };
+template<typename T> T rad2deg(T val) { return T(val * r2d); };
 
 #pragma warning(disable: 4250)
 
@@ -91,6 +100,19 @@ namespace librealsense
             }
         }
         return sizem * sizen;
+    }
+
+    // Comparing parameter against a range of values of the same type
+    // https://stackoverflow.com/questions/15181579/c-most-efficient-way-to-compare-a-variable-to-multiple-values
+    template <typename T>
+    bool val_in_range(const T& val, const std::initializer_list<T>& list)
+    {
+        for (const auto& i : list) {
+            if (val == i) {
+                return true;
+            }
+        }
+        return false;
     }
 
     void copy(void* dst, void const* src, size_t size);
@@ -428,9 +450,11 @@ namespace librealsense
 #pragma pack(pop)
     inline bool operator == (const float3 & a, const float3 & b) { return a.x == b.x && a.y == b.y && a.z == b.z; }
     inline float3 operator + (const float3 & a, const float3 & b) { return{ a.x + b.x, a.y + b.y, a.z + b.z }; }
+    inline float3 operator - (const float3 & a, const float3 & b) { return{ a.x - b.x, a.y - b.y, a.z - b.z }; }
     inline float3 operator * (const float3 & a, float b) { return{ a.x*b, a.y*b, a.z*b }; }
     inline bool operator == (const float4 & a, const float4 & b) { return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w; }
     inline float4 operator + (const float4 & a, const float4 & b) { return{ a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w }; }
+    inline float4 operator - (const float4 & a, const float4 & b) { return{ a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w }; }
     inline bool operator == (const float3x3 & a, const float3x3 & b) { return a.x == b.x && a.y == b.y && a.z == b.z; }
     inline float3 operator * (const float3x3 & a, const float3 & b) { return a.x*b.x + a.y*b.y + a.z*b.z; }
     inline float3x3 operator * (const float3x3 & a, const float3x3 & b) { return{ a*b.x, a*b.y, a*b.z }; }

--- a/src/types.h
+++ b/src/types.h
@@ -44,8 +44,8 @@ const double DBL_EPSILON = 2.2204460492503131e-016;  // smallest such that 1.0+D
 static const double pi = std::acos(-1);
 static const double d2r = pi / 180;
 static const double r2d = 180 / pi;
-template<typename T> T deg2rad(T val) { return T(val * d2r); };
-template<typename T> T rad2deg(T val) { return T(val * r2d); };
+template<typename T> T deg2rad(T val) { return T(val * d2r); }
+template<typename T> T rad2deg(T val) { return T(val * r2d); }
 
 #pragma warning(disable: 4250)
 

--- a/src/win/win-helpers.cpp
+++ b/src/win/win-helpers.cpp
@@ -479,7 +479,7 @@ namespace librealsense
                     std::string uid = "";
                     std::wstring ws(detail_data->DevicePath);
                     std::string path(ws.begin(), ws.end());
-                    
+
                     /* Parse the following USB path format = \?usb#vid_vvvv&pid_pppp&mi_ii#aaaaaaaaaaaaaaaa#{gggggggg-gggg-gggg-gggg-gggggggggggg} */
                     parse_usb_path_multiple_interface(vid, pid, mi, uid, path);
                     if (uid.empty())

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -47,14 +47,13 @@ void print(const rs2_motion_device_intrinsic& intrinsics)
     for (auto i = 0 ; i < sizeof(intrinsics.noise_variances)/sizeof(intrinsics.noise_variances[0]) ; ++i)
         ss << setprecision(15) << intrinsics.noise_variances[i] << "  ";
 
-    ss << "\nData: " << std::endl;
+    ss << "\nSensitivity : " << std::endl;
     for (auto i = 0 ; i < sizeof(intrinsics.data)/sizeof(intrinsics.data[0]) ; ++i)
     {
         for (auto j = 0 ; j < sizeof(intrinsics.data[0])/sizeof(intrinsics.data[0][0]) ; ++j)
-            ss << std::setw(13) << setprecision(10) << intrinsics.data[i][j] << "  ";
+            ss << std::fixed << std::setw(13) << setprecision(10) << intrinsics.data[i][j] << "  ";
         ss << "\n";
     }
-
 
     cout << ss.str() << endl << endl;
 }

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -446,7 +446,7 @@ int main(int argv, const char** argc) try
                     viewer_model.ppf.stop();
                 }
             }
-           
+
             if (device_to_remove)
             {
                 if (auto p = device_to_remove->dev.as<playback>())


### PR DESCRIPTION
Parse and use IMU intrinsic calibration to enhance gyro&accel raw data.
The intrinsic data includes:
- Accel sensitivity matrix and bias.
- Gyro bias (zero-offsets)

The calibration is parsed and applied automatically.
In order to obtain the raw IMU data disable RS2_OPTION_ENABLE_MOTION_CORRECTION option.

Fix tab/spaces inconsistencies.

Tracked on: DSO-11692