### PR TITLE
Add OpenNI2 Headers to Third-Party Directory

### DIFF
--- a/third-party/openni2/Include/Android-Arm/OniPlatformAndroid-Arm.h
+++ b/third-party/openni2/Include/Android-Arm/OniPlatformAndroid-Arm.h
@@ -1,0 +1,43 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_PLATFORM_ANDROID_ARM_H_
+#define _ONI_PLATFORM_ANDROID_ARM_H_
+
+// Start with Linux-x86, and override what's different
+#include "../Linux-x86/OniPlatformLinux-x86.h"
+
+//---------------------------------------------------------------------------
+// Platform Basic Definition
+//---------------------------------------------------------------------------
+#undef ONI_PLATFORM
+#undef ONI_PLATFORM_STRING
+
+#define ONI_PLATFORM ONI_PLATFORM_ANDROID_ARM
+#define ONI_PLATFORM_STRING "Android-Arm"
+
+#ifdef HAVE_ANDROID_OS
+	#define ONI_PLATFORM_ANDROID_OS
+	
+	#undef ONI_PLATFORM_STRING
+	#define ONI_PLATFORM_STRING "AndroidOS-Arm"
+#endif
+
+#endif //_ONI_PLATFORM_LINUX_ARM_H_

--- a/third-party/openni2/Include/Driver/OniDriverAPI.h
+++ b/third-party/openni2/Include/Driver/OniDriverAPI.h
@@ -1,0 +1,378 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_DRIVER_API_H_
+#define _ONI_DRIVER_API_H_
+
+#include "OniPlatform.h"
+#include "OniCTypes.h"
+#include "OniCProperties.h"
+#include "OniDriverTypes.h"
+#include <stdarg.h>
+
+namespace oni { namespace driver {
+
+class DeviceBase;
+class StreamBase;
+
+typedef void (ONI_CALLBACK_TYPE* DeviceConnectedCallback)(const OniDeviceInfo*, void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* DeviceDisconnectedCallback)(const OniDeviceInfo*, void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* DeviceStateChangedCallback)(const OniDeviceInfo* deviceId, int errorState, void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* NewFrameCallback)(StreamBase* streamId, OniFrame*, void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* PropertyChangedCallback)(void* sender, int propertyId, const void* data, int dataSize, void* pCookie);
+
+class StreamServices : public OniStreamServices
+{
+public:
+	int getDefaultRequiredFrameSize()
+	{
+		return OniStreamServices::getDefaultRequiredFrameSize(streamServices);
+	}
+
+	OniFrame* acquireFrame()
+	{
+		return OniStreamServices::acquireFrame(streamServices);
+	}
+
+	void addFrameRef(OniFrame* pFrame)
+	{
+		OniStreamServices::addFrameRef(streamServices, pFrame);
+	}
+
+	void releaseFrame(OniFrame* pFrame)
+	{
+		OniStreamServices::releaseFrame(streamServices, pFrame);
+	}
+};
+
+class StreamBase
+{
+public:
+	StreamBase() : m_newFrameCallback(NULL), m_propertyChangedCallback(NULL) {}
+	virtual ~StreamBase() {}
+
+	virtual void setServices(StreamServices* pStreamServices) { m_pServices = pStreamServices; }
+
+	virtual OniStatus setProperty(int /*propertyId*/, const void* /*data*/, int /*dataSize*/) {return ONI_STATUS_NOT_IMPLEMENTED;}
+	virtual OniStatus getProperty(int /*propertyId*/, void* /*data*/, int* /*pDataSize*/) {return ONI_STATUS_NOT_IMPLEMENTED;}
+	virtual OniBool isPropertySupported(int /*propertyId*/) {return FALSE;}
+	virtual OniStatus invoke(int /*commandId*/, void* /*data*/, int /*dataSize*/) {return ONI_STATUS_NOT_IMPLEMENTED;}
+	virtual OniBool isCommandSupported(int /*commandId*/) {return FALSE;}
+
+	virtual int getRequiredFrameSize() { return getServices().getDefaultRequiredFrameSize(); }
+
+	virtual OniStatus start() = 0;
+	virtual void stop() = 0;
+
+	virtual void setNewFrameCallback(NewFrameCallback handler, void* pCookie) { m_newFrameCallback = handler; m_newFrameCallbackCookie = pCookie; }
+	virtual void setPropertyChangedCallback(PropertyChangedCallback handler, void* pCookie) { m_propertyChangedCallback = handler; m_propertyChangedCookie = pCookie; }
+
+	virtual void notifyAllProperties() { return; }
+
+	virtual OniStatus convertDepthToColorCoordinates(StreamBase* /*colorStream*/, int /*depthX*/, int /*depthY*/, OniDepthPixel /*depthZ*/, int* /*pColorX*/, int* /*pColorY*/) { return ONI_STATUS_NOT_SUPPORTED; }
+
+protected:
+	void raiseNewFrame(OniFrame* pFrame) { (*m_newFrameCallback)(this, pFrame, m_newFrameCallbackCookie); }
+	void raisePropertyChanged(int propertyId, const void* data, int dataSize) { (*m_propertyChangedCallback)(this, propertyId, data, dataSize, m_propertyChangedCookie); }
+
+	StreamServices& getServices() { return *m_pServices; }
+
+private:
+	StreamServices* m_pServices;
+	NewFrameCallback m_newFrameCallback;
+	void* m_newFrameCallbackCookie;
+	PropertyChangedCallback m_propertyChangedCallback;
+	void* m_propertyChangedCookie;
+};
+
+class DeviceBase
+{
+public:
+	DeviceBase() {}
+	virtual ~DeviceBase() {}
+
+	virtual OniStatus getSensorInfoList(OniSensorInfo** pSensorInfos, int* numSensors) = 0;
+
+	virtual StreamBase* createStream(OniSensorType) = 0;
+	virtual void destroyStream(StreamBase* pStream) = 0;
+
+	virtual OniStatus setProperty(int /*propertyId*/, const void* /*data*/, int /*dataSize*/) {return ONI_STATUS_NOT_IMPLEMENTED;}
+	virtual OniStatus getProperty(int /*propertyId*/, void* /*data*/, int* /*pDataSize*/) {return ONI_STATUS_NOT_IMPLEMENTED;}
+	virtual OniBool isPropertySupported(int /*propertyId*/) {return FALSE;}
+	virtual OniStatus invoke(int /*commandId*/, void* /*data*/, int /*dataSize*/) {return ONI_STATUS_NOT_IMPLEMENTED;}
+	virtual OniBool isCommandSupported(int /*commandId*/) {return FALSE;}
+	virtual OniStatus tryManualTrigger() {return ONI_STATUS_OK;}
+
+	virtual void setPropertyChangedCallback(PropertyChangedCallback handler, void* pCookie) { m_propertyChangedCallback = handler; m_propertyChangedCookie = pCookie; }
+	virtual void notifyAllProperties() { return; }
+
+	virtual OniBool isImageRegistrationModeSupported(OniImageRegistrationMode mode) { return (mode == ONI_IMAGE_REGISTRATION_OFF); }
+
+protected:
+	void raisePropertyChanged(int propertyId, const void* data, int dataSize) { (*m_propertyChangedCallback)(this, propertyId, data, dataSize, m_propertyChangedCookie); }
+
+private:
+	PropertyChangedCallback m_propertyChangedCallback;
+	void* m_propertyChangedCookie;
+};
+
+class DriverServices
+{
+public:
+	DriverServices(OniDriverServices* pDriverServices) : m_pDriverServices(pDriverServices) {}
+
+	void errorLoggerAppend(const char* format, ...)
+	{
+		va_list args;
+		va_start(args, format);
+		m_pDriverServices->errorLoggerAppend(m_pDriverServices->driverServices, format, args);
+		va_end(args);
+	}
+
+	void errorLoggerClear()
+	{
+		m_pDriverServices->errorLoggerClear(m_pDriverServices->driverServices);
+	}
+
+	void log(int severity, const char* file, int line, const char* mask, const char* message)
+	{
+		m_pDriverServices->log(m_pDriverServices->driverServices, severity, file, line, mask, message);
+	}
+
+private:
+	OniDriverServices* m_pDriverServices;
+};
+
+class DriverBase
+{
+public:
+	DriverBase(OniDriverServices* pDriverServices) : m_services(pDriverServices)
+	{}
+
+	virtual ~DriverBase() {}
+
+	virtual OniStatus initialize(DeviceConnectedCallback connectedCallback, DeviceDisconnectedCallback disconnectedCallback, DeviceStateChangedCallback deviceStateChangedCallback, void* pCookie)
+	{
+		m_deviceConnectedEvent = connectedCallback;
+		m_deviceDisconnectedEvent = disconnectedCallback;
+		m_deviceStateChangedEvent = deviceStateChangedCallback;
+		m_pCookie = pCookie;
+		return ONI_STATUS_OK;
+	}
+
+	virtual DeviceBase* deviceOpen(const char* uri, const char* mode) = 0;
+	virtual void deviceClose(DeviceBase* pDevice) = 0;
+
+	virtual void shutdown() = 0;
+
+	virtual OniStatus tryDevice(const char* /*uri*/) { return ONI_STATUS_ERROR;}
+
+	virtual void* enableFrameSync(StreamBase** /*pStreams*/, int /*streamCount*/) { return NULL; }
+	virtual void disableFrameSync(void* /*frameSyncGroup*/) {}
+
+protected:
+	void deviceConnected(const OniDeviceInfo* pInfo) { (m_deviceConnectedEvent)(pInfo, m_pCookie); }
+	void deviceDisconnected(const OniDeviceInfo* pInfo) { (m_deviceDisconnectedEvent)(pInfo, m_pCookie); }
+	void deviceStateChanged(const OniDeviceInfo* pInfo, int errorState) { (m_deviceStateChangedEvent)(pInfo, errorState, m_pCookie); }
+
+	DriverServices& getServices() { return m_services; }
+
+private:
+	DeviceConnectedCallback m_deviceConnectedEvent;
+	DeviceDisconnectedCallback m_deviceDisconnectedEvent;
+	DeviceStateChangedCallback m_deviceStateChangedEvent;
+	void* m_pCookie;
+
+	DriverServices m_services;
+};
+
+}} // oni::driver
+
+#define ONI_EXPORT_DRIVER(DriverClass)																						\
+																															\
+oni::driver::DriverBase* g_pDriver = NULL;																					\
+																															\
+/* As Driver */																												\
+ONI_C_API_EXPORT void oniDriverCreate(OniDriverServices* driverServices) {													\
+	g_pDriver = XN_NEW(DriverClass, driverServices);																		\
+}																															\
+ONI_C_API_EXPORT void oniDriverDestroy()																					\
+{																															\
+	g_pDriver->shutdown();																									\
+	XN_DELETE(g_pDriver); g_pDriver = NULL;																					\
+}																															\
+ONI_C_API_EXPORT OniStatus oniDriverInitialize(oni::driver::DeviceConnectedCallback deviceConnectedCallback,				\
+										oni::driver::DeviceDisconnectedCallback deviceDisconnectedCallback,					\
+										oni::driver::DeviceStateChangedCallback deviceStateChangedCallback,					\
+										void* pCookie)																		\
+{																															\
+	return g_pDriver->initialize(deviceConnectedCallback, deviceDisconnectedCallback, deviceStateChangedCallback, pCookie);	\
+}																															\
+																															\
+ONI_C_API_EXPORT OniStatus oniDriverTryDevice(const char* uri)																\
+{																															\
+	return g_pDriver->tryDevice(uri);																						\
+}																															\
+																															\
+/* As Device */																												\
+ONI_C_API_EXPORT oni::driver::DeviceBase* oniDriverDeviceOpen(const char* uri, const char* mode)							\
+{																															\
+	return g_pDriver->deviceOpen(uri, mode);																				\
+}																															\
+ONI_C_API_EXPORT void oniDriverDeviceClose(oni::driver::DeviceBase* pDevice)												\
+{																															\
+	g_pDriver->deviceClose(pDevice);																						\
+}																															\
+																															\
+ONI_C_API_EXPORT OniStatus oniDriverDeviceGetSensorInfoList(oni::driver::DeviceBase* pDevice, OniSensorInfo** pSensorInfos,	\
+															int* numSensors)												\
+{																															\
+	return pDevice->getSensorInfoList(pSensorInfos, numSensors);															\
+}																															\
+																															\
+ONI_C_API_EXPORT oni::driver::StreamBase* oniDriverDeviceCreateStream(oni::driver::DeviceBase* pDevice,						\
+																		OniSensorType sensorType)							\
+{																															\
+	return pDevice->createStream(sensorType);																				\
+}																															\
+																															\
+ONI_C_API_EXPORT void oniDriverDeviceDestroyStream(oni::driver::DeviceBase* pDevice, oni::driver::StreamBase* pStream)		\
+{																															\
+	return pDevice->destroyStream(pStream);																					\
+}																															\
+																															\
+ONI_C_API_EXPORT OniStatus oniDriverDeviceSetProperty(oni::driver::DeviceBase* pDevice, int propertyId,						\
+													const void* data, int dataSize)											\
+{																															\
+	return pDevice->setProperty(propertyId, data, dataSize);																\
+}																															\
+ONI_C_API_EXPORT OniStatus oniDriverDeviceGetProperty(oni::driver::DeviceBase* pDevice, int propertyId,						\
+													void* data, int* pDataSize)												\
+{																															\
+	return pDevice->getProperty(propertyId, data, pDataSize);																\
+}																															\
+ONI_C_API_EXPORT OniBool oniDriverDeviceIsPropertySupported(oni::driver::DeviceBase* pDevice, int propertyId)				\
+{																															\
+	return pDevice->isPropertySupported(propertyId);																		\
+}																															\
+ONI_C_API_EXPORT void oniDriverDeviceSetPropertyChangedCallback(oni::driver::DeviceBase* pDevice,							\
+	oni::driver::PropertyChangedCallback handler, void* pCookie)															\
+{																															\
+	pDevice->setPropertyChangedCallback(handler, pCookie);																	\
+}																															\
+ONI_C_API_EXPORT void oniDriverDeviceNotifyAllProperties(oni::driver::DeviceBase* pDevice)									\
+{																															\
+	pDevice->notifyAllProperties();																							\
+}																															\
+ONI_C_API_EXPORT OniStatus oniDriverDeviceInvoke(oni::driver::DeviceBase* pDevice, int commandId,							\
+												void* data, int dataSize)													\
+{																															\
+	return pDevice->invoke(commandId, data, dataSize);																		\
+}																															\
+ONI_C_API_EXPORT OniBool oniDriverDeviceIsCommandSupported(oni::driver::DeviceBase* pDevice, int commandId)					\
+{																															\
+	return pDevice->isCommandSupported(commandId);																			\
+}																															\
+ONI_C_API_EXPORT OniStatus oniDriverDeviceTryManualTrigger(oni::driver::DeviceBase* pDevice)								\
+{																															\
+	return pDevice->tryManualTrigger();																						\
+}																															\
+ONI_C_API_EXPORT OniBool oniDriverDeviceIsImageRegistrationModeSupported(oni::driver::DeviceBase* pDevice,					\
+	OniImageRegistrationMode mode)																							\
+{																															\
+	return pDevice->isImageRegistrationModeSupported(mode);																	\
+}																															\
+																															\
+/* As Stream */																												\
+ONI_C_API_EXPORT void oniDriverStreamSetServices(oni::driver::StreamBase* pStream, OniStreamServices* pServices)			\
+{																															\
+	pStream->setServices((oni::driver::StreamServices*)pServices);															\
+}																															\
+																															\
+ONI_C_API_EXPORT OniStatus oniDriverStreamSetProperty(oni::driver::StreamBase* pStream, int propertyId,						\
+													const void* data, int dataSize)											\
+{																															\
+	return pStream->setProperty(propertyId, data, dataSize);																\
+}																															\
+ONI_C_API_EXPORT OniStatus oniDriverStreamGetProperty(oni::driver::StreamBase* pStream, int propertyId, void* data,			\
+													int* pDataSize)															\
+{																															\
+	return pStream->getProperty(propertyId, data, pDataSize);																\
+}																															\
+ONI_C_API_EXPORT OniBool oniDriverStreamIsPropertySupported(oni::driver::StreamBase* pStream, int propertyId)				\
+{																															\
+	return pStream->isPropertySupported(propertyId);																		\
+}																															\
+ONI_C_API_EXPORT void oniDriverStreamSetPropertyChangedCallback(oni::driver::StreamBase* pStream,							\
+													oni::driver::PropertyChangedCallback handler, void* pCookie)			\
+{																															\
+	pStream->setPropertyChangedCallback(handler, pCookie);																	\
+}																															\
+ONI_C_API_EXPORT void oniDriverStreamNotifyAllProperties(oni::driver::StreamBase* pStream)									\
+{																															\
+	pStream->notifyAllProperties();																							\
+}																															\
+ONI_C_API_EXPORT OniStatus oniDriverStreamInvoke(oni::driver::StreamBase* pStream, int commandId,							\
+												void* data, int dataSize)													\
+{																															\
+	return pStream->invoke(commandId, data, dataSize);																		\
+}																															\
+ONI_C_API_EXPORT OniBool oniDriverStreamIsCommandSupported(oni::driver::StreamBase* pStream, int commandId)					\
+{																															\
+	return pStream->isCommandSupported(commandId);																			\
+}																															\
+																															\
+ONI_C_API_EXPORT OniStatus oniDriverStreamStart(oni::driver::StreamBase* pStream)											\
+{																															\
+	return pStream->start();																								\
+}																															\
+ONI_C_API_EXPORT void oniDriverStreamStop(oni::driver::StreamBase* pStream)													\
+{																															\
+	pStream->stop();																										\
+}																															\
+																															\
+ONI_C_API_EXPORT int oniDriverStreamGetRequiredFrameSize(oni::driver::StreamBase* pStream)									\
+{																															\
+	return pStream->getRequiredFrameSize();																					\
+}																															\
+																															\
+ONI_C_API_EXPORT void oniDriverStreamSetNewFrameCallback(oni::driver::StreamBase* pStream,									\
+														oni::driver::NewFrameCallback handler, void* pCookie)				\
+{																															\
+	pStream->setNewFrameCallback(handler, pCookie);																			\
+}																															\
+																															\
+ONI_C_API_EXPORT OniStatus oniDriverStreamConvertDepthToColorCoordinates(oni::driver::StreamBase* pDepthStream,				\
+	oni::driver::StreamBase* pColorStream, int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY)		\
+{																															\
+	return pDepthStream->convertDepthToColorCoordinates(pColorStream, depthX, depthY, depthZ, pColorX, pColorY);			\
+}																															\
+																															\
+ONI_C_API_EXPORT void* oniDriverEnableFrameSync(oni::driver::StreamBase** pStreams, int streamCount)						\
+{																															\
+	return g_pDriver->enableFrameSync(pStreams, streamCount);																\
+}																															\
+																															\
+ONI_C_API_EXPORT void oniDriverDisableFrameSync(void* frameSyncGroup)														\
+{																															\
+	return g_pDriver->disableFrameSync(frameSyncGroup);																		\
+}																															\
+
+#endif // _ONI_DRIVER_API_H_

--- a/third-party/openni2/Include/Driver/OniDriverTypes.h
+++ b/third-party/openni2/Include/Driver/OniDriverTypes.h
@@ -1,0 +1,54 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_DRIVER_TYPES_H_
+#define _ONI_DRIVER_TYPES_H_
+
+#include <OniCTypes.h>
+#include <stdarg.h>
+
+#define ONI_STREAM_PROPERTY_PRIVATE_BASE XN_MAX_UINT16
+
+typedef struct
+{
+	int dataSize;
+	void* data;
+} OniGeneralBuffer;
+
+/////// DriverServices
+struct OniDriverServices
+{
+	void* driverServices;
+	void (ONI_CALLBACK_TYPE* errorLoggerAppend)(void* driverServices, const char* format, va_list args);
+	void (ONI_CALLBACK_TYPE* errorLoggerClear)(void* driverServices);
+	void (ONI_CALLBACK_TYPE* log)(void* driverServices, int severity, const char* file, int line, const char* mask, const char* message);
+};
+
+struct OniStreamServices
+{
+	void* streamServices;
+	int (ONI_CALLBACK_TYPE* getDefaultRequiredFrameSize)(void* streamServices);
+	OniFrame* (ONI_CALLBACK_TYPE* acquireFrame)(void* streamServices); // returns a frame with size corresponding to getRequiredFrameSize()
+	void (ONI_CALLBACK_TYPE* addFrameRef)(void* streamServices, OniFrame* pframe);
+	void (ONI_CALLBACK_TYPE* releaseFrame)(void* streamServices, OniFrame* pframe);
+};
+
+
+#endif // _ONI_DRIVER_TYPES_H_

--- a/third-party/openni2/Include/Linux-Arm/OniPlatformLinux-Arm.h
+++ b/third-party/openni2/Include/Linux-Arm/OniPlatformLinux-Arm.h
@@ -1,0 +1,36 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_PLATFORM_LINUX_ARM_H_
+#define _ONI_PLATFORM_LINUX_ARM_H_
+
+// Start with Linux-x86, and override what's different
+#include "../Linux-x86/OniPlatformLinux-x86.h"
+
+//---------------------------------------------------------------------------
+// Platform Basic Definition
+//---------------------------------------------------------------------------
+#undef ONI_PLATFORM
+#undef ONI_PLATFORM_STRING
+#define ONI_PLATFORM ONI_PLATFORM_LINUX_ARM
+#define ONI_PLATFORM_STRING "Linux-Arm"
+
+#endif //_ONI_PLATFORM_LINUX_ARM_H_
+

--- a/third-party/openni2/Include/Linux-x86/OniPlatformLinux-x86.h
+++ b/third-party/openni2/Include/Linux-x86/OniPlatformLinux-x86.h
@@ -1,0 +1,102 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_PLATFORM_LINUX_X86_H_
+#define _ONI_PLATFORM_LINUX_X86_H_
+
+//---------------------------------------------------------------------------
+// Prerequisites
+//---------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------
+// Includes
+//---------------------------------------------------------------------------
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <limits.h>
+#include <stdint.h>
+
+//---------------------------------------------------------------------------
+// Platform Basic Definition
+//---------------------------------------------------------------------------
+#define ONI_PLATFORM ONI_PLATFORM_LINUX_X86
+#define ONI_PLATFORM_STRING "Linux-x86"
+
+//---------------------------------------------------------------------------
+// Platform Capabilities
+//---------------------------------------------------------------------------
+#define ONI_PLATFORM_ENDIAN_TYPE ONI_PLATFORM_IS_LITTLE_ENDIAN
+
+#define ONI_PLATFORM_SUPPORTS_DYNAMIC_LIBS 1
+
+//---------------------------------------------------------------------------
+// Memory
+//---------------------------------------------------------------------------
+/** The default memory alignment. */ 
+#define ONI_DEFAULT_MEM_ALIGN 16
+
+/** The thread static declarator (using TLS). */
+#define ONI_THREAD_STATIC __thread
+
+//---------------------------------------------------------------------------
+// Files
+//---------------------------------------------------------------------------
+/** The maximum allowed file path size (in bytes). */ 
+#define ONI_FILE_MAX_PATH 256
+
+//---------------------------------------------------------------------------
+// Call back
+//---------------------------------------------------------------------------
+/** The std call type. */ 
+#define ONI_STDCALL __stdcall
+
+/** The call back calling convention. */ 
+#define ONI_CALLBACK_TYPE 
+
+/** The C and C++ calling convension. */
+#define ONI_C_DECL
+
+//---------------------------------------------------------------------------
+// Macros
+//---------------------------------------------------------------------------
+/** Returns the date and time at compile time. */ 
+#define ONI_TIMESTAMP __DATE__ " " __TIME__
+
+/** Converts n into a pre-processor string.  */ 
+#define ONI_STRINGIFY(n) ONI_STRINGIFY_HELPER(n)
+#define ONI_STRINGIFY_HELPER(n) #n
+
+//---------------------------------------------------------------------------
+// API Export/Import Macros
+//---------------------------------------------------------------------------
+/** Indicates an exported shared library function. */ 
+#define ONI_API_EXPORT __attribute__ ((visibility("default")))
+
+/** Indicates an imported shared library function. */ 
+#define ONI_API_IMPORT 
+
+/** Indicates a deprecated function */
+#define ONI_API_DEPRECATED(msg) __attribute__((warning("This function is deprecated: " msg)))
+
+#endif //_ONI_PLATFORM_LINUX_X86_H_
+

