### PR TITLE
[Matlab] Fix "Must be a Scalar" and other validation errors

### DIFF
--- a/wrappers/matlab/align.m
+++ b/wrappers/matlab/align.m
@@ -4,7 +4,7 @@ classdef align < realsense.filter
         % Constructor
         function this = align(align_to)
             narginchk(1, 1);
-            validateattributes(align_to, {'realsense.stream', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.stream.count});
+            validateattributes(align_to, {'realsense.stream', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.stream.count)});
             this.objectHandle = realsense.librealsense_mex('rs2::align', 'new', int64(align_to));
             this = this@realsense.filter(out);
         end

--- a/wrappers/matlab/colorizer.m
+++ b/wrappers/matlab/colorizer.m
@@ -6,7 +6,7 @@ classdef colorizer < realsense.filter
             if (nargin == 0)
                 out = realsense.librealsense_mex('rs2::colorizer', 'new');
             else
-                validateattributes(color_scheme, {'numeric'}, {'scalar', 'nonnegative', 'real'});
+                validateattributes(color_scheme, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'});
                 out = realsense.librealsense_mex('rs2::colorizer', 'new', double(color_scheme));
             end
             this = this@realsense.filter(out);

--- a/wrappers/matlab/config.m
+++ b/wrappers/matlab/config.m
@@ -115,11 +115,11 @@ classdef config < handle
         end
         function disable_stream(this, stream, index)
             narginchk(2, 3);
-            validateattributes(stream, {'realsense.stream', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.stream.count}, '', 'stream', 2);
+            validateattributes(stream, {'realsense.stream', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.stream.count)}, '', 'stream', 2);
             if nargin == 2
                 out = realsense.librealsense_mex('rs2::config', 'disable_stream', this.objectHandle, int64(stream));
             else
-                validateattributes(index, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'index', 3);
+                validateattributes(index, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'index', 3);
                 out = realsense.librealsense_mex('rs2::config', 'disable_stream', this.objectHandle, int64(stream), int64(index));
             end
             stream = realsense.stream_profile(out{:});

--- a/wrappers/matlab/config.m
+++ b/wrappers/matlab/config.m
@@ -25,7 +25,7 @@ classdef config < handle
                     which = 'enable_stream#stream';
                 case 3
                     if isa(varargin{2}, 'realsense.format')
-                        validateattributes(varargin{2}, {'realsense.format'}, {'scalar'}, '', 'format', 3);
+                        validateattributes(varargin{2}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 3);
                         which = 'enable_stream#format';
                     else
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
@@ -33,12 +33,12 @@ classdef config < handle
                     end
                 case 4
                     if isa(varargin{2}, 'realsense.format')
-                        validateattributes(varargin{2}, {'realsense.format'}, {'scalar'}, '', 'format', 3);
+                        validateattributes(varargin{2}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 3);
                         validateattributes(varargin{3}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'framerate', 4);
                         which = 'enable_stream#format';
                     elseif isa(varargin{3}, 'realsense.format')
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
-                        validateattributes(varargin{3}, {'realsense.format'}, {'scalar'}, '', 'format', 4);
+                        validateattributes(varargin{3}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 4);
                         which = 'enable_stream#extended';
                     else
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'width', 3);
@@ -48,13 +48,13 @@ classdef config < handle
                 case 5
                     if isa(varargin{3}, 'realsense.format')
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
-                        validateattributes(varargin{3}, {'realsense.format'}, {'scalar'}, '', 'format', 4);
+                        validateattributes(varargin{3}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 4);
                         validateattributes(varargin{4}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'framerate', 5);
                         which = 'enable_stream#extended';
                     elseif isa(varargin{4}, 'realsense.format')
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'width', 3);
                         validateattributes(varargin{3}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'height', 4);
-                        validateattributes(varargin{4}, {'realsense.format'}, {'scalar'}, '', 'format', 5);
+                        validateattributes(varargin{4}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 5);
                         which = 'enable_stream#size';
                     else
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
@@ -66,7 +66,7 @@ classdef config < handle
                     if isa(varargin{4}, 'realsense.format')
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'width', 3);
                         validateattributes(varargin{3}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'height', 4);
-                        validateattributes(varargin{4}, {'realsense.format'}, {'scalar'}, '', 'format', 5);
+                        validateattributes(varargin{4}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 5);
                         validateattributes(varargin{5}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'framerate', 6);
                         which = 'enable_stream#size';
                     else

--- a/wrappers/matlab/config.m
+++ b/wrappers/matlab/config.m
@@ -73,14 +73,14 @@ classdef config < handle
                         validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
                         validateattributes(varargin{3}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'width', 4);
                         validateattributes(varargin{4}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'height', 5);
-                        validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.format.count}, '', 'format', 6);
+                        validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 6);
                         which = 'enable_stream#full';
                     end
                 case 7
                     validateattributes(varargin{2}, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'stream_index', 3);
                     validateattributes(varargin{3}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'width', 4);
                     validateattributes(varargin{4}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'height', 5);
-                    validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.format.count}, '', 'format', 6);
+                    validateattributes(varargin{5}, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'format', 6);
                     validateattributes(varargin{6}, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'framerate', 7);
                     which = 'enable_stream#full';
             end

