### PR TITLE
add realsense-ir-to-vaapi-h264 community example

### DIFF
--- a/examples/readme.md
+++ b/examples/readme.md
@@ -45,3 +45,4 @@ For a detailed explanations and API documentation see our [Documentation](../doc
 5. [RealSense ROS-bag parser](https://github.com/IntelRealSense/librealsense/issues/2215) - code sample for parsing ROS-bag files by [@marcovs](https://github.com/marcovs)
 6. [OpenCV threaded depth cleaner](https://github.com/juniorxsound/ThreadedDepthCleaner) - RealSense depth-map cleaning and inpainting using OpenCV
 7. [Sample of how to use the IMU of D435i as well as doing PCL rotations based on this](https://github.com/GruffyPuffy/imutest)
+8. [realsense-ir-to-vaapi-h264](https://github.com/bmegli/realsense-ir-to-vaapi-h264) - hardware encode infrared stream to H.264 with Intel VAAPI


### PR DESCRIPTION
Adds link in examples Community Projects section.

Example how to use:
- Intel VAAPI through HVE (FFmpeg) to hardware encode
- Realsense D400 greyscale infrared stream
- to H.264 raw video
- stored to disk as example

This will work on Intel hardware (VAAPI support) on Unix-like platforms (again VAAPI support)