--- a/third-party/openni2/Include/MacOSX/OniPlatformMacOSX.h
+++ b/third-party/openni2/Include/MacOSX/OniPlatformMacOSX.h
@@ -1,0 +1,42 @@
+/*****************************************************************************
+*                                                                            *
+*  PrimeSense PSCommon Library                                               *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of PSCommon.                                            *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_PLATFORM_MACOSX_H_
+#define _ONI_PLATFORM_MACOSX_H_
+
+// Start with Linux-x86, and override what's different
+#include "../Linux-x86/OniPlatformLinux-x86.h"
+
+#include <sys/time.h>
+
+#undef ONI_PLATFORM
+#undef ONI_PLATFORM_STRING
+#define ONI_PLATFORM ONI_PLATFORM_MACOSX
+#define ONI_PLATFORM_STRING "MacOSX"
+
+#define ONI_PLATFORM_HAS_NO_TIMED_OPS
+#define ONI_PLATFORM_HAS_NO_CLOCK_GETTIME
+#define ONI_PLATFORM_HAS_NO_SCHED_PARAM
+#define ONI_PLATFORM_HAS_BUILTIN_SEMUN
+
+#undef ONI_THREAD_STATIC
+#define ONI_THREAD_STATIC 
+ 
+#endif //_ONI_PLATFORM_MACOSX_H_

--- a/third-party/openni2/Include/OniCAPI.h
+++ b/third-party/openni2/Include/OniCAPI.h
@@ -1,0 +1,259 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_C_API_H_
+#define _ONI_C_API_H_
+
+#include "OniPlatform.h"
+#include "OniCTypes.h"
+#include "OniCProperties.h"
+#include "OniVersion.h"
+
+/******************************************** General APIs */
+
+/**  Initialize OpenNI2. Use ONI_API_VERSION as the version. */
+ONI_C_API OniStatus oniInitialize(int apiVersion);
+/**  Shutdown OpenNI2 */
+ONI_C_API void oniShutdown();
+
+/**
+ * Get the list of currently connected device.
+ * Each device is represented by its OniDeviceInfo.
+ * pDevices will be allocated inside.
+ */
+ONI_C_API OniStatus oniGetDeviceList(OniDeviceInfo** pDevices, int* pNumDevices);
+/** Release previously allocated device list */
+ONI_C_API OniStatus oniReleaseDeviceList(OniDeviceInfo* pDevices);
+
+ONI_C_API OniStatus oniRegisterDeviceCallbacks(OniDeviceCallbacks* pCallbacks, void* pCookie, OniCallbackHandle* pHandle);
+ONI_C_API void oniUnregisterDeviceCallbacks(OniCallbackHandle handle);
+
+/** Wait for any of the streams to have a new frame */
+ONI_C_API OniStatus oniWaitForAnyStream(OniStreamHandle* pStreams, int numStreams, int* pStreamIndex, int timeout);
+
+/** Get the current version of OpenNI2 */
+ONI_C_API OniVersion oniGetVersion();
+
+/** Translate from format to number of bytes per pixel. Will return 0 for formats in which the number of bytes per pixel isn't fixed. */
+ONI_C_API int oniFormatBytesPerPixel(OniPixelFormat format);
+
+/** Get internal error */
+ONI_C_API const char* oniGetExtendedError();
+
+/******************************************** Device APIs */
+
+/** Open a device. Uri can be taken from the matching OniDeviceInfo. */
+ONI_C_API OniStatus oniDeviceOpen(const char* uri, OniDeviceHandle* pDevice);
+/** Close a device */
+ONI_C_API OniStatus oniDeviceClose(OniDeviceHandle device);
+
+/** Get the possible configurations available for a specific source, or NULL if the source does not exist. */
+ONI_C_API const OniSensorInfo* oniDeviceGetSensorInfo(OniDeviceHandle device, OniSensorType sensorType);
+
+/** Get the OniDeviceInfo of a certain device. */
+ONI_C_API OniStatus oniDeviceGetInfo(OniDeviceHandle device, OniDeviceInfo* pInfo);
+
+/** Create a new stream in the device. The stream will originate from the source. */
+ONI_C_API OniStatus oniDeviceCreateStream(OniDeviceHandle device, OniSensorType sensorType, OniStreamHandle* pStream);
+
+ONI_C_API OniStatus oniDeviceEnableDepthColorSync(OniDeviceHandle device);
+ONI_C_API void oniDeviceDisableDepthColorSync(OniDeviceHandle device);
+ONI_C_API OniBool oniDeviceGetDepthColorSyncEnabled(OniDeviceHandle device);
+
+/** Set property in the device. Use the properties listed in OniTypes.h: ONI_DEVICE_PROPERTY_..., or specific ones supplied by the device. */
+ONI_C_API OniStatus oniDeviceSetProperty(OniDeviceHandle device, int propertyId, const void* data, int dataSize);
+/** Get property in the device. Use the properties listed in OniTypes.h: ONI_DEVICE_PROPERTY_..., or specific ones supplied by the device. */
+ONI_C_API OniStatus oniDeviceGetProperty(OniDeviceHandle device, int propertyId, void* data, int* pDataSize);
+/** Check if the property is supported by the device. Use the properties listed in OniTypes.h: ONI_DEVICE_PROPERTY_..., or specific ones supplied by the device. */
+ONI_C_API OniBool oniDeviceIsPropertySupported(OniDeviceHandle device, int propertyId);
+/** Invoke an internal functionality of the device. */
+ONI_C_API OniStatus oniDeviceInvoke(OniDeviceHandle device, int commandId, void* data, int dataSize);
+/** Check if a command is supported, for invoke */
+ONI_C_API OniBool oniDeviceIsCommandSupported(OniDeviceHandle device, int commandId);
+
+ONI_C_API OniBool oniDeviceIsImageRegistrationModeSupported(OniDeviceHandle device, OniImageRegistrationMode mode);
+
+/** @internal */
+ONI_C_API OniStatus oniDeviceOpenEx(const char* uri, const char* mode, OniDeviceHandle* pDevice);
+
+/******************************************** Stream APIs */
+
+/** Destroy an existing stream */
+ONI_C_API void oniStreamDestroy(OniStreamHandle stream);
+
+/** Get the OniSensorInfo of the certain stream. */
+ONI_C_API const OniSensorInfo* oniStreamGetSensorInfo(OniStreamHandle stream);
+
+/** Start generating data from the stream. */
+ONI_C_API OniStatus oniStreamStart(OniStreamHandle stream);
+/** Stop generating data from the stream. */
+ONI_C_API void oniStreamStop(OniStreamHandle stream);
+
+/** Get the next frame from the stream. This function is blocking until there is a new frame from the stream. For timeout, use oniWaitForStreams() first */
+ONI_C_API OniStatus oniStreamReadFrame(OniStreamHandle stream, OniFrame** pFrame);
+
+/** Register a callback to when the stream has a new frame. */
+ONI_C_API OniStatus oniStreamRegisterNewFrameCallback(OniStreamHandle stream, OniNewFrameCallback handler, void* pCookie, OniCallbackHandle* pHandle);
+/** Unregister a previously registered callback to when the stream has a new frame. */
+ONI_C_API void oniStreamUnregisterNewFrameCallback(OniStreamHandle stream, OniCallbackHandle handle);
+
+/** Set property in the stream. Use the properties listed in OniTypes.h: ONI_STREAM_PROPERTY_..., or specific ones supplied by the device for its streams. */
+ONI_C_API OniStatus oniStreamSetProperty(OniStreamHandle stream, int propertyId, const void* data, int dataSize);
+/** Get property in the stream. Use the properties listed in OniTypes.h: ONI_STREAM_PROPERTY_..., or specific ones supplied by the device for its streams. */
+ONI_C_API OniStatus oniStreamGetProperty(OniStreamHandle stream, int propertyId, void* data, int* pDataSize);
+/** Check if the property is supported the stream. Use the properties listed in OniTypes.h: ONI_STREAM_PROPERTY_..., or specific ones supplied by the device for its streams. */
+ONI_C_API OniBool oniStreamIsPropertySupported(OniStreamHandle stream, int propertyId);
+/** Invoke an internal functionality of the stream. */
+ONI_C_API OniStatus oniStreamInvoke(OniStreamHandle stream, int commandId, void* data, int dataSize);
+/** Check if a command is supported, for invoke */
+ONI_C_API OniBool oniStreamIsCommandSupported(OniStreamHandle stream, int commandId);
+/** Sets the stream buffer allocation functions. Note that this function may only be called while stream is not started. */
+ONI_C_API OniStatus oniStreamSetFrameBuffersAllocator(OniStreamHandle stream, OniFrameAllocBufferCallback alloc, OniFrameFreeBufferCallback free, void* pCookie);
+
+////
+/** Mark another user of the frame. */
+ONI_C_API void oniFrameAddRef(OniFrame* pFrame);
+/** Mark that the frame is no longer needed.  */
+ONI_C_API void oniFrameRelease(OniFrame* pFrame);
+
+// ONI_C_API OniStatus oniConvertRealWorldToProjective(OniStreamHandle stream, OniFloatPoint3D* pRealWorldPoint, OniFloatPoint3D* pProjectivePoint);
+// ONI_C_API OniStatus oniConvertProjectiveToRealWorld(OniStreamHandle stream, OniFloatPoint3D* pProjectivePoint, OniFloatPoint3D* pRealWorldPoint);
+
+/**
+ * Creates a recorder that records to a file.
+ * @param	[in]	fileName	The name of the file that will contain the recording.
+ * @param	[out]	pRecorder	Points to the handle to the newly created recorder.
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniCreateRecorder(const char* fileName, OniRecorderHandle* pRecorder);
+
+/**
+ * Attaches a stream to a recorder. The amount of attached streams is virtually
+ * infinite. You cannot attach a stream after you have started a recording, if
+ * you do: an error will be returned by oniRecorderAttachStream.
+ * @param	[in]	recorder				The handle to the recorder.
+ * @param	[in]	stream					The handle to the stream.
+ * @param	[in]	allowLossyCompression	Allows/denies lossy compression
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniRecorderAttachStream(
+        OniRecorderHandle   recorder, 
+        OniStreamHandle     stream, 
+        OniBool             allowLossyCompression);
+
+/**
+ * Starts recording. There must be at least one stream attached to the recorder,
+ * if not: oniRecorderStart will return an error.
+ * @param[in] recorder The handle to the recorder.
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniRecorderStart(OniRecorderHandle recorder);
+
+/**
+ * Stops recording. You can resume recording via oniRecorderStart.
+ * @param[in] recorder The handle to the recorder.
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API void oniRecorderStop(OniRecorderHandle recorder);
+
+/**
+ * Stops recording if needed, and destroys a recorder.
+ * @param	[in,out]	recorder	The handle to the recorder, the handle will be
+ *									invalidated (nullified) when the function returns.
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniRecorderDestroy(OniRecorderHandle* pRecorder);
+
+ONI_C_API OniStatus oniCoordinateConverterDepthToWorld(OniStreamHandle depthStream, float depthX, float depthY, float depthZ, float* pWorldX, float* pWorldY, float* pWorldZ);
+
+ONI_C_API OniStatus oniCoordinateConverterWorldToDepth(OniStreamHandle depthStream, float worldX, float worldY, float worldZ, float* pDepthX, float* pDepthY, float* pDepthZ);
+
+ONI_C_API OniStatus oniCoordinateConverterDepthToColor(OniStreamHandle depthStream, OniStreamHandle colorStream, int depthX, int depthY, OniDepthPixel depthZ, int* pColorX, int* pColorY);
+
+/******************************************** Log APIs */
+
+/** 
+ * Change the log output folder
+
+ * @param const char * strOutputFolder	[in]	path to the desirebale folder
+ *
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniSetLogOutputFolder(const char* strOutputFolder);
+
+/** 
+ * Get the current log file name
+
+ * @param	char * strFileName	[out]	hold the returned file name
+ * @param	int nBufferSize	[in]	size of strFileName
+ *
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniGetLogFileName(char* strFileName, int nBufferSize);
+
+/** 
+ * Set the Minimum severity for log produce 
+
+ * @param	const char * strMask	[in]	Name of the logger
+ *
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniSetLogMinSeverity(int nMinSeverity);
+
+/** 
+ * Configures if log entries will be printed to console.
+
+ * @param	OniBool bConsoleOutput	[in]	TRUE to print log entries to console, FALSE otherwise.
+ *
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniSetLogConsoleOutput(OniBool bConsoleOutput);
+
+/** 
+ * Configures if log entries will be printed to a log file.
+
+ * @param	OniBool bFileOutput	[in]	TRUE to print log entries to the file, FALSE otherwise.
+ *
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniSetLogFileOutput(OniBool bFileOutput);
+
+#if ONI_PLATFORM == ONI_PLATFORM_ANDROID_ARM
+/** 
+ * Configures if log entries will be printed to the Android log.
+
+ * @param	OniBool bAndroidOutput	[in]	TRUE to print log entries to the Android log, FALSE otherwise.
+ *
+ * @retval ONI_STATUS_OK Upon successful completion.
+ * @retval ONI_STATUS_ERROR Upon any kind of failure.
+ */
+ONI_C_API OniStatus oniSetLogAndroidOutput(OniBool bAndroidOutput);
+#endif
+#endif // _ONI_C_API_H_

--- a/third-party/openni2/Include/OniCEnums.h
+++ b/third-party/openni2/Include/OniCEnums.h
@@ -1,0 +1,84 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_C_ENUMS_H_
+#define _ONI_C_ENUMS_H_
+
+/** Possible failure values */
+typedef enum
+{
+	ONI_STATUS_OK = 0,
+	ONI_STATUS_ERROR = 1,
+	ONI_STATUS_NOT_IMPLEMENTED = 2,
+	ONI_STATUS_NOT_SUPPORTED = 3,
+	ONI_STATUS_BAD_PARAMETER = 4,
+	ONI_STATUS_OUT_OF_FLOW = 5,
+	ONI_STATUS_NO_DEVICE = 6,
+	ONI_STATUS_TIME_OUT = 102,
+} OniStatus;
+
+/** The source of the stream */
+typedef enum
+{
+	ONI_SENSOR_IR = 1,
+	ONI_SENSOR_COLOR = 2,
+	ONI_SENSOR_DEPTH = 3,
+
+} OniSensorType;
+
+/** All available formats of the output of a stream */
+typedef enum
+{
+	// Depth
+	ONI_PIXEL_FORMAT_DEPTH_1_MM = 100,
+	ONI_PIXEL_FORMAT_DEPTH_100_UM = 101,
+	ONI_PIXEL_FORMAT_SHIFT_9_2 = 102,
+	ONI_PIXEL_FORMAT_SHIFT_9_3 = 103,
+
+	// Color
+	ONI_PIXEL_FORMAT_RGB888 = 200,
+	ONI_PIXEL_FORMAT_YUV422 = 201,
+	ONI_PIXEL_FORMAT_GRAY8 = 202,
+	ONI_PIXEL_FORMAT_GRAY16 = 203,
+	ONI_PIXEL_FORMAT_JPEG = 204,
+	ONI_PIXEL_FORMAT_YUYV = 205,
+} OniPixelFormat;
+
+typedef enum
+{
+	ONI_DEVICE_STATE_OK 		= 0,
+	ONI_DEVICE_STATE_ERROR		= 1,
+	ONI_DEVICE_STATE_NOT_READY 	= 2,
+	ONI_DEVICE_STATE_EOF 		= 3
+} OniDeviceState;
+
+typedef enum
+{
+	ONI_IMAGE_REGISTRATION_OFF				= 0,
+	ONI_IMAGE_REGISTRATION_DEPTH_TO_COLOR	= 1,
+} OniImageRegistrationMode;
+
+enum
+{
+	ONI_TIMEOUT_NONE = 0,
+	ONI_TIMEOUT_FOREVER = -1,
+};
+
+#endif // _ONI_C_ENUMS_H_

--- a/third-party/openni2/Include/OniCProperties.h
+++ b/third-party/openni2/Include/OniCProperties.h
@@ -1,0 +1,68 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_C_PROPERTIES_H_
+#define _ONI_C_PROPERTIES_H_
+
+// Device properties
+enum
+{
+	ONI_DEVICE_PROPERTY_FIRMWARE_VERSION		= 0, // By implementation
+	ONI_DEVICE_PROPERTY_DRIVER_VERSION		= 1, // OniVersion
+	ONI_DEVICE_PROPERTY_HARDWARE_VERSION		= 2, // int
+	ONI_DEVICE_PROPERTY_SERIAL_NUMBER		= 3, // string
+	ONI_DEVICE_PROPERTY_ERROR_STATE			= 4, // ??
+	ONI_DEVICE_PROPERTY_IMAGE_REGISTRATION		= 5, // OniImageRegistrationMode
+
+	// Files
+	ONI_DEVICE_PROPERTY_PLAYBACK_SPEED		= 100, // float
+	ONI_DEVICE_PROPERTY_PLAYBACK_REPEAT_ENABLED			= 101, // OniBool
+};
+
+// Stream properties
+enum
+{
+	ONI_STREAM_PROPERTY_CROPPING			= 0, // OniCropping*
+	ONI_STREAM_PROPERTY_HORIZONTAL_FOV		= 1, // float: radians
+	ONI_STREAM_PROPERTY_VERTICAL_FOV		= 2, // float: radians
+	ONI_STREAM_PROPERTY_VIDEO_MODE			= 3, // OniVideoMode*
+
+	ONI_STREAM_PROPERTY_MAX_VALUE			= 4, // int
+	ONI_STREAM_PROPERTY_MIN_VALUE			= 5, // int
+
+	ONI_STREAM_PROPERTY_STRIDE			= 6, // int
+	ONI_STREAM_PROPERTY_MIRRORING			= 7, // OniBool
+
+	ONI_STREAM_PROPERTY_NUMBER_OF_FRAMES		= 8, // int
+
+	// Camera
+	ONI_STREAM_PROPERTY_AUTO_WHITE_BALANCE		= 100, // OniBool
+	ONI_STREAM_PROPERTY_AUTO_EXPOSURE			= 101, // OniBool
+	ONI_STREAM_PROPERTY_EXPOSURE				= 102, // int
+	ONI_STREAM_PROPERTY_GAIN					= 103, // int
+};
+
+// Device commands (for Invoke)
+enum
+{
+	ONI_DEVICE_COMMAND_SEEK				= 1, // OniSeek
+};
+
+#endif // _ONI_C_PROPERTIES_H_

--- a/third-party/openni2/Include/OniCTypes.h
+++ b/third-party/openni2/Include/OniCTypes.h
@@ -1,0 +1,193 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_TYPES_H_
+#define _ONI_TYPES_H_
+
+#include "OniPlatform.h"
+#include "OniCEnums.h"
+
+/** Basic types **/
+typedef int OniBool;
+
+#ifndef TRUE
+#define TRUE 1
+#endif //TRUE
+#ifndef FALSE
+#define FALSE 0
+#endif //FALSE
+
+#define ONI_MAX_STR 256
+#define ONI_MAX_SENSORS 10
+
+struct OniCallbackHandleImpl;
+typedef struct OniCallbackHandleImpl* OniCallbackHandle;
+
+/** Holds an OpenNI version number, which consists of four separate numbers in the format: @c major.minor.maintenance.build. For example: 2.0.0.20. */
+typedef struct
+{
+	/** Major version number, incremented for major API restructuring. */
+	int major;
+	/** Minor version number, incremented when significant new features added. */
+	int minor;
+	/** Maintenance build number, incremented for new releases that primarily provide minor bug fixes. */
+	int maintenance;
+	/** Build number. Incremented for each new API build. Generally not shown on the installer and download site. */
+	int build;
+} OniVersion;
+
+typedef int OniHardwareVersion;
+
+/** Description of the output: format and resolution */
+typedef struct
+{
+	OniPixelFormat pixelFormat;
+	int resolutionX;
+	int resolutionY;
+	int fps;
+} OniVideoMode;
+
+/** List of supported video modes by a specific source */
+typedef struct
+{
+	OniSensorType sensorType;
+	int numSupportedVideoModes;
+	OniVideoMode *pSupportedVideoModes;
+} OniSensorInfo;
+
+/** Basic description of a device */
+typedef struct
+{
+	char uri[ONI_MAX_STR];
+	char vendor[ONI_MAX_STR];
+	char name[ONI_MAX_STR];
+	uint16_t usbVendorId;
+	uint16_t usbProductId;
+} OniDeviceInfo;
+
+struct _OniDevice;
+typedef _OniDevice* OniDeviceHandle;
+
+struct _OniStream;
+typedef _OniStream* OniStreamHandle;
+
+struct _OniRecorder;
+typedef _OniRecorder* OniRecorderHandle;
+
+/** All information of the current frame */
+typedef struct
+{
+	int dataSize;
+	void* data;
+
+	OniSensorType sensorType;
+	uint64_t timestamp;
+	int frameIndex;
+
+	int width;
+	int height;
+
+	OniVideoMode videoMode;
+	OniBool croppingEnabled;
+	int cropOriginX;
+	int cropOriginY;
+
+	int stride;
+} OniFrame;
+
+typedef void (ONI_CALLBACK_TYPE* OniNewFrameCallback)(OniStreamHandle stream, void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* OniGeneralCallback)(void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* OniDeviceInfoCallback)(const OniDeviceInfo* pInfo, void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* OniDeviceStateCallback)(const OniDeviceInfo* pInfo, OniDeviceState deviceState, void* pCookie);
+
+typedef void* (ONI_CALLBACK_TYPE* OniFrameAllocBufferCallback)(int size, void* pCookie);
+typedef void (ONI_CALLBACK_TYPE* OniFrameFreeBufferCallback)(void* data, void* pCookie);
+
+typedef struct
+{
+	OniDeviceInfoCallback		deviceConnected;
+	OniDeviceInfoCallback		deviceDisconnected;
+	OniDeviceStateCallback		deviceStateChanged;
+} OniDeviceCallbacks;
+
+typedef struct
+{
+	int enabled;
+	int originX;
+	int originY;
+	int width;
+	int height;
+} OniCropping;
+
+// Pixel types
+/**
+Pixel type used to store depth images.
+*/
+typedef uint16_t OniDepthPixel;
+
+/**
+Pixel type used to store 16-bit grayscale images
+*/
+typedef uint16_t OniGrayscale16Pixel;
+
+/**
+Pixel type used to store 8-bit grayscale/bayer images
+*/
+typedef uint8_t OniGrayscale8Pixel;
+
+#pragma pack (push, 1)
+
+/** Holds the value of a single color image pixel in 24-bit RGB format. */
+typedef struct
+{
+	/* Red value of this pixel. */
+	uint8_t r;
+	/* Green value of this pixel. */
+	uint8_t g;
+	/* Blue value of this pixel. */
+	uint8_t b;
+} OniRGB888Pixel;
+
+/**
+ Holds the value of two pixels in YUV422 format (Luminance/Chrominance,16-bits/pixel).
+ The first pixel has the values y1, u, v.
+ The second pixel has the values y2, u, v.
+*/
+typedef struct
+{
+	/** First chrominance value for two pixels, stored as blue luminance difference signal. */
+	uint8_t u;
+	/** Overall luminance value of first pixel. */
+	uint8_t y1;
+	/** Second chrominance value for two pixels, stored as red luminance difference signal. */
+	uint8_t v;
+	/** Overall luminance value of second pixel. */
+	uint8_t y2;
+} OniYUV422DoublePixel;
+
+#pragma pack (pop)
+
+typedef struct
+{
+	int frameIndex;
+	OniStreamHandle stream;
+} OniSeek;
+
+#endif // _ONI_TYPES_H_

--- a/third-party/openni2/Include/OniEnums.h
+++ b/third-party/openni2/Include/OniEnums.h
@@ -1,0 +1,86 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_ENUMS_H_
+#define _ONI_ENUMS_H_
+
+namespace openni
+{
+
+/** Possible failure values */
+typedef enum
+{
+	STATUS_OK = 0,
+	STATUS_ERROR = 1,
+	STATUS_NOT_IMPLEMENTED = 2,
+	STATUS_NOT_SUPPORTED = 3,
+	STATUS_BAD_PARAMETER = 4,
+	STATUS_OUT_OF_FLOW = 5,
+	STATUS_NO_DEVICE = 6,
+	STATUS_TIME_OUT = 102,
+} Status;
+
+/** The source of the stream */
+typedef enum
+{
+	SENSOR_IR = 1,
+	SENSOR_COLOR = 2,
+	SENSOR_DEPTH = 3,
+
+} SensorType;
+
+/** All available formats of the output of a stream */
+typedef enum
+{
+	// Depth
+	PIXEL_FORMAT_DEPTH_1_MM = 100,
+	PIXEL_FORMAT_DEPTH_100_UM = 101,
+	PIXEL_FORMAT_SHIFT_9_2 = 102,
+	PIXEL_FORMAT_SHIFT_9_3 = 103,
+
+	// Color
+	PIXEL_FORMAT_RGB888 = 200,
+	PIXEL_FORMAT_YUV422 = 201,
+	PIXEL_FORMAT_GRAY8 = 202,
+	PIXEL_FORMAT_GRAY16 = 203,
+	PIXEL_FORMAT_JPEG = 204,
+	PIXEL_FORMAT_YUYV = 205,
+} PixelFormat;
+
+typedef enum
+{
+	DEVICE_STATE_OK 	= 0,
+	DEVICE_STATE_ERROR 	= 1,
+	DEVICE_STATE_NOT_READY 	= 2,
+	DEVICE_STATE_EOF 	= 3
+} DeviceState;
+
+typedef enum
+{
+	IMAGE_REGISTRATION_OFF				= 0,
+	IMAGE_REGISTRATION_DEPTH_TO_COLOR	= 1,
+} ImageRegistrationMode;
+
+static const int TIMEOUT_NONE = 0;
+static const int TIMEOUT_FOREVER = -1;
+
+} // namespace openni
+
+#endif // _ONI_ENUMS_H_

--- a/third-party/openni2/Include/OniPlatform.h
+++ b/third-party/openni2/Include/OniPlatform.h
@@ -1,0 +1,72 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_PLATFORM_H_
+#define _ONI_PLATFORM_H_
+
+// Supported platforms
+#define ONI_PLATFORM_WIN32 1
+#define ONI_PLATFORM_LINUX_X86 2
+#define ONI_PLATFORM_LINUX_ARM 3
+#define ONI_PLATFORM_MACOSX 4
+#define ONI_PLATFORM_ANDROID_ARM 5
+
+#if (defined _WIN32)
+#	ifndef RC_INVOKED
+#		if _MSC_VER < 1300
+#			error OpenNI Platform Abstraction Layer - Win32 - Microsoft Visual Studio version below 2003 (7.0) are not supported!
+#		endif
+#	endif
+#	include "Win32/OniPlatformWin32.h"
+#elif defined (ANDROID) && defined (__arm__)
+#	include "Android-Arm/OniPlatformAndroid-Arm.h"
+#elif (__linux__ && (i386 || __x86_64__))
+#	include "Linux-x86/OniPlatformLinux-x86.h"
+#elif (__linux__ && __arm__)
+#	include "Linux-Arm/OniPlatformLinux-Arm.h"
+#elif _ARC
+#	include "ARC/OniPlaformARC.h"
+#elif (__APPLE__)
+#	include "MacOSX/OniPlatformMacOSX.h"
+#else
+#	error Xiron Platform Abstraction Layer - Unsupported Platform!
+#endif
+
+#ifdef __cplusplus
+#	define ONI_C extern "C"
+#	define ONI_C_API_EXPORT ONI_C ONI_API_EXPORT
+#	define ONI_C_API_IMPORT ONI_C ONI_API_IMPORT
+#	define ONI_CPP_API_EXPORT ONI_API_EXPORT
+#	define ONI_CPP_API_IMPORT ONI_API_IMPORT
+#else // __cplusplus
+#	define ONI_C_API_EXPORT ONI_API_EXPORT
+#	define ONI_C_API_IMPORT ONI_API_IMPORT
+#endif  // __cplusplus
+
+#ifdef OPENNI2_EXPORT
+#	define ONI_C_API ONI_C_API_EXPORT
+#	define ONI_CPP_API ONI_CPP_API_EXPORT
+#else // OPENNI2_EXPORT
+#	define ONI_C_API ONI_C_API_IMPORT
+#	define ONI_CPP_API ONI_CPP_API_IMPORT
+#endif // OPENNI2_EXPORT
+
+
+#endif // _ONI_PLATFORM_H_

--- a/third-party/openni2/Include/OniProperties.h
+++ b/third-party/openni2/Include/OniProperties.h
@@ -1,0 +1,73 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_PROPERTIES_H_
+#define _ONI_PROPERTIES_H_
+
+namespace openni
+{
+
+// Device properties
+enum
+{
+	DEVICE_PROPERTY_FIRMWARE_VERSION		= 0, // string
+	DEVICE_PROPERTY_DRIVER_VERSION			= 1, // OniVersion
+	DEVICE_PROPERTY_HARDWARE_VERSION		= 2, // int
+	DEVICE_PROPERTY_SERIAL_NUMBER			= 3, // string
+	DEVICE_PROPERTY_ERROR_STATE			= 4, // ??
+	DEVICE_PROPERTY_IMAGE_REGISTRATION		= 5, // OniImageRegistrationMode
+
+	// Files
+	DEVICE_PROPERTY_PLAYBACK_SPEED			= 100, // float
+	DEVICE_PROPERTY_PLAYBACK_REPEAT_ENABLED		= 101, // OniBool
+};
+
+// Stream properties
+enum
+{
+	STREAM_PROPERTY_CROPPING			= 0, // OniCropping*
+	STREAM_PROPERTY_HORIZONTAL_FOV			= 1, // float: radians
+	STREAM_PROPERTY_VERTICAL_FOV			= 2, // float: radians
+	STREAM_PROPERTY_VIDEO_MODE			= 3, // OniVideoMode*
+
+	STREAM_PROPERTY_MAX_VALUE			= 4, // int
+	STREAM_PROPERTY_MIN_VALUE			= 5, // int
+
+	STREAM_PROPERTY_STRIDE				= 6, // int
+	STREAM_PROPERTY_MIRRORING			= 7, // OniBool
+
+	STREAM_PROPERTY_NUMBER_OF_FRAMES		= 8, // int
+
+	// Camera
+	STREAM_PROPERTY_AUTO_WHITE_BALANCE		= 100, // OniBool
+	STREAM_PROPERTY_AUTO_EXPOSURE			= 101, // OniBool
+	STREAM_PROPERTY_EXPOSURE				= 102, // int
+	STREAM_PROPERTY_GAIN					= 103, // int
+
+};
+
+// Device commands (for Invoke)
+enum
+{
+	DEVICE_COMMAND_SEEK				= 1, // OniSeek
+};
+
+} // namespace openni
+#endif // _ONI_PROPERTIES_H_

--- a/third-party/openni2/Include/OniVersion.h
+++ b/third-party/openni2/Include/OniVersion.h
@@ -1,0 +1,43 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#include "OniPlatform.h"
+
+#define ONI_VERSION_MAJOR	2
+#define ONI_VERSION_MINOR	2
+#define ONI_VERSION_MAINTENANCE	0
+#define ONI_VERSION_BUILD	33
+
+/** OpenNI version (in brief string format): "Major.Minor.Maintenance (Build)" */ 
+#define ONI_BRIEF_VERSION_STRING \
+	ONI_STRINGIFY(ONI_VERSION_MAJOR) "." \
+	ONI_STRINGIFY(ONI_VERSION_MINOR) "." \
+	ONI_STRINGIFY(ONI_VERSION_MAINTENANCE) \
+	" (Build " ONI_STRINGIFY(ONI_VERSION_BUILD) ")"
+
+/** OpenNI version (in numeric format): (OpenNI major version * 100000000 + OpenNI minor version * 1000000 + OpenNI maintenance version * 10000 + OpenNI build version). */
+#define ONI_VERSION (ONI_VERSION_MAJOR*100000000 + ONI_VERSION_MINOR*1000000 + ONI_VERSION_MAINTENANCE*10000 + ONI_VERSION_BUILD)
+#define ONI_CREATE_API_VERSION(major, minor) ((major)*1000 + (minor))
+#define ONI_API_VERSION ONI_CREATE_API_VERSION(ONI_VERSION_MAJOR, ONI_VERSION_MINOR)
+
+/** OpenNI version (in string format): "Major.Minor.Maintenance.Build-Platform (MMM DD YYYY HH:MM:SS)". */ 
+#define ONI_VERSION_STRING \
+	ONI_BRIEF_VERSION_STRING  "-" \
+	ONI_PLATFORM_STRING " (" ONI_TIMESTAMP ")"

