### PR TITLE
changed conditions order to avoid segfault

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3182,7 +3182,7 @@ namespace rs2
                 data = "[";
                 std::string comma = "";
                 unsigned int i = 0;
-                while ((pose.floatData[i] != FLT_MAX) && (i<4))
+                while ((i<4) && (pose.floatData[i] != FLT_MAX))
                 {
 
                     data += to_string() << std::fixed << std::setprecision(pose.precision) << (pose.signedNumber ? std::showpos : std::noshowpos) << comma << pose.floatData[i];


### PR DESCRIPTION
Fixed segmentation fault in viewer (occurred when showing pose info overlay for T265).

Fixes: #3423