### PR TITLE
Work in progress on Mac OS support for the T265

### DIFF
--- a/CMake/apple_config.cmake
+++ b/CMake/apple_config.cmake
@@ -2,7 +2,7 @@ message(STATUS "Setting Apple configurations")
 
 macro(os_set_flags)
     set(FORCE_LIBUVC ON)
-    set(BUILD_WITH_TM2 OFF)
+    set(BUILD_WITH_TM2 ON)
 
     add_definitions(-DUSE_SYSTEM_LIBUSB)
 endmacro()

--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -28,7 +28,7 @@ macro(os_set_flags)
 
     if(APPLE)
         set(FORCE_LIBUVC ON)
-        set(BUILD_WITH_TM2 OFF)
+        set(BUILD_WITH_TM2 ON)
     endif()
 endmacro()
 

--- a/src/tm2/controller_event_serializer.h
+++ b/src/tm2/controller_event_serializer.h
@@ -62,11 +62,7 @@ namespace librealsense
             std::string serialized_data = to_string() <<
                 "\"status\": \"" << (int)frame.status << "\","
                 "\"controllerId\": " << (int)frame.controllerId << ","
-                "\"manufacturerId\": " << (int)frame.manufacturerId << ","
-                "\"protocol\": \"" << frame.protocol << "\","
-                "\"app\": \"" << frame.app << "\","
-                "\"softDevice\": \"" << frame.softDevice << "\","
-                "\"bootLoader\": \"" << frame.bootLoader << "\"";
+                "\"manufacturerId\": " << (int)frame.manufacturerId << ",";
             return to_json(event_type_frame(), serialized_data);
         }
         

--- a/third-party/libtm/libtm/src/CMakeLists.txt
+++ b/third-party/libtm/libtm/src/CMakeLists.txt
@@ -41,14 +41,21 @@ set(SOURCE_FILES
     infra/Fence.h
     infra/EventHandler.h
     infra/Poller.h
-    infra/Poller_${OS}.cpp
+    
     infra/Dispatcher.h
     infra/Dispatcher.cpp
     infra/Fsm.h
     infra/Fsm.cpp
     infra/Utils.h
     infra/Utils.cpp
-    infra/Event_${OS}.cpp
+    
+    infra/Event_lin.cpp
+    infra/Event_bsd.cpp
+    infra/Event_win.cpp
+
+    infra/Poller_lin.cpp
+    infra/Poller_win.cpp
+    infra/Poller_bsd.cpp
 )
 
 #Add versioning to DLL

--- a/third-party/libtm/libtm/src/infra/Event_bsd.cpp
+++ b/third-party/libtm/libtm/src/infra/Event_bsd.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
+#ifdef __APPLE__
+
 #include "Event.h"
 #include <unistd.h>
 
@@ -44,3 +46,5 @@ int perc::Event::signal()
     char c = 27;
     return write(mTrigger, &c, 1) == 1;
 }
+
+#endif

--- a/third-party/libtm/libtm/src/infra/Event_lin.cpp
+++ b/third-party/libtm/libtm/src/infra/Event_lin.cpp
@@ -4,6 +4,8 @@ INTEL CORPORATION PROPRIETARY INFORMATION
 Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 *******************************************************************************/
 
+#ifdef __linux__
+
 #include "Event.h"
 #include <unistd.h>
 # include <sys/eventfd.h>
@@ -34,3 +36,5 @@ int perc::Event::signal() {
 
     return !::eventfd_write(mEvent, 1);
 }
+
+#endif

--- a/third-party/libtm/libtm/src/infra/Event_win.cpp
+++ b/third-party/libtm/libtm/src/infra/Event_win.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
+#ifdef _WIN32
+
 #include "Event.h"
 
 perc::Event::Event()
@@ -33,3 +35,5 @@ int perc::Event::signal()
 
     return SetEvent(mEvent);
 }
+
+#endif

--- a/third-party/libtm/libtm/src/infra/Poller_bsd.cpp
+++ b/third-party/libtm/libtm/src/infra/Poller_bsd.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
+#ifdef __APPLE__
+
 #define LOG_TAG "infra/Poller"
 #define LOG_NDEBUG 1    // controls LOGV only
 #include "Log.h"
@@ -93,3 +95,5 @@ namespace perc
         return n;
     }
 }
+
+#endif

--- a/third-party/libtm/libtm/src/infra/Poller_lin.cpp
+++ b/third-party/libtm/libtm/src/infra/Poller_lin.cpp
@@ -4,6 +4,8 @@ INTEL CORPORATION PROPRIETARY INFORMATION
 Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 *******************************************************************************/
 
+#ifdef __linux__
+
 #define LOG_TAG "infra/Poller"
 #define LOG_NDEBUG 1    // controls LOGV only
 #include "Log.h"
@@ -111,3 +113,6 @@ namespace perc
     }
 
 } // namespace perc
+
+
+#endif

--- a/third-party/libtm/libtm/src/infra/Poller_win.cpp
+++ b/third-party/libtm/libtm/src/infra/Poller_win.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
+#ifdef _WIN32
+
 #define LOG_TAG "Poller"
 #define LOG_NDEBUG 1    // controls LOGV only
 #include "Log.h"
@@ -150,3 +152,5 @@ namespace perc
         return 0;
     }
 } // namespace perc
+
+#endif

--- a/third-party/libtm/libtm/src/infra/Utils.cpp
+++ b/third-party/libtm/libtm/src/infra/Utils.cpp
@@ -26,6 +26,27 @@
 
 #include "Utils.h"
 
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#endif
+
 nsecs_t systemTime()
 {
 #ifdef _WIN32
@@ -100,7 +121,7 @@ HostLocalTime getLocalTime()
 
 uint64_t bytesSwap(uint64_t val)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
     return htobe64(val);
 #else
     return _byteswap_uint64(val);

--- a/third-party/libtm/tools/CMakeLists.txt
+++ b/third-party/libtm/tools/CMakeLists.txt
@@ -6,4 +6,4 @@ project(libtm_samples)
 message(STATUS "--------------------------------------------------------------------------------------------------------------------------------------------------------------")
 message(STATUS "Building all projects of ${PROJECT_NAME}")
 
-add_subdirectory(libtm_util)
+#add_subdirectory(libtm_util)


### PR DESCRIPTION
Based on work by @radfordi and @bfulkers-i 

This PR will make the T265 work on Mac OS with the Viewer and other SDK apps. 

Issues to address prior to official release:
a. libtm-util does not compile
b. restarting after stop fails
c. do more validation

Hopefully it can serve as temporary work-around for Mac users, such as in #3386