--- a/third-party/openni2/Include/OpenNI.h
+++ b/third-party/openni2/Include/OpenNI.h
@@ -1,0 +1,2750 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _OPENNI_H_
+#define _OPENNI_H_
+
+#include "OniPlatform.h"
+#include "OniProperties.h"
+#include "OniEnums.h"
+
+#include "OniCAPI.h"
+#include "OniCProperties.h"
+
+/**
+openni is the namespace of the entire C++ API of OpenNI
+*/
+namespace openni
+{
+
+/** Pixel type used to store depth images. */
+typedef uint16_t				DepthPixel;
+
+/** Pixel type used to store IR images. */
+typedef uint16_t				Grayscale16Pixel;
+
+// structs
+/** Holds an OpenNI version number, which consists of four separate numbers in the format: @c major.minor.maintenance.build. For example: 2.0.0.20. */
+typedef struct
+{
+	/** Major version number, incremented for major API restructuring. */
+	int major;
+	/** Minor version number, incremented when significant new features added. */
+	int minor;
+	/** Maintenance build number, incremented for new releases that primarily provide minor bug fixes. */
+	int maintenance;
+	/** Build number. Incremented for each new API build. Generally not shown on the installer and download site. */
+	int build;
+} Version;
+
+/** Holds the value of a single color image pixel in 24-bit RGB format. */
+typedef struct
+{
+	/* Red value of this pixel. */
+	uint8_t r;
+	/* Green value of this pixel. */
+	uint8_t g;
+	/* Blue value of this pixel. */
+	uint8_t b;
+} RGB888Pixel;
+
+/**
+ Holds the value of two pixels in YUV422 format (Luminance/Chrominance,16-bits/pixel).
+ The first pixel has the values y1, u, v.
+ The second pixel has the values y2, u, v.
+*/
+typedef struct
+{
+	/** First chrominance value for two pixels, stored as blue luminance difference signal. */
+	uint8_t u;
+	/** Overall luminance value of first pixel. */
+	uint8_t y1;
+	/** Second chrominance value for two pixels, stored as red luminance difference signal. */
+	uint8_t v;
+	/** Overall luminance value of second pixel. */
+	uint8_t y2;
+} YUV422DoublePixel;
+
+/** This special URI can be passed to @ref Device::open() when the application has no concern for a specific device. */
+#if ONI_PLATFORM != ONI_PLATFORM_WIN32
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic push
+#endif
+static const char* ANY_DEVICE = NULL;
+#if ONI_PLATFORM != ONI_PLATFORM_WIN32
+#pragma GCC diagnostic pop
+#endif
+
+/**
+Provides a simple array class used throughout the API. Wraps a primitive array
+of objects, holding the elements and their count.
+*/
+template<class T>
+class Array
+{
+public:
+	/**
+	Default constructor.  Creates an empty Array and sets the element count to zero.
+	*/
+	Array() : m_data(NULL), m_count(0), m_owner(false) {}
+
+	/**
+	Constructor.  Creates new Array from an existing primitive array of known size.
+
+	@tparam [in] T Object type this Array will contain.
+	@param [in] data Pointer to a primitive array of objects of type T.
+	@param [in] count Number of elements in the primitive array pointed to by data.
+	*/
+	Array(const T* data, int count) : m_owner(false) { _setData(data, count); }
+
+	/**
+	Destructor.  Destroys the Array object.
+	*/
+	~Array()
+	{
+		clear();
+	}
+
+	/**
+	Getter function for the Array size.
+	@returns Current number of elements in the Array.
+	*/
+	int getSize() const { return m_count; }
+
+	/**
+	Implements the array indexing operator for the Array class.
+	*/
+	const T& operator[](int index) const {return m_data[index];}
+
+	/**
+	@internal
+	Setter function for data.  Causes this array to wrap an existing primitive array
+	of specified type.  The optional data ownership flag controls whether the primitive
+	array this Array wraps will be destroyed when this Array is deconstructed.
+	@param [in] T Type of objects array will contain.
+	@param [in] data Pointer to first object in list.
+	@param [in] count Number of objects in list.
+	@param [in] isOwner Optional flag to indicate data ownership
+	*/
+	void _setData(const T* data, int count, bool isOwner = false)
+	{
+		clear();
+		m_count = count;
+		m_owner = isOwner;
+		if (!isOwner)
+		{
+			m_data = data;
+		}
+		else
+		{
+			m_data = new T[count];
+			memcpy((void*)m_data, data, count*sizeof(T));
+		}
+	}
+
+private:
+	Array(const Array<T>&);
+	Array<T>& operator=(const Array<T>&);
+
+	void clear()
+	{
+		if (m_owner && m_data != NULL)
+			delete []m_data;
+		m_owner = false;
+		m_data = NULL;
+		m_count = 0;
+	}
+
+	const T* m_data;
+	int m_count;
+	bool m_owner;
+};
+
+// Forward declaration of all
+class SensorInfo;
+class VideoStream;
+class VideoFrameRef;
+class Device;
+class OpenNI;
+class CameraSettings;
+class PlaybackControl;
+
+/**
+Encapsulates a group of settings for a @ref VideoStream.  Settings stored include
+frame rate, resolution, and pixel format.
+
+This class is used as an input for changing the settings of a @ref VideoStream,
+as well as an output for reporting the current settings of that class.  It is also used
+by @ref SensorInfo to report available video modes of a stream.
+
+Recommended practice is to use @ref SensorInfo::getSupportedVideoModes()
+to obtain a list of valid video modes, and then to use items from that list to pass
+new settings to @ref VideoStream.  This is much less likely to produce an
+invalid video mode than instantiating and manually changing objects of this
+class.
+*/
+class VideoMode : private OniVideoMode
+{
+public:
+	/**
+	Default constructor, creates an empty VideoMode object.  Application programs should, in most
+	cases, use the copy constructor to copy an existing valid video mode.  This is much less
+	error prone that creating and attempting to configure a new VideoMode from scratch.
+	*/
+	VideoMode()
+	{}
+
+	/**
+	Copy constructor, creates a new VideoMode identical to an existing VideoMode.
+
+	@param [in] other Existing VideoMode to copy.
+	*/
+	VideoMode(const VideoMode& other)
+	{
+		*this = other;
+	}
+
+	/**
+	Assignment operator.  Sets the pixel format, frame rate, and resolution of this
+	VideoMode to equal that of a different VideoMode.
+
+	@param [in] other Existing VideoMode to copy settings from.
+	*/
+	VideoMode& operator=(const VideoMode& other)
+	{
+		setPixelFormat(other.getPixelFormat());
+		setResolution(other.getResolutionX(), other.getResolutionY());
+		setFps(other.getFps());
+
+		return *this;
+	}
+
+	/**
+	Getter function for the pixel format of this VideoMode.
+	@returns Current pixel format setting of this VideoMode.
+	*/
+	PixelFormat getPixelFormat() const { return (PixelFormat)pixelFormat; }
+
+	/**
+	Getter function for the X resolution of this VideoMode.
+	@returns Current horizontal resolution of this VideoMode, in pixels.
+	*/
+	int getResolutionX() const { return resolutionX; }
+
+	/**
+	Getter function for the Y resolution of this VideoMode.
+	@returns Current vertical resolution of this VideoMode, in pixels.
+	*/
+	int getResolutionY() const {return resolutionY;}
+
+	/**
+	Getter function for the frame rate of this VideoMode.
+	@returns Current frame rate, measured in frames per second.
+	*/
+	int getFps() const { return fps; }
+
+	/**
+	Setter function for the pixel format of this VideoMode.  Application use of this
+	function is not recommended.  Instead, use @ref SensorInfo::getSupportedVideoModes()
+	to obtain a list of valid video modes.
+	@param [in] format Desired new pixel format for this VideoMode.
+	*/
+	void setPixelFormat(PixelFormat format) { this->pixelFormat = (OniPixelFormat)format; }
+
+	/**
+	Setter function for the resolution of this VideoMode.  Application use of this
+	function is not recommended.  Instead, use @ref SensorInfo::getSupportedVideoModes() to
+	obtain a list of valid video modes.
+	@param [in] resolutionX Desired new horizontal resolution in pixels.
+	@param [in] resolutionY Desired new vertical resolution in pixels.
+	*/
+	void setResolution(int resolutionX, int resolutionY)
+	{
+		this->resolutionX = resolutionX;
+		this->resolutionY = resolutionY;
+	}
+
+	/**
+	Setter function for the frame rate.  Application use of this function is not recommended.
+	Instead, use @ref SensorInfo::getSupportedVideoModes() to obtain a list of valid
+	video modes.
+	@param [in] fps Desired new frame rate, measured in frames per second.
+	*/
+	void setFps(int fps) { this->fps = fps; }
+
+	friend class SensorInfo;
+	friend class VideoStream;
+	friend class VideoFrameRef;
+};
+
+/**
+The SensorInfo class encapsulates all info related to a specific sensor in a specific
+device.  
+A @ref Device object holds a SensorInfo object for each sensor it contains.
+A @ref VideoStream object holds one SensorInfo object, describing the sensor used to produce that stream.
+
+A given SensorInfo object will contain the type of the sensor (Depth, IR or Color), and
+a list of all video modes that the sensor can support.  Each available video mode will have a single
+VideoMode object that can be queried to get the details of that mode.
+
+SensorInfo objects should be the only source of VideoMode objects for the vast majority of
+application programs.
+
+Application programs will never directly instantiate objects of type SensorInfo.  In fact, no
+public constructors are provided.  SensorInfo objects should be obtained either from a Device or @ref VideoStream,
+and in turn be used to provide available video modes for that sensor.
+*/
+class SensorInfo
+{
+public:
+	/**
+	Provides the sensor type of the sensor this object is associated with.
+	@returns Type of the sensor.
+	*/
+	SensorType getSensorType() const { return (SensorType)m_pInfo->sensorType; }
+
+	/**
+	Provides a list of video modes that this sensor can support. This function is the
+	recommended method to be used by applications to obtain @ref VideoMode objects.
+
+	@returns Reference to an array of @ref VideoMode objects, one for each supported
+	video mode.
+	*/
+	const Array<VideoMode>& getSupportedVideoModes() const { return m_videoModes; }
+
+private:
+	SensorInfo(const SensorInfo&);
+	SensorInfo& operator=(const SensorInfo&);
+
+	SensorInfo() : m_pInfo(NULL), m_videoModes(NULL, 0) {}
+
+	SensorInfo(const OniSensorInfo* pInfo) : m_pInfo(NULL), m_videoModes(NULL, 0)
+	{
+		_setInternal(pInfo);
+	}
+
+	void _setInternal(const OniSensorInfo* pInfo)
+	{
+		m_pInfo = pInfo;
+		if (pInfo == NULL)
+		{
+			m_videoModes._setData(NULL, 0);
+		}
+		else
+		{
+			m_videoModes._setData(static_cast<VideoMode*>(pInfo->pSupportedVideoModes), pInfo->numSupportedVideoModes);
+		}
+	}
+
+	const OniSensorInfo* m_pInfo;
+	Array<VideoMode> m_videoModes;
+
+	friend class VideoStream;
+	friend class Device;
+};
+
+/**
+The DeviceInfo class encapsulates info related to a specific device.
+
+Applications will generally obtain objects of this type via calls to @ref OpenNI::enumerateDevices() or
+@ref openni::Device::getDeviceInfo(), and then use the various accessor functions to obtain specific
+information on that device.
+
+There should be no reason for application code to instantiate this object directly.
+*/
+class DeviceInfo : private OniDeviceInfo
+{
+public:
+	/** 
+	Returns the device URI.  URI can be used by @ref Device::open to open a specific device. 
+	The URI string format is determined by the driver.
+	*/
+	const char* getUri() const { return uri; }
+	/** Returns a the vendor name for this device. */
+	const char* getVendor() const { return vendor; }
+	/** Returns the device name for this device. */
+	const char* getName() const { return name; }
+	/** Returns the USB VID code for this device. */
+	uint16_t getUsbVendorId() const { return usbVendorId; }
+	/** Returns the USB PID code for this device. */
+	uint16_t getUsbProductId() const { return usbProductId; }
+
+	friend class Device;
+	friend class OpenNI;
+};
+
+/**
+The @ref VideoFrameRef class encapsulates a single video frame - the output of a @ref VideoStream at a specific time.
+The data contained will be a single frame of color, IR, or depth video, along with associated meta data.
+
+An object of type @ref VideoFrameRef does not actually hold the data of the frame, but only a reference to it. The
+reference can be released by destroying the @ref VideoFrameRef object, or by calling the @ref release() method. The
+actual data of the frame is freed when the last reference to it is released.
+
+The usual way to obtain @ref VideoFrameRef objects is by a call to @ref VideoStream.:readFrame().
+
+All data references by a @ref VideoFrameRef is stored as a primitive array of pixels.  Each pixel will be
+of a type according to the configured pixel format (see @ref VideoMode).
+*/
+class VideoFrameRef
+{
+public:
+	/**
+	Default constructor.  Creates a new empty @ref VideoFrameRef object.
+	This object will be invalid until initialized by a call to @ref VideoStream::readFrame().
+	*/
+	VideoFrameRef()
+	{
+		m_pFrame = NULL;
+	}
+
+	/**
+	Destroy this object and release the reference to the frame.
+	*/
+	~VideoFrameRef()
+	{
+		release();
+	}
+
+	/**
+	Copy constructor.  Creates a new @ref VideoFrameRef object. The newly created
+	object will reference the same frame current object references.
+	@param [in] other Another @ref VideoFrameRef object.
+	*/
+	VideoFrameRef(const VideoFrameRef& other) : m_pFrame(NULL)
+	{
+		_setFrame(other.m_pFrame);
+	}
+
+	/**
+	Make this @ref VideoFrameRef object reference the same frame that the @c other frame references.
+	If this object referenced another frame before calling this method, the previous frame will be released.
+	@param [in] other Another @ref VideoFrameRef object.
+	*/
+	VideoFrameRef& operator=(const VideoFrameRef& other)
+	{
+		_setFrame(other.m_pFrame);
+		return *this;
+	}
+
+	/**
+	Getter function for the size of the data contained by this object.  Useful primarily
+	when allocating buffers.
+	@returns Current size of data pointed to by this object, measured in bytes.
+	*/
+	inline int getDataSize() const
+	{
+		return m_pFrame->dataSize;
+	}
+
+	/**
+	Getter function for the array of data pointed to by this object.
+	@returns Pointer to the actual frame data array.  Type of data
+	pointed to can be determined according to the pixel format (can be obtained by calling @ref getVideoMode()).
+	*/
+	inline const void* getData() const
+	{
+		return m_pFrame->data;
+	}
+
+	/**
+	Getter function for the sensor type used to produce this frame.  Used to determine whether
+	this is an IR, Color or Depth frame.  See the @ref SensorType enumeration for all possible return
+	values from this function.
+	@returns The type of sensor used to produce this frame.
+	*/
+	inline SensorType getSensorType() const
+	{
+		return (SensorType)m_pFrame->sensorType;
+	}
+
+	/**
+	Returns a reference to the @ref VideoMode object assigned to this frame.  This object describes
+	the video mode the sensor was configured to when the frame was produced and can be used
+	to determine the pixel format and resolution of the data.  It will also provide the frame rate
+	that the sensor was running at when it recorded this frame.
+	@returns Reference to the @ref VideoMode assigned to this frame.
+	*/
+	inline const VideoMode& getVideoMode() const
+	{
+		return static_cast<const VideoMode&>(m_pFrame->videoMode);
+	}
+
+	/**
+	Provides a timestamp for the frame.  The 'zero' point for this stamp
+	is implementation specific, but all streams from the same device are guaranteed to use the same zero.
+	This value can therefore be used to compute time deltas between frames from the same device,
+	regardless of whether they are from the same stream.
+	@returns Timestamp of frame, measured in microseconds from an arbitrary zero
+	*/
+	inline uint64_t getTimestamp() const
+	{
+		return m_pFrame->timestamp;
+	}
+
+	/**
+	Frames are provided sequential frame ID numbers by the sensor that produced them.  If frame
+	synchronization has been enabled for a device via @ref Device::setDepthColorSyncEnabled(), then frame
+	numbers for corresponding frames of depth and color are guaranteed to match.
+
+	If frame synchronization is not enabled, then there is no guarantee of matching frame indexes between
+	@ref VideoStream "VideoStreams".  In the latter case, applications should use timestamps instead of frame indexes to
+	align frames in time.
+	@returns Index number for this frame.
+	*/
+	inline int getFrameIndex() const
+	{
+		return m_pFrame->frameIndex;
+	}
+
+	/**
+	Gives the current width of this frame, measured in pixels.  If cropping is enabled, this will be
+	the width of the cropping window.  If cropping is not enabled, then this will simply be equal to
+	the X resolution of the @ref VideoMode used to produce this frame.
+	@returns Width of this frame in pixels.
+	*/
+	inline int getWidth() const
+	{
+		return m_pFrame->width;
+	}
+
+	/**
+	Gives the current height of this frame, measured in pixels.  If cropping is enabled, this will
+	be the length of the cropping window.  If cropping is not enabled, then this will simply be equal
+	to the Y resolution of the @ref VideoMode used to produce this frame.
+	*/
+	inline int getHeight() const
+	{
+		return m_pFrame->height;
+	}
+
+	/**
+	Indicates whether cropping was enabled when the frame was produced.
+	@return true if cropping is enabled, false otherwise
+	*/
+	inline bool getCroppingEnabled() const
+	{
+		return m_pFrame->croppingEnabled == TRUE;
+	}
+
+	/**
+	Indicates the X coordinate of the upper left corner of the crop window.
+	@return Distance of crop origin from left side of image, in pixels.
+	*/
+	inline int getCropOriginX() const
+	{
+		return m_pFrame->cropOriginX;
+	}
+
+	/**
+	Indicates the Y coordinate of the upper left corner of the crop window.
+	@return Distance of crop origin from top of image, in pixels.
+	*/
+	inline int getCropOriginY() const
+	{
+		return m_pFrame->cropOriginY;
+	}
+
+	/**
+	Gives the length of one row of pixels, measured in bytes.  Primarily useful
+	for indexing the array which contains the data.
+	@returns Stride of the array which contains the image for this frame, in bytes
+	*/
+	inline int getStrideInBytes() const
+	{
+		return m_pFrame->stride;
+	}
+
+	/**
+	Check if this object references an actual frame.
+	*/
+	inline bool isValid() const
+	{
+		return m_pFrame != NULL;
+	}
+
+	/** 
+	Release the reference to the frame. Once this method is called, the object becomes invalid, and no method
+	should be called other than the assignment operator, or passing this object to a @ref VideoStream::readFrame() call.
+	*/
+	void release()
+	{
+		if (m_pFrame != NULL)
+		{
+			oniFrameRelease(m_pFrame);
+			m_pFrame = NULL;
+		}
+	}
+
+	/** @internal */
+	void _setFrame(OniFrame* pFrame)
+	{
+		setReference(pFrame);
+		if (pFrame != NULL)
+		{
+			oniFrameAddRef(pFrame);
+		}
+	}
+
+	/** @internal */
+	OniFrame* _getFrame()
+	{
+		return m_pFrame;
+	}
+
+private:
+	friend class VideoStream;
+	inline void setReference(OniFrame* pFrame)
+	{
+		// Initial - don't addref. This is the reference from OpenNI
+		release();
+		m_pFrame = pFrame;
+	}
+
+	OniFrame* m_pFrame; // const!!?
+};
+
+/**
+The @ref VideoStream object encapsulates a single video stream from a device.  Once created, it is used to start data flow
+from the device, and to read individual frames of data.  This is the central class used to obtain data in OpenNI.  It
+provides the ability to manually read data in a polling loop, as well as providing events and a Listener class that can be
+used to implement event-driven data acquisition.
+
+Aside from the video data frames themselves, the class offers a number of functions used for obtaining information about a
+@ref VideoStream.  Field of view, available video modes, and minimum and maximum valid pixel values can all be obtained.
+
+In addition to obtaining data, the @ref VideoStream object is used to set all configuration properties that apply to a specific
+stream (rather than to an entire device).  In particular, it is used to control cropping, mirroring, and video modes.
+
+A pointer to a valid, initialized device that provides the desired stream type is required to create a stream.
+
+Several video streams can be created to stream data from the same sensor. This is useful if several components of an application
+need to read frames separately.
+
+While some device might allow different streams
+from the same sensor to have different configurations, most devices will have a single configuration for the sensor, 
+shared by all streams.
+*/
+class VideoStream
+{
+public:
+	/**
+	The @ref VideoStream::NewFrameListener class is provided to allow the implementation of event driven frame reading.  To use
+	it, create a class that inherits from it and implement override the onNewFrame() method.  Then, register
+	your created class with an active @ref VideoStream using the @ref VideoStream::addNewFrameListener() function.  Once this is done, the
+	event handler function you implemented will be called whenever a new frame becomes available. You may call 
+	@ref VideoStream::readFrame() from within the event handler.
+	*/
+	class NewFrameListener
+	{
+	public:
+		/**
+		Default constructor.
+		*/
+		NewFrameListener() : m_callbackHandle(NULL)
+		{
+		}
+
+		virtual ~NewFrameListener()
+		{
+		}
+
+		/**
+		Derived classes should implement this function to handle new frames.
+		*/
+		virtual void onNewFrame(VideoStream&) = 0;
+
+	private:
+		friend class VideoStream;
+
+		static void ONI_CALLBACK_TYPE callback(OniStreamHandle streamHandle, void* pCookie)
+		{
+			NewFrameListener* pListener = (NewFrameListener*)pCookie;
+			VideoStream stream;
+			stream._setHandle(streamHandle);
+			pListener->onNewFrame(stream);
+			stream._setHandle(NULL);
+		}
+		OniCallbackHandle m_callbackHandle;
+	};
+
+	class FrameAllocator
+	{
+	public:
+		virtual ~FrameAllocator() {}
+		virtual void* allocateFrameBuffer(int size) = 0;
+		virtual void freeFrameBuffer(void* data) = 0;
+
+	private:
+		friend class VideoStream;
+
+		static void* ONI_CALLBACK_TYPE allocateFrameBufferCallback(int size, void* pCookie)
+		{
+			FrameAllocator* pThis = (FrameAllocator*)pCookie;
+			return pThis->allocateFrameBuffer(size);
+		}
+
+		static void ONI_CALLBACK_TYPE freeFrameBufferCallback(void* data, void* pCookie)
+		{
+			FrameAllocator* pThis = (FrameAllocator*)pCookie;
+			pThis->freeFrameBuffer(data);
+		}
+	};
+
+	/**
+	Default constructor.  Creates a new, non-valid @ref VideoStream object.  The object created will be invalid until its create() function
+	is called with a valid Device.
+	*/
+	VideoStream() : m_stream(NULL), m_sensorInfo(), m_pCameraSettings(NULL), m_isOwner(true)
+	{}
+
+	/**
+	Handle constructor. Creates a VideoStream object based on the given initialized handle.
+	This object will not destroy the underlying handle when  @ref destroy() or destructor is called
+	*/
+	explicit VideoStream(OniStreamHandle handle) : m_stream(NULL), m_sensorInfo(), m_pCameraSettings(NULL), m_isOwner(false)
+	{
+		_setHandle(handle);
+	}
+
+	/**
+	Destructor.  The destructor calls the destroy() function, but it is considered a best practice for applications to
+	call destroy() manually on any @ref VideoStream that they run create() on.
+	*/
+	~VideoStream()
+	{
+		destroy();
+	}
+
+	/**
+	Checks to see if this object has been properly initialized and currently points to a valid stream.
+	@returns true if this object has been previously initialized, false otherwise.
+	*/
+	bool isValid() const
+	{
+		return m_stream != NULL;
+	}
+
+	/**
+	Creates a stream of frames from a specific sensor type of a specific device.  You must supply a reference to a
+	Device that supplies the sensor type requested.  You can use @ref Device::hasSensor() to check whether a
+	given sensor is available on your target device before calling create().
+
+	@param [in] device A reference to the @ref Device you want to create the stream on.
+	@param [in] sensorType The type of sensor the stream should produce data from.
+	@returns Status code indicating success or failure for this operation.
+	*/
+	inline Status create(const Device& device, SensorType sensorType);
+
+	/**
+	Destroy this stream.  This function is currently called automatically by the destructor, but it is
+	considered a best practice for applications to manually call this function on any @ref VideoStream that they
+	call create() for.
+	*/
+	inline void destroy();
+
+	/**
+	Provides the @ref SensorInfo object associated with the sensor that is producing this @ref VideoStream.  Note that
+	this function will return NULL if the stream has not yet been initialized with the create() function.
+
+	@ref SensorInfo is useful primarily as a means of learning which video modes are valid for this VideoStream.
+
+	@returns Reference to the SensorInfo object associated with the sensor providing this stream.
+	*/
+	const SensorInfo& getSensorInfo() const
+	{
+		return m_sensorInfo;
+	}
+
+	/**
+	Starts data generation from this video stream.
+	*/
+	Status start()
+	{
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+
+		return (Status)oniStreamStart(m_stream);
+	}
+
+	/**
+	Stops data generation from this video stream.
+	*/
+	void stop()
+	{
+		if (!isValid())
+		{
+			return;
+		}
+
+		oniStreamStop(m_stream);
+	}
+
+	/**
+	Read the next frame from this video stream, delivered as a @ref VideoFrameRef.  This is the primary
+	method for manually obtaining frames of video data.  
+	If no new frame is available, the call will block until one is available.
+	To avoid blocking, use @ref VideoStream::Listener to implement an event driven architecture.  Another
+	alternative is to use @ref OpenNI::waitForAnyStream() to wait for new frames from several streams.
+
+	@param [out] pFrame Pointer to a @ref VideoFrameRef object to hold the reference to the new frame.
+	@returns Status code to indicated success or failure of this function.
+	*/
+	Status readFrame(VideoFrameRef* pFrame)
+	{
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+
+		OniFrame* pOniFrame;
+		Status rc = (Status)oniStreamReadFrame(m_stream, &pOniFrame);
+
+		pFrame->setReference(pOniFrame);
+		return rc;
+	}
+
+	/**
+	Adds a new Listener to receive this VideoStream onNewFrame event.  See @ref VideoStream::NewFrameListener for
+	more information on implementing an event driven frame reading architecture. An instance of a listener can be added to only one source.
+
+	@param [in] pListener Pointer to a @ref VideoStream::NewFrameListener object (or a derivative) that will respond to this event.
+	@returns Status code indicating success or failure of the operation.
+	*/
+	Status addNewFrameListener(NewFrameListener* pListener)
+	{
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+
+		return (Status)oniStreamRegisterNewFrameCallback(m_stream, pListener->callback, pListener, &pListener->m_callbackHandle);
+	}
+
+	/**
+	Removes a Listener from this video stream list.  The listener removed will no longer receive new frame events from this stream.
+	@param [in] pListener Pointer to the listener object to be removed.
+	*/
+	void removeNewFrameListener(NewFrameListener* pListener)
+	{
+		if (!isValid())
+		{
+			return;
+		}
+
+		oniStreamUnregisterNewFrameCallback(m_stream, pListener->m_callbackHandle);
+		pListener->m_callbackHandle = NULL;
+	}
+
+	/**
+	Sets the frame buffers allocator for this video stream.
+	@param [in] pAllocator Pointer to the frame buffers allocator object. Pass NULL to return to default frame allocator.
+	@returns ONI_STATUS_OUT_OF_FLOW The frame buffers allocator cannot be set while stream is streaming.
+	*/
+	Status setFrameBuffersAllocator(FrameAllocator* pAllocator)
+	{
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+
+		if (pAllocator == NULL)
+		{
+			return (Status)oniStreamSetFrameBuffersAllocator(m_stream, NULL, NULL, NULL);
+		}
+		else
+		{
+			return (Status)oniStreamSetFrameBuffersAllocator(m_stream, pAllocator->allocateFrameBufferCallback, pAllocator->freeFrameBufferCallback, pAllocator);
+		}
+	}
+
+	/**
+	@internal
+	Get an internal handle. This handle can be used via the C API.
+	*/
+	OniStreamHandle _getHandle() const
+	{
+		return m_stream;
+	}
+
+	/**
+	Gets an object through which several camera settings can be configured.
+	@returns NULL if the stream doesn't support camera settings.
+	*/
+	CameraSettings* getCameraSettings() {return m_pCameraSettings;}
+
+	/**
+	General function for obtaining the value of stream specific properties.
+	There are convenience functions available for all commonly used properties, so it is not
+	expected that applications will make direct use of the getProperty function very often.
+
+	@param [in] propertyId The numerical ID of the property to be queried.
+	@param [out] data Place to store the value of the property.
+	@param [in,out] dataSize IN: Size of the buffer passed in the @c data argument. OUT: the actual written size.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	Status getProperty(int propertyId, void* data, int* dataSize) const
+	{
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+
+		return (Status)oniStreamGetProperty(m_stream, propertyId, data, dataSize);
+	}
+
+	/**
+	General function for setting the value of stream specific properties.
+	There are convenience functions available for all commonly used properties, so it is not
+	expected that applications will make direct use of the setProperty function very often.
+
+	@param [in] propertyId The numerical ID of the property to be set.
+	@param [in] data Place to store the data to be written to the property.
+	@param [in] dataSize Size of the data to be written to the property.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	Status setProperty(int propertyId, const void* data, int dataSize)
+	{
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+
+		return (Status)oniStreamSetProperty(m_stream, propertyId, data, dataSize);
+	}
+
+	/**
+	Get the current video mode information for this video stream.
+	This includes its resolution, fps and stream format.
+
+	@returns Current video mode information for this video stream.
+	*/
+	VideoMode getVideoMode() const
+	{
+		VideoMode videoMode;
+		getProperty<OniVideoMode>(STREAM_PROPERTY_VIDEO_MODE, static_cast<OniVideoMode*>(&videoMode));
+		return videoMode;
+	}
+
+	/**
+	Changes the current video mode of this stream.  Recommended practice is to use @ref Device::getSensorInfo(), and
+	then @ref SensorInfo::getSupportedVideoModes() to obtain a list of valid video mode settings for this stream.  Then,
+	pass a valid @ref VideoMode to @ref setVideoMode to ensure correct operation.
+
+	@param [in] videoMode Desired new video mode for this stream.
+	returns Status code indicating success or failure of this operation.
+	*/
+	Status setVideoMode(const VideoMode& videoMode)
+	{
+		return setProperty<OniVideoMode>(STREAM_PROPERTY_VIDEO_MODE, static_cast<const OniVideoMode&>(videoMode));
+	}
+
+	/**
+	Provides the maximum possible value for pixels obtained by this stream.  This is most useful for
+	getting the maximum possible value of depth streams.
+	@returns Maximum possible pixel value.
+	*/
+	int getMaxPixelValue() const
+	{
+		int maxValue;
+		Status rc = getProperty<int>(STREAM_PROPERTY_MAX_VALUE, &maxValue);
+		if (rc != STATUS_OK)
+		{
+			return 0;
+		}
+		return maxValue;
+	}
+
+	/**
+	Provides the smallest possible value for pixels obtains by this VideoStream.  This is most useful
+	for getting the minimum possible value that will be reported by a depth stream.
+	@returns Minimum possible pixel value that can come from this stream.
+	*/
+	int getMinPixelValue() const
+	{
+		int minValue;
+		Status rc = getProperty<int>(STREAM_PROPERTY_MIN_VALUE, &minValue);
+		if (rc != STATUS_OK)
+		{
+			return 0;
+		}
+		return minValue;
+	}
+
+	/**
+	Checks whether this stream supports cropping.
+	@returns true if the stream supports cropping, false if it does not.
+	*/
+	bool isCroppingSupported() const
+	{
+		return isPropertySupported(STREAM_PROPERTY_CROPPING);
+	}
+
+	/**
+	Obtains the current cropping settings for this stream.
+	@param [out] pOriginX X coordinate of the upper left corner of the cropping window
+	@param [out] pOriginY Y coordinate of the upper left corner of the cropping window
+	@param [out] pWidth Horizontal width of the cropping window, in pixels
+	@param [out] pHeight Vertical width of the cropping window, in pixels
+	returns true if cropping is currently enabled, false if it is not.
+	*/
+	bool getCropping(int* pOriginX, int* pOriginY, int* pWidth, int* pHeight) const
+	{
+		OniCropping cropping;
+		bool enabled = false;
+
+		Status rc = getProperty<OniCropping>(STREAM_PROPERTY_CROPPING, &cropping);
+
+		if (rc == STATUS_OK)
+		{
+			*pOriginX = cropping.originX;
+			*pOriginY = cropping.originY;
+			*pWidth = cropping.width;
+			*pHeight = cropping.height;
+			enabled = (cropping.enabled == TRUE);
+		}
+
+		return enabled;
+	}
+
+	/**
+	Changes the cropping settings for this stream.  You can use the @ref isCroppingSupported()
+	function to make sure cropping is supported before calling this function.
+	@param [in] originX New X coordinate of the upper left corner of the cropping window.
+	@param [in] originY New Y coordinate of the upper left corner of the cropping window.
+	@param [in] width New horizontal width for the cropping window, in pixels.
+	@param [in] height New vertical height for the cropping window, in pixels.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	Status setCropping(int originX, int originY, int width, int height)
+	{
+		OniCropping cropping;
+		cropping.enabled = true;
+		cropping.originX = originX;
+		cropping.originY = originY;
+		cropping.width = width;
+		cropping.height = height;
+		return setProperty<OniCropping>(STREAM_PROPERTY_CROPPING, cropping);
+	}
+
+	/**
+	Disables cropping.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	Status resetCropping()
+	{
+		OniCropping cropping;
+		cropping.enabled = false;
+		return setProperty<OniCropping>(STREAM_PROPERTY_CROPPING, cropping);
+	}
+
+	/**
+	Check whether mirroring is currently turned on for this stream.
+	@returns true if mirroring is currently enabled, false otherwise.
+	*/
+	bool getMirroringEnabled() const
+	{
+		OniBool enabled;
+		Status rc = getProperty<OniBool>(STREAM_PROPERTY_MIRRORING, &enabled);
+		if (rc != STATUS_OK)
+		{
+			return false;
+		}
+		return enabled == TRUE;
+	}
+
+	/**
+	Enable or disable mirroring for this stream.
+	@param [in] isEnabled true to enable mirroring, false to disable it.
+	@returns Status code indicating the success or failure of this operation.
+	*/
+	Status setMirroringEnabled(bool isEnabled)
+	{
+		return setProperty<OniBool>(STREAM_PROPERTY_MIRRORING, isEnabled ? TRUE : FALSE);
+	}
+
+	/**
+	Gets the horizontal field of view of frames received from this stream.
+	@returns Horizontal field of view, in radians.
+	*/
+	float getHorizontalFieldOfView() const
+	{
+		float horizontal = 0;
+		getProperty<float>(STREAM_PROPERTY_HORIZONTAL_FOV, &horizontal);
+		return horizontal;
+	}
+
+	/**
+	Gets the vertical field of view of frames received from this stream.
+	@returns Vertical field of view, in radians.
+	*/
+	float getVerticalFieldOfView() const
+	{
+		float vertical = 0;
+		getProperty<float>(STREAM_PROPERTY_VERTICAL_FOV, &vertical);
+		return vertical;
+	}
+
+	/**
+	Function for setting a value of a stream property using an arbitrary input type.
+	There are convenience functions available for all commonly used properties, so it is not
+	expected that applications will make direct use of this function very often.
+	@tparam [in] T Data type of the value to be passed to the property.
+	@param [in] propertyId The numerical ID of the property to be set.
+	@param [in] value Data to be sent to the property.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	template <class T>
+	Status setProperty(int propertyId, const T& value)
+	{
+		return setProperty(propertyId, &value, sizeof(T));
+	}
+
+	/**
+	Function for getting the value from a property using an arbitrary output type.
+	There are convenience functions available for all commonly used properties, so it is not
+	expected that applications will make direct use of this function very often.
+	@tparam [in] T Data type of the value to be read.
+	@param [in] propertyId The numerical ID of the property to be read.
+	@param [in, out] value Pointer to a place to store the value read from the property.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	template <class T>
+	Status getProperty(int propertyId, T* value) const
+	{
+		int size = sizeof(T);
+		return getProperty(propertyId, value, &size);
+	}
+
+	/**
+	Checks if a specific property is supported by the video stream.
+	@param [in] propertyId Property to be checked.
+	@returns true if the property is supported, false otherwise.
+	*/
+	bool isPropertySupported(int propertyId) const
+	{
+		if (!isValid())
+		{
+			return false;
+		}
+
+		return oniStreamIsPropertySupported(m_stream, propertyId) == TRUE;
+	}
+
+	/**
+	Invokes a command that takes an arbitrary data type as its input.  It is not expected that
+	application code will need this function frequently, as all commonly used properties have
+	higher level functions provided.
+	@param [in] commandId Numerical code of the property to be invoked.
+	@param [in] data Data to be passed to the property.
+	@param [in] dataSize size of the buffer passed in @c data.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	Status invoke(int commandId, void* data, int dataSize)
+	{
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+
+		return (Status)oniStreamInvoke(m_stream, commandId, data, dataSize);
+	}
+
+	/**
+	Invokes a command that takes an arbitrary data type as its input.  It is not expected that
+	application code will need this function frequently, as all commonly used properties have
+	higher level functions provided.
+	@tparam [in] T Type of data to be passed to the property.
+	@param [in] commandId Numerical code of the property to be invoked.
+	@param [in] value Data to be passed to the property.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	template <class T>
+	Status invoke(int commandId, T& value)
+	{
+		return invoke(commandId, &value, sizeof(T));
+	}
+
+	/**
+	Checks if a specific command is supported by the video stream.
+	@param [in] commandId Command to be checked.
+	@returns true if the command is supported, false otherwise.
+	*/
+	bool isCommandSupported(int commandId) const
+	{
+		if (!isValid())
+		{
+			return false;
+		}
+
+		return (Status)oniStreamIsCommandSupported(m_stream, commandId) == TRUE;
+	}
+
+private:
+	friend class Device;
+
+	void _setHandle(OniStreamHandle stream)
+	{
+		m_sensorInfo._setInternal(NULL);
+		m_stream = stream;
+
+		if (stream != NULL)
+		{
+			m_sensorInfo._setInternal(oniStreamGetSensorInfo(m_stream));
+		}
+	}
+
+private:
+	VideoStream(const VideoStream& other);
+	VideoStream& operator=(const VideoStream& other);
+
+	OniStreamHandle m_stream;
+	SensorInfo m_sensorInfo;
+	CameraSettings* m_pCameraSettings;
+	bool m_isOwner;
+};
+
+/**
+The Device object abstracts a specific device; either a single hardware device, or a file
+device holding a recording from a hardware device.  It offers the ability to connect to
+the device, and obtain information about its configuration and the data streams it can offer.
+
+It provides the means to query and change all configuration parameters that apply to the
+device as a whole.  This includes enabling depth/color image registration and frame
+synchronization.
+
+Devices are used when creating and initializing @ref VideoStream "VideoStreams" -- you will need a valid pointer to
+a Device in order to use the VideoStream.create() function.  This, along with configuration, is
+the primary use of this class for application developers.
+
+Before devices can be created, @ref OpenNI::initialize() must have been run to make the device drivers
+on the system available to the API.
+*/
+class Device
+{
+public:
+	/**
+	Default constructor. Creates a new empty Device object. This object will be invalid until it is initialized by
+	calling its open() function.
+	*/
+	Device() : m_pPlaybackControl(NULL), m_device(NULL), m_isOwner(true)
+	{
+		clearSensors();
+	}
+
+	/**
+	Handle constructor. Creates a Device object based on the given initialized handle.
+	This object will not destroy the underlying handle when  @ref close() or destructor is called
+	*/
+	explicit Device(OniDeviceHandle handle) : m_pPlaybackControl(NULL), m_device(NULL), m_isOwner(false)
+	{
+		_setHandle(handle);
+	}
+
+	/**
+	The destructor calls the @ref close() function, but it is considered a best practice for applications to
+	call @ref close() manually on any @ref Device that they run @ref open() on.
+	*/
+	~Device()
+	{
+		if (m_device != NULL)
+		{
+			close();
+		}
+	}
+
+	/**
+	Opens a device.  This can either open a device chosen arbitrarily from all devices
+	on the system, or open a specific device selected by passing this function the device URI.
+
+	To open any device, simply pass the constant@ref ANY_DEVICE to this function.  If multiple
+	devices are connected to the system, then one of them will be opened.  This procedure is most
+	useful when it is known that exactly one device is (or can be) connected to the system.  In that case,
+	requesting a list of all devices and iterating through it would be a waste of effort.
+
+	If multiple devices are (or may be) connected to a system, then a URI will be required to select
+	a specific device to open.  There are two ways to obtain a URI: from a DeviceConnected event, or
+	by calling @ref OpenNI::enumerateDevices().
+
+	In the case of a DeviceConnected event, the @ref OpenNI::Listener will be provided with a DeviceInfo object
+	as an argument to its @ref OpenNI::Listener::onDeviceConnected "onDeviceConnected()" function.  
+	The DeviceInfo.getUri() function can then be used to obtain the URI.
+
+	If the application is not using event handlers, then it can also call the static function
+	@ref OpenNI::enumerateDevices().  This will return an array of @ref DeviceInfo objects, one for each device
+	currently available to the system.  The application can then iterate through this list and
+	select the desired device.  The URI is again obtained via the @ref DeviceInfo::getUri() function.
+
+	Standard codes of type Status are returned indicating whether opening was successful.
+
+	@param [in] uri String containing the URI of the device to be opened, or @ref ANY_DEVICE.
+	@returns Status code with the outcome of the open operation.
+
+	@remark For opening a recording file, pass the file path as a uri.
+	*/
+	inline Status open(const char* uri);
+
+	/**
+	Closes the device.  This properly closes any files or shuts down hardware, as appropriate.  This
+	function is currently called by the destructor if not called manually by application code, but it
+	is considered a best practice to manually close any device that was opened.
+	*/
+	inline void close();
+
+	/**
+	Provides information about this device in the form of a DeviceInfo object.  This object can
+	be used to access the URI of the device, as well as various USB descriptor strings that might
+	be useful to an application.
+
+	Note that valid device info will not be available if this device has not yet been opened.  If you are
+	trying to obtain a URI to open a device, use OpenNI::enumerateDevices() instead.
+	@returns DeviceInfo object for this Device
+	*/
+	const DeviceInfo& getDeviceInfo() const
+	{
+		return m_deviceInfo;
+	}
+
+	/**
+	This function checks to see if one of the specific sensor types defined in @ref SensorType is
+	available on this device.  This allows an application to, for example, query for the presence
+	of a depth sensor, or color sensor.
+	@param [in] sensorType of sensor to query for
+	@returns true if the Device supports the sensor queried, false otherwise.
+	*/
+	bool hasSensor(SensorType sensorType)
+	{
+		int i;
+		for (i = 0; (i < ONI_MAX_SENSORS) && (m_aSensorInfo[i].m_pInfo != NULL); ++i)
+		{
+			if (m_aSensorInfo[i].getSensorType() == sensorType)
+			{
+				return true;
+			}
+		}
+
+		if (i == ONI_MAX_SENSORS)
+		{
+			return false;
+		}
+
+		const OniSensorInfo* pInfo = oniDeviceGetSensorInfo(m_device, (OniSensorType)sensorType);
+
+		if (pInfo == NULL)
+		{
+			return false;
+		}
+
+		m_aSensorInfo[i]._setInternal(pInfo);
+
+		return true;
+	}
+
+	/**
+	Get the @ref SensorInfo for a specific sensor type on this device.  The @ref SensorInfo
+	is useful primarily for determining which video modes are supported by the sensor.
+	@param [in] sensorType of sensor to get information about.
+	@returns SensorInfo object corresponding to the sensor type specified, or NULL if such a sensor
+			is not available from this device.
+	*/
+	const SensorInfo* getSensorInfo(SensorType sensorType)
+	{
+		int i;
+		for (i = 0; (i < ONI_MAX_SENSORS) && (m_aSensorInfo[i].m_pInfo != NULL); ++i)
+		{
+			if (m_aSensorInfo[i].getSensorType() == sensorType)
+			{
+				return &m_aSensorInfo[i];
+			}
+		}
+
+		// not found. check to see we have additional space
+		if (i == ONI_MAX_SENSORS)
+		{
+			return NULL;
+		}
+
+		const OniSensorInfo* pInfo = oniDeviceGetSensorInfo(m_device, (OniSensorType)sensorType);
+		if (pInfo == NULL)
+		{
+			return NULL;
+		}
+
+		m_aSensorInfo[i]._setInternal(pInfo);
+		return &m_aSensorInfo[i];
+	}
+
+	/**
+	@internal
+	Get an internal handle. This handle can be used via the C API.
+	*/
+	OniDeviceHandle _getHandle() const
+	{
+		return m_device;
+	}
+
+	/**
+	Gets an object through which playback of a file device can be controlled.
+	@returns NULL if this device is not a file device.
+	*/
+	PlaybackControl* getPlaybackControl() {return m_pPlaybackControl;}
+
+	/**
+	Get the value of a general property of the device.
+	There are convenience functions for all the commonly used properties, such as
+	image registration and frame synchronization.  It is expected for this reason
+	that this function will rarely be directly used by applications.
+
+	@param [in] propertyId Numerical ID of the property you would like to check.
+	@param [out] data Place to store the value of the property.
+	@param [in,out] dataSize IN: Size of the buffer passed in the @c data argument. OUT: the actual written size.
+	@returns Status code indicating results of this operation.
+	*/
+	Status getProperty(int propertyId, void* data, int* dataSize) const
+	{
+		return (Status)oniDeviceGetProperty(m_device, propertyId, data, dataSize);
+	}
+
+	/**
+	Sets the value of a general property of the device.
+	There are convenience functions for all the commonly used properties, such as
+	image registration and frame synchronization.  It is expected for this reason
+	that this function will rarely be directly used by applications.
+
+	@param [in] propertyId The numerical ID of the property to be set.
+	@param [in] data Place to store the data to be written to the property.
+	@param [in] dataSize Size of the data to be written to the property.
+	@returns Status code indicating results of this operation.
+	*/
+	Status setProperty(int propertyId, const void* data, int dataSize)
+	{
+		return (Status)oniDeviceSetProperty(m_device, propertyId, data, dataSize);
+	}
+
+	/**
+	Checks to see if this device can support registration of color video and depth video.
+	Image registration is used to properly superimpose two images from cameras located at different
+	points in space.  Please see the OpenNi 2.0 Programmer's Guide for more information about
+	registration.
+	@returns true if image registration is supported by this device, false otherwise.
+	*/
+	bool isImageRegistrationModeSupported(ImageRegistrationMode mode) const
+	{
+		return (oniDeviceIsImageRegistrationModeSupported(m_device, (OniImageRegistrationMode)mode) == TRUE);
+	}
+
+	/**
+	Gets the current image registration mode of this device.
+	Image registration is used to properly superimpose two images from cameras located at different
+	points in space.  Please see the OpenNi 2.0 Programmer's Guide for more information about
+	registration.
+	@returns Current image registration mode.  See @ref ImageRegistrationMode for possible return values.
+	*/
+	ImageRegistrationMode getImageRegistrationMode() const
+	{
+		ImageRegistrationMode mode;
+		Status rc = getProperty<ImageRegistrationMode>(DEVICE_PROPERTY_IMAGE_REGISTRATION, &mode);
+		if (rc != STATUS_OK)
+		{
+			return IMAGE_REGISTRATION_OFF;
+		}
+		return mode;
+	}
+
+	/**
+	Sets the image registration on this device.
+	Image registration is used to properly superimpose two images from cameras located at different
+	points in space.  Please see the OpenNi 2.0 Programmer's Guide for more information about
+	registration.
+
+	See @ref ImageRegistrationMode for a list of valid settings to pass to this function. 
+	
+	It is a good practice to first check if the mode is supported by calling @ref isImageRegistrationModeSupported().
+
+	@param [in] mode Desired new value for the image registration mode.
+	@returns Status code for the operation.
+	*/
+	Status setImageRegistrationMode(ImageRegistrationMode mode)
+	{
+		return setProperty<ImageRegistrationMode>(DEVICE_PROPERTY_IMAGE_REGISTRATION, mode);
+	}
+
+	/**
+	Checks whether this Device object is currently connected to an actual file or hardware device.
+	@returns true if the Device is connected, false otherwise.
+	*/
+	bool isValid() const
+	{
+		return m_device != NULL;
+	}
+
+	/**
+	Checks whether this device is a file device (i.e. a recording).
+	@returns true if this is a file device, false otherwise.
+	*/
+	bool isFile() const
+	{
+		return isPropertySupported(DEVICE_PROPERTY_PLAYBACK_SPEED) &&
+			isPropertySupported(DEVICE_PROPERTY_PLAYBACK_REPEAT_ENABLED) &&
+			isCommandSupported(DEVICE_COMMAND_SEEK);
+	}
+
+	/**
+	Used to turn the depth/color frame synchronization feature on and off.  When frame synchronization
+	is enabled, the device will deliver depth and image frames that are separated in time
+	by some maximum value.  When disabled, the phase difference between depth and image frame
+	generation cannot be guaranteed.
+	@param [in] isEnabled Set to TRUE to enable synchronization, FALSE to disable it
+	@returns Status code indicating success or failure of this operation
+	*/
+	Status setDepthColorSyncEnabled(bool isEnabled)
+	{
+		Status rc = STATUS_OK;
+
+		if (isEnabled)
+		{
+			rc = (Status)oniDeviceEnableDepthColorSync(m_device);
+		}
+		else
+		{
+			oniDeviceDisableDepthColorSync(m_device);
+		}
+
+		return rc;
+	}
+
+	bool getDepthColorSyncEnabled()
+	{
+		return oniDeviceGetDepthColorSyncEnabled(m_device) == TRUE;
+	}
+
+	/**
+	Sets a property that takes an arbitrary data type as its input.  It is not expected that
+	application code will need this function frequently, as all commonly used properties have
+	higher level functions provided.
+
+	@tparam T Type of data to be passed to the property.
+	@param [in] propertyId The numerical ID of the property to be set.
+	@param [in] value Place to store the data to be written to the property.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	template <class T>
+	Status setProperty(int propertyId, const T& value)
+	{
+		return setProperty(propertyId, &value, sizeof(T));
+	}
+
+	/**
+	Checks a property that provides an arbitrary data type as its output.  It is not expected that
+	application code will need this function frequently, as all commonly used properties have
+	higher level functions provided.
+	@tparam [in] T Data type of the value to be read.
+	@param [in] propertyId The numerical ID of the property to be read.
+	@param [in, out] value Pointer to a place to store the value read from the property.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	template <class T>
+	Status getProperty(int propertyId, T* value) const
+	{
+		int size = sizeof(T);
+		return getProperty(propertyId, value, &size);
+	}
+
+	/**
+	Checks if a specific property is supported by the device.
+	@param [in] propertyId Property to be checked.
+	@returns true if the property is supported, false otherwise.
+	*/
+	bool isPropertySupported(int propertyId) const
+	{
+		return oniDeviceIsPropertySupported(m_device, propertyId) == TRUE;
+	}
+
+	/**
+	Invokes a command that takes an arbitrary data type as its input.  It is not expected that
+	application code will need this function frequently, as all commonly used properties have
+	higher level functions provided.
+	@param [in] commandId Numerical code of the property to be invoked.
+	@param [in] data Data to be passed to the property.
+	@param [in] dataSize size of the buffer passed in @c data.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	Status invoke(int commandId, void* data, int dataSize)
+	{
+		return (Status)oniDeviceInvoke(m_device, commandId, data, dataSize);
+	}
+
+	/**
+	Invokes a command that takes an arbitrary data type as its input.  It is not expected that
+	application code will need this function frequently, as all commonly used properties have
+	higher level functions provided.
+	@tparam [in] T Type of data to be passed to the property.
+	@param [in] propertyId Numerical code of the property to be invoked.
+	@param [in] value Data to be passed to the property.
+	@returns Status code indicating success or failure of this operation.
+	*/
+	template <class T>
+	Status invoke(int propertyId, T& value)
+	{
+		return invoke(propertyId, &value, sizeof(T));
+	}
+
+	/**
+	Checks if a specific command is supported by the device.
+	@param [in] commandId Command to be checked.
+	@returns true if the command is supported, false otherwise.
+	*/
+	bool isCommandSupported(int commandId) const
+	{
+		return oniDeviceIsCommandSupported(m_device, commandId) == TRUE;
+	}
+
+	/** @internal **/
+	inline Status _openEx(const char* uri, const char* mode);
+
+private:
+	Device(const Device&);
+	Device& operator=(const Device&);
+
+	void clearSensors()
+	{
+		for (int i = 0; i < ONI_MAX_SENSORS; ++i)
+		{
+			m_aSensorInfo[i]._setInternal(NULL);
+		}
+	}
+
+	inline Status _setHandle(OniDeviceHandle deviceHandle);
+
+private:
+	PlaybackControl* m_pPlaybackControl;
+
+	OniDeviceHandle m_device;
+	DeviceInfo m_deviceInfo;
+	SensorInfo m_aSensorInfo[ONI_MAX_SENSORS];
+
+	bool m_isOwner;
+};
+
+/**
+ * The PlaybackControl class provides access to a series of specific to playing back
+ * a recording from a file device.
+ *
+ * When playing a stream back from a recording instead of playing from a live device,
+ * it is possible to vary playback speed, change the current time location (ie
+ * fast forward / rewind / seek), specify whether the playback should be repeated at the end
+ * of the recording, and query the total size of the recording.
+ *
+ * Since none of these functions make sense in the context of a physical device, they are
+ * split out into a seperate playback control class.  To use, simply create your file device, 
+ * create a PlaybackControl, and then attach the PlaybackControl to the file device.
+ */
+class PlaybackControl
+{
+public:
+
+	/**
+	 * Deconstructor.  Destroys a PlaybackControl class.  The deconstructor presently detaches
+	 * from its recording automatically, but it is considered a best practice for applications to 
+	 * manually detach from any stream that was attached to.
+	 */
+	~PlaybackControl()
+	{
+		detach();
+	}
+
+	/**
+	 * Getter function for the current playback speed of this device.
+	 *
+	 * This value is expressed as a multiple of the speed the original
+	 * recording was taken at.  For example, if the original recording was at 30fps, and 
+	 * playback speed is set to 0.5, then the recording will play at 15fps.  If playback speed
+	 * is set to 2.0, then the recording would playback at 60fps.
+	 *
+	 * In addition, there are two "special" values.  A playback speed of 0.0 indicates that the
+	 * playback should occur as fast as the system is capable of returning frames.  This is 
+	 * most useful when testing algorithms on large datasets, as it enables playback to be
+	 * done at a much higher rate than would otherwise be possible.
+	 *
+	 * A value of -1 indicates that speed is "manual".  In this mode, new frames will only
+	 * become available when an application manually reads them.  If used in a polling loop,
+	 * this setting also enables systems to read and process frames limited only by 
+	 * available processing speeds.
+	 *
+	 * @returns Current playback speed of the device, measured as ratio of recording speed.
+	*/
+	float getSpeed() const
+	{
+		if (!isValid())
+		{
+			return 0.0f;
+		}
+		float speed;
+		Status rc = m_pDevice->getProperty<float>(DEVICE_PROPERTY_PLAYBACK_SPEED, &speed);
+		if (rc != STATUS_OK)
+		{
+			return 1.0f;
+		}
+		return speed;
+	}
+	/**
+	* Setter function for the playback speed of the device.  For a full explaination of 
+	* what this value means @see PlaybackControl::getSpeed().
+	*
+	* @param [in] speed Desired new value of playback speed, as ratio of original recording.
+	* @returns Status code indicating success or failure of this operation.
+	*/
+	Status setSpeed(float speed)
+	{
+		if (!isValid())
+		{
+			return STATUS_NO_DEVICE;
+		}
+		return m_pDevice->setProperty<float>(DEVICE_PROPERTY_PLAYBACK_SPEED, speed);
+	}
+
+	/**
+	* Gets the current repeat setting of the file device.
+	*
+	* @returns true if repeat is enabled, false if not enabled.
+	*/
+	bool getRepeatEnabled() const
+	{
+		if (!isValid())
+		{
+			return false;
+		}
+
+		OniBool repeat;
+		Status rc = m_pDevice->getProperty<OniBool>(DEVICE_PROPERTY_PLAYBACK_REPEAT_ENABLED, &repeat);
+		if (rc != STATUS_OK)
+		{
+			return false;
+		}
+
+		return repeat == TRUE;
+	}
+
+	/**
+	* Changes the current repeat mode of the device.  If repeat mode is turned on, then the recording will
+	* begin playback again at the beginning after the last frame is read.  If turned off, no more frames 
+	* will become available after last frame is read.
+	*
+	* @param [in] repeat New value for repeat -- true to enable, false to disable
+	* @returns Status code indicating success or failure of this operations.
+	*/
+	Status setRepeatEnabled(bool repeat)
+	{
+		if (!isValid())
+		{
+			return STATUS_NO_DEVICE;
+		}
+
+		return m_pDevice->setProperty<OniBool>(DEVICE_PROPERTY_PLAYBACK_REPEAT_ENABLED, repeat ? TRUE : FALSE);
+	}
+
+	/**
+	* Seeks within a VideoStream to a given FrameID.  Note that when this function is called on one 
+	* stream, all other streams will also be changed to the corresponding place in the recording.  The FrameIDs
+	* of different streams may not match, since FrameIDs may differ for streams that are not synchronized, but
+	* the recording will set all streams to the same moment in time.
+	*
+	* @param [in] stream Stream for which the frameIndex value is valid.  
+	* @param [in] frameIndex Frame index to move playback to
+	* @returns Status code indicating success or failure of this operation
+	*/
+	Status seek(const VideoStream& stream, int frameIndex)
+	{
+		if (!isValid())
+		{
+			return STATUS_NO_DEVICE;
+		}
+		OniSeek seek;
+		seek.frameIndex = frameIndex;
+		seek.stream = stream._getHandle();
+		return m_pDevice->invoke(DEVICE_COMMAND_SEEK, seek);
+	}
+
+	/**
+	 * Provides the a count of frames that this recording contains for a given stream.  This is useful
+	 * both to determine the length of the recording, and to ensure that a valid Frame Index is set when using
+	 * the @ref PlaybackControl::seek() function.
+	 *
+	 * @param [in] stream The video stream to count frames for
+	 * @returns Number of frames in provided @ref VideoStream, or 0 if the stream is not part of the recording
+	*/
+	int getNumberOfFrames(const VideoStream& stream) const
+	{
+		int numOfFrames = -1;
+		Status rc = stream.getProperty<int>(STREAM_PROPERTY_NUMBER_OF_FRAMES, &numOfFrames);
+		if (rc != STATUS_OK)
+		{
+			return 0;
+		}
+		return numOfFrames;
+	}
+
+	bool isValid() const
+	{
+		return m_pDevice != NULL;
+	}
+private:
+	Status attach(Device* device)
+	{
+		if (!device->isValid() || !device->isFile())
+		{
+			return STATUS_ERROR;
+		}
+
+		detach();
+		m_pDevice = device;
+
+		return STATUS_OK;
+	}
+	void detach()
+	{
+		m_pDevice = NULL;
+	}
+
+	friend class Device;
+	PlaybackControl(Device* pDevice) : m_pDevice(NULL)
+	{
+		if (pDevice != NULL)
+		{
+			attach(pDevice);
+		}
+	}
+
+	Device* m_pDevice;
+};
+
+class CameraSettings
+{
+public:
+	// setters
+	Status setAutoExposureEnabled(bool enabled)
+	{
+		return setProperty(STREAM_PROPERTY_AUTO_EXPOSURE, enabled ? TRUE : FALSE);
+	}
+	Status setAutoWhiteBalanceEnabled(bool enabled)
+	{
+		return setProperty(STREAM_PROPERTY_AUTO_WHITE_BALANCE, enabled ? TRUE : FALSE);
+	}
+
+	bool getAutoExposureEnabled() const
+	{
+		OniBool enabled = FALSE;
+
+		Status rc = getProperty(STREAM_PROPERTY_AUTO_EXPOSURE, &enabled);
+		return rc == STATUS_OK && enabled == TRUE;
+	}
+	bool getAutoWhiteBalanceEnabled() const
+	{
+		OniBool enabled = FALSE;
+
+		Status rc = getProperty(STREAM_PROPERTY_AUTO_WHITE_BALANCE, &enabled);
+		return rc == STATUS_OK && enabled == TRUE;
+	}
+
+	Status setGain(int gain)
+	{
+		return setProperty(STREAM_PROPERTY_GAIN, gain);
+	}
+	Status setExposure(int exposure)
+	{
+		return setProperty(STREAM_PROPERTY_EXPOSURE, exposure);
+	}
+	int getGain()
+	{
+		int gain;
+		Status rc = getProperty(STREAM_PROPERTY_GAIN, &gain);
+		if (rc != STATUS_OK)
+		{
+			return 100;
+		}
+		return gain;
+	}
+	int getExposure()
+	{
+		int exposure;
+		Status rc = getProperty(STREAM_PROPERTY_EXPOSURE, &exposure);
+		if (rc != STATUS_OK)
+		{
+			return 0;
+		}
+		return exposure;
+	}
+
+	bool isValid() const {return m_pStream != NULL;}
+private:
+	template <class T>
+	Status getProperty(int propertyId, T* value) const
+	{
+		if (!isValid()) return STATUS_NOT_SUPPORTED;
+
+		return m_pStream->getProperty<T>(propertyId, value);
+	}
+	template <class T>
+	Status setProperty(int propertyId, const T& value)
+	{
+		if (!isValid()) return STATUS_NOT_SUPPORTED;
+
+		return m_pStream->setProperty<T>(propertyId, value);
+	}
+
+	friend class VideoStream;
+	CameraSettings(VideoStream* pStream)
+	{
+		m_pStream = pStream;
+	}
+
+	VideoStream* m_pStream;
+};
+
+
+/**
+ * The OpenNI class is a static entry point to the library.  It is used by every OpenNI 2.0 
+ * application to initialize the SDK and drivers to enable creation of valid device objects.  
+ *
+ * It also defines a listener class and events that enable for event driven notification of 
+ * device connection, device disconnection, and device configuration changes.  
+ *
+ * In addition, it gives access to SDK version information and provides a function that allows 
+ * you to wait for data to become available on any one of a list of streams (as opposed to 
+ * waiting for data on one specific stream with functions provided by the VideoStream class)
+ *
+*/
+class OpenNI
+{
+public:
+
+	/**
+	 * The OpenNI::DeviceConnectedListener class provides a means of registering for, and responding to  
+	 * when a device is connected.
+	 *
+	 * onDeviceConnected is called whenever a new device is connected to the system (ie this event
+	 * would be triggered when a new sensor is manually plugged into the host system running the 
+	 * application)
+	 *
+	 * To use this class, you should write a new class that inherits from it, and override the
+	 * onDeviceConnected method.  Once you instantiate your class, use the
+	 * OpenNI::addDeviceConnectedListener() function to add your listener object to OpenNI's list of listeners.  Your
+	 * handler function will then be called whenever the event occurs.  A OpenNI::removeDeviceConnectedListener()
+	 * function is also provided, if you want to have your class stop listening to these events for any
+	 * reason.
+	*/
+	class DeviceConnectedListener
+	{
+	public:
+		DeviceConnectedListener()
+		{
+			m_deviceConnectedCallbacks.deviceConnected = deviceConnectedCallback;
+			m_deviceConnectedCallbacks.deviceDisconnected = NULL;
+			m_deviceConnectedCallbacks.deviceStateChanged = NULL;
+			m_deviceConnectedCallbacksHandle = NULL;
+		}
+		
+		virtual ~DeviceConnectedListener()
+		{
+		}
+		
+		/**
+		* Callback function for the onDeviceConnected event.  This function will be 
+		* called whenever this event occurs.  When this happens, a pointer to the @ref DeviceInfo
+		* object for the newly connected device will be supplied.  Note that once a 
+		* device is removed, if it was opened by a @ref Device object, that object can no longer be
+	 	* used to access the device, even if it was reconnected. Once a device was reconnected, 
+	 	* @ref Device::open() should be called again in order to use this device.
+		*
+		* If you wish to open the new device as it is connected, simply query the provided DeviceInfo
+		* object to obtain the URI of the device, and pass this URI to the Device.Open() function.
+		*/
+		virtual void onDeviceConnected(const DeviceInfo*) = 0;
+	private:
+		static void ONI_CALLBACK_TYPE deviceConnectedCallback(const OniDeviceInfo* pInfo, void* pCookie)
+		{
+			DeviceConnectedListener* pListener = (DeviceConnectedListener*)pCookie;
+			pListener->onDeviceConnected(static_cast<const DeviceInfo*>(pInfo));
+		}
+
+ 		friend class OpenNI;
+		OniDeviceCallbacks m_deviceConnectedCallbacks;
+		OniCallbackHandle m_deviceConnectedCallbacksHandle;
+
+	};
+	/**
+	 * The OpenNI::DeviceDisconnectedListener class provides a means of registering for, and responding to  
+	 * when a device is disconnected.
+	 *
+	 * onDeviceDisconnected is called when a device is removed from the system.  Note that once a 
+	 * device is removed, if it was opened by a @ref Device object, that object can no longer be
+	 * used to access the device, even if it was reconnected. Once a device was reconnected, 
+	 * @ref Device::open() should be called again in order to use this device.
+	 *
+	 * To use this class, you should write a new class that inherits from it, and override the
+	 * onDeviceDisconnected method.  Once you instantiate your class, use the
+	 * OpenNI::addDeviceDisconnectedListener() function to add your listener object to OpenNI's list of listeners.  Your
+	 * handler function will then be called whenever the event occurs.  A OpenNI::removeDeviceDisconnectedListener()
+	 * function is also provided, if you want to have your class stop listening to these events for any
+	 * reason.
+	*/
+	class DeviceDisconnectedListener
+	{
+	public:
+		DeviceDisconnectedListener()
+		{
+			m_deviceDisconnectedCallbacks.deviceConnected = NULL;
+			m_deviceDisconnectedCallbacks.deviceDisconnected = deviceDisconnectedCallback;
+			m_deviceDisconnectedCallbacks.deviceStateChanged = NULL;
+			m_deviceDisconnectedCallbacksHandle = NULL;
+		}
+		
+		virtual ~DeviceDisconnectedListener()
+		{
+		}
+		
+		/**
+		 * Callback function for the onDeviceDisconnected event. This function will be
+		 * called whenever this event occurs.  When this happens, a pointer to the DeviceInfo
+		 * object for the newly disconnected device will be supplied.  Note that once a 
+		 * device is removed, if it was opened by a @ref Device object, that object can no longer be
+	 	 * used to access the device, even if it was reconnected. Once a device was reconnected, 
+	 	 * @ref Device::open() should be called again in order to use this device.
+		*/
+		virtual void onDeviceDisconnected(const DeviceInfo*) = 0;
+	private:
+		static void ONI_CALLBACK_TYPE deviceDisconnectedCallback(const OniDeviceInfo* pInfo, void* pCookie)
+		{
+			DeviceDisconnectedListener* pListener = (DeviceDisconnectedListener*)pCookie;
+			pListener->onDeviceDisconnected(static_cast<const DeviceInfo*>(pInfo));
+		}
+
+		friend class OpenNI;
+		OniDeviceCallbacks m_deviceDisconnectedCallbacks;
+		OniCallbackHandle m_deviceDisconnectedCallbacksHandle;
+	};
+	/**
+	 * The OpenNI::DeviceStateChangedListener class provides a means of registering for, and responding to  
+	 * when a device's state is changed.
+	 *
+	 * onDeviceStateChanged is triggered whenever the state of a connected device is changed.
+	 *
+	 * To use this class, you should write a new class that inherits from it, and override the
+	 * onDeviceStateChanged method.  Once you instantiate your class, use the
+	 * OpenNI::addDeviceStateChangedListener() function to add your listener object to OpenNI's list of listeners.  Your
+	 * handler function will then be called whenever the event occurs.  A OpenNI::removeDeviceStateChangedListener()
+	 * function is also provided, if you want to have your class stop listening to these events for any
+	 * reason.
+	*/
+	class DeviceStateChangedListener
+	{
+	public:
+		DeviceStateChangedListener()
+		{
+			m_deviceStateChangedCallbacks.deviceConnected = NULL;
+			m_deviceStateChangedCallbacks.deviceDisconnected = NULL;
+			m_deviceStateChangedCallbacks.deviceStateChanged = deviceStateChangedCallback;
+			m_deviceStateChangedCallbacksHandle = NULL;
+		}
+		
+		virtual ~DeviceStateChangedListener()
+		{
+		}
+		
+		/**
+		* Callback function for the onDeviceStateChanged event.  This function will be 
+		* called whenever this event occurs.  When this happens, a pointer to a DeviceInfo
+		* object for the affected device will be supplied, as well as the new DeviceState 
+		* value of that device.
+		*/
+		virtual void onDeviceStateChanged(const DeviceInfo*, DeviceState) = 0;
+	private:
+		static void ONI_CALLBACK_TYPE deviceStateChangedCallback(const OniDeviceInfo* pInfo, OniDeviceState state, void* pCookie)
+		{
+			DeviceStateChangedListener* pListener = (DeviceStateChangedListener*)pCookie;
+			pListener->onDeviceStateChanged(static_cast<const DeviceInfo*>(pInfo), DeviceState(state));
+		}
+
+		friend class OpenNI;
+		OniDeviceCallbacks m_deviceStateChangedCallbacks;
+		OniCallbackHandle m_deviceStateChangedCallbacksHandle;
+	};
+
+	/**
+	Initialize the library.
+	This will load all available drivers, and see which devices are available
+	It is forbidden to call any other method in OpenNI before calling @ref initialize().
+	*/
+	static Status initialize()
+	{
+		return (Status)oniInitialize(ONI_API_VERSION); // provide version of API, to make sure proper struct sizes are used
+	}
+
+	/**
+	Stop using the library. Unload all drivers, close all streams and devices.
+	Once @ref shutdown was called, no other calls to OpenNI is allowed.
+	*/
+	static void shutdown()
+	{
+		oniShutdown();
+	}
+
+	/**
+	* Returns the version of OpenNI
+	*/
+	static Version getVersion()
+	{
+		OniVersion oniVersion = oniGetVersion();
+		Version version;
+		version.major = oniVersion.major;
+		version.minor = oniVersion.minor;
+		version.maintenance = oniVersion.maintenance;
+		version.build = oniVersion.build;
+		return version;
+	}
+
+	/**
+	* Retrieves the calling thread's last extended error information. The last extended error information is maintained 
+	* on a per-thread basis. Multiple threads do not overwrite each other's last extended error information.
+	*
+	* The extended error information is cleared on every call to an OpenNI method, so you should call this method
+	* immediately after a call to an OpenNI method which have failed.
+	*/
+	static const char* getExtendedError()
+	{
+		return oniGetExtendedError();
+	}
+
+	/**
+	Fills up an array of @ref DeviceInfo objects with devices that are available.
+	@param [in,out] deviceInfoList An array to be filled with devices.
+	*/
+	static void enumerateDevices(Array<DeviceInfo>* deviceInfoList)
+	{
+		OniDeviceInfo* m_pDeviceInfos;
+		int m_deviceInfoCount;
+		oniGetDeviceList(&m_pDeviceInfos, &m_deviceInfoCount);
+		deviceInfoList->_setData((DeviceInfo*)m_pDeviceInfos, m_deviceInfoCount, true);
+		oniReleaseDeviceList(m_pDeviceInfos);
+	}
+
+	/**
+	Wait for a new frame from any of the streams provided. The function blocks until any of the streams
+	has a new frame available, or the timeout has passed.
+	@param [in] pStreams An array of streams to wait for.
+	@param [in] streamCount The number of streams in @c pStreams
+	@param [out] pReadyStreamIndex The index of the first stream that has new frame available.
+	@param [in] timeout [Optional] A timeout before returning if no stream has new data. Default value is @ref TIMEOUT_FOREVER.
+	*/
+	static Status waitForAnyStream(VideoStream** pStreams, int streamCount, int* pReadyStreamIndex, int timeout = TIMEOUT_FOREVER)
+	{
+		static const int ONI_MAX_STREAMS = 50;
+		OniStreamHandle streams[ONI_MAX_STREAMS];
+
+		if (streamCount > ONI_MAX_STREAMS)
+		{
+			printf("Too many streams for wait: %d > %d\n", streamCount, ONI_MAX_STREAMS);
+			return STATUS_BAD_PARAMETER;
+		}
+
+		*pReadyStreamIndex = -1;
+		for (int i = 0; i < streamCount; ++i)
+		{
+			if (pStreams[i] != NULL)
+			{
+				streams[i] = pStreams[i]->_getHandle();
+			}
+			else
+			{
+				streams[i] = NULL;
+			}
+		}
+		Status rc = (Status)oniWaitForAnyStream(streams, streamCount, pReadyStreamIndex, timeout);
+
+		return rc;
+	}
+
+	/**
+	* Add a listener to the list of objects that receive the event when a device is connected.  See the 
+	* @ref OpenNI::DeviceConnectedListener class for details on utilizing the events provided by OpenNI.
+	* 
+	* @param pListener Pointer to the Listener to be added to the list
+	* @returns Status code indicating success or failure of this operation.
+	*/
+	static Status addDeviceConnectedListener(DeviceConnectedListener* pListener)
+	{
+		if (pListener->m_deviceConnectedCallbacksHandle != NULL)
+		{
+			return STATUS_ERROR;
+		}
+		return (Status)oniRegisterDeviceCallbacks(&pListener->m_deviceConnectedCallbacks, pListener, &pListener->m_deviceConnectedCallbacksHandle);
+	}
+	/**
+	* Add a listener to the list of objects that receive the event when a device is disconnected.  See the 
+	* @ref OpenNI::DeviceDisconnectedListener class for details on utilizing the events provided by OpenNI.
+	* 
+	* @param pListener Pointer to the Listener to be added to the list
+	* @returns Status code indicating success or failure of this operation.
+	*/
+	static Status addDeviceDisconnectedListener(DeviceDisconnectedListener* pListener)
+	{
+		if (pListener->m_deviceDisconnectedCallbacksHandle != NULL)
+		{
+			return STATUS_ERROR;
+		}
+		return (Status)oniRegisterDeviceCallbacks(&pListener->m_deviceDisconnectedCallbacks, pListener, &pListener->m_deviceDisconnectedCallbacksHandle);
+	}
+	/**
+	* Add a listener to the list of objects that receive the event when a device's state changes.  See the 
+	* @ref OpenNI::DeviceStateChangedListener class for details on utilizing the events provided by OpenNI.
+	* 
+	* @param pListener Pointer to the Listener to be added to the list
+	* @returns Status code indicating success or failure of this operation.
+	*/
+	static Status addDeviceStateChangedListener(DeviceStateChangedListener* pListener)
+	{
+		if (pListener->m_deviceStateChangedCallbacksHandle != NULL)
+		{
+			return STATUS_ERROR;
+		}
+		return (Status)oniRegisterDeviceCallbacks(&pListener->m_deviceStateChangedCallbacks, pListener, &pListener->m_deviceStateChangedCallbacksHandle);
+	}
+	/**
+	* Remove a listener from the list of objects that receive the event when a device is connected.  See
+	* the @ref OpenNI::DeviceConnectedListener class for details on utilizing the events provided by OpenNI.
+	*
+	* @param pListener Pointer to the Listener to be removed from the list
+	* @returns Status code indicating the success or failure of this operation.
+	*/
+	static void removeDeviceConnectedListener(DeviceConnectedListener* pListener)
+	{
+		oniUnregisterDeviceCallbacks(pListener->m_deviceConnectedCallbacksHandle);
+		pListener->m_deviceConnectedCallbacksHandle = NULL;
+	}
+	/**
+	* Remove a listener from the list of objects that receive the event when a device is disconnected.  See
+	* the @ref OpenNI::DeviceDisconnectedListener class for details on utilizing the events provided by OpenNI.
+	*
+	* @param pListener Pointer to the Listener to be removed from the list
+	* @returns Status code indicating the success or failure of this operation.
+	*/
+	static void removeDeviceDisconnectedListener(DeviceDisconnectedListener* pListener)
+	{
+		oniUnregisterDeviceCallbacks(pListener->m_deviceDisconnectedCallbacksHandle);
+		pListener->m_deviceDisconnectedCallbacksHandle = NULL;
+	}
+	/**
+	* Remove a listener from the list of objects that receive the event when a device's state changes.  See
+	* the @ref OpenNI::DeviceStateChangedListener class for details on utilizing the events provided by OpenNI.
+	*
+	* @param pListener Pointer to the Listener to be removed from the list
+	* @returns Status code indicating the success or failure of this operation.
+	*/
+	static void removeDeviceStateChangedListener(DeviceStateChangedListener* pListener)
+	{
+		oniUnregisterDeviceCallbacks(pListener->m_deviceStateChangedCallbacksHandle);
+		pListener->m_deviceStateChangedCallbacksHandle = NULL;
+	}
+
+	/** 
+	 * Change the log output folder
+	
+	 * @param	const char * strLogOutputFolder	[in]	log required folder
+	 *
+	 * @retval STATUS_OK Upon successful completion.
+	 * @retval STATUS_ERROR Upon any kind of failure.
+	 */
+	static Status setLogOutputFolder(const char *strLogOutputFolder)
+	{
+		return (Status)oniSetLogOutputFolder(strLogOutputFolder);
+	}
+
+	/** 
+	 * Get current log file name
+	
+	 * @param	char * strFileName	[out]	returned file name buffer
+	 * @param	int	nBufferSize	[in]	Buffer size
+	 *
+	 * @retval STATUS_OK Upon successful completion.
+	 * @retval STATUS_ERROR Upon any kind of failure.
+	 */
+	static Status getLogFileName(char *strFileName, int nBufferSize)
+	{
+		return (Status)oniGetLogFileName(strFileName, nBufferSize);
+	}
+
+	/** 
+	 * Set minimum severity for log produce
+	
+	 * @param	const char * strMask	[in]	Logger name
+	 * @param	int nMinSeverity	[in]	Logger severity
+	 *
+	 * @retval STATUS_OK Upon successful completion.
+	 * @retval STATUS_ERROR Upon any kind of failure.
+	 */
+	static Status setLogMinSeverity(int nMinSeverity)
+	{
+		return(Status) oniSetLogMinSeverity(nMinSeverity);
+	}
+	
+	/** 
+	* Configures if log entries will be printed to console.
+
+	* @param	const OniBool bConsoleOutput	[in]	TRUE to print log entries to console, FALSE otherwise.
+	*
+	* @retval STATUS_OK Upon successful completion.
+	* @retval STATUS_ERROR Upon any kind of failure.
+	 */
+	static Status setLogConsoleOutput(bool bConsoleOutput)
+	{
+		return (Status)oniSetLogConsoleOutput(bConsoleOutput);
+	}
+
+	/** 
+	* Configures if log entries will be printed to file.
+
+	* @param	const OniBool bConsoleOutput	[in]	TRUE to print log entries to file, FALSE otherwise.
+	*
+	* @retval STATUS_OK Upon successful completion.
+	* @retval STATUS_ERROR Upon any kind of failure.
+	 */
+	static Status setLogFileOutput(bool bFileOutput)
+	{
+		return (Status)oniSetLogFileOutput(bFileOutput);
+	}
+
+	#if ONI_PLATFORM == ONI_PLATFORM_ANDROID_ARM
+	/** 
+	 * Configures if log entries will be printed to the Android log.
+
+	 * @param	OniBool bAndroidOutput bAndroidOutput	[in]	TRUE to print log entries to the Android log, FALSE otherwise.
+	 *
+	 * @retval STATUS_OK Upon successful completion.
+	 * @retval STATUS_ERROR Upon any kind of failure.
+	 */
+	
+	static Status setLogAndroidOutput(bool bAndroidOutput)
+	{
+		return (Status)oniSetLogAndroidOutput(bAndroidOutput);
+	}
+	#endif
+	
+private:
+	OpenNI()
+	{
+	}
+};
+
+/**
+The CoordinateConverter class converts points between the different coordinate systems.
+
+<b>Depth and World coordinate systems</b>
+
+OpenNI applications commonly use two different coordinate systems to represent depth.  These two systems are referred to as Depth
+and World representation.
+
+Depth coordinates are the native data representation.  In this system, the frame is a map (two dimensional array), and each pixel is
+assigned a depth value.  This depth value represents the distance between the camera plane and whatever object is in the given
+pixel. The X and Y coordinates are simply the location in the map, where the origin is the top-left corner of the field of view.
+
+World coordinates superimpose a more familiar 3D Cartesian coordinate system on the world, with the camera lens at the origin.
+In this system, every point is specified by 3 points -- x, y and z.  The x axis of this system is along a line that passes
+through the infrared projector and CMOS imager of the camera.  The y axis is parallel to the front face of the camera, and
+perpendicular to the x axis (it will also be perpendicular to the ground if the camera is upright and level).  The z axis
+runs into the scene, perpendicular to both the x and y axis.  From the perspective of the camera, an object moving from
+left to right is moving along the increasing x axis.  An object moving up is moving along the increasing y axis, and an object
+moving away from the camera is moving along the increasing z axis.
+
+Mathematically, the Depth coordinate system is the projection of the scene on the CMOS. If the sensor's angular field of view and
+resolution are known, then an angular size can be calculated for each pixel.  This is how the conversion algorithms work.  The
+dependence of this calculation on FoV and resolution is the reason that a @ref VideoStream pointer must be provided to these
+functions.  The @ref VideoStream pointer is used to determine parameters for the specific points to be converted.
+
+Since Depth coordinates are a projective, the apparent size of objects in depth coordinates (measured in pixels)
+will increase as an object moves closer to the sensor.  The size of objects in the World coordinate system is independent of
+distance from the sensor.
+
+Note that converting from Depth to World coordinates is relatively expensive computationally.  It is generally not practical to convert
+the entire raw depth map to World coordinates.  A better approach is to have your computer vision algorithm work in Depth
+coordinates for as long as possible, and only converting a few specific points to World coordinates right before output.
+
+Note that when converting from Depth to World or vice versa, the Z value remains the same.
+*/
+class CoordinateConverter
+{
+public:
+	/**
+	Converts a single point from the World coordinate system to the Depth coordinate system.
+	@param [in] depthStream Reference to an openni::VideoStream that will be used to determine the format of the Depth coordinates
+	@param [in] worldX The X coordinate of the point to be converted, measured in millimeters in World coordinates
+	@param [in] worldY The Y coordinate of the point to be converted, measured in millimeters in World coordinates
+	@param [in] worldZ The Z coordinate of the point to be converted, measured in millimeters in World coordinates
+	@param [out] pDepthX Pointer to a place to store the X coordinate of the output value, measured in pixels with 0 at far left of image
+	@param [out] pDepthY Pointer to a place to store the Y coordinate of the output value, measured in pixels with 0 at top of image
+	@param [out] pDepthZ Pointer to a place to store the Z(depth) coordinate of the output value, measured in the @ref PixelFormat of depthStream
+	*/
+	static Status convertWorldToDepth(const VideoStream& depthStream, float worldX, float worldY, float worldZ, int* pDepthX, int* pDepthY, DepthPixel* pDepthZ)
+	{
+		float depthX, depthY, depthZ;
+		Status rc = (Status)oniCoordinateConverterWorldToDepth(depthStream._getHandle(), worldX, worldY, worldZ, &depthX, &depthY, &depthZ);
+		*pDepthX = (int)depthX;
+		*pDepthY = (int)depthY;
+		*pDepthZ = (DepthPixel)depthZ;
+		return rc;
+	}
+
+	/**
+	Converts a single point from the World coordinate system to a floating point representation of the Depth coordinate system
+	@param [in] depthStream Reference to an openni::VideoStream that will be used to determine the format of the Depth coordinates
+	@param [in] worldX The X coordinate of the point to be converted, measured in millimeters in World coordinates
+	@param [in] worldY The Y coordinate of the point to be converted, measured in millimeters in World coordinates
+	@param [in] worldZ The Z coordinate of the point to be converted, measured in millimeters in World coordinates
+	@param [out] pDepthX Pointer to a place to store the X coordinate of the output value, measured in pixels with 0.0 at far left of the image
+	@param [out] pDepthY Pointer to a place to store the Y coordinate of the output value, measured in pixels with 0.0 at the top of the image
+	@param [out] pDepthZ Pointer to a place to store the Z(depth) coordinate of the output value, measured in millimeters with 0.0 at the camera lens
+	*/
+	static Status convertWorldToDepth(const VideoStream& depthStream, float worldX, float worldY, float worldZ, float* pDepthX, float* pDepthY, float* pDepthZ)
+	{
+		return (Status)oniCoordinateConverterWorldToDepth(depthStream._getHandle(), worldX, worldY, worldZ, pDepthX, pDepthY, pDepthZ);
+	}
+
+	/**
+	Converts a single point from the Depth coordinate system to the World coordinate system.
+	@param [in] depthStream Reference to an openi::VideoStream that will be used to determine the format of the Depth coordinates
+	@param [in] depthX The X coordinate of the point to be converted, measured in pixels with 0 at the far left of the image
+	@param [in] depthY The Y coordinate of the point to be converted, measured in pixels with 0 at the top of the image
+	@param [in] depthZ the Z(depth) coordinate of the point to be converted, measured in the @ref PixelFormat of depthStream
+	@param [out] pWorldX Pointer to a place to store the X coordinate of the output value, measured in millimeters in World coordinates
+	@param [out] pWorldY Pointer to a place to store the Y coordinate of the output value, measured in millimeters in World coordinates
+	@param [out] pWorldZ Pointer to a place to store the Z coordinate of the output value, measured in millimeters in World coordinates
+	*/
+	static Status convertDepthToWorld(const VideoStream& depthStream, int depthX, int depthY, DepthPixel depthZ, float* pWorldX, float* pWorldY, float* pWorldZ)
+	{
+		return (Status)oniCoordinateConverterDepthToWorld(depthStream._getHandle(), float(depthX), float(depthY), float(depthZ), pWorldX, pWorldY, pWorldZ);
+	}
+
+	/**
+	Converts a single point from a floating point representation of the Depth coordinate system to the World coordinate system.
+	@param [in] depthStream Reference to an openi::VideoStream that will be used to determine the format of the Depth coordinates
+	@param [in] depthX The X coordinate of the point to be converted, measured in pixels with 0.0 at the far left of the image
+	@param [in] depthY The Y coordinate of the point to be converted, measured in pixels with 0.0 at the top of the image
+	@param [in] depthZ Z(depth) coordinate of the point to be converted, measured in the @ref PixelFormat of depthStream
+	@param [out] pWorldX Pointer to a place to store the X coordinate of the output value, measured in millimeters in World coordinates
+	@param [out] pWorldY Pointer to a place to store the Y coordinate of the output value, measured in millimeters in World coordinates
+	@param [out] pWorldZ Pointer to a place to store the Z coordinate of the output value, measured in millimeters in World coordinates
+	*/
+	static Status convertDepthToWorld(const VideoStream& depthStream, float depthX, float depthY, float depthZ, float* pWorldX, float* pWorldY, float* pWorldZ)
+	{
+		return (Status)oniCoordinateConverterDepthToWorld(depthStream._getHandle(), depthX, depthY, depthZ, pWorldX, pWorldY, pWorldZ);
+	}
+
+	/**
+	For a given depth point, provides the coordinates of the corresponding color value.  Useful for superimposing the depth and color images.
+	This operation is the same as turning on registration, but is performed on a single pixel rather than the whole image.
+	@param [in] depthStream Reference to a openni::VideoStream that produced the depth value
+	@param [in] colorStream Reference to a openni::VideoStream that we want to find the appropriate color pixel in
+	@param [in] depthX X value of the depth point, given in Depth coordinates and measured in pixels
+	@param [in] depthY Y value of the depth point, given in Depth coordinates and measured in pixels
+	@param [in] depthZ Z(depth) value of the depth point, given in the @ref PixelFormat of depthStream
+	@param [out] pColorX The X coordinate of the color pixel that overlaps the given depth pixel, measured in pixels
+	@param [out] pColorY The Y coordinate of the color pixel that overlaps the given depth pixel, measured in pixels
+	*/
+	static Status convertDepthToColor(const VideoStream& depthStream, const VideoStream& colorStream, int depthX, int depthY, DepthPixel depthZ, int* pColorX, int* pColorY)
+	{
+		return (Status)oniCoordinateConverterDepthToColor(depthStream._getHandle(), colorStream._getHandle(), depthX, depthY, depthZ, pColorX, pColorY);
+	}
+};
+
+/**
+ * The Recorder class is used to record streams to an ONI file.
+ *
+ * After a recorder is instantiated, it must be initialized with a specific filename where
+ * the recording will be stored.  The recorder is then attached to one or more streams.  Once 
+ * this is complete, the recorder can be told to start recording.  The recorder will store
+ * every frame from every stream to the specified file.  Later, this file can be used to 
+ * initialize a file Device, and used to play back the same data that was recorded.
+ *
+ * Opening a file device is done by passing its path as the uri to the @ref Device::open() method.
+ * 
+ * @see PlaybackControl for options available to play a reorded file.
+ * 
+ */
+class Recorder
+{
+public:
+    /**
+     * Creates a recorder. The recorder is not valid, i.e. @ref isValid() returns
+     * false. You must initialize the recorder before use with @ref create().
+     */
+    Recorder() : m_recorder(NULL)
+    {
+    }
+
+    /**
+     * Destroys a recorder. This will also stop recording.
+     */
+    ~Recorder()
+    {
+		destroy();
+    }
+
+    /**
+     * Initializes a recorder. You can initialize the recorder only once.  Attempts
+	 * to intialize more than once will result in an error code being returned.
+	 *
+	 * Initialization assigns the recorder to an output file that will be used for 
+	 * recording.  Before use, the @ref attach() function must also be used to assign input
+	 * data to the Recorder.
+	 *
+     * @param	[in]	fileName	The name of a file which will contain the recording.
+	 * @returns Status code which indicates success or failure of the operation.
+     */
+    Status create(const char* fileName)
+    {
+        if (!isValid())
+        {
+            return (Status)oniCreateRecorder(fileName, &m_recorder);
+        }
+        return STATUS_ERROR;
+    }
+
+    /**
+     * Verifies if the recorder is valid, i.e. if one can record with this recorder.  A
+	 * recorder object is not valid until the @ref create() method is called.
+	 *
+     * @returns true if the recorder has been intialized, false otherwise.
+     */
+    bool isValid() const
+    {
+        return NULL != getHandle();
+    }
+
+    /**
+     * Attaches a stream to the recorder. Note, this won't start recording, you
+     * should explicitly start it using @ref start() method. As soon as the recording
+     * process has been started, no more streams can be attached to the recorder.
+	 *
+	 * @param [in] stream	The stream to be recorded.
+	 * @param [in] allowLossyCompression [Optional] If this value is true, the recorder might use
+	 *	a lossy compression, which means that when the recording will be played-back, there might
+	 *  be small differences from the original frame. Default value is false.
+     */
+    Status attach(VideoStream& stream, bool allowLossyCompression = false)
+    {
+        if (!isValid() || !stream.isValid())
+        {
+            return STATUS_ERROR;
+        }
+        return (Status)oniRecorderAttachStream(
+                m_recorder,
+                stream._getHandle(),
+                allowLossyCompression);
+    }
+
+    /**
+     * Starts recording. 
+	 * Once this method is called, the recorder will take all subsequent frames from the attached streams
+	 * and store them in the file.
+	 * You may not attach additional streams once recording was started.
+     */
+    Status start()
+    {
+		if (!isValid())
+		{
+			return STATUS_ERROR;
+		}
+        return (Status)oniRecorderStart(m_recorder);
+    }
+
+    /**
+     * Stops recording. You may use @ref start() to resume the recording.
+     */
+    void stop()
+    {
+		if (isValid())
+		{
+			oniRecorderStop(m_recorder);
+		}
+    }
+
+	/**
+	Destroys the recorder object.
+	*/
+	void destroy()
+	{
+		if (isValid())
+		{
+			oniRecorderDestroy(&m_recorder);
+		}
+	}
+
+private:
+	Recorder(const Recorder&);
+	Recorder& operator=(const Recorder&);
+
+    /**
+     * Returns a handle of this recorder.
+     */
+    OniRecorderHandle getHandle() const
+    {
+        return m_recorder;
+    }
+
+
+    OniRecorderHandle m_recorder;
+};
+
+// Implemetation
+Status VideoStream::create(const Device& device, SensorType sensorType)
+{
+	OniStreamHandle streamHandle;
+	Status rc = (Status)oniDeviceCreateStream(device._getHandle(), (OniSensorType)sensorType, &streamHandle);
+	if (rc != STATUS_OK)
+	{
+		return rc;
+	}
+
+	m_isOwner = true;
+	_setHandle(streamHandle);
+
+	if (isPropertySupported(STREAM_PROPERTY_AUTO_WHITE_BALANCE) && isPropertySupported(STREAM_PROPERTY_AUTO_EXPOSURE))
+	{
+		m_pCameraSettings = new CameraSettings(this);
+	}
+
+	return STATUS_OK;
+}
+
+void VideoStream::destroy()
+{
+	if (!isValid())
+	{
+		return;
+	}
+
+	if (m_pCameraSettings != NULL)
+	{
+		delete m_pCameraSettings;
+		m_pCameraSettings = NULL;
+	}
+
+	if (m_stream != NULL)
+	{
+		if(m_isOwner)
+			oniStreamDestroy(m_stream);
+		m_stream = NULL;
+	}
+}
+
+Status Device::open(const char* uri)
+{
+	//If we are not the owners, we stick with our own device
+	if(!m_isOwner)
+	{
+		if(isValid()){
+			return STATUS_OK;
+		}else{
+			return STATUS_OUT_OF_FLOW;
+		}
+	}
+
+	OniDeviceHandle deviceHandle;
+	Status rc = (Status)oniDeviceOpen(uri, &deviceHandle);
+	if (rc != STATUS_OK)
+	{
+		return rc;
+	}
+
+	_setHandle(deviceHandle);
+
+	return STATUS_OK;
+}
+
+Status Device::_openEx(const char* uri, const char* mode)
+{
+	//If we are not the owners, we stick with our own device
+	if(!m_isOwner)
+	{
+		if(isValid()){
+			return STATUS_OK;
+		}else{
+			return STATUS_OUT_OF_FLOW;
+		}
+	}
+
+	OniDeviceHandle deviceHandle;
+	Status rc = (Status)oniDeviceOpenEx(uri, mode, &deviceHandle);
+	if (rc != STATUS_OK)
+	{
+		return rc;
+	}
+
+	_setHandle(deviceHandle);
+
+	return STATUS_OK;
+}
+
+Status Device::_setHandle(OniDeviceHandle deviceHandle)
+{
+	if (m_device == NULL)
+	{
+		m_device = deviceHandle;
+
+		clearSensors();
+
+		oniDeviceGetInfo(m_device, &m_deviceInfo);
+
+		if (isFile())
+		{
+			m_pPlaybackControl = new PlaybackControl(this);
+		}
+
+		// Read deviceInfo
+		return STATUS_OK;
+	}
+
+	return STATUS_OUT_OF_FLOW;
+}
+
+void Device::close()
+{
+	if (m_pPlaybackControl != NULL)
+	{
+		delete m_pPlaybackControl;
+		m_pPlaybackControl = NULL;
+	}
+
+	if (m_device != NULL)
+	{
+		if(m_isOwner)
+		{
+			oniDeviceClose(m_device);
+		}
+
+		m_device = NULL;
+	}
+}
+
+
+}
+
+#endif // _OPEN_NI_HPP_

