### PR TITLE
T265 query devices fix

### DIFF
--- a/examples/align/rs-align.cpp
+++ b/examples/align/rs-align.cpp
@@ -215,7 +215,7 @@ rs2_stream find_stream_to_align(const std::vector<rs2::stream_profile>& streams)
     rs2_stream align_to = RS2_STREAM_ANY;
     bool depth_stream_found = false;
     bool color_stream_found = false;
-    for (rs2::stream_profile sp : streams)
+    for (const rs2::stream_profile& sp : streams)
     {
         rs2_stream profile_stream = sp.stream_type();
         if (profile_stream != RS2_STREAM_DEPTH)

--- a/examples/align/rs-align.cpp
+++ b/examples/align/rs-align.cpp
@@ -136,7 +136,7 @@ float get_depth_scale(rs2::device dev)
             return dpt.get_depth_scale();
         }
     }
-    throw std::runtime_error("Device does not have a depth sensor");
+    throw std::runtime_error("The demo requires a Depth sensor to run");
 }
 
 void render_slider(rect location, float& clipping_dist)

--- a/examples/example.hpp
+++ b/examples/example.hpp
@@ -364,21 +364,17 @@ private:
     }
 };
 
-class text_renderer
+/// \brief Print flat 2D text over openGl window
+struct text_renderer
 {
-public:
     // Provide textual representation only
     void put_text(const std::string& msg, float norm_x_pos, float norm_y_pos, const rect& r)
     {
-        if (!_gl_handle)
-            glGenTextures(1, &_gl_handle);
-
         set_viewport(r);
         draw_text(int(norm_x_pos * r.w), int(norm_y_pos * r.h), msg.c_str());
     }
-private:
-    mutable GLuint _gl_handle = 0;
 };
+
 ////////////////////////
 // Image display code //
 ////////////////////////
@@ -468,7 +464,6 @@ public:
     }
 
 private:
-
     GLuint          _gl_handle = 0;
     rs2_stream      _stream_type = RS2_STREAM_ANY;
     int             _stream_index{};
@@ -590,8 +585,8 @@ public:
          }
          else
          {
-             _main_win.put_text("Connect one or more cameras to run", 
-                 0.45f, 0.5f, { 0.f,0.f, float(_width) , float(_height) });
+             _main_win.put_text("Connect one or more Intel RealSense devices and rerun the example",
+                 0.4f, 0.5f, { 0.f,0.f, float(_width) , float(_height) });
          }
     }
 

--- a/examples/measure/rs-measure.cpp
+++ b/examples/measure/rs-measure.cpp
@@ -337,7 +337,7 @@ int main(int argc, char * argv[]) try
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
             // First render the colorized depth image
-            depth_image.render(colorized_depth.as<rs2::video_frame>(), { 0, 0, app.width(), app.height() });
+            depth_image.render(colorized_depth, { 0, 0, app.width(), app.height() });
             // Next, set global alpha for the color image to 90%
             // (to make it slightly translucent)
             //glColor4f(1.f, 1.f, 1.f, 0.9f);

--- a/examples/measure/rs-measure.cpp
+++ b/examples/measure/rs-measure.cpp
@@ -337,7 +337,7 @@ int main(int argc, char * argv[]) try
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
             // First render the colorized depth image
-            depth_image.render(colorized_depth, { 0, 0, app.width(), app.height() });
+            depth_image.render(colorized_depth.as<rs2::video_frame>(), { 0, 0, app.width(), app.height() });
             // Next, set global alpha for the color image to 90%
             // (to make it slightly translucent)
             //glColor4f(1.f, 1.f, 1.f, 0.9f);

--- a/examples/measure/rs-measure.cpp
+++ b/examples/measure/rs-measure.cpp
@@ -501,7 +501,7 @@ void render_shortest_path(const rs2::depth_frame& depth,
         auto y = (float(pixel1.second) / depth.get_height()) * app.height();
         glVertex2f(x, y);
 
-        if (i == path.size() / 2) center = { x, y };
+        if (i == (path.size() / 2)) center = { int(x), int(y) };
     }
     glEnd();
 

--- a/examples/multicam/readme.md
+++ b/examples/multicam/readme.md
@@ -9,14 +9,14 @@ The multicam sample demonstrates the ability to use the SDK for streaming and re
 The application opens and renders a mosaic view of all automatically-selected streams provided by the connected devices. (The selection is device-tailored and takes into account USB-type constrains).
 Each tile displays an unique stream produced by a specific camera. The stream name appear at the top left.
 
-In the following example we used five Intel® RealSense™ devices to produce the mosaic: D435i, D415, SR300 and two T265 tracking cameras. Those were responsible to generate:
+In the following snapshot we use five Intel® RealSense™ devices to produce the mosaic: D435i, D415, SR300 and two T265 tracking cameras. Those are responsible to generate:
  - Three Depth streams (D435i, D415, SR300)
  - Three Color streams (D435i, D415, SR300)
  - Two Pose streams (T265x2)
  - Four Fisheye streams (T265x2)
  - Six IMU streams (D435i, T265x2)  
 
- Alltogether the mosaic consist of 18 simultaneous live feeds:
+ Alltogether the mosaic comprise of 18 simultaneous live feeds:
 
 <p align="center"><img src="https://raw.githubusercontent.com/wiki/IntelRealSense/librealsense/res/Multicam.gif" alt="screenshot gif"/></p>
 
@@ -47,7 +47,7 @@ window app(1280, 960, "CPP Multi-Camera Example");
 
 The `window` class resides in `example.hpp` and lets us easily open a new window and prepare textures for rendering.
 
-Next, we define the objects to be used in this demo.
+Next, we define the objects to be used in the example.
 
 ```cpp
 rs2::context ctx;    // Create librealsense context for managing devices
@@ -57,9 +57,9 @@ rs2::colorizer              colorizer;      // Utility class to convert depth da
 std::vector<rs2::pipeline>  pipelines;
 ```
 The `rs2::context` encapsulates all of the devices and sensors, and provides some additional functionalities. We employ the `rs2::colorizer ` to convert depth data to RGB format.  
-In this demo we use multiple `rs2::pipeline` objects, each controlling a lifetime of a single HW device.
+In the example we use multiple `rs2::pipeline` objects, each controlling a lifetime of a single HW device.
 
-The demo flow starts with listing and activating all the connected Intel® RealSense™ devices
+The example's flow starts with listing and activating all the connected Intel® RealSense™ devices:
 ```cpp
 // Start a streaming pipe per each connected device
 for (auto&& dev : ctx.query_devices())
@@ -87,10 +87,9 @@ Since we do not specify explicit stream requests, each device is configured inte
 After adding the device, we begin our main loop of the application:  
 ```cpp
 while (app)
-{...}
 ```
 
-Every demo cycle we traverse the configured devices and retrieve all the available frames:
+Every application cycle we traverse the registered devices and retrieve all the available frames:
 
 ```cpp
 // Collect the new frames from all the connected devices
@@ -112,13 +111,13 @@ To minimize UI impact we're using non-blocking frames polling method:
 ```cpp
     if (pipe.poll_for_frames(&fs))
 ```
-In order to simplify the presentation, we split those `rs2::frameset` containers into separate frames and store them with a standard C++ container for later use.   
+In order to simplify the presentation, we split those `rs2::frameset` containers into separate frames and store them with a standard C++ container for later use:  
 ```cpp
 for (rs2::frame& f : fs)
     new_frames.emplace_back(f);
 ```
 
-The Depth data is delivered as `uint16_t` type which cannot be rendered directly, therefore we use `rs2::colorizer` to convert the depth representation into human-readable RGB map
+The Depth data is delivered as `uint16_t` type which cannot be rendered directly, therefore we use `rs2::colorizer` to convert the depth representation into human-readable RGB map:
 ```cpp
 // Convert the newly-arrived frames to render-friendly format
 for (const auto& frame : new_frames)

--- a/examples/multicam/readme.md
+++ b/examples/multicam/readme.md
@@ -2,20 +2,26 @@
 
 ## Overview
 
-The multicam sample demonstrates the ability to use the SDK for streaming and rendering multiple devices.
+The multicam sample demonstrates the ability to use the SDK for streaming and rendering multiple devices simultaneously.
 
 ## Expected Output
 
-The application should open a window that is split to a number of view ports (at least one per camera).
-Each part of the split window should display a single stream from a different camera, and at the top left should appear the name of the stream. 
+The application opens and renders a mosaic view of all automatically-selected streams provided by the connected devices. (The selection is device-tailored and takes into account USB-type constrains).
+Each tile displays an unique stream produced by a specific camera. The stream name appear at the top left.
 
-In the following example we've used two Intel® RealSense™ Depth Cameras pointing at different locations.
+In the following example we used five Intel® RealSense™ devices to produce the mosaic: D435i, D415, SR300 and two T265 tracking cameras. Those were responsible to generate:
+ - Three Depth streams (D435i, D415, SR300)
+ - Three Color streams (D435i, D415, SR300)
+ - Two Pose streams (T265x2)
+ - Four Fisheye streams (T265x2)
+ - Six IMU streams (D435i, T265x2)  
 
-<p align="center"><img src="https://raw.githubusercontent.com/wiki/IntelRealSense/librealsense/res/multi-cam-expected.gif" alt="screenshot gif"/></p>
+ Alltogether the mosaic consist of 18 simultaneous live feeds:
 
-> Note: The above animation was cropped to display only the depth streams.
+<p align="center"><img src="https://raw.githubusercontent.com/wiki/IntelRealSense/librealsense/res/Multicam.gif" alt="screenshot gif"/></p>
 
-## Code Overview 
+
+## Code Overview
 
 As with any SDK application we include the Intel RealSense Cross Platform API:
 
@@ -31,11 +37,6 @@ In this example we will also use the auxiliary library of `example.hpp`:
 
 `examples.hpp` lets us easily open a new window and prepare textures for rendering.
 
-We define an additional class to help manage the state of the application and the connected devices:
-```cpp
-class device_container{ ... }
-```
-We will elaborate on `device_container` later in this overview.
 
 The first object we use is a `window`, that will be used to display the images from all the cameras.
 
@@ -46,173 +47,87 @@ window app(1280, 960, "CPP Multi-Camera Example");
 
 The `window` class resides in `example.hpp` and lets us easily open a new window and prepare textures for rendering.
 
-Next, we declare a `device_container ` object:
-```cpp
-device_container connected_devices;
-```
-This object encapsulates the connected cameras. It is used to manage the state of the program, and all of operations related to the cameras and rendering of frames.
-
-The last variable we declare is `rs2::context`.
+Next, we define the objects to be used in this demo.
 
 ```cpp
 rs2::context ctx;    // Create librealsense context for managing devices
+
+rs2::colorizer              colorizer;      // Utility class to convert depth data RGB
+
+std::vector<rs2::pipeline>  pipelines;
 ```
-`context` encapsulates all of the devices and sensors, and provides some additional functionalities.
-In this example we will ask the `context` to notify us on device changes (connections and disconnections).
- 
+The `rs2::context` encapsulates all of the devices and sensors, and provides some additional functionalities. We employ the `rs2::colorizer ` to convert depth data to RGB format.  
+In this demo we use multiple `rs2::pipeline` objects, each controlling a lifetime of a single HW device.
+
+The demo flow starts with listing and activating all the connected Intel® RealSense™ devices
 ```cpp
