### PR TITLE
opencv: only use the C++ API

### DIFF
--- a/wrappers/opencv/cv-helpers.hpp
+++ b/wrappers/opencv/cv-helpers.hpp
@@ -24,7 +24,7 @@ cv::Mat frame_to_mat(const rs2::frame& f)
     else if (f.get_profile().format() == RS2_FORMAT_RGB8)
     {
         auto r = Mat(Size(w, h), CV_8UC3, (void*)f.get_data(), Mat::AUTO_STEP);
-        cvtColor(r, r, CV_RGB2BGR);
+        cvtColor(r, r, COLOR_RGB2BGR);
         return r;
     }
     else if (f.get_profile().format() == RS2_FORMAT_Z16)

--- a/wrappers/opencv/dnn/rs-dnn.cpp
+++ b/wrappers/opencv/dnn/rs-dnn.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) try
     const auto window_name = "Display Image";
     namedWindow(window_name, WINDOW_AUTOSIZE);
 
-    while (cvGetWindowHandle(window_name))
+    while (getWindowProperty(window_name, WND_PROP_AUTOSIZE) >= 0)
     {
         // Wait for the next set of frames
         auto data = pipe.wait_for_frames();
@@ -124,7 +124,7 @@ int main(int argc, char** argv) try
 
                 rectangle(color_mat, Rect(Point(center.x, center.y - labelSize.height),
                     Size(labelSize.width, labelSize.height + baseLine)),
-                    Scalar(255, 255, 255), CV_FILLED);
+                    Scalar(255, 255, 255), FILLED);
                 putText(color_mat, ss.str(), center,
                         FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0,0,0));
             }

--- a/wrappers/opencv/grabcuts/rs-grabcuts.cpp
+++ b/wrappers/opencv/grabcuts/rs-grabcuts.cpp
@@ -45,7 +45,7 @@ int main(int argc, char * argv[]) try
     // Skips some frames to allow for auto-exposure stabilization
     for (int i = 0; i < 10; i++) pipe.wait_for_frames();
 
-    while (waitKey(1) < 0 && cvGetWindowHandle(window_name))
+    while (waitKey(1) < 0 && getWindowProperty(window_name, WND_PROP_AUTOSIZE) >= 0)
     {
         frameset data = pipe.wait_for_frames();
         // Make sure the frameset is spatialy aligned 
@@ -61,14 +61,14 @@ int main(int argc, char * argv[]) try
 
         // Generate "near" mask image:
         auto near = frame_to_mat(bw_depth);
-        cvtColor(near, near, CV_BGR2GRAY);
+        cvtColor(near, near, COLOR_BGR2GRAY);
         // Take just values within range [180-255]
         // These will roughly correspond to near objects due to histogram equalization
         create_mask_from_depth(near, 180, THRESH_BINARY);
 
         // Generate "far" mask image:
         auto far = frame_to_mat(bw_depth);
-        cvtColor(far, far, CV_BGR2GRAY);
+        cvtColor(far, far, COLOR_BGR2GRAY);
         far.setTo(255, far == 0); // Note: 0 value does not indicate pixel near the camera, and requires special attention 
         create_mask_from_depth(far, 100, THRESH_BINARY_INV);
 

--- a/wrappers/opencv/imshow/rs-imshow.cpp
+++ b/wrappers/opencv/imshow/rs-imshow.cpp
@@ -18,7 +18,7 @@ int main(int argc, char * argv[]) try
     const auto window_name = "Display Image";
     namedWindow(window_name, WINDOW_AUTOSIZE);
 
-    while (waitKey(1) < 0 && cvGetWindowHandle(window_name))
+    while (waitKey(1) < 0 && getWindowProperty(window_name, WND_PROP_AUTOSIZE) >= 0)
     {
         rs2::frameset data = pipe.wait_for_frames(); // Wait for next set of frames from the camera
         rs2::frame depth = data.get_depth_frame().apply_filter(color_map);

--- a/wrappers/opencv/latency-tool/latency-detector.h
+++ b/wrappers/opencv/latency-tool/latency-detector.h
@@ -156,11 +156,11 @@ public:
         _instructions = Mat::zeros(Size(display_w, 120), CV_8UC1);
 
         putText(_instructions, "Point the camera at the screen. Ensure all white circles are being captured",
-            Point(display_w / 2 - 470, 30), CV_FONT_HERSHEY_SIMPLEX,
+            Point(display_w / 2 - 470, 30), FONT_HERSHEY_SIMPLEX,
             0.8, Scalar(255, 255, 255), 2, LINE_AA);
 
         putText(_instructions, "Press any key to exit...",
-            Point(display_w / 2 - 160, 70), CV_FONT_HERSHEY_SIMPLEX,
+            Point(display_w / 2 - 160, 70), FONT_HERSHEY_SIMPLEX,
             0.8, Scalar(255, 255, 255), 2, LINE_AA);
     }
 
@@ -270,7 +270,7 @@ private:
         ss << "Total Collected Samples: " << _latency.total();
 
         putText(_instructions, ss.str().c_str(),
-            Point(80, 20), CV_FONT_HERSHEY_SIMPLEX,
+            Point(80, 20), FONT_HERSHEY_SIMPLEX,
             0.8, Scalar(255, 255, 255), 2, LINE_AA);
 
         ss.str("");
@@ -278,14 +278,14 @@ private:
         ss << "(Average)" << _latency.avg() << "ms";
 
         putText(_instructions, ss.str().c_str(),
-            Point(80, 60), CV_FONT_HERSHEY_SIMPLEX,
+            Point(80, 60), FONT_HERSHEY_SIMPLEX,
             0.8, Scalar(255, 255, 255), 2, LINE_AA);
 
         ss.str("");
         ss << "Software Processing: " << _processing_time.median() << "ms";
 
         putText(_instructions, ss.str().c_str(),
-            Point(80, 100), CV_FONT_HERSHEY_SIMPLEX,
+            Point(80, 100), FONT_HERSHEY_SIMPLEX,
             0.8, Scalar(255, 255, 255), 2, LINE_AA);
     }
 

--- a/wrappers/opencv/latency-tool/rs-latency-tool.cpp
+++ b/wrappers/opencv/latency-tool/rs-latency-tool.cpp
@@ -43,7 +43,7 @@ int main(int argc, char * argv[]) try
     //sensor.start(pipe);
 
     const auto window_name = "Display Image";
-    namedWindow(window_name, CV_WINDOW_NORMAL);
+    namedWindow(window_name, WINDOW_NORMAL);
     setWindowProperty(window_name, WND_PROP_FULLSCREEN, WINDOW_FULLSCREEN);
 
     const int display_w = 1280;
@@ -55,7 +55,7 @@ int main(int argc, char * argv[]) try
 
     detector d(digits, display_w);
 
-    while (cvGetWindowHandle(window_name))
+    while (getWindowProperty(window_name, WND_PROP_AUTOSIZE) >= 0)
     {
         // Wait for frameset from the camera
         for (auto f : pipe.wait_for_frames())


### PR DESCRIPTION
This is a more complete version of https://github.com/IntelRealSense/librealsense/pull/3091 which completely gets rid of the C API usage.
Note that the C++ API used in this PR was already available in OpenCV 2.4.