--- a/wrappers/matlab/device.m
+++ b/wrappers/matlab/device.m
@@ -52,13 +52,13 @@ classdef device < handle
         end
         function value = supports(this, info)
             narginchk(2, 2);
-            validateattributes(info, {'realsense.camera_info', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.camera_info.count}, '', 'info', 2);
+            validateattributes(info, {'realsense.camera_info', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.camera_info.count)}, '', 'info', 2);
             this.do_init();
             value = realsense.librealsense_mex('rs2::device', 'supports', this.objectHandle, int64(info));
         end
         function info = get_info(this, info)
             narginchk(2, 2);
-            validateattributes(info, {'realsense.camera_info', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.camera_info.count}, '', 'info', 2);
+            validateattributes(info, {'realsense.camera_info', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.camera_info.count)}, '', 'info', 2);
             this.do_init();
             info = realsense.librealsense_mex('rs2::device', 'get_info', this.objectHandle, int64(info));
         end

--- a/wrappers/matlab/frame.m
+++ b/wrappers/matlab/frame.m
@@ -30,12 +30,12 @@ classdef frame < handle
         end
         function metadata = get_frame_metadata(this, frame_metadata)
             narginchk(2, 2);
-            validateattributes(frame_metadata, {'realsense.frame_metadata_value', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.frame_metadata_value.count}, '', 'frame_metadata', 2);
+            validateattributes(frame_metadata, {'realsense.frame_metadata_value', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.frame_metadata_value.count)}, '', 'frame_metadata', 2);
             metadata = realsense.librealsense_mex('rs2::frame', 'get_frame_metadata', this.objectHandle, int64(frame_metadata));
         end
         function value = supports_frame_metadata(this, frame_metadata)
             narginchk(2, 2);
-            validateattributes(frame_metadata, {'realsense.frame_metadata_value', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.frame_metadata_value.count}, '', 'frame_metadata', 2);
+            validateattributes(frame_metadata, {'realsense.frame_metadata_value', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.frame_metadata_value.count)}, '', 'frame_metadata', 2);
             value = realsense.librealsense_mex('rs2::frame', 'supports_frame_metadata', this.objectHandle, int64(frame_metadata));
         end
         function frame_number = get_frame_number(this)

--- a/wrappers/matlab/frameset.m
+++ b/wrappers/matlab/frameset.m
@@ -33,7 +33,7 @@ classdef frameset < realsense.frame
             if (nargin == 1)
                 ret = realsense.librealsense_mex('rs2::frameset', 'get_infrared_frame', this.objectHandle);
             else
-                validateattributes(index, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', 2}, '', 'index', 2);
+                validateattributes(index, {'numeric'}, {'scalar', 'real', 'integer'}, '', 'index', 2);
                 ret = realsense.librealsense_mex('rs2::frameset', 'get_infrared_frame', this.objectHandle, int64_t(index));
             end
             infrared_frame = realsense.video_frame(ret);

--- a/wrappers/matlab/sensor.m
+++ b/wrappers/matlab/sensor.m
@@ -20,12 +20,12 @@ classdef sensor < realsense.options
         end
         function value = supports_camera_info(this, info)
             narginchk(2, 2)
-            validateattributes(info, {'realsense.camera_info', 'numeric'},{'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.camera_info.count}, '', 'info', 2);
+            validateattributes(info, {'realsense.camera_info', 'numeric'},{'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.camera_info.count)}, '', 'info', 2);
             value = realsense.librealsense_mex('rs2::sensor', 'supports#rs2_camera_info', this.objectHandle, int64(info));
         end
         function value = get_info(this, info)
             narginchk(2, 2)
-            validateattributes(info, {'realsense.camera_info', 'numeric'},{'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.camera_info.count}, '', 'info', 2);
+            validateattributes(info, {'realsense.camera_info', 'numeric'},{'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.camera_info.count)}, '', 'info', 2);
             value = realsense.librealsense_mex('rs2::sensor', 'get_info', this.objectHandle, int64(info));
         end
         function close(this)

--- a/wrappers/matlab/stream_profile.m
+++ b/wrappers/matlab/stream_profile.m
@@ -38,9 +38,9 @@ classdef stream_profile < handle
         end
         function profile = clone(this, type, index, fmt)
             narginchk(4, 4);
-            validateattributes(type, {'realsense.stream', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.stream.count}, '', 'type', 2);
+            validateattributes(type, {'realsense.stream', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.stream.count)}, '', 'type', 2);
             validateattributes(index, {'numeric'}, {'scalar', 'nonnegative', 'real', 'integer'}, '', 'index', 3);
-            validateattributes(fmt, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', realsense.format.count}, '', 'fmt', 4);
+            validateattributes(fmt, {'realsense.format', 'numeric'}, {'scalar', 'nonnegative', 'real', 'integer', '<=', int64(realsense.format.count)}, '', 'fmt', 4);
             out = realsense.librealsense_mex('rs2::stream_profile', 'clone', this.objectHandle, int64(type), int64(index), int64(fmt));
             profile = realsense.stream_profile(out{:});
         end


### PR DESCRIPTION
Building on PR #2954, validate format parameter's value in the rest of config.enable_stream's branches.
Additionally, correct similar "Must be Scalar" and other validation errors elsewhere in the matlab binding