--- a/third-party/openni2/Include/PS1080.h
+++ b/third-party/openni2/Include/PS1080.h
@@ -1,0 +1,632 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _PS1080_H_
+#define _PS1080_H_
+
+#include <OniCTypes.h>
+
+/** The maximum permitted Xiron device name string length. */ 
+#define XN_DEVICE_MAX_STRING_LENGTH 200
+
+/* 
+ * private properties of PS1080 devices.
+ *
+ * @remarks 
+ * properties structure is 0x1080XXYY where XX is range and YY is code.
+ * range values:
+ * F0 - device properties
+ * E0 - device commands
+ * 00 - common stream properties
+ * 10 - depth stream properties
+ * 20 - color stream properties
+ */
+enum
+{
+	/*******************************************************************/
+	/* Device properties                                               */
+	/*******************************************************************/
+
+	/** unsigned long long (XnSensorUsbInterface) */
+	XN_MODULE_PROPERTY_USB_INTERFACE = 0x1080F001, // "UsbInterface"
+	/** Boolean */ 
+	XN_MODULE_PROPERTY_MIRROR = 0x1080F002, // "Mirror"
+	/** unsigned long long, get only */
+	XN_MODULE_PROPERTY_RESET_SENSOR_ON_STARTUP = 0x1080F004, // "ResetSensorOnStartup"
+	/** unsigned long long, get only */
+	XN_MODULE_PROPERTY_LEAN_INIT = 0x1080F005, // "LeanInit"
+	/** char[XN_DEVICE_MAX_STRING_LENGTH], get only */
+	XN_MODULE_PROPERTY_SERIAL_NUMBER = 0x1080F006, // "ID"
+	/** XnVersions, get only */
+	XN_MODULE_PROPERTY_VERSION = 0x1080F007, // "Version"
+	/** Boolean */
+	XN_MODULE_PROPERTY_FIRMWARE_FRAME_SYNC = 0x1080F008,
+	/** Boolean */
+	XN_MODULE_PROPERTY_HOST_TIMESTAMPS = 0x1080FF77, // "HostTimestamps"
+	/** Boolean */
+	XN_MODULE_PROPERTY_CLOSE_STREAMS_ON_SHUTDOWN = 0x1080FF78, // "CloseStreamsOnShutdown"
+	/** Integer */
+	XN_MODULE_PROPERTY_FIRMWARE_LOG_INTERVAL = 0x1080FF7F, // "FirmwareLogInterval"
+	/** Boolean */
+	XN_MODULE_PROPERTY_PRINT_FIRMWARE_LOG = 0x1080FF80, // "FirmwareLogPrint"
+	/** Integer */
+	XN_MODULE_PROPERTY_FIRMWARE_LOG_FILTER = 0x1080FF81, // "FirmwareLogFilter"
+	/** String, get only */
+	XN_MODULE_PROPERTY_FIRMWARE_LOG = 0x1080FF82, // "FirmwareLog"
+	/** Integer */
+	XN_MODULE_PROPERTY_FIRMWARE_CPU_INTERVAL = 0x1080FF83, // "FirmwareCPUInterval"
+	/** String, get only */
+	XN_MODULE_PROPERTY_PHYSICAL_DEVICE_NAME = 0x1080FF7A, // "PhysicalDeviceName"
+	/** String, get only */
+	XN_MODULE_PROPERTY_VENDOR_SPECIFIC_DATA = 0x1080FF7B, // "VendorSpecificData"
+	/** String, get only */
+	XN_MODULE_PROPERTY_SENSOR_PLATFORM_STRING = 0x1080FF7C, // "SensorPlatformString"
+
+	/*******************************************************************/
+	/* Device commands (activated via SetProperty/GetProperty)         */
+	/*******************************************************************/
+
+	/** XnInnerParam */
+	XN_MODULE_PROPERTY_FIRMWARE_PARAM = 0x1080E001, // "FirmwareParam"
+	/** unsigned long long, set only */
+	XN_MODULE_PROPERTY_RESET = 0x1080E002, // "Reset"
+	/** XnControlProcessingData */
+	XN_MODULE_PROPERTY_IMAGE_CONTROL = 0x1080E003, // "ImageControl"
+	/** XnControlProcessingData */
+	XN_MODULE_PROPERTY_DEPTH_CONTROL = 0x1080E004, // "DepthControl"
+	/** XnAHBData */
+	XN_MODULE_PROPERTY_AHB = 0x1080E005, // "AHB"
+	/** XnLedState */
+	XN_MODULE_PROPERTY_LED_STATE = 0x1080E006, // "LedState"
+	/** Boolean */
+	XN_MODULE_PROPERTY_EMITTER_STATE = 0x1080E007, // "EmitterState"
+
+	/** XnCmosBlankingUnits */
+	XN_MODULE_PROPERTY_CMOS_BLANKING_UNITS = 0x1080FF74, // "CmosBlankingUnits"
+	/** XnCmosBlankingTime */
+	XN_MODULE_PROPERTY_CMOS_BLANKING_TIME = 0x1080FF75, // "CmosBlankingTime"
+	/** XnFlashFileList, get only */
+	XN_MODULE_PROPERTY_FILE_LIST = 0x1080FF84, // "FileList"
+	/** XnParamFlashData, get only */
+	XN_MODULE_PROPERTY_FLASH_CHUNK = 0x1080FF85, // "FlashChunk"
+	XN_MODULE_PROPERTY_FILE = 0x1080FF86, // "FlashFile"
+	/** Integer */
+	XN_MODULE_PROPERTY_DELETE_FILE = 0x1080FF87, // "DeleteFile"
+	XN_MODULE_PROPERTY_FILE_ATTRIBUTES = 0x1080FF88, // "FileAttributes"
+	XN_MODULE_PROPERTY_TEC_SET_POINT = 0x1080FF89, // "TecSetPoint"
+	/** get only */
+	XN_MODULE_PROPERTY_TEC_STATUS = 0x1080FF8A, // "TecStatus"
+	/** get only */
+	XN_MODULE_PROPERTY_TEC_FAST_CONVERGENCE_STATUS = 0x1080FF8B, // "TecFastConvergenceStatus"
+	XN_MODULE_PROPERTY_EMITTER_SET_POINT = 0x1080FF8C, // "EmitterSetPoint"
+	/** get only */
+	XN_MODULE_PROPERTY_EMITTER_STATUS = 0x1080FF8D, // "EmitterStatus"
+	XN_MODULE_PROPERTY_I2C = 0x1080FF8E, // "I2C"
+	/** Integer, set only */
+	XN_MODULE_PROPERTY_BIST = 0x1080FF8F, // "BIST"
+	/** XnProjectorFaultData, set only */
+	XN_MODULE_PROPERTY_PROJECTOR_FAULT = 0x1080FF90, // "ProjectorFault"
+	/** Boolean, set only */
+	XN_MODULE_PROPERTY_APC_ENABLED = 0x1080FF91, // "APCEnabled"
+	/** Boolean */
+	XN_MODULE_PROPERTY_FIRMWARE_TEC_DEBUG_PRINT = 0x1080FF92, // "TecDebugPrint"
+
+	/*******************************************************************/
+	/* Common stream properties                                        */
+	/*******************************************************************/
+
+	/** unsigned long long */ 
+	XN_STREAM_PROPERTY_INPUT_FORMAT = 0x10800001, // "InputFormat"
+	/** unsigned long long (XnCroppingMode) */
+	XN_STREAM_PROPERTY_CROPPING_MODE = 0x10800002, // "CroppingMode"
+
+	/*******************************************************************/
+	/* Depth stream properties                                         */
+	/*******************************************************************/
+
+	/** unsigned long long */
+	XN_STREAM_PROPERTY_CLOSE_RANGE = 0x1080F003, // "CloseRange"
+	/** XnPixelRegistration - get only */
+	XN_STREAM_PROPERTY_PIXEL_REGISTRATION = 0x10801001, // "PixelRegistration"
+	/** unsigned long long */
+	XN_STREAM_PROPERTY_WHITE_BALANCE_ENABLED = 0x10801002, // "WhiteBalancedEnabled"
+	/** unsigned long long */ 
+	XN_STREAM_PROPERTY_GAIN = 0x10801003, // "Gain"
+	/** unsigned long long */ 
+	XN_STREAM_PROPERTY_HOLE_FILTER = 0x10801004, // "HoleFilter"
+	/** unsigned long long (XnProcessingType) */ 
+	XN_STREAM_PROPERTY_REGISTRATION_TYPE = 0x10801005, // "RegistrationType"
+	/** XnDepthAGCBin* */
+	XN_STREAM_PROPERTY_AGC_BIN = 0x10801006, // "AGCBin"
+	/** unsigned long long, get only */ 
+	XN_STREAM_PROPERTY_CONST_SHIFT = 0x10801007, // "ConstShift"
+	/** unsigned long long, get only */ 
+	XN_STREAM_PROPERTY_PIXEL_SIZE_FACTOR = 0x10801008, // "PixelSizeFactor"
+	/** unsigned long long, get only */ 
+	XN_STREAM_PROPERTY_MAX_SHIFT = 0x10801009, // "MaxShift"
+	/** unsigned long long, get only */ 
+	XN_STREAM_PROPERTY_PARAM_COEFF = 0x1080100A, // "ParamCoeff"
+	/** unsigned long long, get only */ 
+	XN_STREAM_PROPERTY_SHIFT_SCALE = 0x1080100B, // "ShiftScale"
+	/** unsigned long long, get only */ 
+	XN_STREAM_PROPERTY_ZERO_PLANE_DISTANCE = 0x1080100C, // "ZPD"
+	/** double, get only */ 
+	XN_STREAM_PROPERTY_ZERO_PLANE_PIXEL_SIZE = 0x1080100D, // "ZPPS"
+	/** double, get only */ 
+	XN_STREAM_PROPERTY_EMITTER_DCMOS_DISTANCE = 0x1080100E, // "LDDIS"
+	/** double, get only */ 
+	XN_STREAM_PROPERTY_DCMOS_RCMOS_DISTANCE = 0x1080100F, // "DCRCDIS"
+	/** OniDepthPixel[], get only */ 
+	XN_STREAM_PROPERTY_S2D_TABLE = 0x10801010, // "S2D"
+	/** unsigned short[], get only */ 
+	XN_STREAM_PROPERTY_D2S_TABLE = 0x10801011, // "D2S"
+	/** get only */
+	XN_STREAM_PROPERTY_DEPTH_SENSOR_CALIBRATION_INFO = 0x10801012,
+	/** Boolean */
+	XN_STREAM_PROPERTY_GMC_MODE	= 0x1080FF44, // "GmcMode"
+	/** Boolean */
+	XN_STREAM_PROPERTY_GMC_DEBUG = 0x1080FF45, // "GmcDebug"
+	/** Boolean */
+	XN_STREAM_PROPERTY_WAVELENGTH_CORRECTION = 0x1080FF46, // "WavelengthCorrection"
+	/** Boolean */
+	XN_STREAM_PROPERTY_WAVELENGTH_CORRECTION_DEBUG = 0x1080FF47, // "WavelengthCorrectionDebug"
+
+	/*******************************************************************/
+	/* Color stream properties                                         */
+	/*******************************************************************/
+	/** Integer */ 
+	XN_STREAM_PROPERTY_FLICKER = 0x10802001, // "Flicker"
+};
+
+typedef enum 
+{
+	XN_SENSOR_FW_VER_UNKNOWN = 0,
+	XN_SENSOR_FW_VER_0_17 = 1,
+	XN_SENSOR_FW_VER_1_1 = 2,
+	XN_SENSOR_FW_VER_1_2 = 3,
+	XN_SENSOR_FW_VER_3_0 = 4,
+	XN_SENSOR_FW_VER_4_0 = 5,
+	XN_SENSOR_FW_VER_5_0 = 6,
+	XN_SENSOR_FW_VER_5_1 = 7,
+	XN_SENSOR_FW_VER_5_2 = 8,
+	XN_SENSOR_FW_VER_5_3 = 9,
+	XN_SENSOR_FW_VER_5_4 = 10,
+	XN_SENSOR_FW_VER_5_5 = 11,
+	XN_SENSOR_FW_VER_5_6 = 12,
+	XN_SENSOR_FW_VER_5_7 = 13,
+	XN_SENSOR_FW_VER_5_8 = 14,
+} XnFWVer;
+
+typedef enum {
+	XN_SENSOR_VER_UNKNOWN = 0,
+	XN_SENSOR_VER_2_0 = 1,
+	XN_SENSOR_VER_3_0 = 2,
+	XN_SENSOR_VER_4_0 = 3,
+	XN_SENSOR_VER_5_0 = 4
+} XnSensorVer;
+
+typedef enum {
+	XN_SENSOR_HW_VER_UNKNOWN = 0,
+	XN_SENSOR_HW_VER_FPDB_10 = 1,
+	XN_SENSOR_HW_VER_CDB_10  = 2,
+	XN_SENSOR_HW_VER_RD_3  = 3,
+	XN_SENSOR_HW_VER_RD_5  = 4,
+	XN_SENSOR_HW_VER_RD1081  = 5,
+	XN_SENSOR_HW_VER_RD1082  = 6,
+	XN_SENSOR_HW_VER_RD109  = 7	
+} XnHWVer;
+
+typedef enum {
+	XN_SENSOR_CHIP_VER_UNKNOWN = 0,
+	XN_SENSOR_CHIP_VER_PS1000 = 1,
+	XN_SENSOR_CHIP_VER_PS1080 = 2,
+	XN_SENSOR_CHIP_VER_PS1080A6 = 3
+} XnChipVer;
+
+typedef enum
+{
+	XN_CMOS_TYPE_IMAGE = 0,
+	XN_CMOS_TYPE_DEPTH = 1,
+
+	XN_CMOS_COUNT
+} XnCMOSType;
+
+typedef enum
+{
+	XN_IO_IMAGE_FORMAT_BAYER = 0,
+	XN_IO_IMAGE_FORMAT_YUV422 = 1,
+	XN_IO_IMAGE_FORMAT_JPEG = 2,
+	XN_IO_IMAGE_FORMAT_JPEG_420 = 3,
+	XN_IO_IMAGE_FORMAT_JPEG_MONO = 4,
+	XN_IO_IMAGE_FORMAT_UNCOMPRESSED_YUV422 = 5,
+	XN_IO_IMAGE_FORMAT_UNCOMPRESSED_BAYER = 6,
+	XN_IO_IMAGE_FORMAT_UNCOMPRESSED_YUYV = 7,
+} XnIOImageFormats;
+
+typedef enum
+{
+	XN_IO_DEPTH_FORMAT_UNCOMPRESSED_16_BIT = 0,
+	XN_IO_DEPTH_FORMAT_COMPRESSED_PS = 1,
+	XN_IO_DEPTH_FORMAT_UNCOMPRESSED_10_BIT = 2,
+	XN_IO_DEPTH_FORMAT_UNCOMPRESSED_11_BIT = 3,
+	XN_IO_DEPTH_FORMAT_UNCOMPRESSED_12_BIT = 4,
+} XnIODepthFormats;
+
+typedef enum
+{
+	XN_RESET_TYPE_POWER = 0,
+	XN_RESET_TYPE_SOFT = 1,
+	XN_RESET_TYPE_SOFT_FIRST = 2,
+} XnParamResetType;
+
+typedef enum XnSensorUsbInterface
+{
+	XN_SENSOR_USB_INTERFACE_DEFAULT = 0,
+	XN_SENSOR_USB_INTERFACE_ISO_ENDPOINTS = 1,
+	XN_SENSOR_USB_INTERFACE_BULK_ENDPOINTS = 2,
+	XN_SENSOR_USB_INTERFACE_ISO_ENDPOINTS_LOW_DEPTH = 3,
+} XnSensorUsbInterface;
+
+typedef enum XnProcessingType
+{
+	XN_PROCESSING_DONT_CARE = 0,
+	XN_PROCESSING_HARDWARE = 1,
+	XN_PROCESSING_SOFTWARE = 2,
+} XnProcessingType;
+
+typedef enum XnCroppingMode
+{
+	XN_CROPPING_MODE_NORMAL = 1,
+	XN_CROPPING_MODE_INCREASED_FPS = 2,
+	XN_CROPPING_MODE_SOFTWARE_ONLY = 3,
+} XnCroppingMode;
+
+enum
+{
+	XN_ERROR_STATE_OK = 0,
+	XN_ERROR_STATE_DEVICE_PROJECTOR_FAULT = 1,
+	XN_ERROR_STATE_DEVICE_OVERHEAT = 2,
+};
+
+typedef enum XnFirmwareCroppingMode
+{
+	XN_FIRMWARE_CROPPING_MODE_DISABLED = 0,
+	XN_FIRMWARE_CROPPING_MODE_NORMAL = 1,
+	XN_FIRMWARE_CROPPING_MODE_INCREASED_FPS = 2,
+} XnFirmwareCroppingMode;
+
+typedef enum
+{
+	XnLogFilterDebug		= 0x0001,
+	XnLogFilterInfo			= 0x0002,
+	XnLogFilterError		= 0x0004,
+	XnLogFilterProtocol		= 0x0008,
+	XnLogFilterAssert		= 0x0010,
+	XnLogFilterConfig		= 0x0020,
+	XnLogFilterFrameSync	= 0x0040,
+	XnLogFilterAGC			= 0x0080,
+	XnLogFilterTelems		= 0x0100,
+
+	XnLogFilterAll			= 0xFFFF
+} XnLogFilter;
+
+typedef enum
+{
+	XnFileAttributeReadOnly	= 0x8000
+} XnFilePossibleAttributes;
+
+typedef enum
+{
+	XnFlashFileTypeFileTable					= 0x00,
+	XnFlashFileTypeScratchFile					= 0x01,
+	XnFlashFileTypeBootSector					= 0x02,
+	XnFlashFileTypeBootManager					= 0x03,
+	XnFlashFileTypeCodeDownloader				= 0x04,
+	XnFlashFileTypeMonitor						= 0x05,
+	XnFlashFileTypeApplication					= 0x06,
+	XnFlashFileTypeFixedParams					= 0x07,
+	XnFlashFileTypeDescriptors					= 0x08,
+	XnFlashFileTypeDefaultParams				= 0x09,
+	XnFlashFileTypeImageCmos					= 0x0A,
+	XnFlashFileTypeDepthCmos					= 0x0B,
+	XnFlashFileTypeAlgorithmParams				= 0x0C,
+	XnFlashFileTypeReferenceQVGA				= 0x0D,
+	XnFlashFileTypeReferenceVGA					= 0x0E,
+	XnFlashFileTypeMaintenance					= 0x0F,
+	XnFlashFileTypeDebugParams					= 0x10,
+	XnFlashFileTypePrimeProcessor				= 0x11,
+	XnFlashFileTypeGainControl					= 0x12,
+	XnFlashFileTypeRegistartionParams			= 0x13,
+	XnFlashFileTypeIDParams						= 0x14,
+	XnFlashFileTypeSensorTECParams				= 0x15,
+	XnFlashFileTypeSensorAPCParams				= 0x16,
+	XnFlashFileTypeSensorProjectorFaultParams	= 0x17,
+	XnFlashFileTypeProductionFile				= 0x18,
+	XnFlashFileTypeUpgradeInProgress			= 0x19,
+	XnFlashFileTypeWavelengthCorrection			= 0x1A,
+	XnFlashFileTypeGMCReferenceOffset			= 0x1B,
+	XnFlashFileTypeSensorNESAParams				= 0x1C,
+	XnFlashFileTypeSensorFault					= 0x1D,
+	XnFlashFileTypeVendorData					= 0x1E,
+} XnFlashFileType;
+
+typedef enum XnBistType
+{
+	//Auto tests
+	XN_BIST_IMAGE_CMOS = 1 << 0,
+	XN_BIST_IR_CMOS = 1 << 1,
+	XN_BIST_POTENTIOMETER = 1 << 2,
+	XN_BIST_FLASH = 1 << 3,
+	XN_BIST_FULL_FLASH = 1 << 4,
+	XN_BIST_PROJECTOR_TEST_MASK = 1 << 5,
+	XN_BIST_TEC_TEST_MASK = 1 << 6,
+
+	// Manual tests
+	XN_BIST_NESA_TEST_MASK = 1 << 7,
+	XN_BIST_NESA_UNLIMITED_TEST_MASK = 1 << 8,
+
+	// Mask of all the auto tests
+	XN_BIST_ALL = (0xFFFFFFFF & ~XN_BIST_NESA_TEST_MASK & ~XN_BIST_NESA_UNLIMITED_TEST_MASK),
+
+} XnBistType;
+
+typedef enum XnBistError
+{
+	XN_BIST_RAM_TEST_FAILURE = 1 << 0,
+	XN_BIST_IR_CMOS_CONTROL_BUS_FAILURE = 1 << 1,
+	XN_BIST_IR_CMOS_DATA_BUS_FAILURE = 1 << 2,
+	XN_BIST_IR_CMOS_BAD_VERSION = 1 << 3,
+	XN_BIST_IR_CMOS_RESET_FAILUE = 1 << 4,
+	XN_BIST_IR_CMOS_TRIGGER_FAILURE = 1 << 5,
+	XN_BIST_IR_CMOS_STROBE_FAILURE = 1 << 6,
+	XN_BIST_COLOR_CMOS_CONTROL_BUS_FAILURE = 1 << 7,
+	XN_BIST_COLOR_CMOS_DATA_BUS_FAILURE = 1 << 8,
+	XN_BIST_COLOR_CMOS_BAD_VERSION = 1 << 9,
+	XN_BIST_COLOR_CMOS_RESET_FAILUE = 1 << 10,
+	XN_BIST_FLASH_WRITE_LINE_FAILURE = 1 << 11,
+	XN_BIST_FLASH_TEST_FAILURE = 1 << 12,
+	XN_BIST_POTENTIOMETER_CONTROL_BUS_FAILURE = 1 << 13,
+	XN_BIST_POTENTIOMETER_FAILURE = 1 << 14,
+	XN_BIST_AUDIO_TEST_FAILURE = 1 << 15,
+	XN_BIST_PROJECTOR_TEST_LD_FAIL = 1 << 16,
+	XN_BIST_PROJECTOR_TEST_LD_FAILSAFE_TRIG_FAIL = 1 << 17,
+	XN_BIST_PROJECTOR_TEST_FAILSAFE_HIGH_FAIL = 1 << 18,
+	XN_BIST_PROJECTOR_TEST_FAILSAFE_LOW_FAIL = 1 << 19,
+	XN_TEC_TEST_HEATER_CROSSED = 1 << 20,
+	XN_TEC_TEST_HEATER_DISCONNETED = 1 << 21,
+	XN_TEC_TEST_TEC_CROSSED = 1 << 22,
+	XN_TEC_TEST_TEC_FAULT = 1 << 23,
+} XnBistError;
+
+typedef enum XnDepthCMOSType
+{
+	XN_DEPTH_CMOS_NONE = 0,
+	XN_DEPTH_CMOS_MT9M001 = 1,
+	XN_DEPTH_CMOS_AR130 = 2,
+} XnDepthCMOSType;
+
+typedef enum XnImageCMOSType
+{
+	XN_IMAGE_CMOS_NONE = 0,
+	XN_IMAGE_CMOS_MT9M112 = 1,
+	XN_IMAGE_CMOS_MT9D131 = 2,
+	XN_IMAGE_CMOS_MT9M114 = 3,
+} XnImageCMOSType;
+
+#define XN_IO_MAX_I2C_BUFFER_SIZE 10
+#define XN_MAX_LOG_SIZE	(6*1024)
+
+#pragma pack (push, 1)
+
+typedef struct XnSDKVersion
+{
+	unsigned char nMajor;
+	unsigned char nMinor;
+	unsigned char nMaintenance;
+	unsigned short nBuild;
+} XnSDKVersion;
+
+typedef struct {
+	unsigned char nMajor;
+	unsigned char nMinor;
+	unsigned short nBuild;
+	unsigned int nChip;
+	unsigned short nFPGA;
+	unsigned short nSystemVersion;
+
+	XnSDKVersion SDK;
+
+	XnHWVer		HWVer;
+	XnFWVer		FWVer;
+	XnSensorVer SensorVer;
+	XnChipVer	ChipVer;
+} XnVersions;
+
+typedef struct
+{
+	unsigned short nParam;
+	unsigned short nValue;
+} XnInnerParamData;
+
+typedef struct XnDepthAGCBin 
+{
+	unsigned short nBin;
+	unsigned short nMin;
+	unsigned short nMax;
+} XnDepthAGCBin;
+
+typedef struct XnControlProcessingData
+{
+	unsigned short nRegister;
+	unsigned short nValue;
+} XnControlProcessingData;
+
+typedef struct XnAHBData
+{
+	unsigned int nRegister;
+	unsigned int nValue;
+	unsigned int nMask;
+} XnAHBData;
+
+typedef struct XnPixelRegistration
+{
+	unsigned int nDepthX;
+	unsigned int nDepthY;
+	uint16_t nDepthValue;
+	unsigned int nImageXRes;
+	unsigned int nImageYRes;
+	unsigned int nImageX; // out
+	unsigned int nImageY; // out
+} XnPixelRegistration;
+
+typedef struct XnLedState
+{
+	uint16_t nLedID;
+	uint16_t nState;
+} XnLedState;
+
+typedef struct XnCmosBlankingTime
+{
+	XnCMOSType nCmosID;
+	float nTimeInMilliseconds;
+	uint16_t nNumberOfFrames;
+} XnCmosBlankingTime;
+
+typedef struct XnCmosBlankingUnits
+{
+	XnCMOSType nCmosID;
+	uint16_t nUnits;
+	uint16_t nNumberOfFrames;
+} XnCmosBlankingUnits;
+
+typedef struct XnI2CWriteData
+{
+	uint16_t nBus;
+	uint16_t nSlaveAddress;
+	uint16_t cpWriteBuffer[XN_IO_MAX_I2C_BUFFER_SIZE];
+	uint16_t nWriteSize;
+} XnI2CWriteData;
+
+typedef struct XnI2CReadData
+{
+	uint16_t nBus;
+	uint16_t nSlaveAddress;
+	uint16_t cpReadBuffer[XN_IO_MAX_I2C_BUFFER_SIZE];
+	uint16_t cpWriteBuffer[XN_IO_MAX_I2C_BUFFER_SIZE];
+	uint16_t nReadSize;
+	uint16_t nWriteSize;
+} XnI2CReadData;
+
+typedef struct XnTecData
+{
+	uint16_t m_SetPointVoltage;
+	uint16_t m_CompensationVoltage;
+	uint16_t m_TecDutyCycle; //duty cycle on heater/cooler
+	uint16_t m_HeatMode; //TRUE - heat, FALSE - cool
+	int32_t m_ProportionalError;
+	int32_t m_IntegralError;
+	int32_t m_DerivativeError;
+	uint16_t m_ScanMode; //0 - crude, 1 - precise
+} XnTecData;
+
+typedef struct XnTecFastConvergenceData
+{
+	int16_t     m_SetPointTemperature;  // set point temperature in celsius,
+	// scaled by factor of 100 (extra precision)
+	int16_t     m_MeasuredTemperature;  // measured temperature in celsius,
+	// scaled by factor of 100 (extra precision)
+	int32_t 	m_ProportionalError;    // proportional error in system clocks
+	int32_t 	m_IntegralError;        // integral error in system clocks
+	int32_t 	m_DerivativeError;      // derivative error in system clocks
+	uint16_t 	m_ScanMode; // 0 - initial, 1 - crude, 2 - precise
+	uint16_t    m_HeatMode; // 0 - idle, 1 - heat, 2 - cool
+	uint16_t    m_TecDutyCycle; // duty cycle on heater/cooler in percents
+	uint16_t	m_TemperatureRange;	// 0 - cool, 1 - room, 2 - warm
+} XnTecFastConvergenceData;
+
+typedef struct XnEmitterData
+{
+	uint16_t m_State; //idle, calibrating
+	uint16_t m_SetPointVoltage; //this is what should be written to the XML
+	uint16_t m_SetPointClocks; //target cross duty cycle
+	uint16_t m_PD_Reading; //current cross duty cycle in system clocks(high time)
+	uint16_t m_EmitterSet; //duty cycle on emitter set in system clocks (high time).
+	uint16_t m_EmitterSettingLogic; //TRUE = positive logic, FALSE = negative logic
+	uint16_t m_LightMeasureLogic; //TRUE - positive logic, FALSE - negative logic
+	uint16_t m_IsAPCEnabled;
+	uint16_t m_EmitterSetStepSize; // in MilliVolts
+	uint16_t m_ApcTolerance; // in system clocks (only valid up till v5.2)
+	uint16_t m_SubClocking; //in system clocks (only valid from v5.3)
+	uint16_t m_Precision; // (only valid from v5.3)
+} XnEmitterData;
+
+typedef struct
+{
+	uint16_t nId;
+	uint16_t nAttribs;
+} XnFileAttributes;
+
+typedef struct
+{
+	uint32_t nOffset;
+	const char* strFileName;
+	uint16_t nAttributes;
+} XnParamFileData;
+
+typedef struct
+{
+	uint32_t nOffset;
+	uint32_t nSize;
+	unsigned char* pData;
+} XnParamFlashData;
+
+typedef struct  {
+	uint16_t nId;
+	uint16_t nType;
+	uint32_t nVersion;
+	uint32_t nOffset;
+	uint32_t nSize;
+	uint16_t nCrc;
+	uint16_t nAttributes;
+	uint16_t nReserve;
+} XnFlashFile;
+
+typedef struct  
+{
+	XnFlashFile* pFiles;
+	uint16_t nFiles;
+} XnFlashFileList;
+
+typedef struct XnProjectorFaultData
+{
+	uint16_t nMinThreshold;
+	uint16_t nMaxThreshold;
+	int32_t bProjectorFaultEvent;
+} XnProjectorFaultData;
+
+typedef struct XnBist
+{
+	uint32_t nTestsMask;
+	uint32_t nFailures;
+} XnBist;
+
+#pragma pack (pop)
+
+#endif //_PS1080_H_

