### PR TITLE
rs-enumerate enhancements

### DIFF
--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -30,7 +30,7 @@ typedef enum rs2_recording_mode
     RS2_RECORDING_MODE_COUNT
 } rs2_recording_mode;
 
-/** \brief All the parameters are requaired to define video stream*/
+/** \brief All the parameters are required to define video stream*/
 typedef struct rs2_video_stream
 {
     rs2_stream type;
@@ -44,7 +44,7 @@ typedef struct rs2_video_stream
     rs2_intrinsics intrinsics;
 } rs2_video_stream;
 
-/** \brief All the parameters are requaired to define motion stream*/
+/** \brief All the parameters are required to define motion stream*/
 typedef struct rs2_motion_stream
 {
     rs2_stream type;
@@ -55,7 +55,7 @@ typedef struct rs2_motion_stream
     rs2_motion_device_intrinsic intrinsics;
 } rs2_motion_stream;
 
-/** \brief All the parameters are requaired to define pose stream*/
+/** \brief All the parameters are required to define pose stream*/
 typedef struct rs2_pose_stream
 {
     rs2_stream type;
@@ -65,7 +65,7 @@ typedef struct rs2_pose_stream
     rs2_format fmt;
 } rs2_pose_stream;
 
-/** \brief All the parameters are requaired to define video frame*/
+/** \brief All the parameters are required to define video frame*/
 typedef struct rs2_software_video_frame
 {
     void* pixels;
@@ -78,7 +78,7 @@ typedef struct rs2_software_video_frame
     const rs2_stream_profile* profile;
 } rs2_software_video_frame;
 
-/** \brief All the parameters are requaired to define motion frame*/
+/** \brief All the parameters are required to define motion frame*/
 typedef struct rs2_software_motion_frame
 {
     void* data;
@@ -89,7 +89,7 @@ typedef struct rs2_software_motion_frame
     const rs2_stream_profile* profile;
 } rs2_software_motion_frame;
 
