### PR TITLE
Fixed rs-convert crash

### DIFF
--- a/tools/convert/rs-convert.cpp
+++ b/tools/convert/rs-convert.cpp
@@ -105,18 +105,17 @@ int main(int argc, char** argv) try
     auto frameNumber = 0ULL;
     
     rs2::frameset frameset;
+    uint64_t posLast = playback.get_position();
     while (pipe->try_wait_for_frames(&frameset, 1000)) 
     {
-        int posP = static_cast<int>(playback.get_position() * 100. / duration.count());
+        int posP = static_cast<int>(posLast * 100. / duration.count());
 
         if (posP > progress) {
             progress = posP;
             cout << posP << "%" << "\r" << flush;
         }
 
-        if (frameset[0].get_frame_number() < frameNumber) {
-            break;
-        }
+
 
         frameNumber = frameset[0].get_frame_number();
 
@@ -129,6 +128,11 @@ int main(int argc, char** argv) try
             [] (shared_ptr<rs2::tools::converter::converter_base>& converter) {
                 converter->wait();
             });
+        const uint64_t posCurr = playback.get_position();
+        if(static_cast<int64_t>(posCurr - posLast) < 0){
+            break;
+        }
+        posLast = posCurr;
     }
 
     cout << endl;


### PR DESCRIPTION
In `rs-convert`, the loop termination condition is based on the frame number.

Sometimes something weird may happen: the frame with lower frame number will arrive after the frames with higher frame numbers, e.g., the frame 991 first, then frame 990. This situation is rare, but it happens, and the loop termination condition may cause the `rs-convert` to terminate before converting all the frames, as described in issue #3208 and #1919. 

Inspired by @UnaNancyOwen in [his tool](https://github.com/UnaNancyOwen/rs_bag2image), I changed the termination condition to the playback position, which will not cause early terminations in such situation.

