### PR TITLE
add API function unload_tracking_module. 

### DIFF
--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -64,6 +64,13 @@ rs2_device* rs2_context_add_device(rs2_context* ctx, const char* file, rs2_error
 void rs2_context_remove_device(rs2_context* ctx, const char* file, rs2_error** error);
 
 /**
+ * Removes tracking module.
+ * query_devices locks the tracking module. 
+ * If the tracking module device is should be removed so that other applications could find it.
+ */
+void rs2_context_unload_tracking_module(rs2_context* ctx, rs2_error** error);
+
+/**
 * create a static snapshot of all connected devices at the time of the call
 * \param context     Object representing librealsense session
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored

--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -65,8 +65,10 @@ void rs2_context_remove_device(rs2_context* ctx, const char* file, rs2_error** e
 
 /**
  * Removes tracking module.
- * query_devices locks the tracking module. 
- * If the tracking module device is should be removed so that other applications could find it.
+ * function query_devices() locks the tracking module in the tm_context object. 
+ * If the tracking module device is not used it should be removed using this function, so that other applications could find it.
+ * This function can be used both before the call to query_device() to prevent enabling tracking modules or afterwards to 
+ * release them.
  */
 void rs2_context_unload_tracking_module(rs2_context* ctx, rs2_error** error);
 

--- a/include/librealsense2/hpp/rs_context.hpp
+++ b/include/librealsense2/hpp/rs_context.hpp
@@ -198,6 +198,13 @@ namespace rs2
             rs2::error::handle(e);
         }
 
+        void unload_tracking_module()
+        {
+            rs2_error* e = nullptr;
+            rs2_context_unload_tracking_module(_context.get(), &e);
+            rs2::error::handle(e);
+        }
+
         context(std::shared_ptr<rs2_context> ctx)
             : _context(ctx)
         {}

--- a/src/context.h
+++ b/src/context.h
@@ -131,6 +131,10 @@ namespace librealsense
 
         std::shared_ptr<device_interface> add_device(const std::string& file);
         void remove_device(const std::string& file);
+#if WITH_TRACKING
+        void unload_tracking_module() {_tm2_context.reset();};
+#endif
+
 
     private:
         void on_device_changed(platform::backend_device_group old,

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -213,6 +213,7 @@ EXPORTS
 
     rs2_context_add_device
     rs2_context_remove_device
+    rs2_context_unload_tracking_module
 
     rs2_playback_device_get_file_path
     rs2_playback_get_duration

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1131,6 +1131,15 @@ void rs2_context_remove_device(rs2_context* ctx, const char* file, rs2_error** e
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, ctx, file)
 
+void rs2_context_unload_tracking_module(rs2_context* ctx, rs2_error** error) BEGIN_API_CALL
+{
+#if WITH_TRACKING
+    VALIDATE_NOT_NULL(ctx);
+    ctx->ctx->unload_tracking_module();
+#endif
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, ctx)
+
 const char* rs2_playback_device_get_file_path(const rs2_device* device, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(device);


### PR DESCRIPTION
Used to cleam _tm_context object if tracking module is not used, so it will be available for other applications.
Can be used prior to query_devices() to prevent connecting to tracking modules or afterwards to release all tracking modules.
