### PR TITLE
Fix kernel patch flow

### DIFF
--- a/scripts/patch-realsense-ubuntu-lts.sh
+++ b/scripts/patch-realsense-ubuntu-lts.sh
@@ -112,7 +112,8 @@ if [ ! -f scripts/ubuntu-retpoline-extract-one ]; then
 	for f in $(find . -name 'retpoline-extract-one'); do cp ${f} scripts/ubuntu-retpoline-extract-one; done;
 	echo $$$
 fi
-sudo make silentoldconfig modules_prepare
+#Reuse current kernel configuration. Assign default values to newly-introduced options.
+sudo make olddefconfig modules_prepare
 
 #Vermagic identity is required
 IFS='.' read -a kernel_version <<< "$LINUX_BRANCH"


### PR DESCRIPTION
Replace Kconfig's `silentoldconfig` with `olddefconfig` option to allow unattended patch application when new configurable kernel options appear.

Change-Id: I115ce542f82a256303f6d80e743fc23fb9dd182e
Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>