-/** \brief All the parameters are requaired to define pose frame*/
+/** \brief All the parameters are required to define pose frame*/
 typedef struct rs2_software_pose_frame
 {
     struct pose_frame_info

--- a/tools/enumerate-devices/readme.md
+++ b/tools/enumerate-devices/readme.md
@@ -4,8 +4,8 @@
 `rs-enumerate-devices` tool is a console application providing information about connected devices.
 
 ## Usage
-After installing `librealsense` run ` rs-enumerate-devices` to launch the tool. 
-An example for output for a D415 camera is: 
+After installing `librealsense` run ` rs-enumerate-devices` to launch the tool.
+An example for output for a D415 camera is:
 
 ```
 Name                          :     Intel RealSense 415    
@@ -22,8 +22,6 @@ Product Id                    :     0AD3
 |Flag   |Description   |
 |---|---|
 |`-s`|Provide short summary, one line per device|
-|`-o`|List supported device options|
-|`-m`|List supported stream profiles|
-|`-c`|Provide calibration information|
-
-
+|`-o`|List supported device controls and options|
+|`-c`|Provide calibration (Intrinsic/Extrinsic) information|
+| None| List supported streaming modes|

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -14,21 +14,39 @@ using namespace std;
 using namespace TCLAP;
 using namespace rs2;
 
+std::vector<std::string> tokenize_floats(string input, char separator){
+    std::vector<std::string> tokens;
+    stringstream ss(input);
+    string token;
+
+    while (std::getline(ss, token, separator)) {
+        tokens.push_back(token);
+    }
+
+    return tokens;
+}
+
 void print(const rs2_extrinsics& extrinsics)
 {
     stringstream ss;
-     ss << "Rotation Matrix:\n";
+     ss << " Rotation Matrix:\n";
 
+    // Align displayed data along decimal point
     for (auto i = 0 ; i < 3 ; ++i)
     {
         for (auto j = 0 ; j < 3 ; ++j)
         {
-            ss << left << setw(15) << setprecision(5) << extrinsics.rotation[j*3 +i];
+            std::ostringstream oss;
+            oss << extrinsics.rotation[j*3 +i];
+            auto tokens = tokenize_floats(oss.str().c_str(),'.');
+            ss << right << setw(4) << tokens[0];
+            if (tokens.size()>1)
+                ss << "." << left <<setw(12) << tokens[1];
         }
         ss << endl;
     }
 
-    ss << "\nTranslation Vector: ";
+    ss << "\n Translation Vector: ";
     for (auto i = 0 ; i < sizeof(extrinsics.translation)/sizeof(extrinsics.translation[0]) ; ++i)
         ss << setprecision(15) << extrinsics.translation[i] << "  ";
 
@@ -61,14 +79,14 @@ void print(const rs2_motion_device_intrinsic& intrinsics)
 void print(const rs2_intrinsics& intrinsics)
 {
     stringstream ss;
-     ss << left << setw(14) << "Width: "      << "\t" << intrinsics.width  << endl <<
-           left << setw(14) << "Height: "     << "\t" << intrinsics.height << endl <<
-           left << setw(14) << "PPX: "        << "\t" << setprecision(15)  << intrinsics.ppx << endl <<
-           left << setw(14) << "PPY: "        << "\t" << setprecision(15)  << intrinsics.ppy << endl <<
-           left << setw(14) << "Fx: "         << "\t" << setprecision(15)  << intrinsics.fx  << endl <<
-           left << setw(14) << "Fy: "         << "\t" << setprecision(15)  << intrinsics.fy  << endl <<
-           left << setw(14) << "Distortion: " << "\t" << rs2_distortion_to_string(intrinsics.model) << endl <<
-           left << setw(14) << "Coeffs: ";
+     ss << left << setw(14) << "  Width: "      << "\t" << intrinsics.width  << endl <<
+           left << setw(14) << "  Height: "     << "\t" << intrinsics.height << endl <<
+           left << setw(14) << "  PPX: "        << "\t" << setprecision(15)  << intrinsics.ppx << endl <<
+           left << setw(14) << "  PPY: "        << "\t" << setprecision(15)  << intrinsics.ppy << endl <<
+           left << setw(14) << "  Fx: "         << "\t" << setprecision(15)  << intrinsics.fx  << endl <<
+           left << setw(14) << "  Fy: "         << "\t" << setprecision(15)  << intrinsics.fy  << endl <<
+           left << setw(14) << "  Distortion: " << "\t" << rs2_distortion_to_string(intrinsics.model) << endl <<
+           left << setw(14) << "  Coeffs: ";
 
     for (auto i = 0 ; i < sizeof(intrinsics.coeffs)/sizeof(intrinsics.coeffs[0]) ; ++i)
         ss << "\t" << setprecision(15) << intrinsics.coeffs[i] << "  ";
@@ -157,16 +175,14 @@ string get_str_formats(const set<rs2_format>& formats)
 
 int main(int argc, char** argv) try
 {
-    CmdLine cmd("librealsense rs-enumerate-devices example tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-enumerate-devices tool", ' ', RS2_API_VERSION_STR);
 
     SwitchArg compact_view_arg("s", "short", "Provide short summary of the devices");
-    SwitchArg show_options("o", "option", "Show all supported options per subdevice");
-    SwitchArg show_modes("m", "modes", "Show all supported stream modes per subdevice");
-    SwitchArg show_calibration_data("c", "calib_data", "Show extrinsic and intrinsic of all subdevices");
+    SwitchArg show_options_arg("o", "option", "Show all supported options per subdevice");
+    SwitchArg show_calibration_data_arg("c", "calib_data", "Show extrinsic and intrinsic of all subdevices");
     cmd.add(compact_view_arg);
-    cmd.add(show_options);
-    cmd.add(show_modes);
-    cmd.add(show_calibration_data);
+    cmd.add(show_options_arg);
+    cmd.add(show_calibration_data_arg);
 
     cmd.parse(argc, argv);
 
@@ -182,7 +198,12 @@ int main(int argc, char** argv) try
         return EXIT_SUCCESS;
     }
 
-    if (compact_view_arg.getValue())
+    bool compact_view           = compact_view_arg.getValue();
+    bool show_options           = show_options_arg.getValue();
+    bool show_calibration_data  = show_calibration_data_arg.getValue();
+    bool show_modes             = !compact_view;
+
+    if (compact_view)
     {
         cout << left << setw(30) << "Device Name"
             << setw(20) << "Serial Number"
@@ -199,11 +220,11 @@ int main(int argc, char** argv) try
                 << endl;
         }
 
-        if (show_options.getValue() || show_modes.getValue())
+        if (show_options || show_calibration_data)
             cout << "\n\nNote:  \"-s\" option is not compatible with the other flags specified,"
                  << " all the additional options are skipped" << endl;
 
-        return EXIT_SUCCESS;
+        show_options = show_calibration_data = false;
     }
 
     for (auto i = 0; i < device_count; ++i)
@@ -222,13 +243,13 @@ int main(int argc, char** argv) try
 
         cout << endl;
 
-        if (show_options.getValue())
+        if (show_options)
         {
             for (auto&& sensor : dev.query_sensors())
             {
                 cout << "Options for " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
 
-                cout << setw(55) << " Supported options:" << setw(10) << "min" << setw(10)
+                cout << setw(35) << " Supported options:" << setw(10) << "min" << setw(10)
                      << " max" << setw(6) << " step" << setw(10) << " default" << endl;
                 for (auto j = 0; j < RS2_OPTION_COUNT; ++j)
                 {
@@ -236,7 +257,7 @@ int main(int argc, char** argv) try
                     if (sensor.supports(opt))
                     {
                         auto range = sensor.get_option_range(opt);
-                        cout << "    " << left << setw(50) << opt << " : "
+                        cout << "    " << left << setw(30) << opt << " : "
                              << setw(5) << range.min << "... " << setw(12) << range.max
                              << setw(6) << range.step << setw(10) << range.def << "\n";
                     }
@@ -246,25 +267,26 @@ int main(int argc, char** argv) try
             }
         }
 
-        if (show_modes.getValue())
+        if (show_modes)
         {
             for (auto&& sensor : dev.query_sensors())
             {
                 cout << "Stream Profiles supported by " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
 
-                cout << setw(55) << " Supported modes:" << setw(10) << "stream" << setw(10)
-                     << " resolution" << setw(6) << " fps" << setw(10) << " format" << endl;
+                cout << " Supported modes:\n" << setw(16) << "    stream" << setw(16)
+                     << " resolution" << setw(10) << " fps" << setw(10) << " format" << endl;
                 // Show which streams are supported by this device
                 for (auto&& profile : sensor.get_stream_profiles())
                 {
                     if (auto video = profile.as<video_stream_profile>())
                     {
                         cout << "    " << profile.stream_name() << "\t  " << video.width() << "x"
-                            << video.height() << "\t@ " << profile.fps() << "Hz\t" << profile.format() << endl;
+                            << video.height() << "\t@ " << profile.fps() << setw(6) << "Hz\t" << profile.format() << endl;
                     }
                     else
                     {
-                        cout << "    " << profile.stream_name() << "\t@ " << profile.fps() << "Hz\t" << profile.format() << endl;
+                        cout << "    " << profile.stream_name() << "\t N/A\t\t@ " << profile.fps()
+                            << setw(6) << "Hz\t" << profile.format() << endl;
                     }
                 }
 
@@ -272,31 +294,8 @@ int main(int argc, char** argv) try
             }
         }
 
-        for (auto&& sensor : dev.query_sensors())
-        {
-            cout << "Stream Profiles supported by " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
-
-            cout << setw(55) << " Supported modes:" << setw(10) << "stream" << setw(10)
-                 << " resolution" << setw(6) << " fps" << setw(10) << " format" << endl;
-            // Show which streams are supported by this device
-            for (auto&& profile : sensor.get_stream_profiles())
-            {
-                if (auto video = profile.as<video_stream_profile>())
-                {
-                    cout << "    " << profile.stream_name() << "\t  " << video.width() << "x"
-                        << video.height() << "\t@ " << profile.fps() << "Hz\t" << profile.format() << endl;
-                }
-                else
-                {
-                    cout << "    " << profile.stream_name() << "\t@ " << profile.fps() << "Hz\t" << profile.format() << endl;
-                }
-            }
-
-            cout << endl;
-        }
-
         // Print Intrinsics
-        if (show_calibration_data.getValue())
+        if (show_calibration_data)
         {
             std::map<stream_and_index, stream_profile> streams;
             std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_intrinsics>>> intrinsics_map;
@@ -368,9 +367,9 @@ int main(int argc, char** argv) try
                 auto stream_res = kvp.first;
                 for (auto& intrinsics : kvp.second)
                 {
-                    auto formats = get_str_formats(intrinsics.first);
-                    cout << "Intrinsic of \"" << stream_res.stream_name << "\"\t  " << stream_res.width << "x"
-                        << stream_res.height << "\t  " << formats << endl;
+                    auto formats = "{" + get_str_formats(intrinsics.first) + "}";
+                    cout << " Intrinsic of \"" << stream_res.stream_name << "\" / " << stream_res.width << "x"
+                        << stream_res.height << " / " << formats << endl;
                     if (intrinsics.second == rs2_intrinsics{})
                     {
                         cout << "Intrinsic NOT available!\n\n";
@@ -423,8 +422,6 @@ int main(int argc, char** argv) try
             }
         }
     }
-
-    cout << endl;
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
    Update rs-enumerate-devices presentation logics:
    - Remove redundant -m flag (invoked by default, unless -s specified)
    - Remove duplicate modes listing when invoked with -m flag
    - Documentation review
    - Adjust data alignment - each subset indentation is hierarchically moved to the right
    - Improve readability by introducing vertical alignment along the decimal point when presenting float values (extrinsic matrices):
    Old:
    0.99999        -0.0041276     -0.00091868
    0.0041225      0.99998        -0.0055234
    0.00094146     0.0055196      0.99998
    
    New:
       0.999991        -0.00412763      -0.000918684
       0.0041225        0.999976        -0.00552339
       0.000941461      0.00551955       0.999984