--- a/third-party/openni2/Include/PSLink.h
+++ b/third-party/openni2/Include/PSLink.h
@@ -1,0 +1,199 @@
+#ifndef __XN_PRIME_CLIENT_PROPS_H__
+#define __XN_PRIME_CLIENT_PROPS_H__
+
+#include <PrimeSense.h>
+
+enum
+{
+	/**** Device properties ****/
+
+	/* XnDetailedVersion, get only */
+	LINK_PROP_FW_VERSION = 0x12000001, // "FWVersion"
+	/* Int, get only */
+	LINK_PROP_VERSIONS_INFO_COUNT = 0x12000002, // "VersionsInfoCount"
+	/* General - array - XnComponentVersion * count elements, get only */
+	LINK_PROP_VERSIONS_INFO = 0x12000003, // "VersionsInfo"
+	/* Int - 0 means off, 1 means on. */
+	LINK_PROP_EMITTER_ACTIVE = 0x12000008, // "EmitterActive"
+	/* String. Set only */
+	LINK_PROP_PRESET_FILE = 0x1200000a, // "PresetFile"
+	/* Get only */
+	LINK_PROP_BOOT_STATUS = 0x1200000b,
+
+	/**** Device commands ****/
+	/* XnCommandGetFwStreams */
+	LINK_COMMAND_GET_FW_STREAM_LIST = 0x1200F001,
+	/* XnCommandCreateStream */
+	LINK_COMMAND_CREATE_FW_STREAM = 0x1200F002,
+	/* XnCommandDestroyStream */
+	LINK_COMMAND_DESTROY_FW_STREAM = 0x1200F003,
+	/* XnCommandStartStream */
+	LINK_COMMAND_START_FW_STREAM = 0x1200F004,
+	/* XnCommandStopStream */
+	LINK_COMMAND_STOP_FW_STREAM = 0x1200F005,
+	/* XnCommandGetFwStreamVideoModeList */
+	LINK_COMMAND_GET_FW_STREAM_VIDEO_MODE_LIST = 0x1200F006,
+	/* XnCommandSetFwStreamVideoMode */
+	LINK_COMMAND_SET_FW_STREAM_VIDEO_MODE = 0x1200F007,
+	/* XnCommandGetFwStreamVideoMode */
+	LINK_COMMAND_GET_FW_STREAM_VIDEO_MODE = 0x1200F008,
+
+	/**** Stream properties ****/
+	/* Int. 1 - Shifts 9.3, 2 - Grayscale16, 3 - YUV422, 4 - Bayer8 */
+	LINK_PROP_PIXEL_FORMAT = 0x12001001, // "PixelFormat"
+	/* Int. 0 - None, 1 - 8z, 2 - 16z, 3 - 24z, 4 - 6-bit, 5 - 10-bit, 6 - 11-bit, 7 - 12-bit */
+	LINK_PROP_COMPRESSION = 0x12001002, // "Compression"
+
+	/**** Depth Stream properties ****/
+	/* Real, get only */
+	LINK_PROP_DEPTH_SCALE = 0x1200000b, // "DepthScale"
+	/* Int, get only */
+	LINK_PROP_MAX_SHIFT = 0x12002001, // "MaxShift"
+	/* Int, get only */
+	LINK_PROP_ZERO_PLANE_DISTANCE = 0x12002002, // "ZPD"
+	/* Int, get only */
+	LINK_PROP_CONST_SHIFT = 0x12002003, // "ConstShift"
+	/* Int, get only */
+	LINK_PROP_PARAM_COEFF = 0x12002004, // "ParamCoeff"
+	/* Int, get only */
+	LINK_PROP_SHIFT_SCALE = 0x12002005, // "ShiftScale"
+	/* Real, get only */
+	LINK_PROP_ZERO_PLANE_PIXEL_SIZE = 0x12002006, // "ZPPS"
+	/* Real, get only */
+	LINK_PROP_ZERO_PLANE_OUTPUT_PIXEL_SIZE = 0x12002007, // "ZPOPS"
+	/* Real, get only */
+	LINK_PROP_EMITTER_DEPTH_CMOS_DISTANCE = 0x12002008, // "LDDIS"
+	/*  General - array - MaxShift * XnDepthPixel elements, get only */
+	LINK_PROP_SHIFT_TO_DEPTH_TABLE = 0x12002009, // "S2D"
+	/* General - array - MaxDepth * uint16_t elements, get only */
+	LINK_PROP_DEPTH_TO_SHIFT_TABLE = 0x1200200a, // "D2S"
+};
+
+typedef enum XnFileZone
+{
+	XN_ZONE_FACTORY                 = 0x0000,
+	XN_ZONE_UPDATE                  = 0x0001,
+} XnFileZone;
+
+typedef enum XnBootErrorCode
+{
+	XN_BOOT_OK                      = 0x0000,
+	XN_BOOT_BAD_CRC                 = 0x0001,
+	XN_BOOT_UPLOAD_IN_PROGRESS      = 0x0002,
+	XN_BOOT_FW_LOAD_FAILED          = 0x0003,
+} XnBootErrorCode;
+
+typedef enum XnFwStreamType
+{
+	XN_FW_STREAM_TYPE_COLOR			= 0x0001,
+	XN_FW_STREAM_TYPE_IR			= 0x0002,
+	XN_FW_STREAM_TYPE_SHIFTS		= 0x0003,
+	XN_FW_STREAM_TYPE_AUDIO			= 0x0004,
+	XN_FW_STREAM_TYPE_DY			= 0x0005,
+	XN_FW_STREAM_TYPE_LOG			= 0x0008,
+} XnFwStreamType;
+
+typedef enum XnFwPixelFormat
+{
+	XN_FW_PIXEL_FORMAT_NONE			= 0x0000,
+	XN_FW_PIXEL_FORMAT_SHIFTS_9_3	= 0x0001,
+	XN_FW_PIXEL_FORMAT_GRAYSCALE16	= 0x0002,
+	XN_FW_PIXEL_FORMAT_YUV422		= 0x0003,
+	XN_FW_PIXEL_FORMAT_BAYER8		= 0x0004,
+} XnFwPixelFormat;
+
+typedef enum XnFwCompressionType
+{
+	XN_FW_COMPRESSION_NONE			= 0x0000,
+	XN_FW_COMPRESSION_8Z			= 0x0001,
+	XN_FW_COMPRESSION_16Z			= 0x0002,
+	XN_FW_COMPRESSION_24Z			= 0x0003,
+	XN_FW_COMPRESSION_6_BIT_PACKED	= 0x0004,
+	XN_FW_COMPRESSION_10_BIT_PACKED	= 0x0005,
+	XN_FW_COMPRESSION_11_BIT_PACKED = 0x0006,
+	XN_FW_COMPRESSION_12_BIT_PACKED	= 0x0007,
+} XnFwCompressionType;
+
+#pragma pack (push, 1)
+
+#define XN_MAX_VERSION_MODIFIER_LENGTH 16
+typedef struct XnDetailedVersion
+{
+	uint8_t m_nMajor;
+	uint8_t m_nMinor;
+	uint16_t m_nMaintenance;
+	uint32_t m_nBuild;
+	char m_strModifier[XN_MAX_VERSION_MODIFIER_LENGTH];
+} XnDetailedVersion;
+
+typedef struct XnBootStatus
+{
+	XnFileZone zone;
+	XnBootErrorCode errorCode;
+} XnBootStatus;
+
+typedef struct XnFwStreamInfo
+{
+	XnFwStreamType type;
+	char creationInfo[80];
+} XnFwStreamInfo;
+
+typedef struct XnFwStreamVideoMode
+{
+	uint32_t m_nXRes;
+	uint32_t m_nYRes;
+	uint32_t m_nFPS;
+	XnFwPixelFormat m_nPixelFormat;
+	XnFwCompressionType m_nCompression;
+} XnFwStreamVideoMode;
+
+typedef struct XnCommandGetFwStreamList
+{
+	uint32_t count;	// in: number of allocated elements in streams array. out: number of written elements in the array
+	XnFwStreamInfo* streams;
+} XnCommandGetFwStreamList;
+
+typedef struct XnCommandCreateStream
+{
+	XnFwStreamType type;
+	const char* creationInfo;
+	uint32_t id; // out
+} XnCommandCreateStream;
+
+typedef struct XnCommandDestroyStream
+{
+	uint32_t id;
+} XnCommandDestroyStream;
+
+typedef struct XnCommandStartStream
+{
+	uint32_t id;
+} XnCommandStartStream;
+
+typedef struct XnCommandStopStream
+{
+	uint32_t id;
+} XnCommandStopStream;
+
+typedef struct XnCommandGetFwStreamVideoModeList
+{
+	int streamId;
+	uint32_t count;	// in: number of allocated elements in videoModes array. out: number of written elements in the array
+	XnFwStreamVideoMode* videoModes;
+} XnCommandGetFwStreamVideoModeList;
+
+typedef struct XnCommandSetFwStreamVideoMode
+{
+	int streamId;
+	XnFwStreamVideoMode videoMode;
+} XnCommandSetFwStreamVideoMode;
+
+typedef struct XnCommandGetFwStreamVideoMode
+{
+	int streamId;
+	XnFwStreamVideoMode videoMode; // out
+} XnCommandGetFwStreamVideoMode;
+
+#pragma pack (pop)
+
+#endif //__XN_PRIME_CLIENT_PROPS_H__

