### PR TITLE
Switch to use stable libusb version

### DIFF
--- a/CMake/external_libusb.cmake
+++ b/CMake/external_libusb.cmake
@@ -5,7 +5,7 @@ ExternalProject_Add(
     libusb
 
     GIT_REPOSITORY "https://github.com/libusb/libusb.git"
-    GIT_TAG "master"
+    GIT_TAG "v1.0.22"
 
     UPDATE_COMMAND ${CMAKE_COMMAND} -E copy
             ${CMAKE_CURRENT_SOURCE_DIR}/third-party/libusb/CMakeLists.txt


### PR DESCRIPTION
We are getting multiple reports that (#3047) regarding instability in latest libusb master on Windows.
Switching to use more stable release. 