### PR TITLE
changed "push pop" to "enqueue dequeue"

### DIFF
--- a/examples/post-processing/rs-post-processing.cpp
+++ b/examples/post-processing/rs-post-processing.cpp
@@ -90,7 +90,7 @@ int main(int argc, char * argv[]) try
     filters.emplace_back("Spatial", spat_filter);
     filters.emplace_back("Temporal", temp_filter);
 
-    // Declaring two concurrent queues that will be used to push and pop frames from different threads
+    // Declaring two concurrent queues that will be used to enqueue and dequeue frames from different threads
     rs2::frame_queue original_data;
     rs2::frame_queue filtered_data;
 


### PR DESCRIPTION
The original comment stated the queues were used to "push and pop" frames.  "Push and pop" is usually associated with stacks.  

I updated the comment to "enqueue and dequeue" which clearly refers to queues, and matches the enqueue() member method of rs2::frame_queue, which is called later.