### PR TITLE
Patch IIO HID initialization

### DIFF
--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -7,41 +7,11 @@
 #include "backend.h"
 #include "types.h"
 
-#include <cassert>
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-
-#include <algorithm>
-#include <functional>
-#include <string>
-#include <sstream>
-#include <fstream>
-#include <regex>
 #include <thread>
-#include <utility> // for pair
-#include <chrono>
-#include <thread>
-#include <atomic>
 
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <limits.h>
-#include <cmath>
-#include <errno.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-#include <sys/ioctl.h>
-#include <linux/usb/video.h>
-#include <linux/uvcvideo.h>
-#include <linux/videodev2.h>
-#include <fts.h>
-#include <regex>
-#include <list>
-
-#include <sys/signalfd.h>
-#include <signal.h>
 
 #pragma GCC diagnostic ignored "-Woverflow"
 

--- a/src/linux/backend-hid.h
+++ b/src/linux/backend-hid.h
@@ -5,37 +5,7 @@
 #include "backend.h"
 #include "types.h"
 
-#include <cassert>
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-
-#include <algorithm>
-#include <functional>
-#include <string>
-#include <sstream>
-#include <fstream>
-#include <regex>
-#include <thread>
-#include <utility> // for pair
-#include <chrono>
-#include <thread>
-#include <atomic>
-
-#include <dirent.h>
-#include <fcntl.h>
-#include <unistd.h>
 #include <limits.h>
-#include <cmath>
-#include <errno.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-#include <sys/ioctl.h>
-#include <linux/usb/video.h>
-#include <linux/uvcvideo.h>
-#include <linux/videodev2.h>
-#include <fts.h>
-#include <regex>
 #include <list>
 
 namespace librealsense

--- a/src/linux/backend-hid.h
+++ b/src/linux/backend-hid.h
@@ -62,9 +62,10 @@ namespace librealsense
         };
 
         template<typename T>
-        inline bool write_fs_arithmetic(const std::string& path, const T& val)
+        inline bool write_fs_attribute(const std::string& path, const T& val)
         {
-            static_assert((std::is_arithmetic<T>::value), "write_arithmetic_fs incompatible type");
+            static_assert(((std::is_arithmetic<T>::value)||(std::is_same<T,std::string>::value)),
+                "write_fs_attribute supports arithmetic and std::string types only");
             bool res = false;
             std::fstream fs_handle(path);
             if (!fs_handle.good())
@@ -75,7 +76,7 @@ namespace librealsense
 
             try // Read/Modify/Confirm
             {
-                T cval = 0;
+                T cval{};
                 fs_handle >> cval;
 
                 if (cval!=val)


### PR DESCRIPTION
At enumeration stage Linux HID IIO async invocation may cause improper initialization order, resulting in Accelerometer's trigger driver mapping missing.
The patch establishes the required trigger mapping, thus allowing the accel_3d driver function properly
Addressing #2965.
Tracked on: dso-11745