--- a/third-party/openni2/Include/PrimeSense.h
+++ b/third-party/openni2/Include/PrimeSense.h
@@ -1,0 +1,229 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _PRIME_SENSE_H_
+#define _PRIME_SENSE_H_
+
+#include <OniCTypes.h>
+
+/**
+* Additional properties for PrimeSense devices
+*
+* @remarks 
+* properties structure is 0x1D27XXYY where XX is range and YY is code.
+* range values:
+* 00 - common stream properties
+* 10 - depth stream properties
+* E0 - device commands
+* F0 - device properties
+*/
+enum
+{
+	// Stream Properties
+	PS_PROPERTY_DUMP_DATA = 0x1d270001, // boolean
+
+	// Device Properties
+	PS_PROPERTY_USB_INTERFACE = 0x1d27F001, // values from XnUsbInterfaceType
+};
+
+/**
+* Additional commands for PrimeSense devices
+*
+* @remarks 
+* Commands structure is 0x1D27XXYY where XX is range and YY is code.
+* range values:
+* E0 - device commands
+*/
+enum
+{
+	// Device Commands - use via invoke()
+	PS_COMMAND_AHB_READ = 0x1d27E001, // XnCommandAHB
+	PS_COMMAND_AHB_WRITE = 0x1d27E002, // XnCommandAHB
+	PS_COMMAND_I2C_READ = 0x1d27E003, // XnCommandI2C
+	PS_COMMAND_I2C_WRITE = 0x1d27E004, // XnCommandI2C
+	PS_COMMAND_SOFT_RESET = 0x1d27E005, // no arguments
+	PS_COMMAND_POWER_RESET = 0x1d27E006, // no arguments
+	PS_COMMAND_BEGIN_FIRMWARE_UPDATE = 0x1d27E007, // no arguments
+	PS_COMMAND_END_FIRMWARE_UPDATE = 0x1d27E008, // no arguments
+	PS_COMMAND_UPLOAD_FILE = 0x1d27E009, // XnCommandUploadFile
+	PS_COMMAND_DOWNLOAD_FILE = 0x1d27E00A, // XnCommandDownloadFile
+	PS_COMMAND_GET_FILE_LIST = 0x1d27E00B, // an array of XnFileEntry
+	PS_COMMAND_FORMAT_ZONE = 0x1d27E00C, // XnCommandFormatZone
+	PS_COMMAND_DUMP_ENDPOINT = 0x1d27E00D, // XnCommandDumpEndpoint
+	PS_COMMAND_GET_I2C_DEVICE_LIST = 0x1d27E00E, // XnCommandGetI2CDevices
+	PS_COMMAND_GET_BIST_LIST = 0x1d27E00F, // XnCommandGetBistList
+	PS_COMMAND_EXECUTE_BIST = 0x1d27E010, // XnCommandExecuteBist
+	PS_COMMAND_USB_TEST = 0x1d27E011, // XnCommandUsbTest
+	PS_COMMAND_GET_LOG_MASK_LIST = 0x1d27E012, // XnCommandGetLogMaskList
+	PS_COMMAND_SET_LOG_MASK_STATE = 0x1d27E013, // XnCommandSetLogMaskState
+	PS_COMMAND_START_LOG = 0x1d27E014, // no arguments
+	PS_COMMAND_STOP_LOG = 0x1d27E015, // no arguments
+};
+
+typedef enum XnUsbInterfaceType
+{
+	PS_USB_INTERFACE_DONT_CARE = 0,
+	PS_USB_INTERFACE_ISO_ENDPOINTS = 1,
+	PS_USB_INTERFACE_BULK_ENDPOINTS = 2,
+} XnUsbInterfaceType;
+
+#pragma pack (push, 1)
+
+// Data Types
+typedef struct XnFwFileVersion
+{
+	uint8_t major;
+	uint8_t minor;
+	uint8_t maintenance;
+	uint8_t build;
+} XnFwFileVersion;
+
+typedef enum XnFwFileFlags
+{
+	XN_FILE_FLAG_BAD_CRC					= 0x0001,
+} XnFwFileFlags;
+
+typedef struct XnFwFileEntry
+{
+	char name[32];
+	XnFwFileVersion version;
+	uint32_t address;
+	uint32_t size;
+	uint16_t crc;
+	uint16_t zone;
+	XnFwFileFlags flags; // bitmap 
+} XnFwFileEntry;
+
+typedef struct XnI2CDeviceInfo
+{
+	uint32_t id;
+	char name[32];
+} XnI2CDeviceInfo;
+
+typedef struct XnBistInfo
+{
+	uint32_t id;
+	char name[32];
+} XnBistInfo;
+
+typedef struct XnFwLogMask
+{
+	uint32_t id;
+	char name[32];
+} XnFwLogMask;
+
+typedef struct XnUsbTestEndpointResult
+{
+	double averageBytesPerSecond;
+	uint32_t lostPackets;
+} XnUsbTestEndpointResult;
+
+// Commands
+
+typedef struct XnCommandAHB
+{
+	uint32_t address;		// Address of this register
+	uint32_t offsetInBits;	// Offset of the field in bits within address
+	uint32_t widthInBits;	// Width of the field in bits
+	uint32_t value;			// For read requests, this is where the actual value will be filled. For write requests, the value to write.
+} XnCommandAHB;
+
+typedef struct XnCommandI2C
+{
+	uint32_t deviceID;		// Device to communicate with
+	uint32_t addressSize;	// Size of the address, in bytes (1-4)
+	uint32_t address;		// Address
+	uint32_t valueSize;		// Size of the value, in bytes (1-4)
+	uint32_t mask;			// For write request - a mask to be applied to the value. For read requests - ignored.
+	uint32_t value;			// For write request - the value to be written. For read requests - the place where the actual value is written to
+} XnCommandI2C;
+
+typedef struct XnCommandUploadFile  
+{
+	const char* filePath;
+	uint32_t uploadToFactory;
+} XnCommandUploadFile;  
+
+typedef struct XnCommandDownloadFile  
+{
+	uint16_t zone;
+	const char*  firmwareFileName;
+	const char*  targetPath;
+} XnCommandDownloadFile;  
+
+typedef struct XnCommandGetFileList
+{
+	uint32_t count;		// in: number of allocated elements in files array. out: number of written elements in the array
+	XnFwFileEntry* files;
+} XnCommandGetFileList;
+
+typedef struct XnCommandFormatZone 
+{
+	uint8_t zone;
+} XnCommandFormatZone;
+
+typedef struct XnCommandDumpEndpoint
+{
+	uint8_t endpoint;
+	bool enabled;
+} XnCommandDumpEndpoint;
+
+typedef struct XnCommandGetI2CDeviceList
+{
+	uint32_t count;	// in: number of allocated elements in devices array. out: number of written elements in the array
+	XnI2CDeviceInfo* devices;
+} XnCommandGetI2CDeviceList;
+
+typedef struct XnCommandGetBistList
+{
+	uint32_t count;	// in: number of allocated elements in tests array. out: number of written elements in the array
+	XnBistInfo* tests;
+} XnCommandGetBistList;
+
+typedef struct XnCommandExecuteBist
+{
+	uint32_t id;
+	uint32_t errorCode;
+	uint32_t extraDataSize;	// in: number of allocated bytes in extraData. out: number of written bytes in extraData
+	uint8_t* extraData;
+} XnCommandExecuteBist;
+
+typedef struct XnCommandUsbTest
+{
+	uint32_t seconds;
+	uint32_t endpointCount;	// in: number of allocated bytes in endpoints array. out: number of written bytes in array
+	XnUsbTestEndpointResult* endpoints;
+} XnCommandUsbTest;
+
+typedef struct XnCommandGetLogMaskList
+{
+	uint32_t count;	// in: number of allocated elements in masks array. out: number of written elements in the array
+	XnFwLogMask* masks;
+} XnCommandGetLogMaskList;
+
+typedef struct XnCommandSetLogMaskState
+{
+	uint32_t mask;
+	bool enabled;
+} XnCommandSetLogMaskState;
+
+#pragma pack (pop)
+
+#endif //_PRIME_SENSE_H_

