### PR TITLE
Update to definition of variable 'out' in align.m

### DIFF
--- a/wrappers/matlab/align.m
+++ b/wrappers/matlab/align.m
@@ -5,7 +5,7 @@ classdef align < realsense.filter
         function this = align(align_to)
             narginchk(1, 1);
             validateattributes(align_to, {'realsense.stream', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.stream.count});
-            this.objectHandle = realsense.librealsense_mex('rs2::align', 'new', int64(align_to));
+            out = realsense.librealsense_mex('rs2::align', 'new', int64(align_to));
             this = this@realsense.filter(out);
         end
         


### PR DESCRIPTION
It solves the error about a constructor call to the 'filter' superclass after the object being used, or after a return.