### PR TITLE
WinOS Metadata Script: fix D435i PID for headless+module

### DIFF
--- a/scripts/realsense_metadata_win10.ps1
+++ b/scripts/realsense_metadata_win10.ps1
@@ -68,10 +68,12 @@ $MultiPinDevices =
     "USB\VID_8086&PID_0B07&MI_00",# D430+RGB(AWGC)
     "USB\VID_8086&PID_0B0C&MI_00",# D405
     "USB\VID_8086&PID_0B0D&MI_00",# L500
+    "USB\VID_8086&PID_0B3A&MI_00",# D435i
     "USB\VID_8086&PID_0B3D&MI_00",# L515
-    "USB\VID_8086&PID_0B18&MI_00",# D435i
-    "USB\VID_8086&PID_0B4B&MI_00" # D430i
-	
+    "USB\VID_8086&PID_0B49&MI_00",# D416
+    "USB\VID_8086&PID_0B4B&MI_00",# D430i
+    "USB\VID_8086&PID_0B4D&MI_00" # D465
+
 #Inhibit system warnings and erros, such as permissions or missing values
 $ErrorActionPreference = "silentlycontinue"
 


### PR DESCRIPTION
Register PIDs for additional SKUs