### PR TITLE
CMake improvements for Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,12 @@ lib/
 ubuntu-xenial/
 ubuntu-xenial-hwe/
 
+# Docs
+doc/doxygen/html/
+*.html.lnk
+
 # CMake
-build/
+build*/
 connectivity_check
 
 # XCode
@@ -83,4 +87,3 @@ librealsense-log.txt
 *.json
 *.ini
 *.cxx
-

--- a/CMake/windows_config.cmake
+++ b/CMake/windows_config.cmake
@@ -8,9 +8,7 @@ macro(os_set_flags)
     # Makes VS15 find the DLL when trying to run examples/tests
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-    # build with multiple cores
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+
     ## Check for Windows Version ##
     if( (${CMAKE_SYSTEM_VERSION} EQUAL 6.1) OR (FORCE_WINUSB_UVC) ) # Windows 7
         message(STATUS "Build for Win7")
@@ -26,7 +24,17 @@ macro(os_set_flags)
         set(BACKEND RS2_USE_WINUSB_UVC_BACKEND)
     endif()
 
-    if (MSVC)
+    if(MSVC)
+        # Set CMAKE_DEBUG_POSTFIX to "d" to add a trailing "d" to library
+        # built in debug mode. In this Windows user can compile, build and install the
+        # library in both Release and Debug configuration avoiding naming clashes in the
+        # installation directories.
+        set(CMAKE_DEBUG_POSTFIX "d")
+
+        # build with multiple cores
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /wd4819")
         set(LRS_TRY_USE_AVX true)
         add_definitions(-D_UNICODE)


### PR DESCRIPTION
This PR is a followup of issue #3597 that tries to address the problem of #3483 and to add `CMAKE_DEBUG_POSTFIX` when compiling with `MS Visual Studio` and emulators (those that are recognized by CMake as `MSVC` generators).

The main difference lies in `third-party/libtm/resources/CMakeLists.txt` where multiple `file(APPEND ...)` commands are replaced with a single `file(WRITE ...)` command. This is to resolve a problem where sometimes the files where malformed.
⚠️ Note that strange indentation of the `file(WRITE ...)` commands is necessary to have a proper indentation in the generated files. If you don't like it (I personally don't 😄) I reformat the string into a single line by adding `\n`s, but I think the result is even uglier than the former and much less readable 🙃.

I also added two new entries in the `.gitignore` file:
 1. exclude all folders that starts with `build`, for example I may have a folder `build` for Release and a `buildd` folder for Debug.
 2. exclude the doxygen-generated documentation files.

Note that in order to close #3597 we also need #3507 to be merged.

Fixes #3483.