### PR TITLE
Changing IMU Table link and adding JSON writer

### DIFF
--- a/tools/rs-imu-calibration/rs-imu-calibration.py
+++ b/tools/rs-imu-calibration/rs-imu-calibration.py
@@ -305,7 +305,7 @@ def get_D435_IMU_Calib_Table(X):
     
     header_size = header.size()
     data_size = 37*4 + 96
-    size_of_buffer = header_size + data_size    # according to table "D435 IMU Calib Table" in "https://sharepoint.ger.ith.intel.com/sites/3D_project/Shared%20Documents/Arch/D400/FW/D435i_IMU_Calibration_eeprom_0_52.xlsx"
+    size_of_buffer = header_size + data_size    # according to table "D435 IMU Calib Table" here: https://user-images.githubusercontent.com/6958867/50902974-20507500-1425-11e9-8ca5-8bd2ac2d0ea1.png
     assert(size_of_buffer % 4 == 0)
     buffer = np.ones(size_of_buffer, dtype=np.uint8) * 255
 
@@ -451,7 +451,7 @@ def check_X(X, accel, show_graph):
     if show_graph:
         import pylab
         pylab.plot(norm_data, '.b')
-        pylab.hold(True)
+        #pylab.hold(True)
         pylab.plot(norm_fdata, '.g')
         pylab.show()
     print ('norm (raw data  ): %f' % np.mean(norm_data))

--- a/tools/rs-imu-calibration/rs-imu-calibration.py
+++ b/tools/rs-imu-calibration/rs-imu-calibration.py
@@ -593,6 +593,9 @@ def main():
 
         directory = os.path.dirname(accel_file) if accel_file else '.'
 
+        with open(os.path.join(directory,"calibration.json"), 'w') as outfile:
+            outfile.write(json_data)
+
         #concatinate the two 12 element arrays and save
         intrinsic_buffer = np.zeros([6,4])
 


### PR DESCRIPTION
IMU Calibration table was posted to a public location as a Github comment. Replaced the link to the private Intel sharepoint.  

Added a bit to write the json data created to a local file. 

Commented out pylab.hold, its deprecated but not sure of the best way to handle it for backwards compat.