### PR TITLE
Replace vec2mat with reshape #2 

### DIFF
--- a/wrappers/matlab/readme.md
+++ b/wrappers/matlab/readme.md
@@ -43,7 +43,7 @@ function depth_example()
     for i = 1:5
         fs = pipe.wait_for_frames();
     end
-
+    
     % Stop streaming
     pipe.stop();
 
@@ -55,10 +55,7 @@ function depth_example()
     % Get actual data and convert into a format imshow can use
     % (Color data arrives as [R, G, B, R, G, B, ...] vector)
     data = color.get_data();
-    channels = vec2mat(data, 3);
-    img(:,:,1) = vec2mat(channels(:,1), color.get_width());
-    img(:,:,2) = vec2mat(channels(:,2), color.get_width());
-    img(:,:,3) = vec2mat(channels(:,3), color.get_width());
+    img = permute(reshape(data',[3,color.get_width(),color.get_height()]),[3 2 1]);
 
     % Display image
     imshow(img);


### PR DESCRIPTION
Pull request #2708  had suggested replacing `vec2mat` function with `reshape` function in [depth_example.m](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/matlab/depth_example.m) file under MATLAB wrapper folder. This request was accepted and was merged.

The code of depth_example.m also appears in the [readme.md](https://github.com/IntelRealSense/librealsense/blob/master/wrappers/matlab/readme.md) file located at the same folder, however the `vec2mat` function still remains in the code under the readme.md file. To keep the consistency of code, and also to minimise the use of existing MATLAB toolboxs, I suggest changing `vec2mat` functions to `reshape` function in the readme.md file, just like how it was changed in depth_example.m file.