--- a/third-party/openni2/Include/Win32/OniPlatformWin32.h
+++ b/third-party/openni2/Include/Win32/OniPlatformWin32.h
@@ -1,0 +1,139 @@
+/*****************************************************************************
+*                                                                            *
+*  OpenNI 2.x Alpha                                                          *
+*  Copyright (C) 2012 PrimeSense Ltd.                                        *
+*                                                                            *
+*  This file is part of OpenNI.                                              *
+*                                                                            *
+*  Licensed under the Apache License, Version 2.0 (the "License");           *
+*  you may not use this file except in compliance with the License.          *
+*  You may obtain a copy of the License at                                   *
+*                                                                            *
+*      http://www.apache.org/licenses/LICENSE-2.0                            *
+*                                                                            *
+*  Unless required by applicable law or agreed to in writing, software       *
+*  distributed under the License is distributed on an "AS IS" BASIS,         *
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  *
+*  See the License for the specific language governing permissions and       *
+*  limitations under the License.                                            *
+*                                                                            *
+*****************************************************************************/
+#ifndef _ONI_PLATFORM_WIN32_H_
+#define _ONI_PLATFORM_WIN32_H_
+
+//---------------------------------------------------------------------------
+// Prerequisites
+//---------------------------------------------------------------------------
+#ifndef WINVER						// Allow use of features specific to Windows XP or later
+	#define WINVER 0x0501
+#endif
+#ifndef _WIN32_WINNT				// Allow use of features specific to Windows XP or later
+	#define _WIN32_WINNT 0x0501
+#endif						
+#ifndef _WIN32_WINDOWS				// Allow use of features specific to Windows 98 or later
+	#define _WIN32_WINDOWS 0x0410
+#endif
+#ifndef _WIN32_IE					// Allow use of features specific to IE 6.0 or later
+	#define _WIN32_IE 0x0600
+#endif
+#define WIN32_LEAN_AND_MEAN			// Exclude rarely-used stuff from Windows headers
+
+// Undeprecate CRT functions
+#ifndef _CRT_SECURE_NO_DEPRECATE 
+	#define _CRT_SECURE_NO_DEPRECATE 1
+#endif
+
+//---------------------------------------------------------------------------
+// Includes
+//---------------------------------------------------------------------------
+#include <windows.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <malloc.h>
+#include <io.h>
+#include <time.h>
+#include <assert.h>
+#include <float.h>
+#include <crtdbg.h>
+
+#if _MSC_VER < 1600 // Visual Studio 2008 and older doesn't have stdint.h...
+typedef signed char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+typedef __int64 int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned __int64 uint64_t;
+#else
+#include <stdint.h>
+#endif
+
+//---------------------------------------------------------------------------
+// Platform Basic Definition
+//---------------------------------------------------------------------------
+#define ONI_PLATFORM ONI_PLATFORM_WIN32
+#define ONI_PLATFORM_STRING "Win32"
+
+//---------------------------------------------------------------------------
+// Platform Capabilities
+//---------------------------------------------------------------------------
+#define ONI_PLATFORM_ENDIAN_TYPE ONI_PLATFORM_IS_LITTLE_ENDIAN
+
+#define ONI_PLATFORM_SUPPORTS_DYNAMIC_LIBS 1
+
+//---------------------------------------------------------------------------
+// Memory
+//---------------------------------------------------------------------------
+/** The default memory alignment. */ 
+#define ONI_DEFAULT_MEM_ALIGN 16
+
+/** The thread static declarator (using TLS). */
+#define ONI_THREAD_STATIC __declspec(thread)
+
+//---------------------------------------------------------------------------
+// Files
+//---------------------------------------------------------------------------
+/** The maximum allowed file path size (in bytes). */ 
+#define ONI_FILE_MAX_PATH MAX_PATH
+
+//---------------------------------------------------------------------------
+// Call backs
+//---------------------------------------------------------------------------
+/** The std call type. */ 
+#define ONI_STDCALL __stdcall
+
+/** The call back calling convention. */ 
+#define ONI_CALLBACK_TYPE ONI_STDCALL
+
+/** The C and C++ calling convension. */
+#define ONI_C_DECL __cdecl
+
+//---------------------------------------------------------------------------
+// Macros
+//---------------------------------------------------------------------------
+/** Returns the date and time at compile time. */ 
+#define ONI_TIMESTAMP __DATE__ " " __TIME__
+
+/** Converts n into a pre-processor string.  */ 
+#define ONI_STRINGIFY(n) ONI_STRINGIFY_HELPER(n)
+#define ONI_STRINGIFY_HELPER(n) #n
+
+//---------------------------------------------------------------------------
+// API Export/Import Macros
+//---------------------------------------------------------------------------
+/** Indicates an exported shared library function. */ 
+#define ONI_API_EXPORT __declspec(dllexport)
+
+/** Indicates an imported shared library function. */ 
+#define ONI_API_IMPORT __declspec(dllimport)
+
+/** Indicates a deprecated function */
+#if _MSC_VER < 1400 // Before VS2005 there was no support for declspec deprecated...
+	#define ONI_API_DEPRECATED(msg)
+#else
+	#define ONI_API_DEPRECATED(msg) __declspec(deprecated(msg))
+#endif
+
+#endif //_ONI_PLATFORM_WIN32_H_

