### PR TITLE
Fix libusb error C2001 on Visual C++

### DIFF
--- a/third-party/libusb/CMakeLists.txt
+++ b/third-party/libusb/CMakeLists.txt
@@ -69,6 +69,8 @@ if(WIN32)
             string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
         endif(${flag_var} MATCHES "/MD")
     endforeach(flag_var)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /source-charset:utf-8")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /source-charset:utf-8")
 endif()
 
 if(ANDROID)


### PR DESCRIPTION
This pull request fixes compiler error C2001 of libusb on Visual C++.
It is necessary to explicitly specify the character encoding to UTF-8.
```
C:\librealsense\build\third-party\libusb\libusb\strerror.c(111): error C2001: newline in constant [C:\librealsense\build\libusb-prefix\src\libusb-build\usb.vcxproj]
C:\librealsense\build\third-party\libusb\libusb\strerror.c(117): error C2001: newline in constant [C:\librealsense\build\libusb-prefix\src\libusb-build\usb.vcxproj]
```