-// Register callback for tracking which devices are currently connected
-ctx.set_devices_changed_callback([&](rs2::event_information& info)
+// Start a streaming pipe per each connected device
+for (auto&& dev : ctx.query_devices())
 {
-    connected_devices.remove_devices(info);
-    for (auto&& dev : info.get_new_devices())
-    {
-        connected_devices.enable_device(dev);
-    }
-});
-```
-Using `set_devices_changed_callback` we can register any callable object that accepts `event_information&` as its parameter.
-`event_information` contains a list of devices that were disconnected, and the list of the currently connected devices.
-In this case, once the `context` notifies us about a change, we update `connected_devices` about the removed, and order it to start streaming from new devices.
-
-After we registered to get notification from the `context` we query it for all connected devices, and add each one:
-```cpp
-// Initial population of the device list
-for (auto&& dev : ctx.query_devices()) // Query the list of connected RealSense devices
-{
-    connected_devices.enable_device(dev);
-}
-```
-`enable_device` adds the device to the internal list of devices in use, and starts it.  Each device is wrapped with a `rs2::pipeline` to easily configure and start streaming from it. 
-
-The `pipeline` holds a queue of the latest frames, and allows polling from this queue. We will use it later on.
-
-After adding the device, we begin our main loop of the application.
-In this loop we will display all of the streams from all the devices.
-
-```cpp
-while (app) // Application still alive?
-{
-```
-
-Every iteration we first try to poll all available frames from all device:
-
-```cpp
-   connected_devices.poll_frames();
-```
-Diving into `device_container::poll_frames` :
-```cpp
-void poll_frames()
-{
-    std::lock_guard<std::mutex> lock(_mutex);
-    // Go over all device
-    for (auto&& view : _devices)
-    {
-        // Ask each pipeline if there are new frames available
-        rs2::frame f;
-        if (view.second.pipe.poll_for_frame(&f))
-        {
-```
-
-In the above code, we go over all devices, which are actually `view_port`s.
-`view_port` is a helper struct which encapsulates a pipeline, its latest polled frames, and 2 other utilities that allow converting depth stream to color (`colorizer`), and render frames to the window (`texture`).
-For each pipeline, we try to poll for frames. 
-
-```cpp
-             for (int i = 0; i < frameset.size(); i++)
-                {
-                    rs2::frame new_frame = frameset[i];
-                    int stream_id = new_frame.get_profile().unique_id();
-                    view.second.frames_per_stream[stream_id] = view.second.colorize_frame(new_frame); //update view port with the new stream
-                }
-        }
-    }
-}
-```
-A frameset is an wrapper to a `composite_frame`, which holds more than a single type of frame.
-In the above code, we store each frame separately instead of the previously polled frame.
-The stored frames will be used next to count the number of active streams and for rendering to screen.
- 
-Back to main...
-
-After polling for frames, we count the number of active streams and display an appropriate message to the user:
-```cpp
-    auto total_number_of_streams = connected_devices.stream_count();
-    if (total_number_of_streams == 0)
-    {
-        draw_text(std::max(0.f, (app.width() / 2) - no_cammera_message.length() * 3), app.height() / 2, no_cammera_message.c_str());
-        continue;
-    }
-    if (connected_devices.device_count() == 1)
-    {
-        draw_text(0, 10, "Please connect another camera");
-    }
-```
-According to the number of streams we calculate the alignment of the view ports in the window:
-
-```cpp
-    int cols = std::ceil(std::sqrt(total_number_of_streams));
-    int rows = std::ceil(total_number_of_streams / static_cast<float>(cols));
-
-    float view_width = (app.width() / cols);
-    float view_height = (app.height() / rows);
-```
-
-And finally call `render_textures`:
-```cpp
-    connected_devices.render_textures(cols, rows, view_width, view_height);
-```
-
-
-In `device_container::render_textures` we go over all the stored frames:
-
-```cpp
-void render_textures(int cols, int rows, float view_width, float view_height)
-{
-    std::lock_guard<std::mutex> lock(_mutex);
-    int stream_no = 0;
-    for (auto&& view : _devices)
-    {
-        // For each device get its frames
-        for (auto&& id_to_frame : view.second.frames_per_stream)
-        {
-```
-
-If a new frame was stored, we upload it to the graphics buffer:
-
-```cpp
-            // If the frame is available
-            if (id_to_frame.second)
-            {
-                view.second.tex.upload(id_to_frame.second);
-            }
-```
-
-Next, we calculate the correct location of the current stream:
-```cpp
-            rect frame_location{ view_width * (stream_no % cols), view_height * (stream_no / cols), view_width, view_height };
-```            
-
-And finally, since this example shows multi-**camera** streaming, we verify that the stream is of video frames. 
-Note that the library supports streaming of video, motion information, and other.
-
-As with the `composite_frame` that we've seen earlier, a `frame` can also be a  `rs2::video_frame` which represents a camera image and have additional properties such as width and height.
-```cpp
-            if (rs2::video_frame vid_frame = id_to_frame.second.as<rs2::video_frame>())
-            {
-```
-We use the width and height of the frame to scale it into the view port:
-```cpp
-               rect adjuested = frame_location.adjust_ratio({ static_cast<float>(vid_frame.get_width())
-                                                             , static_cast<float>(vid_frame.get_height()) });
-```
-And finally, call `show` with the position of the stream, to render it to screen.
-```cpp
-                view.second.tex.show(adjuested);
-                stream_no++;
-            }
-        }
-    }
+    rs2::pipeline pipe(ctx);
+    rs2::config cfg;
+    cfg.enable_device(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+    pipe.start(cfg);
+    pipelines.emplace_back(pipe);
 }
 ```
 
+First, we allocate `rs2::pipeline` object per recognized device. Note that we share the `rs2::context` object between all `rs2::pipeline` instances.  
+```cpp
+rs2::pipeline pipe(ctx);
+```
+To map the specific device to the newly-allocated pipeline we define `rs2::config` object, and assign it with the device's serial number.  
+Then we request `rs::pipeline` to start streaming and produce frames.
+```cpp
+pipe.start(cfg);
+```
+
+Since we do not specify explicit stream requests, each device is configured internally to run a set of predefined stream profiles recommended for that specific device.  
+
+After adding the device, we begin our main loop of the application:  
+```cpp
+while (app)
+{...}
+```
+
+Every demo cycle we traverse the configured devices and retrieve all the available frames:
+
+```cpp
+// Collect the new frames from all the connected devices
+std::vector<rs2::frame> new_frames;
+for (auto &&pipe : pipelines)
+{
+   rs2::frameset fs;
+   if (pipe.poll_for_frames(&fs))
+   {
+       for (rs2::frame& f : fs)
+           new_frames.emplace_back(f);
+   }
+}
+```
+Each `rs::pipeline` produces a synchronized collection of frames for all streams configured for its allocated device. These are contained in `rs2::frameset` object.
+The `rs2::frameset` itself is an wrapper for a `composite_frame`, which can holds more than a single type of frame.  
+
+To minimize UI impact we're using non-blocking frames polling method:
+```cpp
+    if (pipe.poll_for_frames(&fs))
+```
+In order to simplify the presentation, we split those `rs2::frameset` containers into separate frames and store them with a standard C++ container for later use.   
+```cpp
+for (rs2::frame& f : fs)
+    new_frames.emplace_back(f);
+```
+
+The Depth data is delivered as `uint16_t` type which cannot be rendered directly, therefore we use `rs2::colorizer` to convert the depth representation into human-readable RGB map
+```cpp
+// Convert the newly-arrived frames to render-friendly format
+for (const auto& frame : new_frames)
+{
+    render_frames[frame.get_profile().unique_id()] = colorizer.process(frame);
+}
+```
+
+And finally send the collected frames to update the openGl mosaic:
+```cpp
+    app.show(render_frames);
+```

--- a/examples/multicam/rs-multicam.cpp
+++ b/examples/multicam/rs-multicam.cpp
@@ -41,7 +41,7 @@ int main(int argc, char * argv[]) try
             rs2::frameset fs;
             if (pipe.poll_for_frames(&fs))
             {
-                for (rs2::frame& f : fs)
+                for (const rs2::frame& f : fs)
                     new_frames.emplace_back(f);
             }
         }

--- a/examples/multicam/rs-multicam.cpp
+++ b/examples/multicam/rs-multicam.cpp
@@ -9,66 +9,95 @@
 #include <algorithm>
 #include <mutex>                    // std::mutex, std::lock_guard
 #include <cmath>                    // std::ceil
+#include <queue>
 
-const std::string no_camera_message = "No camera connected, please connect 1 or more";
-const std::string platform_camera_name = "Platform Camera";
+const std::string no_camera_message     = "No camera connected, please connect 1 or more";
+const std::string connect_more_cameras  = "Please connect more cameras";
+const std::string platform_camera_name  = "Platform Camera";
+
+class device_events
+{
+public:
+    void add_event(const rs2::event_information& evt)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        _dev_events.push(evt);
+    }
+
+    bool try_get_event(rs2::event_information& evt)
+    {
+        std::lock_guard<std::mutex> lock(_mtx);
+        if (_dev_events.empty())
+            return false;
+
+        evt = std::move(_dev_events.front());
+        _dev_events.pop();
+        return true;
+    }
+private:
+    std::queue<rs2::event_information> _dev_events;
+    std::mutex  _mtx;
+};
 
 class device_container
 {
+    class frames_container
+    {
+    public:
+        frames_container() : _raw(1){};
+        rs2::frame_queue    _raw;
+        rs2::frame          _processed;
+    };
+
     // Helper struct per pipeline
     struct view_port
     {
-        std::map<int, rs2::frame> frames_per_stream;
-        rs2::colorizer colorize_frame;
-        texture tex;
-        rs2::pipeline pipe;
-        rs2::pipeline_profile profile;
+    public:
+        view_port()
+        {
+        }
+        ~view_port() {};
+        view_port(const view_port&) = delete;               // non construction-copyable
+        view_port(view_port&& vp):                          // moveable
+            colorize_frame(std::move(vp.colorize_frame)),
+            tex(std::move(vp.tex)),
+            pipe(std::move(vp.pipe)),
+            profile(std::move(vp.profile)){}
+        std::map<int, frames_container> frames_per_stream;
+        rs2::colorizer          colorize_frame;
+        texture                 tex;
+        rs2::pipeline           pipe;
+        rs2::pipeline_profile   profile;
     };
 
 public:
 
-    void enable_device(rs2::device dev)
+    device_container(rs2::context& ctx) : _ctx(ctx) {}
+
+    void refresh_devices(void)
     {
-        std::string serial_number(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
-        std::lock_guard<std::mutex> lock(_mutex);
-
-        if (_devices.find(serial_number) != _devices.end())
+        rs2::event_information info({}, {});
+        // Process one event at a time
+        if (_dev_events.try_get_event(info))
         {
-            return; //already in
+            remove_devices(info);
+            for (auto&& dev : info.get_new_devices())
+            {
+                std::cout << "Adding new device !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << dev.get_info(RS2_CAMERA_INFO_NAME) << " , " << dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << std::endl;
+                enable_device(dev);
+            }
         }
-
-        // Ignoring platform cameras (webcams, etc..)
-        if (platform_camera_name == dev.get_info(RS2_CAMERA_INFO_NAME))
-        {
-            return;
-        }
-        // Create a pipeline from the given device
-        rs2::pipeline p;
-        rs2::config c;
-        c.enable_device(serial_number);
-        // Start the pipeline with the configuration
-        rs2::pipeline_profile profile = p.start(c);
-        // Hold it internally
-        _devices.emplace(serial_number, view_port{ {},{},{}, p, profile });
-
     }
 
-    void remove_devices(const rs2::event_information& info)
+    size_t stream_count()
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        // Go over the list of devices and check if it was disconnected
-        auto itr = _devices.begin();
-        while(itr != _devices.end())
+        size_t count = 0;
+        for (auto&& sn_to_dev : _devices)
         {
-            if (info.was_removed(itr->second.profile.get_device()))
-            {
-                itr = _devices.erase(itr);
-            }
-            else
-            {
-                ++itr;
-            }
+            count += sn_to_dev.second.frames_per_stream.size();
         }
+        return count;
     }
 
     size_t device_count()
@@ -77,112 +106,185 @@ public:
         return _devices.size();
     }
 
-    int stream_count()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        int count = 0;
-        for (auto&& sn_to_dev : _devices)
-        {
-            for (auto&& stream : sn_to_dev.second.frames_per_stream)
-            {
-                if (stream.second)
-                {
-                    count++;
-                }
-            }
-        }
-        return count;
-    }
-
-    void poll_frames()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        // Go over all device
-        for (auto&& view : _devices)
-        {
-            // Ask each pipeline if there are new frames available
-            rs2::frameset frameset;
-            if (view.second.pipe.poll_for_frames(&frameset))
-            {
-                for (int i = 0; i < frameset.size(); i++)
-                {
-                    rs2::frame new_frame = frameset[i];
-                    int stream_id = new_frame.get_profile().unique_id();
-                    view.second.frames_per_stream[stream_id] = view.second.colorize_frame.process(new_frame); //update view port with the new stream
-                }
-            }
-        }
-    }
-    void render_textures(int cols, int rows, float view_width, float view_height)
+    void process_and_render(int cols, int rows, float view_width, float view_height)
     {
         std::lock_guard<std::mutex> lock(_mutex);
         int stream_no = 0;
         for (auto&& view : _devices)
         {
             // For each device get its frames
-            for (auto&& id_to_frame : view.second.frames_per_stream)
+            for (auto&& frames_queue : view.second.frames_per_stream)
             {
-                rect frame_location{ view_width * (stream_no % cols), view_height * (stream_no / cols), view_width, view_height };
-                if (rs2::video_frame vid_frame = id_to_frame.second.as<rs2::video_frame>())
+                //Enhance visuzalization, where appropriate
+                rs2::frame f;
+                if (frames_queue.second._raw.poll_for_frame(&f))
                 {
-                    view.second.tex.render(vid_frame, frame_location);
-                    stream_no++;
+                    if (f.as<rs2::frameset>().size() > 1)
+                    {
+                        throw std::runtime_error("Processing requires frames decomposition!");
+                    }
+
+                    frames_queue.second._processed = view.second.colorize_frame.process(f);
+                }
+
+                // Render frame
+                if (frames_queue.second._processed)
+                {
+                    rect frame_location{ view_width * (stream_no % cols), view_height * (stream_no / cols), view_width, view_height };
+                    if (rs2::video_frame vid_frame = frames_queue.second._processed.as<rs2::video_frame>())
+                    {
+                        view.second.tex.render(vid_frame, frame_location);
+                        stream_no++;
+                    }
+                    if (rs2::motion_frame mot_frame = frames_queue.second._processed.as<rs2::motion_frame>())
+                    {
+                        view.second.tex.render(mot_frame, frame_location);
+                        stream_no++;
+                    }
+                    if (rs2::pose_frame pos_frame = frames_queue.second._processed.as<rs2::pose_frame>())
+                    {
+                        view.second.tex.render(pos_frame, frame_location);
+                        stream_no++;
+                    }
                 }
             }
         }
     }
-private:
-    std::mutex _mutex;
-    std::map<std::string, view_port> _devices;
-};
 
+    void add_dev_event(rs2::event_information& info)
+    {
+        _dev_events.add_event(info);
+    }
+
+    void enable_device(rs2::device dev)
+    {
+        std::string serial_number(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        if (_devices.find(serial_number) != _devices.end())
+        {
+            std::cout << __FUNCTION__ << " Device s.n " << serial_number << " is already registered, skipped" << std::endl;
+            return; //already in
+        }
+        std::cout << __FUNCTION__ << " !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!      Enabling device " << dev.get_info(RS2_CAMERA_INFO_NAME) << " s.n: " << serial_number << std::endl;
+        // Ignoring platform cameras (webcams, etc..)
+        if (platform_camera_name == dev.get_info(RS2_CAMERA_INFO_NAME))
+        {
+            std::cout << __FUNCTION__ << " !!!!!!!!!!!!!!!!!!!!!!!!!!        Platform camera found, return" << std::endl;
+            return;
+        }
+        // Create a pipeline from the given device
+        rs2::pipeline p(_ctx);
+        rs2::config c;
+        c.enable_device(serial_number);
+
+        _devices.emplace(serial_number, view_port());
+
+        rs2::pipeline_profile profile = p.start(c, [serial_number, this](const rs2::frame& frame)
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            // With callbacks, both the synchronized and unsynchronized frames would arrive in a single frameset
+            if (auto fs = frame.as<rs2::frameset>())
+            {
+                for (const rs2::frame& f : fs)
+                {
+                    //std::cout << "Enq: Frame type " << f.get_profile().stream_name() << " format: " << f.get_profile().format() << " stream id: " << f.get_profile().unique_id() << " fn: " << f.get_frame_number() << std::endl;
+                    if (_devices.find(serial_number) != _devices.end())
+                        _devices[serial_number].frames_per_stream[f.get_profile().unique_id()]._raw.enqueue(f);
+                }
+            }
+            else
+            {
+                // Stream that bypass synchronization (such as IMU) will produce single frames
+                if (_devices.find(serial_number) != _devices.end())
+                    _devices[serial_number].frames_per_stream[frame.get_profile().unique_id()]._raw.enqueue(frame);
+                /*std::cout << "Enq: Single  type " << frame.get_profile().stream_name() << " format: " << frame.get_profile().format()
+                    << " stream id: " << frame.get_profile().unique_id() << " fn: " << frame.get_frame_number() << std::endl;*/
+            }
+        });
+
+        _devices[serial_number].pipe = p;
+        _devices[serial_number].profile = profile;
+        // Hold it internally
+        std::cout << "!!!!!!!!!!!!!!  Starting with device " << profile.get_device().get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << " streams: " << profile.get_streams().size() << std::endl;
+    }
+
+    void remove_devices(const rs2::event_information& info)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        // Go over the list of devices and check if it was disconnected
+        auto itr = _devices.begin();
+        while (itr != _devices.end())
+        {
+            if (info.was_removed(itr->second.profile.get_device()))
+            {
+                std::cout << "Device erased !!!!!!!!!!!!!!!!! " << itr->first << std::endl;
+                itr = _devices.erase(itr);
+                std::cout << "Devices left = " << _devices.size() << std::endl;
+            }
+            else
+            {
+                ++itr;
+            }
+        }
+    }
+
+ private:
+    std::mutex                          _mutex;
+    std::map<std::string, view_port>    _devices;
+    rs2::context&                       _ctx;
+    device_events                       _dev_events;
+};
 
 int main(int argc, char * argv[]) try
 {
     // Create a simple OpenGL window for rendering:
     window app(1280, 960, "CPP Multi-Camera Example");
 
-    device_container connected_devices;
+    rs2::log_to_console(RS2_LOG_SEVERITY_WARN);
 
     rs2::context ctx;    // Create librealsense context for managing devices
 
-                         // Register callback for tracking which devices are currently connected
-    ctx.set_devices_changed_callback([&](rs2::event_information& info)
-    {
-        connected_devices.remove_devices(info);
-        for (auto&& dev : info.get_new_devices())
-        {
-            connected_devices.enable_device(dev);
-        }
-    });
+    device_container connected_devices(ctx);
 
-    // Initial population of the device list
-    for (auto&& dev : ctx.query_devices()) // Query the list of connected RealSense devices
+    // Enumerate all the connected devices
+    for (auto&& dev : ctx.query_devices())
     {
+        std::cout << "Enabling device " << dev.get_info(RS2_CAMERA_INFO_NAME) << " , " << dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << std::endl;
         connected_devices.enable_device(dev);
     }
 
+    // Register user callback for tracking device connect/disconnect events
+    ctx.set_devices_changed_callback([&](rs2::event_information& info)
+    {
+        std::cout << "set_devices_changed_callback fired !!!!!!!!!!!!!!! " << std::endl;
+        connected_devices.add_dev_event(info);
+    });
+
     while (app) // Application still alive?
     {
-        connected_devices.poll_frames();
-        auto total_number_of_streams = connected_devices.stream_count();
-        if (total_number_of_streams == 0)
+        connected_devices.refresh_devices();
+        auto total_streams = connected_devices.stream_count();
+        if (0 == total_streams)
         {
             draw_text(int(std::max(0.f, (app.width() / 2) - no_camera_message.length() * 3)),
                       int(app.height() / 2), no_camera_message.c_str());
-            continue;
         }
-        if (connected_devices.device_count() == 1)
+        if (1 ==connected_devices.device_count())
         {
-            draw_text(0, 10, "Please connect another camera");
+            draw_text(0, 10, connect_more_cameras.c_str());
         }
-        int cols = int(std::ceil(std::sqrt(total_number_of_streams)));
-        int rows = int(std::ceil(total_number_of_streams / static_cast<float>(cols)));
 
-        float view_width = (app.width() / cols);
-        float view_height = (app.height() / rows);
+        // Update UI
+        if (total_streams)
+        {
+            int cols = int(std::ceil(std::sqrt(total_streams)));
+            int rows = int(std::ceil(total_streams / static_cast<float>(cols)));
 
-        connected_devices.render_textures(cols, rows, view_width, view_height);
+            float view_width = (app.width() / cols);
+            float view_height = (app.height() / rows);
+            connected_devices.process_and_render(cols, rows, view_width, view_height);
+        }
     }
 
     return EXIT_SUCCESS;

--- a/examples/multicam/rs-multicam.cpp
+++ b/examples/multicam/rs-multicam.cpp
@@ -4,270 +4,56 @@
 #include <librealsense2/rs.hpp>     // Include RealSense Cross Platform API
 #include "example.hpp"              // Include short list of convenience functions for rendering
 
-#include <string>
 #include <map>
-#include <algorithm>
-#include <mutex>                    // std::mutex, std::lock_guard
-#include <cmath>                    // std::ceil
-#include <queue>
-
-const std::string no_camera_message     = "No camera connected, please connect 1 or more";
-const std::string connect_more_cameras  = "Please connect more cameras";
-const std::string platform_camera_name  = "Platform Camera";
-
-class device_events
-{
-public:
-    void add_event(const rs2::event_information& evt)
-    {
-        std::lock_guard<std::mutex> lock(_mtx);
-        _dev_events.push(evt);
-    }
-
-    bool try_get_event(rs2::event_information& evt)
-    {
-        std::lock_guard<std::mutex> lock(_mtx);
-        if (_dev_events.empty())
-            return false;
-
-        evt = std::move(_dev_events.front());
-        _dev_events.pop();
-        return true;
-    }
-private:
-    std::queue<rs2::event_information> _dev_events;
-    std::mutex  _mtx;
-};
-
-class device_container
-{
-    class frames_container
-    {
-    public:
-        frames_container() : _raw(1){}
-        rs2::frame_queue    _raw;
-        rs2::frame          _processed;
-    };
-
-    // Helper struct per pipeline
-    struct view_port
-    {
-    public:
-        view_port(){}
-        ~view_port(){}
-        view_port(const view_port&) = delete;               // non construction-copyable
-        view_port(view_port&& vp):                          // moveable
-            colorize_frame(std::move(vp.colorize_frame)),
-            tex(std::move(vp.tex)),
-            pipe(std::move(vp.pipe)),
-            profile(std::move(vp.profile)){}
-        std::map<int, frames_container> frames_per_stream;
-        rs2::colorizer          colorize_frame;
-        texture                 tex;
-        rs2::pipeline           pipe;
-        rs2::pipeline_profile   profile;
-    };
-
-public:
-
-    device_container(rs2::context& ctx) : _ctx(ctx) {}
-
-    void refresh_devices(void)
-    {
-        rs2::event_information info({}, {});
-        // Process one event at a time
-        if (_dev_events.try_get_event(info))
-        {
-            remove_devices(info);
-            for (auto&& dev : info.get_new_devices())
-            {
-                enable_device(dev);
-            }
-        }
-    }
-
-    size_t stream_count()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        size_t count = 0;
-        for (auto&& sn_to_dev : _devices)
-        {
-            count += sn_to_dev.second.frames_per_stream.size();
-        }
-        return count;
-    }
-
-    size_t device_count()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        return _devices.size();
-    }
-
-    void process_and_render(int cols, int rows, float view_width, float view_height)
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        int stream_no = 0;
-        for (auto&& view : _devices)
-        {
-            // For each device get its frames
-            for (auto&& frames_queue : view.second.frames_per_stream)
-            {
-                //Enhance visuzalization, where appropriate
-                rs2::frame f;
-                if (frames_queue.second._raw.poll_for_frame(&f))
-                {
-                    if (f.as<rs2::frameset>().size() > 1)
-                    {
-                        throw std::runtime_error("Processing requires frames decomposition!");
-                    }
-
-                    frames_queue.second._processed = view.second.colorize_frame.process(f);
-                }
-
-                // Render frame
-                if (frames_queue.second._processed)
-                {
-                    rect frame_location{ view_width * (stream_no % cols), view_height * (stream_no / cols), view_width, view_height };
-                    if (rs2::video_frame vid_frame = frames_queue.second._processed.as<rs2::video_frame>())
-                    {
-                        view.second.tex.render(vid_frame, frame_location);
-                        stream_no++;
-                    }
-                    if (rs2::motion_frame mot_frame = frames_queue.second._processed.as<rs2::motion_frame>())
-                    {
-                        view.second.tex.render(mot_frame, frame_location);
-                        stream_no++;
-                    }
-                    if (rs2::pose_frame pos_frame = frames_queue.second._processed.as<rs2::pose_frame>())
-                    {
-                        view.second.tex.render(pos_frame, frame_location);
-                        stream_no++;
-                    }
-                }
-            }
-        }
-    }
-
-    void add_dev_event(rs2::event_information& info)
-    {
-        _dev_events.add_event(info);
-    }
-
-    void enable_device(rs2::device dev)
-    {
-        std::string serial_number(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
-        std::lock_guard<std::mutex> lock(_mutex);
-
-        if (_devices.find(serial_number) != _devices.end())
-        {
-            return; //already in
-        }
-        // Ignoring platform cameras (webcams, etc..)
-        if (platform_camera_name == dev.get_info(RS2_CAMERA_INFO_NAME))
-        {
-            return;
-        }
-        // Create a pipeline from the given device
-        rs2::pipeline p(_ctx);
-        rs2::config c;
-        c.enable_device(serial_number);
-
-        _devices.emplace(serial_number, view_port());
-
-        rs2::pipeline_profile profile = p.start(c, [serial_number, this](const rs2::frame& frame)
-        {
-            // With callbacks, both the synchronized and unsynchronized frames would arrive in a single frameset
-            if (auto fs = frame.as<rs2::frameset>())
-            {
-                for (const rs2::frame& f : fs)
-                {
-                    if (_devices.find(serial_number) != _devices.end())
-                        _devices[serial_number].frames_per_stream[f.get_profile().unique_id()]._raw.enqueue(f);
-                }
-            }
-            else // Single frames
-            {
-                if (_devices.find(serial_number) != _devices.end())
-                    _devices[serial_number].frames_per_stream[frame.get_profile().unique_id()]._raw.enqueue(frame);
-            }
-        });
-
-        _devices[serial_number].pipe = p;
-        _devices[serial_number].profile = profile;
-    }
-
-    void remove_devices(const rs2::event_information& info)
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        // Go over the list of devices and check if it was disconnected
-        auto itr = _devices.begin();
-        while (itr != _devices.end())
-        {
-            if (info.was_removed(itr->second.profile.get_device()))
-            {
-                itr = _devices.erase(itr);
-            }
-            else
-            {
-                ++itr;
-            }
-        }
-    }
-
- private:
-    std::mutex                          _mutex;
-    std::map<std::string, view_port>    _devices;
-    rs2::context&                       _ctx;
-    device_events                       _dev_events;
-};
+#include <vector>
 
 int main(int argc, char * argv[]) try
 {
     // Create a simple OpenGL window for rendering:
     window app(1280, 960, "CPP Multi-Camera Example");
 
-    rs2::log_to_console(RS2_LOG_SEVERITY_ERROR);
+    rs2::context                ctx;            // Create librealsense context for managing devices
 
-    rs2::context ctx;    // Create librealsense context for managing devices
+    rs2::colorizer              colorizer;      // Utility class to convert depth data RGB colorspace
 
-    device_container connected_devices(ctx);
+    std::vector<rs2::pipeline>  pipelines;
 
-    // Enumerate all the connected devices
+    // Start a streaming pipe per each connected device
     for (auto&& dev : ctx.query_devices())
     {
-        connected_devices.enable_device(dev);
+        rs2::pipeline pipe(ctx);
+        rs2::config cfg;
+        cfg.enable_device(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+        pipe.start(cfg);
+        pipelines.emplace_back(pipe);
     }
 
-    // Register user callback for tracking device connect/disconnect events
-    ctx.set_devices_changed_callback([&](rs2::event_information& info)
+    // We'll keep track for the last frame of each stream available to make the presentation persistent
+    std::map<int, rs2::frame> render_frames;
+
+    // Main app loop
+    while (app)
     {
-        connected_devices.add_dev_event(info);
-    });
-
-    while (app) // Application still alive?
-    {
-        connected_devices.refresh_devices();
-        auto total_streams = connected_devices.stream_count();
-        if (0 == total_streams)
+        // Collect the new frames from all the connected devices
+        std::vector<rs2::frame> new_frames;
+        for (auto &&pipe : pipelines)
         {
-            draw_text(int(std::max(0.f, (app.width() / 2) - no_camera_message.length() * 3)),
-                      int(app.height() / 2), no_camera_message.c_str());
-        }
-        if (1 ==connected_devices.device_count())
-        {
-            draw_text(0, 10, connect_more_cameras.c_str());
+            rs2::frameset fs;
+            if (pipe.poll_for_frames(&fs))
+            {
+                for (rs2::frame& f : fs)
+                    new_frames.emplace_back(f);
+            }
         }
 
-        // Update UI
-        if (total_streams)
+        // Convert the newly-arrived frames to render-firendly format
+        for (const auto& frame : new_frames)
         {
-            int cols = int(std::ceil(std::sqrt(total_streams)));
-            int rows = int(std::ceil(total_streams / static_cast<float>(cols)));
-
-            float view_width = (app.width() / cols);
-            float view_height = (app.height() / rows);
-            connected_devices.process_and_render(cols, rows, view_width, view_height);
+            render_frames[frame.get_profile().unique_id()] = colorizer.process(frame);
         }
+
+        // Present all the collected frames with openGl mosaic
+        app.show(render_frames);
     }
 
     return EXIT_SUCCESS;

--- a/examples/multicam/rs-multicam.cpp
+++ b/examples/multicam/rs-multicam.cpp
@@ -226,7 +226,7 @@ int main(int argc, char * argv[]) try
     // Create a simple OpenGL window for rendering:
     window app(1280, 960, "CPP Multi-Camera Example");
 
-    rs2::log_to_console(RS2_LOG_SEVERITY_WARN);
+    rs2::log_to_console(RS2_LOG_SEVERITY_ERROR);
 
     rs2::context ctx;    // Create librealsense context for managing devices
 

--- a/examples/post-processing/rs-post-processing.cpp
+++ b/examples/post-processing/rs-post-processing.cpp
@@ -183,13 +183,13 @@ int main(int argc, char * argv[]) try
         // Draw the pointclouds of the original and the filtered frames (if the are available already)
         if (colored_depth && original_points)
         {
-            glViewport(0, h / 2, w / 2, h / 2);
-            draw_pointcloud(w / 2, h / 2, original_view_orientation, original_points);
+            glViewport(0, int(h) / 2, int(w) / 2, int(h) / 2);
+            draw_pointcloud(int(w) / 2, int(h) / 2, original_view_orientation, original_points);
         }
         if (colored_filtered && filtered_points)
         {
-            glViewport(w / 2, h / 2, w / 2, h / 2);
-            draw_pointcloud(w / 2, h / 2, filtered_view_orientation, filtered_points);
+            glViewport(int(w) / 2, int(h) / 2, int(w) / 2, int(h) / 2);
+            draw_pointcloud(int(w) / 2, int(h) / 2, filtered_view_orientation, filtered_points);
         }
         // Update time of current frame's arrival
         auto curr = std::chrono::high_resolution_clock::now();

--- a/examples/record-playback/rs-record-playback.cpp
+++ b/examples/record-playback/rs-record-playback.cpp
@@ -194,7 +194,7 @@ int main(int argc, char * argv[]) try
         ImGui::Render();
 
         // Render depth frames from the default configuration, the recorder or the playback
-        depth_image.render(depth.as<rs2::video_frame>(), { app.width() * 0.25f, app.height() * 0.25f, app.width() * 0.5f, app.height() * 0.75f  });
+        depth_image.render(depth, { app.width() * 0.25f, app.height() * 0.25f, app.width() * 0.5f, app.height() * 0.75f  });
     }
     return EXIT_SUCCESS;
 }

--- a/examples/record-playback/rs-record-playback.cpp
+++ b/examples/record-playback/rs-record-playback.cpp
@@ -194,7 +194,7 @@ int main(int argc, char * argv[]) try
         ImGui::Render();
 
         // Render depth frames from the default configuration, the recorder or the playback
-        depth_image.render(depth, { app.width() * 0.25f, app.height() * 0.25f, app.width() * 0.5f, app.height() * 0.75f  });
+        depth_image.render(depth.as<rs2::video_frame>(), { app.width() * 0.25f, app.height() * 0.25f, app.width() * 0.5f, app.height() * 0.75f  });
     }
     return EXIT_SUCCESS;
 }

--- a/examples/sensor-control/helper.h
+++ b/examples/sensor-control/helper.h
@@ -81,7 +81,7 @@ namespace helper
                     {
                         try
                         {
-                            renderer.render(colorize.process(decimate.process(frame)), { 0, 0, view_width, view_height });
+                            renderer.render(colorize.process(decimate.process(frame)).as<rs2::video_frame>(), { 0, 0, view_width, view_height });
                         }
                         catch (const std::exception& e)
                         {

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -817,7 +817,7 @@ namespace rs2
         * Retrieve back the pose data from T2xx position tracking sensor
         * \return rs2_pose - orientation and velocity data.
         */
-        rs2_pose get_pose_data()
+        rs2_pose get_pose_data() const
         {
             rs2_pose pose_data;
             rs2_error* e = nullptr;

--- a/src/backend.h
+++ b/src/backend.h
@@ -335,7 +335,7 @@ namespace librealsense
         {
             void* device_ptr;
 
-            operator std::string()
+            operator std::string() const
             {
                 std::ostringstream oss;
                 oss << device_ptr;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -123,9 +123,8 @@ namespace librealsense
             break;
         case backend_type::playback:
             _backend = std::make_shared<platform::playback_backend>(filename, section, min_api_version);
-
             break;
-        default: throw invalid_value_exception(to_string() << "Undefined backend type " << static_cast<int>(type));
+            // Strongly-typed enum. Default is redundant
         }
 
        environment::get_instance().set_time_service(_backend->create_time_service());
@@ -212,7 +211,7 @@ namespace librealsense
     class platform_camera_sensor : public uvc_sensor
     {
     public:
-        platform_camera_sensor(const std::shared_ptr<context>& ctx,
+        platform_camera_sensor(const std::shared_ptr<context>&,
             device* owner,
             std::shared_ptr<platform::uvc_device> uvc_device,
             std::unique_ptr<frame_timestamp_reader> timestamp_reader)
@@ -283,7 +282,7 @@ namespace librealsense
             color_ep->try_register_pu(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);
         }
 
-        virtual rs2_intrinsics get_intrinsics(unsigned int subdevice, const stream_profile& profile) const
+        virtual rs2_intrinsics get_intrinsics(unsigned int, const stream_profile&) const
         {
             return rs2_intrinsics {};
         }
@@ -293,13 +292,12 @@ namespace librealsense
             std::vector<tagged_profile> markers;
             markers.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             return markers;
-        };
+        }
     };
 
     std::shared_ptr<device_interface> platform_camera_info::create(std::shared_ptr<context> ctx,
                                                                    bool register_device_notifications) const
     {
-        auto&& backend = ctx->get_backend();
         return std::make_shared<platform_camera>(ctx, _uvcs, this->get_device_data(), register_device_notifications);
     }
 
@@ -328,6 +326,21 @@ namespace librealsense
         // to allow them to modify context later on
         auto ctx = t->shared_from_this();
 
+        if (mask & RS2_PRODUCT_LINE_D400)
+        {
+            auto ds5_devices = ds5_info::pick_ds5_devices(ctx, devices);
+            std::copy(begin(ds5_devices), end(ds5_devices), std::back_inserter(list));
+        }
+
+        auto l500_devices = l500_info::pick_l500_devices(ctx, devices.uvc_devices, devices.usb_devices);
+        std::copy(begin(l500_devices), end(l500_devices), std::back_inserter(list));
+
+        if (mask & RS2_PRODUCT_LINE_SR300)
+        {
+            auto sr300_devices = sr300_info::pick_sr300_devices(ctx, devices.uvc_devices, devices.usb_devices);
+            std::copy(begin(sr300_devices), end(sr300_devices), std::back_inserter(list));
+        }
+
 #ifdef WITH_TRACKING
         if (_tm2_context)
         {
@@ -335,21 +348,6 @@ namespace librealsense
             std::copy(begin(tm2_devices), end(tm2_devices), std::back_inserter(list));
         }
 #endif
-
-        auto l500_devices = l500_info::pick_l500_devices(ctx, devices.uvc_devices, devices.usb_devices);
-        std::copy(begin(l500_devices), end(l500_devices), std::back_inserter(list));
-
-        if (mask & RS2_PRODUCT_LINE_D400)
-        {
-            auto ds5_devices = ds5_info::pick_ds5_devices(ctx, devices);
-            std::copy(begin(ds5_devices), end(ds5_devices), std::back_inserter(list));
-        }
-
-        if (mask & RS2_PRODUCT_LINE_SR300)
-        {
-            auto sr300_devices = sr300_info::pick_sr300_devices(ctx, devices.uvc_devices, devices.usb_devices);
-            std::copy(begin(sr300_devices), end(sr300_devices), std::back_inserter(list));
-        }
 
         auto recovery_devices = recovery_info::pick_recovery_devices(ctx, devices.usb_devices);
         std::copy(begin(recovery_devices), end(recovery_devices), std::back_inserter(list));
@@ -565,7 +563,7 @@ namespace librealsense
     void context::unload_tracking_module()
     {
         _tm2_context.reset();
-    };
+    }
 #endif
 
     std::vector<std::vector<platform::uvc_device_info>> group_devices_by_unique_id(const std::vector<platform::uvc_device_info>& devices)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -444,6 +444,12 @@ namespace librealsense
         return callback_id;
     }
 
+    void context::unregister_internal_device_callback(uint64_t cb_id)
+    {
+        std::lock_guard<std::mutex> lock(_devices_changed_callbacks_mtx);
+        _devices_changed_callbacks.erase(cb_id);
+    }
+
     void context::set_devices_changed_callback(devices_changed_callback_ptr callback)
     {
         _device_watcher->stop();
@@ -453,12 +459,6 @@ namespace librealsense
         {
             on_device_changed(old, curr, _playback_devices, _playback_devices);
         });
-    }
-
-    void context::unregister_internal_device_callback(uint64_t cb_id)
-    {
-        std::lock_guard<std::mutex> lock(_devices_changed_callbacks_mtx);
-        _devices_changed_callbacks.erase(cb_id);
     }
 
     std::vector<platform::uvc_device_info> filter_by_product(const std::vector<platform::uvc_device_info>& devices, const std::set<uint16_t>& pid_list)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,6 +21,7 @@
 #include "context.h"
 
 #ifdef WITH_TRACKING
+#include "tm2/tm-context.h"
 #include "tm2/tm-info.h"
 #endif
 
@@ -559,6 +560,13 @@ namespace librealsense
         _playback_devices.erase(it);
         on_device_changed({},{}, prev_playback_devices, _playback_devices);
     }
+
+#if WITH_TRACKING
+    void context::unload_tracking_module()
+    {
+        _tm2_context.reset();
+    };
+#endif
 
     std::vector<std::vector<platform::uvc_device_info>> group_devices_by_unique_id(const std::vector<platform::uvc_device_info>& devices)
     {

--- a/src/context.h
+++ b/src/context.h
@@ -115,19 +115,17 @@ namespace librealsense
             rs2_recording_mode mode = RS2_RECORDING_MODE_COUNT,
             std::string min_api_version = "0.0.0");
 
-        void stop(){_device_watcher->stop();}
+        void stop(){ if (!_devices_changed_callbacks.size()) _device_watcher->stop();}
         ~context();
         std::vector<std::shared_ptr<device_info>> query_devices(int mask) const;
         const platform::backend& get_backend() const { return *_backend; }
 
         uint64_t register_internal_device_callback(devices_changed_callback_ptr callback);
-        void set_devices_changed_callback(devices_changed_callback_ptr callback);
         void unregister_internal_device_callback(uint64_t cb_id);
+        void set_devices_changed_callback(devices_changed_callback_ptr callback);
 
         std::vector<std::shared_ptr<device_info>> create_devices(platform::backend_device_group devices,
             const std::map<std::string, std::weak_ptr<device_info>>& playback_devices, int mask) const;
-
-
 
         std::shared_ptr<device_interface> add_device(const std::string& file);
         void remove_device(const std::string& file);
@@ -154,7 +152,6 @@ namespace librealsense
         std::shared_ptr<platform::device_watcher> _device_watcher;
         std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
-
 
         devices_changed_callback_ptr _devices_changed_callback;
         std::map<int, std::weak_ptr<const stream_interface>> _streams;

--- a/src/context.h
+++ b/src/context.h
@@ -7,9 +7,6 @@
 #include "backend.h"
 #include "mock/recorder.h"
 #include "core/streaming.h"
-#if WITH_TRACKING
-    #include "tm2/tm-context.h"
-#endif
 
 #include <vector>
 #include <media/playback/playback_device.h>
@@ -106,6 +103,9 @@ namespace librealsense
 
     typedef std::vector<std::shared_ptr<device_info>> devices_info;
 
+    //FW Decl
+    class tm2_context;
+
     class context : public std::enable_shared_from_this<context>
     {
     public:
@@ -135,7 +135,7 @@ namespace librealsense
         void add_software_device(std::shared_ptr<device_info> software_device);
 
 #if WITH_TRACKING
-        void unload_tracking_module() {_tm2_context.reset();};
+        void unload_tracking_module();
 #endif
 
     private:

--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -16,17 +16,20 @@ namespace librealsense
         std::vector<std::shared_ptr<device_info>> result;
         for (auto dev : devices)
         {
+            bool filtered = false;
             auto data = dev->get_device_data();
             for (const auto& uvc : data.uvc_devices)
             {
                 if (uvc.vid == vid || vid == 0)
                 {
                     result.push_back(dev);
+                    filtered = true;
                     break;
                 }
             }
 
-            if (data.tm2_devices.size() && (0== vid))
+            // TODO: enable T265 filter by VID:PID via tm2_device_info
+            if ((!filtered) && data.tm2_devices.size())
                 result.push_back(dev);
         }
         return result;

--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -17,7 +17,7 @@ namespace librealsense
         for (auto dev : devices)
         {
             auto data = dev->get_device_data();
-            for (auto uvc : data.uvc_devices)
+            for (const auto& uvc : data.uvc_devices)
             {
                 if (uvc.vid == vid || vid == 0)
                 {
@@ -25,6 +25,9 @@ namespace librealsense
                     break;
                 }
             }
+
+            if (data.tm2_devices.size() && (0== vid))
+                result.push_back(dev);
         }
         return result;
     }

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -17,6 +17,8 @@ namespace librealsense
     public:
         explicit device_hub(std::shared_ptr<librealsense::context> ctx, int mask = RS2_PRODUCT_LINE_ANY, int vid = 0, bool register_device_notifications = true);
 
+        ~device_hub();
+
         /**
          * The function implements both blocking and non-blocking device generation functionality based on the input parameters:
          * Calling the function with zero timeout results in searching and fetching the device specified by the `serial` parameter
@@ -43,11 +45,6 @@ namespace librealsense
 
         std::shared_ptr<librealsense::context> get_context();
 
-        ~device_hub()
-        {
-            _ctx->stop();
-        }
-
     private:
         std::shared_ptr<device_interface> create_device(const std::string& serial, bool cycle_devices = true);
         std::shared_ptr<librealsense::context> _ctx;
@@ -56,6 +53,7 @@ namespace librealsense
         std::vector<std::shared_ptr<device_info>> _device_list;
         int _camera_index = 0;
         int _vid = 0;
+        uint64_t _device_changes_callback_id;
         bool _register_device_notifications;
     };
 }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1465,12 +1465,10 @@ namespace librealsense
             _md_fd(0),
             _md_name(info.metadata_node_id)
         {
-            LOG_INFO(__FUNCTION__);
         }
 
         v4l_uvc_meta_device::~v4l_uvc_meta_device()
         {
-            LOG_INFO(__FUNCTION__);
         }
 
         void v4l_uvc_meta_device::streamon() const

--- a/src/tm2/tm-context.cpp
+++ b/src/tm2/tm-context.cpp
@@ -18,26 +18,30 @@ namespace librealsense
 {
     tm2_context::tm2_context(context* ctx)
         : _is_disposed(false), _ctx(ctx)
+    {}
+
+    tm2_context::~tm2_context()
     {
+        _is_disposed = true;
+        if (_t.joinable())
+            _t.join();
     }
 
     void tm2_context::create_manager()
     {
+        std::lock_guard<std::mutex> lock(_manager_mutex);
+        if (_manager == nullptr)
         {
-            std::lock_guard<std::mutex> lock(_manager_mutex);
+            _manager = std::shared_ptr<TrackingManager>(perc::TrackingManager::CreateInstance(this),
+                [](perc::TrackingManager* ptr) { perc::TrackingManager::ReleaseInstance(ptr); });
             if (_manager == nullptr)
             {
-                _manager = std::shared_ptr<TrackingManager>(perc::TrackingManager::CreateInstance(this),
-                    [](perc::TrackingManager* ptr) { perc::TrackingManager::ReleaseInstance(ptr); });
-                if (_manager == nullptr)
-                {
-                    LOG_DEBUG("Failed to create TrackingManager");
-                    return;
-                }
-                _t = std::thread(&tm2_context::thread_proc, this);
-
-                LOG_INFO("LibTm version 0x" << std::hex << _manager->version());
+                LOG_WARNING("Failed to create TrackingManager");
+                return;
             }
+            _t = std::thread(&tm2_context::thread_proc, this);
+
+            LOG_INFO("LibTm version 0x" << std::hex << _manager->version());
         }
     }
 
@@ -48,15 +52,21 @@ namespace librealsense
 
     std::vector<perc::TrackingDevice*> tm2_context::query_devices() const
     {
-        return _devices;
-    }
+        std::lock_guard<std::mutex> lock(_manager_mutex);
 
-    tm2_context::~tm2_context()
-    {
-        _is_disposed = true;
-        if (_t.joinable())
-            _t.join();
-        
+        auto started = std::chrono::high_resolution_clock::now();
+        std::chrono::milliseconds elapsed(0);
+        // Provide up to 5 sec for T265 initialization
+        // Note that the current implementation is limited to single valid tm2 context instance.
+        // Therefore uninitialized managers will be disregarded
+        while (_manager && !(_manager->isInitialized()) && (elapsed.count() < 5000))
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - started);
+            //LOG_WARNING("_manager: " << _manager << " init state: " << (_manager ? _manager->isInitialized() : 0));
+        }
+        LOG_DEBUG("T265 query acomplished after " << std::dec << elapsed.count() << " ms]");
+        return _devices;
     }
 
     void tm2_context::onStateChanged(TrackingManager::EventType state, TrackingDevice* dev, TrackingData::DeviceInfo devInfo)
@@ -68,13 +78,13 @@ namespace librealsense
             case TrackingManager::ATTACH:
             {
                 _devices.push_back(dev);
-                LOG_INFO("TM2 Device Attached - " << dev);
+                LOG_WARNING("TM2 Device Attached - " << dev);
                 added = std::make_shared<tm2_info>(get_manager(), dev, _ctx->shared_from_this());
                 break;
             }
             case TrackingManager::DETACH:
             {
-                LOG_INFO("TM2 Device Detached");
+                LOG_WARNING("TM2 Device Detached");
                 removed = std::make_shared<tm2_info>(get_manager(), dev, _ctx->shared_from_this());
                 auto itr = std::find_if(_devices.begin(), _devices.end(), [dev](TrackingDevice* d) { return dev == d; });
                 _devices.erase(itr);

--- a/src/tm2/tm-context.cpp
+++ b/src/tm2/tm-context.cpp
@@ -63,7 +63,6 @@ namespace librealsense
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - started);
-            //LOG_WARNING("_manager: " << _manager << " init state: " << (_manager ? _manager->isInitialized() : 0));
         }
         LOG_DEBUG("T265 query acomplished after " << std::dec << elapsed.count() << " ms]");
         return _devices;
@@ -78,13 +77,13 @@ namespace librealsense
             case TrackingManager::ATTACH:
             {
                 _devices.push_back(dev);
-                LOG_WARNING("TM2 Device Attached - " << dev);
+                LOG_INFO("TM2 Device Attached - " << dev);
                 added = std::make_shared<tm2_info>(get_manager(), dev, _ctx->shared_from_this());
                 break;
             }
             case TrackingManager::DETACH:
             {
-                LOG_WARNING("TM2 Device Detached");
+                LOG_INFO("TM2 Device Detached");
                 removed = std::make_shared<tm2_info>(get_manager(), dev, _ctx->shared_from_this());
                 auto itr = std::find_if(_devices.begin(), _devices.end(), [dev](TrackingDevice* d) { return dev == d; });
                 _devices.erase(itr);

--- a/src/tm2/tm-context.h
+++ b/src/tm2/tm-context.h
@@ -29,13 +29,12 @@ namespace librealsense
         friend class connect_disconnect_listener;
         std::shared_ptr<perc::TrackingManager::Listener> _listener;
         std::shared_ptr<perc::TrackingManager> _manager;
-        std::mutex _manager_mutex;
+        mutable std::mutex _manager_mutex;
         std::vector<perc::TrackingDevice*> _devices;
         context* _ctx;
 
         //_is_disposed is used in _t, keep this order:
         std::atomic_bool _is_disposed;
         std::thread _t;
-        
     };
 }

--- a/src/tm2/tm-conversions.h
+++ b/src/tm2/tm-conversions.h
@@ -86,7 +86,7 @@ namespace librealsense
         case perc::SIXDOF_INTERRUPT_RATE_FISHEYE:
             return 30;
         case perc::SIXDOF_INTERRUPT_RATE_IMU:
-            return 262; //TODO - going to change by TM2 to something else...
+            return 200; //TODO - going to change by TM2 to something else...
         default:
             throw invalid_value_exception("Invalid TM2 pose rate");
         }

--- a/src/tm2/tm-device.cpp
+++ b/src/tm2/tm-device.cpp
@@ -630,7 +630,7 @@ namespace librealsense
 
     rs2_motion_device_intrinsic tm2_sensor::get_motion_intrinsics(const motion_stream_profile_interface& profile) const
     {
-        rs2_motion_device_intrinsic result;
+        rs2_motion_device_intrinsic result{};
         TrackingData::MotionIntrinsics tm_intrinsics{};
         int stream_index = profile.get_stream_index();
         if (stream_index != 0) //firmware only accepts stream 0

--- a/third-party/libtm/libtm/include/TrackingManager.h
+++ b/third-party/libtm/libtm/include/TrackingManager.h
@@ -25,7 +25,6 @@ namespace perc
             virtual void onError(Status, TrackingDevice* device)= 0;
         };
 
-    public:
         // factory
         static TrackingManager* CreateInstance(Listener*, void* param = 0);
         // release existing manager and clean the pointer
@@ -46,5 +45,7 @@ namespace perc
         */
         virtual uint64_t version() = 0;
         virtual ~TrackingManager() {}
+
+        virtual bool isInitialized() const = 0;
     };
 } 

--- a/third-party/libtm/libtm/src/Device.cpp
+++ b/third-party/libtm/libtm/src/Device.cpp
@@ -2709,7 +2709,7 @@ namespace perc {
                 break;
             }
 
-            // Add some statistics calculations            
+            // Add some statistics calculations
             totalBytesReceived += actual;
             if (timeOfFirstByte == 0)
                 timeOfFirstByte = systemTime();

--- a/third-party/libtm/libtm/src/Manager.cpp
+++ b/third-party/libtm/libtm/src/Manager.cpp
@@ -67,6 +67,10 @@ void TrackingManager::ReleaseInstance(TrackingManager*& manager)
 // -[interface]----------------------------------------------------------------
 Manager::Manager(Listener* lis, void* param) : mDispatcher(new Dispatcher()), mListener(nullptr), mContext(nullptr), mFwFileName(""), mLibUsbDeviceToTrackingDeviceMap(), mEvent(), mCompleteQMutex(), mCompleteQ(), mTrackingDeviceInfoMap()
 {
+    // Evgeni
+    //setHostLogControl({ LogVerbosityLevel::Warning, LogOutputMode::LogOutputModeScreen, true });
+    setHostLogControl({ LogVerbosityLevel::None, LogOutputMode::LogOutputModeScreen, true });
+
     // start running context 
     mThread = std::thread([this] {
         mFsm.init(FSM(main), this, mDispatcher.get(), LOG_TAG);
@@ -77,15 +81,7 @@ Manager::Manager(Listener* lis, void* param) : mDispatcher(new Dispatcher()), mL
     {
         throw std::runtime_error("Failed to init manager");
     }
-
-
-    TrackingData::LogControl logControl(LogVerbosityLevel::None,
-        LogOutputMode::LogOutputModeBuffer,
-        true);
-
-    setHostLogControl(logControl);
 }
-
 
 Manager::~Manager()
 {
@@ -455,7 +451,7 @@ DEFINE_FSM_ACTION(Manager, ACTIVE_STATE, ON_ATTACH, msg)
     }
 
     /* USB Device Firmware Upgrade (DFU) */
-    if (mUsbPlugListener->identifyUDFDevice(&desc) == true)
+    if (mUsbPlugListener->identifyDFUDevice(&desc) == true)
     {
         libusb_ref_device(m.device);
 
@@ -547,7 +543,7 @@ DEFINE_FSM_ACTION(Manager, ACTIVE_STATE, ON_DETACH, msg)
         delete device;
         libusb_unref_device(m.device);
     }
-    else if (mUsbPlugListener->identifyUDFDevice(&desc) == true)
+    else if (mUsbPlugListener->identifyDFUDevice(&desc) == true)
     {
         libusb_unref_device(m.device);
     }

--- a/third-party/libtm/libtm/src/Manager.cpp
+++ b/third-party/libtm/libtm/src/Manager.cpp
@@ -32,7 +32,7 @@ TrackingManager* TrackingManager::CreateInstance(Listener* lis, void* param)
     {
         if (Manager::instanceExist)
         {
-            LOGE("Manager instance already exist");
+            LOGW("Manager instance already exist");
             return nullptr;
         }
         Manager::instanceExist = true;

--- a/third-party/libtm/libtm/src/Manager.cpp
+++ b/third-party/libtm/libtm/src/Manager.cpp
@@ -67,8 +67,6 @@ void TrackingManager::ReleaseInstance(TrackingManager*& manager)
 // -[interface]----------------------------------------------------------------
 Manager::Manager(Listener* lis, void* param) : mDispatcher(new Dispatcher()), mListener(nullptr), mContext(nullptr), mFwFileName(""), mLibUsbDeviceToTrackingDeviceMap(), mEvent(), mCompleteQMutex(), mCompleteQ(), mTrackingDeviceInfoMap()
 {
-    // Evgeni
-    //setHostLogControl({ LogVerbosityLevel::Warning, LogOutputMode::LogOutputModeScreen, true });
     setHostLogControl({ LogVerbosityLevel::None, LogOutputMode::LogOutputModeScreen, true });
 
     // start running context 

--- a/third-party/libtm/libtm/src/Manager.cpp
+++ b/third-party/libtm/libtm/src/Manager.cpp
@@ -67,7 +67,7 @@ void TrackingManager::ReleaseInstance(TrackingManager*& manager)
 // -[interface]----------------------------------------------------------------
 Manager::Manager(Listener* lis, void* param) : mDispatcher(new Dispatcher()), mListener(nullptr), mContext(nullptr), mFwFileName(""), mLibUsbDeviceToTrackingDeviceMap(), mEvent(), mCompleteQMutex(), mCompleteQ(), mTrackingDeviceInfoMap()
 {
-    setHostLogControl({ LogVerbosityLevel::None, LogOutputMode::LogOutputModeScreen, true });
+    setHostLogControl({ LogVerbosityLevel::Error, LogOutputMode::LogOutputModeScreen, true });
 
     // start running context 
     mThread = std::thread([this] {

--- a/third-party/libtm/libtm/src/Manager.h
+++ b/third-party/libtm/libtm/src/Manager.h
@@ -44,7 +44,6 @@ namespace perc
         static std::mutex instanceExistMutex;
         static bool instanceExist;
 
-        // Await USB device discovery completion
         bool isInitialized() const override { return mUsbPlugListener->isInitialized(); }
 
     protected:

--- a/third-party/libtm/libtm/src/Manager.h
+++ b/third-party/libtm/libtm/src/Manager.h
@@ -44,6 +44,9 @@ namespace perc
         static std::mutex instanceExistMutex;
         static bool instanceExist;
 
+        // Await USB device discovery completion
+        bool isInitialized() const override { return mUsbPlugListener->isInitialized(); }
+
     protected:
         std::thread mThread;
         std::shared_ptr<Dispatcher> mDispatcher;

--- a/third-party/libtm/libtm/src/UsbPlugListener.cpp
+++ b/third-party/libtm/libtm/src/UsbPlugListener.cpp
@@ -163,7 +163,8 @@ void perc::UsbPlugListener::EnumerateDevices()
         // Schedule 1000ms for loading if DFU device(s) were found, otherwise 500msec
         mUSBMinTimeout = mUSBSetupTimeout = systemTime() + (bootLoader_count ? 1000000000 : 500000000);
         mDevicesToProcess = bootLoader_count;
-        LOGE("usb_setup_init, %d dfu devices, %d TM2 devices, time=%lu , min timeout =%lu", bootLoader_count, TM_count, systemTime(), mUSBSetupTimeout);
+        LOGD("usb_setup_init, %d dfu devices, %d TM2 devices, time=%lu , min timeout =%lu",
+                bootLoader_count, TM_count, systemTime(), mUSBSetupTimeout);
         break;
     case usb_setup_progress:
         // New devices discovered during the setup phase will add 1 sec
@@ -171,26 +172,27 @@ void perc::UsbPlugListener::EnumerateDevices()
         {
             mUSBSetupTimeout = systemTime() + 1000000000;
             mDevicesToProcess += bootLoader_count;
-            LOGE("usb_setup_progress, %d new dfu devices, time=%lu, new timeout=%lu", bootLoader_count, systemTime(), mUSBSetupTimeout);
+            LOGD("usb_setup_progress, %d new dfu devices, time=%lu, new timeout=%lu",
+                bootLoader_count, systemTime(), mUSBSetupTimeout);
         }
 
         if (TM_count)
         {
-            LOGE("New TM2 discovered were  %d time=%lu, timeout=%lu", TM_count, systemTime(), mUSBSetupTimeout);
+            LOGE("New TM2 discovered %d time=%lu, timeout=%lu", TM_count, systemTime(), mUSBSetupTimeout);
         }
         mDevicesToProcess -= TM_count;
 
         if (systemTime() >= mUSBSetupTimeout)
         {
             mInitialized.store(usb_setup_timeout);
-            LOGE("EnumerateDevices: ,timeout occurred time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
+            LOGD("EnumerateDevices: ,timeout occurred time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
         }
         else
         {
             if ((systemTime() >= mUSBMinTimeout) && (!mDevicesToProcess))
             {
                 mInitialized.store(usb_setup_success);
-                LOGE("EnumerateDevices: ,usb_setup_success time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
+                LOGD("EnumerateDevices: ,usb_setup_success time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
             }
             // else wait for process co complete
         }

--- a/third-party/libtm/libtm/src/UsbPlugListener.cpp
+++ b/third-party/libtm/libtm/src/UsbPlugListener.cpp
@@ -160,39 +160,37 @@ void perc::UsbPlugListener::EnumerateDevices()
     {
     case usb_setup_init:
         mInitialized.store(usb_setup_progress);
-        // Schedule 1000ms for loading if DFU device(s) were found, otherwise 500msec
-        mUSBMinTimeout = mUSBSetupTimeout = systemTime() + (bootLoader_count ? 1000000000 : 500000000);
+        // One-time overhead: schedule 1 sec for loading if DFU device(s) were present, otherwise 300 msec. 
+        mUSBMinTimeout = mUSBSetupTimeout = systemTime() + (bootLoader_count ? 1000000000 : 300000000);
         mDevicesToProcess = bootLoader_count;
-        LOGD("usb_setup_init, %d dfu devices, %d TM2 devices, time=%lu , min timeout =%lu",
-                bootLoader_count, TM_count, systemTime(), mUSBSetupTimeout);
+        LOGT("usb_setup_init, %d dfu devices, %d TM2 devices, time=%lu , min timeout =%lu", bootLoader_count, TM_count, systemTime(), mUSBSetupTimeout);
         break;
     case usb_setup_progress:
-        // New devices discovered during the setup phase will add 1 sec
+        // Devices discovered during the setup phase will add 1 sec
         if (bootLoader_count)
         {
             mUSBSetupTimeout = systemTime() + 1000000000;
             mDevicesToProcess += bootLoader_count;
-            LOGD("usb_setup_progress, %d new dfu devices, time=%lu, new timeout=%lu",
-                bootLoader_count, systemTime(), mUSBSetupTimeout);
+            LOGT("usb_setup_progress, %d new dfu devices, time=%lu, new timeout=%lu", bootLoader_count, systemTime(), mUSBSetupTimeout);
         }
 
         if (TM_count)
         {
-            LOGE("New TM2 discovered %d time=%lu, timeout=%lu", TM_count, systemTime(), mUSBSetupTimeout);
+            LOGT("New TM2 discovered were  %d time=%lu, timeout=%lu", TM_count, systemTime(), mUSBSetupTimeout);
         }
         mDevicesToProcess -= TM_count;
 
         if (systemTime() >= mUSBSetupTimeout)
         {
             mInitialized.store(usb_setup_timeout);
-            LOGD("EnumerateDevices: ,timeout occurred time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
+            LOGT("EnumerateDevices: ,timeout occurred time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
         }
         else
         {
             if ((systemTime() >= mUSBMinTimeout) && (!mDevicesToProcess))
             {
                 mInitialized.store(usb_setup_success);
-                LOGD("EnumerateDevices: ,usb_setup_success time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
+                LOGT("EnumerateDevices: ,usb_setup_success time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
             }
             // else wait for process co complete
         }

--- a/third-party/libtm/libtm/src/UsbPlugListener.cpp
+++ b/third-party/libtm/libtm/src/UsbPlugListener.cpp
@@ -11,6 +11,9 @@
 
 using namespace std::chrono;
 
+const size_t ENUMERATE_TIMEOUT_NSEC         = 500000000; // 500 msec periodic query
+const size_t ENUMERATE_TIMEOUT_STARTUP_NSEC = 10000000;  // 10 msec at startup
+
 typedef enum {
     USB_1_0 = 0x0100, // USB 1.0 (Low Speed 1.5 Mbps)
     USB_1_1 = 0x0110, // USB 1.1 (Full Speed 12 Mbps)
@@ -20,18 +23,19 @@ typedef enum {
     USB_3_1 = 0x0310, // USB 3.1 (Super Speed + 10.0 Gbps)
 } USB_SPECIFICIATION_VERSION;
 
-perc::UsbPlugListener::UsbPlugListener(Owner& owner) : mOwner(owner), mMessage(0)
+perc::UsbPlugListener::UsbPlugListener(Owner& owner) : mOwner(owner), mMessage(0),
+    mInitialized(usb_setup_init), mNextScanIntervalMs(ENUMERATE_TIMEOUT_STARTUP_NSEC), mDevicesToProcess(0)
 {
-    // schedule the listener itself for every 100 milliseconds
-    mOwner.dispatcher().scheduleTimer(this, ENUMERATE_TIMEOUT_NSEC, mMessage);
+    // schedule the listener to query USB devices according to the initialization phase: 10 msec during boot, then 500 msec
+    mOwner.dispatcher().scheduleTimer(this, mNextScanIntervalMs, mMessage);
 }
 
 void perc::UsbPlugListener::onTimeout(uintptr_t timerId, const Message & msg)
 {
     EnumerateDevices();
 
-    /* Reschedule the listener itself for every 100 milliseconds */
-    mOwner.dispatcher().scheduleTimer(this, ENUMERATE_TIMEOUT_NSEC, mMessage);
+    /* Reschedule the listener itself */
+    mOwner.dispatcher().scheduleTimer(this, mNextScanIntervalMs, mMessage);
 }
 
 bool perc::UsbPlugListener::identifyDevice(libusb_device_descriptor* desc)
@@ -44,9 +48,9 @@ bool perc::UsbPlugListener::identifyDevice(libusb_device_descriptor* desc)
     return false;
 }
 
-bool perc::UsbPlugListener::identifyUDFDevice(libusb_device_descriptor* desc)
+bool perc::UsbPlugListener::identifyDFUDevice(libusb_device_descriptor* desc)
 {
-    if ((desc->idVendor == TM2_UDF_DEV_VID) && (desc->idProduct == TM2_UDF_DEV_PID) && (desc->bcdUSB >= USB_2_0))
+    if ((desc->idVendor == TM2_DFU_DEV_VID) && (desc->idProduct == TM2_DFU_DEV_PID) && (desc->bcdUSB >= USB_2_0))
     {
         return true;
     }
@@ -79,6 +83,8 @@ void perc::UsbPlugListener::EnumerateDevices()
     libusb_device **list = NULL;
     int rc = 0;
     ssize_t count = 0;
+    size_t bootLoader_count = 0;
+    size_t TM_count = 0;
 
     count = libusb_get_device_list(NULL, &list);
 
@@ -99,7 +105,9 @@ void perc::UsbPlugListener::EnumerateDevices()
 
         LOGV("%d: VID 0x%04X, PID 0x%04X, bcdUSB 0x%x, iSerialNumber %d", idx, desc.idVendor, desc.idProduct, desc.bcdUSB, desc.iSerialNumber);
 
-        if ((identifyDevice(&desc) == true) || (identifyUDFDevice(&desc) == true))
+        auto tm2_dev = identifyDevice(&desc);
+        auto dfu_dev = identifyDFUDevice(&desc);
+        if (tm2_dev || dfu_dev)
         {
             std::lock_guard<std::mutex> lk(mDeviceToPortMapLock);
             DeviceToPortMap devicePort(device);
@@ -107,7 +115,10 @@ void perc::UsbPlugListener::EnumerateDevices()
 
             if (mDeviceToPortMap.find(devicePort) == mDeviceToPortMap.end())
             {
-                LOGD("Found USB device %s on port %d: VID 0x%04X, PID 0x%04X, %s",(desc.idVendor == TM2_UDF_DEV_VID)?"Movidius":(desc.idProduct == TM2_T265_PID)?"T265":"T260", devicePort.portChain[0], desc.idVendor, desc.idProduct, usbSpeed(desc.bcdUSB));
+                LOGD("Found USB device %s on port %d: VID 0x%04X, PID 0x%04X, %s",(desc.idVendor == TM2_DFU_DEV_VID)?"Movidius":(desc.idProduct == TM2_T265_PID)?"T265":"T260", devicePort.portChain[0], desc.idVendor, desc.idProduct, usbSpeed(desc.bcdUSB));
+                if (dfu_dev) bootLoader_count++;
+                if (tm2_dev) TM_count++;
+
                 st = mOwner.onAttach(device);
             }
 
@@ -144,4 +155,50 @@ void perc::UsbPlugListener::EnumerateDevices()
 
     // free the list
     libusb_free_device_list(list, 1);
+
+    switch (mInitialized)
+    {
+    case usb_setup_init:
+        mInitialized = usb_setup_progress;
+        // Schedule 1000ms for loading if DFU device(s) were found, otherwise 500msec
+        mUSBMinTimeout = mUSBSetupTimeout = systemTime() + (bootLoader_count ? 1000000000 : 500000000);
+        mDevicesToProcess = bootLoader_count;
+        LOGE("usb_setup_init, %d dfu devices, %d TM2 devices, time=%lu , min timeout =%lu", bootLoader_count, TM_count, systemTime(), mUSBSetupTimeout);
+        break;
+    case usb_setup_progress:
+        // New devices discovered during the setup phase will add 1 sec
+        if (bootLoader_count)
+        {
+            mUSBSetupTimeout = systemTime() + 1000000000;
+            mDevicesToProcess += bootLoader_count;
+            LOGE("usb_setup_progress, %d new dfu devices, time=%lu, new timeout=%lu", bootLoader_count, systemTime(), mUSBSetupTimeout);
+        }
+
+        if (TM_count)
+        {
+            LOGE("New TM2 discovered were  %d time=%lu, timeout=%lu", TM_count, systemTime(), mUSBSetupTimeout);
+        }
+        mDevicesToProcess -= TM_count;
+
+        if (systemTime() >= mUSBSetupTimeout)
+        {
+            mInitialized = usb_setup_timeout;
+            LOGE("EnumerateDevices: ,timeout occurred time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
+        }
+        else
+        {
+            if ((systemTime() >= mUSBMinTimeout) && (!mDevicesToProcess))
+            {
+                mInitialized = usb_setup_success;
+                LOGE("EnumerateDevices: ,usb_setup_success time=%lu, timeout=%lu", systemTime(), mUSBSetupTimeout);
+            }
+            // else wait for process co complete
+        }
+        break;
+    default: // Init completed
+        break;
+    }
+
+    if (mInitialized & (usb_setup_success | usb_setup_timeout))
+        mNextScanIntervalMs = ENUMERATE_TIMEOUT_NSEC;
 }

--- a/third-party/libtm/libtm/src/UsbPlugListener.h
+++ b/third-party/libtm/libtm/src/UsbPlugListener.h
@@ -17,10 +17,8 @@
 #define TM2_DEV_VID 0x8087
 #define TM2_T265_PID 0x0B37
 #define TM2_T260_PID 0x0AF3
-#define TM2_UDF_DEV_VID 0x03E7
-#define TM2_UDF_DEV_PID 0x2150
-#define ENUMERATE_TIMEOUT_NSEC 500000000
-
+#define TM2_DFU_DEV_VID 0x03E7
+#define TM2_DFU_DEV_PID 0x2150
 
 namespace perc
 {
@@ -36,16 +34,18 @@ namespace perc
             virtual Dispatcher& dispatcher() = 0;
         };
 
-    public:
         UsbPlugListener(Owner& owner);
         ~UsbPlugListener();
         
         bool identifyDevice(libusb_device_descriptor* desc);
-        bool identifyUDFDevice(libusb_device_descriptor* desc);
+        bool identifyDFUDevice(libusb_device_descriptor* desc);
 
         // [interface] EventHandler
         virtual void onTimeout(uintptr_t timerId, const Message &msg);
         static const char *usbSpeed(uint16_t bcdUSB);
+
+        enum usb_setup_e { usb_setup_init = 1, usb_setup_progress = 1<<1, usb_setup_success = 1<<2, usb_setup_timeout= 1<<3};
+        bool isInitialized(void) const { return mInitialized & (usb_setup_success | usb_setup_timeout); }
 
     private:
         void EnumerateDevices();
@@ -106,5 +106,11 @@ namespace perc
         };
         std::map<DeviceToPortMap, bool> mDeviceToPortMap;
         std::mutex mDeviceToPortMapLock;
+
+        size_t                  mNextScanIntervalMs;             // Calculate the next time USB devices scan will be scheduled
+        std::atomic<usb_setup_e> mInitialized;
+        nsecs_t                 mUSBSetupTimeout;
+        nsecs_t                 mUSBMinTimeout;
+        size_t                  mDevicesToProcess;
     };
 }

--- a/third-party/libtm/libtm/src/UsbPlugListener.h
+++ b/third-party/libtm/libtm/src/UsbPlugListener.h
@@ -45,7 +45,7 @@ namespace perc
         static const char *usbSpeed(uint16_t bcdUSB);
 
         enum usb_setup_e { usb_setup_init = 1, usb_setup_progress = 1<<1, usb_setup_success = 1<<2, usb_setup_timeout= 1<<3};
-        bool isInitialized(void) const { return mInitialized & (usb_setup_success | usb_setup_timeout); }
+        bool isInitialized(void) const { return mInitialized.load() & (usb_setup_success | usb_setup_timeout); }
 
     private:
         void EnumerateDevices();

--- a/third-party/libtm/libtm/src/infra/Log.cpp
+++ b/third-party/libtm/libtm/src/infra/Log.cpp
@@ -100,7 +100,6 @@ const char* logPrioritySign[] = { "U" ,/* LOG_UNKNOWN */
 const LogVerbosityLevel prio2verbosity[] = {None, None, Verbose, Debug, Trace, Info, Warning, Error, Error, None};
 
 // LOG_FATAL is always enabled by default
-//Ev #define isPriorityEnabled(prio)     (LOG_FATAL == prio || (gLogManager.configuration[LogSourceHost].verbosityMask & LOG_PRI2MASK(prio)))
 bool isPriorityEnabled(int prio)
 {
     return (LOG_FATAL == prio || (gLogManager.configuration[LogSourceHost].verbosityMask & LOG_PRI2MASK(prio)));

--- a/third-party/libtm/libtm/src/infra/Log.cpp
+++ b/third-party/libtm/libtm/src/infra/Log.cpp
@@ -100,7 +100,11 @@ const char* logPrioritySign[] = { "U" ,/* LOG_UNKNOWN */
 const LogVerbosityLevel prio2verbosity[] = {None, None, Verbose, Debug, Trace, Info, Warning, Error, Error, None};
 
 // LOG_FATAL is always enabled by default
-#define isPriorityEnabled(prio)     (LOG_FATAL == prio || (gLogManager.configuration[LogSourceHost].verbosityMask & LOG_PRI2MASK(prio)))
+//Ev #define isPriorityEnabled(prio)     (LOG_FATAL == prio || (gLogManager.configuration[LogSourceHost].verbosityMask & LOG_PRI2MASK(prio)))
+bool isPriorityEnabled(int prio)
+{
+    return (LOG_FATAL == prio || (gLogManager.configuration[LogSourceHost].verbosityMask & LOG_PRI2MASK(prio)));
+}
 
 void __perc_Log_write(int prio, const char *tag, const char *text)
 {


### PR DESCRIPTION
T265: make context::query_devices to discover and enumerate device in a robust and deterministic manner.

Changes: 
1. Implement device discovery and proper enumeration flow:
- Invoke device discovery events
- Wait for a predefined amount of time.
- For each discovered DFU-mode device:
	- extend the timeout  ( bounded by global max timeout)
	- Track DFU vs FW-Loaded devices.
- Stop when all DFU-devices have been loaded, or alternatively a timeout occurred.
2. Device_hub to use internal device event callback instead of overriding user-defined callback 
3.  Examples utils - add support pose and motion data render  (pose as text). Adjust demos affected by the change: `rs-record-playback`, `rs-align`, `rs-measure`.
4 Reorder query_devices to prioritize D400 over T265
5. `rs-multicam`:
  - Rework to handle hw events in the main thread instead of callback. 
 -  Adapt for high-fps rate devices
5. `rs-enumerate-devices`  - to provide a robust enumeration of all the connected T265 devices on startup (tested with up to four units)

Optimizations& Bug fixes:
 - Reducing TM2 initialization time by 500 msec
 - Device_hub to track TM2 connect events
 - T265 logger initialization to prevent race condition with the FSM thread startup logs
 - T265 6DOF Pose frame rate - 200fps and not as previously stated
 - Uninitialized T265 intrinsic parameter
 - TM2 Header compilation dependency
 - GCC/Cland-proposed fixes

Addresses #3488, #3465, #3361,  also related to #3437, #3434
Tracked on: TM2-4235