### PR TITLE
Fixing USB2 detection bug

### DIFF
--- a/src/win/win-helpers.cpp
+++ b/src/win/win-helpers.cpp
@@ -509,9 +509,9 @@ namespace librealsense
                     std::wstring targetKey(reinterpret_cast<const wchar_t*>(driver_key.data()));
 
                     // recursively check all hubs, searching for composite device
-                    std::wstringstream buf;
                     for (int i = 0;; i++)
                     {
+                        std::wstringstream buf;
                         buf << "\\\\.\\HCD" << i;
                         std::wstring hcd = buf.str();
 


### PR DESCRIPTION
Fixing somewhat obscure bug that was causing D400 cameras connected to USB2 port to be mistakenly treated as USB3 (causing problems in various samples and tools). This was specific to Windows, and could occur when the camera was connected through anything but the first root hub.