### PR TITLE
Libuvc_installation - add script to facilitate libuvc backend 

### DIFF
--- a/doc/libuvc_installation.md
+++ b/doc/libuvc_installation.md
@@ -1,0 +1,22 @@
+# LibUVC-backend installation
+
+> If kernel patching is not possible, or any steps during official [installation.md](./installation.md) fail,
+> you should try **libuvc-backend** version of librealsense
+> This method is not officially validated but can run on wider range of platforms including older / newer kernel version
+
+> This script requires internet connection. Please make sure network proxy settings are correct
+
+1. Make sure no RealSense device is connected
+2. Open the terminal, run:
+```sh
+$ wget https://github.com/IntelRealSense/librealsense/raw/master/scripts/libuvc_installation.sh
+$ chmod +x ./libuvc_installation.sh
+$ ./libuvc_installation.sh
+```
+3. Wait until `Librealsense script completed` message is displayed (may take some time)
+4. Connect RealSense device
+5. Run `rs-enumerate-devices` from the terminal to verify the installation
+
+> At the moment, the script assumes Ubuntu 16 with graphic subsystem
+
+> If you encounter any problems or would like to extend the script to additional system, please [let us know via a new GitHub issue](https://github.com/IntelRealSense/librealsense/issues/new)

--- a/scripts/libuvc_installation.sh
+++ b/scripts/libuvc_installation.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -xe
+
+#Locally suppress stderr to avoid raising not relevant messages
+exec 3>&2
+exec 2> /dev/null
+con_dev=$(ls /dev/video* | wc -l)
+exec 2>&3
+
+if [ $con_dev -ne 0 ];
+then
+	echo -e "\e[32m"
+	read -p "Remove all RealSense cameras attached. Hit any key when ready"
+	echo -e "\e[0m"
+fi
+
+lsb_release -a
+echo "Kernel version $(uname -r)"
+sudo apt-get update
+cd ~/
+sudo rm -rf ./librealsense_build
+mkdir librealsense_build && cd librealsense_build
+
+if [ $(sudo swapon --show | wc -l) -eq 0 ];
+then
+	echo "No swapon - setting up 1Gb swap file"
+	sudo fallocate -l 2G /swapfile
+	sudo chmod 600 /swapfile
+	sudo mkswap /swapfile
+	sudo swapon /swapfile
+	sudo swapon --show
+fi
+
+echo Installing Librealsense-required dev packages
+sudo apt-get install git libssl-dev libusb-1.0-0-dev pkg-config libgtk-3-dev unzip -y
+rm -f ./master.zip
+
+wget https://github.com/IntelRealSense/librealsense/archive/master.zip
+unzip ./master.zip -d .
+cd ./librealsense-master
+
+echo Install udev-rules
+sudo cp config/99-realsense-libusb.rules /etc/udev/rules.d/ 
+sudo udevadm control --reload-rules && udevadm trigger 
+mkdir build && cd build
+cmake ../ -DFORCE_LIBUVC=true -DCMAKE_BUILD_TYPE=release
+make -j2
+sudo make install
+echo -e "\e[92m\n\e[1mLibrealsense script completed.\n\e[0m"
+
+
+
+


### PR DESCRIPTION
The script performs the following:
 - Install librealsense-required build and runtime components.
 - Install permission rules required by Realsense devices
 - Download the latest librealsense SDK version from official github repository.
 - Configures and builds the SDK enforcing Libuvc backend

Note: The following Realsense devices are supported with Libuvc backend: SR300/D415/D435

Change-Id: I34e5101d02790713ac94b129c39ace182e728fe9