### PR TITLE
[Unity] Support linear color space

### DIFF
--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsStreamTextureRenderer.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsStreamTextureRenderer.cs
@@ -180,8 +180,9 @@ public class RsStreamTextureRenderer : MonoBehaviour
             }
 
             using (var p = frame.Profile) {
-                bool isGammaColorSpace = QualitySettings.activeColorSpace == ColorSpace.Gamma;
-                texture = new Texture2D(frame.Width, frame.Height, Convert(p.Format), false, isGammaColorSpace)
+                bool linear = (QualitySettings.activeColorSpace != ColorSpace.Linear)
+                    || (p.Stream != Stream.Color && p.Stream != Stream.Infrared);
+                texture = new Texture2D(frame.Width, frame.Height, Convert(p.Format), false, linear)
                 {
                     wrapMode = TextureWrapMode.Clamp,
                     filterMode = filterMode

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsStreamTextureRenderer.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsStreamTextureRenderer.cs
@@ -180,7 +180,8 @@ public class RsStreamTextureRenderer : MonoBehaviour
             }
 
             using (var p = frame.Profile) {
-                texture = new Texture2D(frame.Width, frame.Height, Convert(p.Format), false, true)
+                bool isGammaColorSpace = QualitySettings.activeColorSpace == ColorSpace.Gamma;
+                texture = new Texture2D(frame.Width, frame.Height, Convert(p.Format), false, isGammaColorSpace)
                 {
                     wrapMode = TextureWrapMode.Clamp,
                     filterMode = filterMode


### PR DESCRIPTION
When color mode setting is Linear, a color image texture looks brighter than it actually is.
This PR fixes the problem.

![image](https://user-images.githubusercontent.com/4415085/55623053-cb7e8980-57dc-11e9-85fc-37fadfef1475.png)
