### PR TITLE
Fix a comparison-instead-of-assignment bug.

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -68,7 +68,7 @@ int lockf64(int fd, int cmd, off64_t length)
     fl.l_len = length;
 
     if (cmd == F_ULOCK) {
-        fl.l_type == F_UNLCK;
+        fl.l_type = F_UNLCK;
         cmd = F_SETLK64;
         return fcntl(fd, F_SETLK64, &fl);
     }

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -12,6 +12,7 @@
 #include <cstring>
 
 #include <algorithm>
+#include <array>
 #include <functional>
 #include <string>
 #include <sstream>


### PR DESCRIPTION
This fixes a bug where == was used instead of =. It was caught by
-Wunused-comparison. This also adds a missing import.