### PR TITLE
Added support for motion_module for playback backward compatibility

### DIFF
--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -805,6 +805,13 @@ namespace librealsense
         return false;
     }
 
+    bool ros_reader::is_motion_module_sensor(std::string sensor_name)
+    {
+        if (sensor_name.compare("Motion Module") == 0)
+            return true;
+        return false;
+    }
+
     bool ros_reader::is_ds5_PID(int pid)
     {
         using namespace ds;
@@ -862,6 +869,10 @@ namespace librealsense
             else if (is_color_sensor(sensor_name))
             {
                 return std::make_shared<recommended_proccesing_blocks_snapshot>(get_color_recommended_proccesing_blocks());
+            }
+            else if (is_motion_module_sensor(sensor_name))
+            {
+                return std::make_shared<recommended_proccesing_blocks_snapshot>(processing_blocks{});
             }
             throw io_exception("Unrecognized sensor name" + sensor_name);
         }

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -80,6 +80,7 @@ namespace librealsense
         void update_proccesing_blocks(const rosbag::Bag& file, uint32_t sensor_index, const nanoseconds& time, uint32_t file_version, snapshot_collection& sensor_extensions, uint32_t version, std::string pid, std::string sensor_name);
         bool is_depth_sensor(std::string sensor_name);
         bool is_color_sensor(std::string sensor_name);
+        bool is_motion_module_sensor(std::string sensor_name);
         bool is_ds5_PID(int pid);
         bool is_sr300_PID(int pid);
         bool is_l500_PID(int pid);


### PR DESCRIPTION
Fixed issue #3494
The new API `get_recommended_filters` required change on the record and playback sensors
and handle backward compatibility of old `.bag` files.