--- a/third-party/openni2/LICENSE
+++ b/third-party/openni2/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third-party/openni2/NOTICE
+++ b/third-party/openni2/NOTICE
@@ -1,0 +1,509 @@
+OpenNI 2.X
+
+Copyright (c) 2012 PrimeSense Ltd.
+
+This product is licensed under the Apache License, Version 2.0 (the "License");
+
+You should have received a copy of the Apache License along with OpenNI 2.X. 
+If not, see:
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the 
+License for the specific language governing permissions and limitations under 
+the License.
+
+The following open source components are included in OpenNI 2.X:
+
+1. LibJPEG, 6b of 27-Mar-1998
+
+Source code can be downloaded from: http://libjpeg.sourceforge.net/
+
+This software is based in part on the work of the Independent JPEG Group. 
+OpenNI 2.X source code also contains the source code of libjpeg, as well as 
+its license terms. An online copy can be found at: 
+
+https://github.com/OpenNI/OpenNI2/blob/master/ThirdParty/LibJPEG/README
+
+This license can be found at:
+https://github.com/aseprite/aseprite/blob/master/docs/licenses/libjpeg-LICENSE.
+txt
+
+We've made some minor modifications to the source code.
+
+The authors make NO WARRANTY or representation, either express or implied, 
+with respect to this software, its quality, accuracy, merchantability, or 
+fitness for a particular purpose.  This software is provided "AS IS", and 
+you, its user, assume the entire risk as to its quality and accuracy. 
+This software is copyright (C) 1991-1998, Thomas G. Lane.
+All Rights Reserved except as specified below.
+
+Permission is hereby granted to use, copy, modify, and distribute this 
+software (or portions thereof) for any purpose, without fee, subject to these 
+conditions: 
+(1) If any part of the source code for this software is distributed, then 
+this README file must be included, with this copyright and no-warranty notice 
+unaltered; and any additions, deletions, or changes to the original files 
+must be clearly indicated in accompanying documentation. 
+(2) If only executable code is distributed, then the accompanying 
+documentation must state that "this software is based in part on the work of 
+the Independent JPEG Group". 
+(3) Permission for use of this software is granted only if the user accepts 
+full responsibility for any undesirable consequences; the authors accept NO 
+LIABILITY for damages of any kind.
+These conditions apply to any software derived from or based on the IJG code, 
+not just to the unmodified library.  If you use our work, you ought to 
+acknowledge us. 
+Permission is NOT granted for the use of any IJG author's name or company 
+name in advertising or publicity relating to this software or products 
+derived from it.  This software may be referred to only as "the Independent 
+JPEG Group's software".
+We specifically permit and encourage the use of this software as the basis of 
+commercial products, provided that all warranty or liability claims are 
+assumed by the product vendor. 
+ansi2knr.c is included in this distribution by permission of L. Peter 
+Deutsch, sole proprietor of its copyright holder, Aladdin Enterprises of 
+Menlo Park, CA. ansi2knr.c is NOT covered by the above copyright and 
+conditions, but instead by the usual distribution terms of the Free Software 
+Foundation; principally,  that you must include source code if you 
+redistribute it.  (See the file
+ansi2knr.c for full details.)  However, since ansi2knr.c is not needed as 
+part of any program generated from the IJG code, this does not limit you more 
+than the foregoing paragraphs do. 
+The Unix configuration script "configure" was produced with GNU Autoconf. It 
+is copyright by the Free Software Foundation but is freely distributable. The 
+same holds for its supporting scripts (config.guess, config.sub, ltconfig, 
+ltmain.sh).  Another support script, install-sh, is copyright by M.I.T. but 
+is also freely distributable. 
+It appears that the arithmetic coding option of the JPEG spec is covered by 
+patents owned by IBM, AT&T, and Mitsubishi.  Hence arithmetic coding cannot 
+legally be used without obtaining one or more licenses.  For this reason, 
+support for arithmetic coding has been removed from the free JPEG software. 
+(Since arithmetic coding provides only a marginal gain over the unpatented 
+Huffman mode, it is unlikely that very many implementations will support 
+it.)  So far as we are aware, there are no patent restrictions on the 
+remaining code.
+The IJG distribution formerly included code to read and write GIF files. To 
+avoid entanglement with the Unisys LZW patent, GIF reading support has been 
+removed altogether, and the GIF writer has been simplified to produce 
+"uncompressed GIFs".  This technique does not use the LZW algorithm; the 
+resulting GIF files are larger than usual, but are readable by all standard 
+GIF decoders. 
+We are required to state that "The Graphics Interchange Format(c) is the 
+Copyright property of CompuServe Incorporated.  GIF(sm) is a Service Mark 
+property of CompuServe Incorporated." 
+
+2. LibUSB, 1.0.9, under GNU Lesser General Public License, v 2.1 (or any 
+later version)
+
+OpenNI 2.X uses a modified version of libusb, which was modified by 
+PrimeSense on 2012. 
+
+The modified source code is distributed along with OpenNI 2.X source code and 
+can be found in the following path: 
+ThirdParty/PSCommon/XnLib/ThirdParty/libusb-1.0.9-Android
+
+
+Copyright (C) 2007-2008 Daniel Drake <dsd@gentoo.org>
+Copyright (c) 2001 Johannes Erdfelt <johannes@erdfelt.com>
+
+This library is free software; you can redistribute it and/or modify it under 
+the terms of the GNU Lesser General Public License as published by the Free 
+Software Foundation; either version 2.1 of the License, or (at your option) 
+any later version. 
+
+This library is distributed in the hope that it will be useful, but WITHOUT 
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS 
+FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more 
+details. 
+
+You should have received a copy of the GNU Lesser General Public License 
+along with this library; if not, write to the Free Software Foundation, Inc., 
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Full text of the license is available below.
+
+3. GLUT 3.7.x 
+
+Some of the samples arrive with GLUT binaries and headers for Windows. Those 
+are under the following copyright:
+
+This license can be found at: 
+http://user.xmission.com/~nate/glut/README-win32.txt
+
+The OpenGL Utility Toolkit (GLUT) distribution contains source code published 
+in a book titled "Programming OpenGL for the X Window System" (ISBN: 
+0-201-48359-9) published by Addison-Wesley.  The programs and associated 
+files contained in the distribution were developed by Mark J. Kilgard and are 
+Copyright 1994, 1995, 1996 by Mark J. Kilgard (unless otherwise noted).  The 
+programs are not in the public domain, but they are freely distributable 
+without licensing fees. These programs are provided without guarantee or 
+warrantee expressed or implied.
+
+THIS SOURCE CODE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,  EITHER 
+EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OR 
+MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+OpenGL (R) is a registered trademark of Silicon Graphics, Inc.
+
+*****************************************************************************
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.51 Franklin Street, 
+Fifth Floor, Boston, MA  02110-1301 USA. Everyone is permitted to copy and 
+distribute verbatim copies of this license document, but changing it is not 
+allowed.
+[This is the first released version of the Lesser GPL.  It also counts as the 
+successor of the GNU Library Public License, version 2, hence the version 
+number 2.1.]
+Preamble
+The licenses for most software are designed to take away your freedom to 
+share and change it.  By contrast, the GNU General Public Licenses are 
+intended to guarantee your freedom to share and change free software--to make 
+sure the software is free for all its users.
+This license, the Lesser General Public License, applies to some specially 
+designated software packages--typically libraries--of the Free Software 
+Foundation and other authors who decide to use it.  You can use it too, but 
+we suggest you first think carefully about whether this license or the 
+ordinary General Public License is the better strategy to use in any 
+particular case, based on the explanations below.
+When we speak of free software, we are referring to freedom of use, not 
+price.  Our General Public Licenses are designed to make sure that you have 
+the freedom to distribute copies of free software (and charge for this 
+service if you wish); that you receive source code or can get it if you want 
+it; that you can change the software and use pieces of it in new free 
+programs; and that you are informed that you can do these things.
+To protect your rights, we need to make restrictions that forbid distributors 
+to deny you these rights or to ask you to surrender these rights.  These 
+restrictions translate to certain responsibilities for you if you distribute 
+copies of the library or if you modify it.
+For example, if you distribute copies of the library, whether gratis or for a 
+fee, you must give the recipients all the rights that we gave you.  You must 
+make sure that they, too, receive or can get the source code.  If you link 
+other code with the library, you must provide complete object files to the 
+recipients, so that they can relink them with the library after making 
+changes to the library and recompiling it.  And you must show them these 
+terms so they know their rights.
+We protect your rights with a two-step method: (1) we copyright the library, 
+and (2) we offer you this license, which gives you legal permission to copy, 
+distribute and/or modify the library.
+To protect each distributor, we want to make it very clear that there is no 
+warranty for the free library.  Also, if the library is modified by someone 
+else and passed on, the recipients should know that what they have is not the 
+original version, so that the original author's reputation will not be 
+affected by problems that might be introduced by others.
+Finally, software patents pose a constant threat to the existence of any free 
+program.  We wish to make sure that a company cannot effectively restrict the 
+users of a free program by obtaining a restrictive license from a patent 
+holder.  Therefore, we insist that any patent license obtained for a version 
+of the library must be consistent with the full freedom of use specified in 
+this license.
+Most GNU software, including some libraries, is covered by the ordinary GNU 
+General Public License.  This license, the GNU Lesser General Public License, 
+applies to certain designated libraries, and is quite different from the 
+ordinary General Public License.  We use this license for certain libraries 
+in order to permit linking those libraries into non-free programs.
+When a program is linked with a library, whether statically or using a shared 
+library, the combination of the two is legally speaking a combined work, a 
+derivative of the original library.  The ordinary General Public License 
+therefore permits such linking only if the entire combination fits its 
+criteria of freedom.  The Lesser General Public License permits more lax 
+criteria for linking other code with the library.
+We call this license the "Lesser" General Public License because it does Less 
+to protect the user's freedom than the ordinary General Public License.  It 
+also provides other free software developers Less of an advantage over 
+competing non-free programs.  These disadvantages are the reason we use the 
+ordinary General Public License for many libraries.  However, the Lesser 
+license provides advantages in certain special circumstances.
+For example, on rare occasions, there may be a special need to encourage the 
+widest possible use of a certain library, so that it becomes a de-facto 
+standard.  To achieve this, non-free programs must be allowed to use the 
+library.  A more frequent case is that a free library does the same job as 
+widely used non-free libraries.  In this case, there is little to gain by 
+limiting the free library to free software only, so we use the Lesser General 
+Public License.
+In other cases, permission to use a particular library in non-free programs 
+enables a greater number of people to use a large body of free software.  For 
+example, permission to use the GNU C Library in non-free programs enables 
+many more people to use the whole GNU operating system, as well as its 
+variant, the GNU/Linux operating system.
+Although the Lesser General Public License is Less protective of the users' 
+freedom, it does ensure that the user of a program that is linked with the 
+Library has the freedom and the wherewithal to run that program using a 
+modified version of the Library.
+The precise terms and conditions for copying, distribution and modification 
+follow.  Pay close attention to the difference between a "work based on the 
+library" and a "work that uses the library".  The former contains code 
+derived from the library, whereas the latter must be combined with the 
+library in order to run.
+GNU LESSER GENERAL PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+0. This License Agreement applies to any software library or other program 
+which contains a notice placed by the copyright holder or other authorized 
+party saying it may be distributed under the terms of this Lesser General 
+Public License (also called "this License"). 
+Each licensee is addressed as "you".
+A "library" means a collection of software functions and/or data prepared so 
+as to be conveniently linked with application programs (which use some of 
+those functions and data) to form executables.
+The "Library", below, refers to any such software library or work which has 
+been distributed under these terms.  A "work based on the Library" means 
+either the Library or any derivative work under copyright law: that is to 
+say, a work containing the Library or a portion of it, either verbatim or 
+with modifications and/or translated straightforwardly into another 
+language.  (Hereinafter, translation is included without limitation in the 
+term "modification".)
+"Source code" for a work means the preferred form of the work for making 
+modifications to it.  For a library, complete source code means all the 
+source code for all modules it contains, plus any associated interface 
+definition files, plus the scripts used to control compilation and 
+installation of the library.
+Activities other than copying, distribution and modification are not covered 
+by this License; they are outside its scope.  The act of running a program 
+using the Library is not restricted, and output from such a program is 
+covered only if its contents constitute a work based on the Library 
+(independent of the use of the Library in a tool for writing it).  Whether 
+that is true depends on what the Library does and what the program that uses 
+the Library does.
+1. You may copy and distribute verbatim copies of the Library's complete 
+source code as you receive it, in any medium, provided that you conspicuously 
+and appropriately publish on each copy an appropriate copyright notice and 
+disclaimer of warranty; keep intact all the notices that refer to this 
+License and to the absence of any warranty; and distribute a copy of this 
+License along with the Library.
+You may charge a fee for the physical act of transferring a copy, and you may 
+at your option offer warranty protection in exchange for a fee.
+2. You may modify your copy or copies of the Library or any portion of it, 
+thus forming a work based on the Library, and copy and distribute such 
+modifications or work under the terms of Section 1 above, provided that you 
+also meet all of these conditions: 
+a) The modified work must itself be a software library.
+b) You must cause the files modified to carry prominent notices stating that 
+you changed the files and the date of any change.
+c) You must cause the whole of the work to be licensed at no charge to all 
+third parties under the terms of this License.
+d) If a facility in the modified Library refers to a function or a table of 
+data to be supplied by an application program that uses the facility, other 
+than as an argument passed when the facility is invoked, then you must make a 
+good faith effort to ensure that,in the event an application does not supply 
+such function or table, the facility still operates, and performs whatever 
+part of its purpose remains meaningful.
+(For example, a function in a library to compute square roots has a purpose 
+that is entirely well-defined independent of the application.  Therefore, 
+Subsection 2d requires that any application-supplied function or table used 
+by this function must be optional: if the application does not supply it, the 
+square root function must still compute square roots.)
+These requirements apply to the modified work as a whole.  If identifiable 
+sections of that work are not derived from the Library, and can be reasonably 
+considered independent and separate works in themselves, then this License, 
+and its terms, do not apply to those sections when you distribute them as 
+separate works.  But when you distribute the same sections as part of a whole 
+which is a work based on the Library, the distribution of the whole must be 
+on the terms of this License, whose permissions for other licensees extend to 
+the entire whole, and thus to each and every part regardless of who wrote it.
+Thus, it is not the intent of this section to claim rights or contest your 
+rights to work written entirely by you; rather, the intent is to exercise the 
+right to control the distribution of derivative or collective works based on 
+the Library.
+In addition, mere aggregation of another work not based on the Library with 
+the Library (or with a work based on the Library) on a volume of a storage or 
+distribution medium does not bring the other work under the scope of this 
+License.
+3. You may opt to apply the terms of the ordinary GNU General Public License 
+instead of this License to a given copy of the Library.  To do this, you must 
+alter all the notices that refer to this License, so that they refer to the 
+ordinary GNU General Public License, version 2, instead of to this License.  
+(If a newer version than version 2 of the ordinary GNU General Public License 
+has appeared, then you can specify that version instead if you wish.)  Do not 
+make any other change in these notices.
+Once this change is made in a given copy, it is irreversible for that copy, 
+so the ordinary GNU General Public License applies to all subsequent copies 
+and derivative works made from that copy.
+This option is useful when you wish to copy part of the code of the Library 
+into a program that is not a library.
+4. You may copy and distribute the Library (or a portion or derivative of it, 
+under Section 2) in object code or executable form under the terms of 
+Sections 1 and 2 above provided that you accompany it with the complete 
+corresponding machine-readable source code, which must be distributed under 
+the terms of Sections 1 and 2 above on a medium customarily used for software 
+interchange.
+If distribution of object code is made by offering access to copy from a 
+designated place, then offering equivalent access to copy the source code 
+from the same place satisfies the requirement to distribute the source code, 
+even though third parties are not compelled to copy the source along with the 
+object code.
+5. A program that contains no derivative of any portion of the Library, but 
+is designed to work with the Library by being compiled or linked with it, is 
+called a "work that uses the Library".  Such a work, in isolation, is not a 
+derivative work of the Library, and therefore falls outside the scope of this 
+License.
+However, linking a "work that uses the Library" with the Library creates an 
+executable that is a derivative of the Library (because it contains portions 
+of the Library), rather than a "work that uses the library".  The executable 
+is therefore covered by this License. Section 6 states terms for distribution 
+of such executables.
+When a "work that uses the Library" uses material from a header file that is 
+part of the Library, the object code for the work may be a derivative work of 
+the Library even though the source code is not. Whether this is true is 
+especially significant if the work can be linked without the Library, or if 
+the work is itself a library.  The threshold for this to be true is not 
+precisely defined by law.
+If such an object file uses only numerical parameters, data structure layouts 
+and accessors, and small macros and small inline functions (ten lines or less 
+in length), then the use of the object file is unrestricted, regardless of 
+whether it is legally a derivative work.  (Executables containing this object 
+code plus portions of the Library will still fall under Section 6.)
+Otherwise, if the work is a derivative of the Library, you may distribute the 
+object code for the work under the terms of Section 6. Any executables 
+containing that work also fall under Section 6, whether or not they are 
+linked directly with the Library itself.
+6. As an exception to the Sections above, you may also combine or link a 
+"work that uses the Library" with the Library to produce a work containing 
+portions of the Library, and distribute that work under terms of your choice, 
+provided that the terms permit modification of the work for the customer's 
+own use and reverse engineering for debugging such modifications.
+You must give prominent notice with each copy of the work that the Library is 
+used in it and that the Library and its use are covered by this License.  You 
+must supply a copy of this License.  If the work during execution displays 
+copyright notices, you must include the copyright notice for the Library 
+among them, as well as a reference directing the user to the copy of this 
+License.  Also, you must do one of these things:
+a) Accompany the work with the complete corresponding machine-readable source 
+code for the Library including whatever changes were used in the work (which 
+must be distributed under Sections 1 and 2 above); and, if the work is an 
+executable linked with the Library, with the complete machine-readable "work 
+that uses the Library", as object code and/or source code, so that the user 
+can modify the Library and then relink to produce a modified executable 
+containing the modified Library.  (It is understood that the user who changes 
+the contents of definitions files in the Library will not necessarily be able 
+to recompile the application to use the modified definitions.)
+b) Use a suitable shared library mechanism for linking with the Library.  A 
+suitable mechanism is one that (1) uses at run time a copy of the library 
+already present on the user's computer system, rather than copying library 
+functions into the executable, and (2) will operate properly with a modified 
+version of the library, if the user installs one, as long as the modified 
+version is interface-compatible with the version that the work was made with.
+c) Accompany the work with a written offer, valid for at least three years, 
+to give the same user the materials specified in Subsection 6a, above, for a 
+charge no more than the cost of performing this distribution.
+d) If distribution of the work is made by offering access to copy from a 
+designated place, offer equivalent access to copy the above specified 
+materials from the same place.
+e) Verify that the user has already received a copy of these materials or 
+that you have already sent this user a copy.
+For an executable, the required form of the "work that uses the Library" must 
+include any data and utility programs needed for reproducing the executable 
+from it.  However, as a special exception, the materials to be distributed 
+need not include anything that is normally distributed (in either source or 
+binary form) with the major components (compiler, kernel, and so on) of the 
+operating system on which the executable runs, unless that component itself 
+accompanies the executable.
+It may happen that this requirement contradicts the license restrictions of 
+other proprietary libraries that do not normally accompany the operating 
+system.  Such a contradiction means you cannot use both them and the Library 
+together in an executable that you distribute.
+7. You may place library facilities that are a work based on the Library 
+side-by-side in a single library together with other library facilities not 
+covered by this License, and distribute such a combined library, provided 
+that the separate distribution of the work based on the Library and of the 
+other library facilities is otherwise permitted, and provided that you do 
+these two things:
+a) Accompany the combined library with a copy of the same work based on the 
+Library, uncombined with any other library facilities.  This must be 
+distributed under the terms of the Sections above.
+b) Give prominent notice with the combined library of the fact that part of 
+it is a work based on the Library, and explaining where to find the 
+accompanying uncombined form of the same work.
+8. You may not copy, modify, sublicense, link with, or distribute the Library 
+except as expressly provided under this License.  Any attempt otherwise to 
+copy, modify, sublicense, link with, or distribute the Library is void, and 
+will automatically terminate your rights under this License.  However, 
+parties who have received copies, or rights, from you under this License will 
+not have their licenses terminated so long as such parties remain in full 
+compliance.
+9. You are not required to accept this License, since you have not signed 
+it.  However, nothing else grants you permission to modify or distribute the 
+Library or its derivative works.  These actions are prohibited by law if you 
+do not accept this License.  Therefore, by modifying or distributing the 
+Library (or any work based on the Library), you indicate your acceptance of 
+this License to do so, and all its terms and conditions for copying, 
+distributing or modifying the Library or works based on it.
+10. Each time you redistribute the Library (or any work based on the 
+Library), the recipient automatically receives a license from the original 
+licensor to copy, distribute, link with or modify the Library subject to 
+these terms and conditions.  You may not impose any further restrictions on 
+the recipients' exercise of the rights granted herein. You are not 
+responsible for enforcing compliance by third parties with this License.
+11. If, as a consequence of a court judgment or allegation of patent 
+infringement or for any other reason (not limited to patent issues), 
+conditions are imposed on you (whether by court order, agreement or 
+otherwise) that contradict the conditions of this License, they do not excuse 
+you from the conditions of this License.  If you cannot distribute so as to 
+satisfy simultaneously your obligations under this License and any other 
+pertinent obligations, then as a consequence you may not distribute the 
+Library at all.  For example, if a patent license would not permit 
+royalty-free redistribution of the Library by all those who receive copies 
+directly or indirectly through you, then the only way you could satisfy both 
+it and this License would be to refrain entirely from distribution of the 
+Library.
+If any portion of this section is held invalid or unenforceable under any 
+particular circumstance, the balance of the section is intended to apply, and 
+the section as a whole is intended to apply in other circumstances.
+It is not the purpose of this section to induce you to infringe any patents 
+or other property right claims or to contest validity of any such claims; 
+this section has the sole purpose of protecting the integrity of the free 
+software distribution system which is implemented by public license 
+practices.  Many people have made generous contributions to the wide range of 
+software distributed through that system in reliance on consistent 
+application of that system; it is up to the author/donor to decide if he or 
+she is willing to distribute software through any other system and a licensee 
+cannot impose that choice.
+This section is intended to make thoroughly clear what is believed to be a 
+consequence of the rest of this License.
+12. If the distribution and/or use of the Library is restricted in certain 
+countries either by patents or by copyrighted interfaces, the original 
+copyright holder who places the Library under this License may add an 
+explicit geographical distribution limitation excluding those countries, so 
+that distribution is permitted only in or among countries not thus excluded.  
+In such case, this License incorporates the limitation as if written in the 
+body of this License.
+13. The Free Software Foundation may publish revised and/or new versions of 
+the Lesser General Public License from time to time. Such new versions will 
+be similar in spirit to the present version, but may differ in detail to 
+address new problems or concerns.
+Each version is given a distinguishing version number.  If the Library 
+specifies a version number of this License which applies to it and "any later 
+version", you have the option of following the terms and conditions either of 
+that version or of any later version published by the Free Software 
+Foundation.  If the Library does not specify a license version number, you 
+may choose any version ever published by the Free Software Foundation.
+14. If you wish to incorporate parts of the Library into other free programs 
+whose distribution conditions are incompatible with these, write to the 
+author to ask for permission.  For software which is copyrighted by the Free 
+Software Foundation, write to the Free Software Foundation; we sometimes make 
+exceptions for this.  Our decision will be guided by the two goals of 
+preserving the free status of all derivatives of our free software and of 
+promoting the sharing and reuse of software generally.
+NO WARRANTY
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR 
+THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE 
+STATED IN WRITING THE COPYRIGHT HOLDERS and OTHER PARTIES PROVIDE THE LIBRARY 
+"AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, 
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF 
+THE LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE 
+COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING 
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY and REDISTRIBUTE 
+THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY 
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE 
+OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR 
+DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR 
+A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH 
+HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+END OF TERMS AND CONDITIONS
+
+
+

--- a/wrappers/openni2/CMakeLists.txt
+++ b/wrappers/openni2/CMakeLists.txt
@@ -2,16 +2,10 @@ cmake_minimum_required (VERSION 3.8.0)
 project (rs2driver)
 
 # DEPS
-set(OPENNI2_DIR "c:/Program Files/OpenNI2" CACHE FILEPATH "OpenNI2 SDK directory")
 set(REALSENSE2_DIR "c:/Program Files (x86)/Intel RealSense SDK 2.0" CACHE FILEPATH "RealSense2 SDK directory")
 
 # INCLUDE DIR
-if (UNIX)
-    include_directories (${OPENNI2_DIR})
-else ()
-    include_directories (${OPENNI2_DIR}/Include)
-endif ()
-
+include_directories (../../third-party/openni2/Include)
 include_directories (${REALSENSE2_DIR}/include)
 include_directories (src)
 


### PR DESCRIPTION
This pull request is a proposal to generate OpenNI2 driver more easily.
The OpenNI2 header is required to generate the OpenNI2 driver. It is not requred OpenNI2 library.
So, I propose to add OpenNI2 header to librealsense/third-party. (I think it is no problem, because OpenNI2 is distributed under Apache License Version 2.0.)
It will be able to generate OpenNI2 driver whether OpenNI2 is installed on user system.
What do you think? Thanks,

