### PR TITLE
W10 support

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -1280,6 +1280,9 @@ namespace rs2
 				}
 				break;
 			}
+            case RS2_FORMAT_Y10BPACK:
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
+                break;
 			//case RS2_FORMAT_RAW10:
 			//{
 			//    // Visualize Raw10 by performing a naive down sample. Each 2x2 block contains one red pixel, two green pixels, and one blue pixel, so combine them into a single RGB triple.

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -1189,16 +1189,16 @@ namespace rs2
             glBindTexture(GL_TEXTURE_2D, texture);
             stride = stride == 0 ? width : stride;
             //glPixelStorei(GL_UNPACK_ROW_LENGTH, stride);
-			switch (format)
-			{
-			case RS2_FORMAT_ANY:
-				throw std::runtime_error("not a valid format");
-			case RS2_FORMAT_Z16:
-			case RS2_FORMAT_DISPARITY16:
-				if (frame.is<depth_frame>())
-				{
-					if (auto colorized_frame = colorize->colorize(frame).as<video_frame>())
-					{
+            switch (format)
+            {
+            case RS2_FORMAT_ANY:
+                throw std::runtime_error("not a valid format");
+            case RS2_FORMAT_Z16:
+            case RS2_FORMAT_DISPARITY16:
+                if (frame.is<depth_frame>())
+                {
+                    if (auto colorized_frame = colorize->colorize(frame).as<video_frame>())
+                    {
                         data = colorized_frame.get_data();
                         // Override the first pixel in the colorized image for occlusion invalidation.
                         memset((void*)data,0, colorized_frame.get_bytes_per_pixel());
@@ -1207,19 +1207,19 @@ namespace rs2
                             colorized_frame.get_height(),
                             0, GL_RGB, GL_UNSIGNED_BYTE,
                             colorized_frame.get_data());
-						rendered_frame = colorized_frame;
-					}
-				}
-				else glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
+                        rendered_frame = colorized_frame;
+                    }
+                }
+                else glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
 
-				break;
-			case RS2_FORMAT_DISPARITY32:
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, data);
-				break;
-			case RS2_FORMAT_XYZ32F:
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_FLOAT, data);
-				break;
-			case RS2_FORMAT_YUYV:
+                break;
+            case RS2_FORMAT_DISPARITY32:
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, data);
+                break;
+            case RS2_FORMAT_XYZ32F:
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_FLOAT, data);
+                break;
+            case RS2_FORMAT_YUYV:
                 if (yuy2rgb)
                 {
                     if (auto colorized_frame = yuy2rgb->process(frame).as<video_frame>())
@@ -1233,79 +1233,79 @@ namespace rs2
                 {
                     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, data);
                 }
-				break;
-			case RS2_FORMAT_UYVY: // Use luminance component only to avoid costly UVUY->RGB conversion
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
-				break;
-			case RS2_FORMAT_RGB8: case RS2_FORMAT_BGR8: // Display both RGB and BGR by interpreting them RGB, to show the flipped byte ordering. Obviously, GL_BGR could be used on OpenGL 1.2+
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data);
-				break;
-			case RS2_FORMAT_RGBA8: case RS2_FORMAT_BGRA8: // Display both RGBA and BGRA by interpreting them RGBA, to show the flipped byte ordering. Obviously, GL_BGRA could be used on OpenGL 1.2+
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-				break;
-			case RS2_FORMAT_Y8:
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
-				break;
-			case RS2_FORMAT_MOTION_XYZ32F:
-			{
-				if (auto motion = frame.as<motion_frame>())
-				{
-					auto axes = motion.get_motion_data();
-					draw_motion_data(axes.x, axes.y, axes.z);
-				}
-				else
-				{
-					throw std::runtime_error("Not expecting a frame with motion format that is not a motion_frame");
-				}
-				break;
-			}
-			case RS2_FORMAT_Y16:
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
-				break;
-			case RS2_FORMAT_RAW8:
-			case RS2_FORMAT_MOTION_RAW:
-			case RS2_FORMAT_GPIO_RAW:
-				glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
-				break;
-			case RS2_FORMAT_6DOF:
-			{
-				if (auto pose = frame.as<pose_frame>())
-				{
-					rs2_pose pose_data = pose.get_pose_data();
-					draw_pose_data(pose_data, frame.get_profile().unique_id());
-				}
-				else
-				{
-					throw std::runtime_error("Not expecting a frame with 6DOF format that is not a pose_frame");
-				}
-				break;
-			}
+                break;
+            case RS2_FORMAT_UYVY: // Use luminance component only to avoid costly UVUY->RGB conversion
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
+                break;
+            case RS2_FORMAT_RGB8: case RS2_FORMAT_BGR8: // Display both RGB and BGR by interpreting them RGB, to show the flipped byte ordering. Obviously, GL_BGR could be used on OpenGL 1.2+
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data);
+                break;
+            case RS2_FORMAT_RGBA8: case RS2_FORMAT_BGRA8: // Display both RGBA and BGRA by interpreting them RGBA, to show the flipped byte ordering. Obviously, GL_BGRA could be used on OpenGL 1.2+
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
+                break;
+            case RS2_FORMAT_Y8:
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
+                break;
+            case RS2_FORMAT_MOTION_XYZ32F:
+            {
+                if (auto motion = frame.as<motion_frame>())
+                {
+                    auto axes = motion.get_motion_data();
+                    draw_motion_data(axes.x, axes.y, axes.z);
+                }
+                else
+                {
+                    throw std::runtime_error("Not expecting a frame with motion format that is not a motion_frame");
+                }
+                break;
+            }
+            case RS2_FORMAT_Y16:
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
+                break;
+            case RS2_FORMAT_RAW8:
+            case RS2_FORMAT_MOTION_RAW:
+            case RS2_FORMAT_GPIO_RAW:
+                glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
+                break;
+            case RS2_FORMAT_6DOF:
+            {
+                if (auto pose = frame.as<pose_frame>())
+                {
+                    rs2_pose pose_data = pose.get_pose_data();
+                    draw_pose_data(pose_data, frame.get_profile().unique_id());
+                }
+                else
+                {
+                    throw std::runtime_error("Not expecting a frame with 6DOF format that is not a pose_frame");
+                }
+                break;
+            }
             case RS2_FORMAT_Y10BPACK:
                 glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, data);
                 break;
-			//case RS2_FORMAT_RAW10:
-			//{
-			//    // Visualize Raw10 by performing a naive down sample. Each 2x2 block contains one red pixel, two green pixels, and one blue pixel, so combine them into a single RGB triple.
-			//    rgb.clear(); rgb.resize(width / 2 * height / 2 * 3);
-			//    auto out = rgb.data(); auto in0 = reinterpret_cast<const uint8_t *>(data), in1 = in0 + width * 5 / 4;
-			//    for (auto y = 0; y<height; y += 2)
-			//    {
-			//        for (auto x = 0; x<width; x += 4)
-			//        {
-			//            *out++ = in0[0]; *out++ = (in0[1] + in1[0]) / 2; *out++ = in1[1]; // RGRG -> RGB RGB
-			//            *out++ = in0[2]; *out++ = (in0[3] + in1[2]) / 2; *out++ = in1[3]; // GBGB
-			//            in0 += 5; in1 += 5;
-			//        }
-			//        in0 = in1; in1 += width * 5 / 4;
-			//    }
-			//    glPixelStorei(GL_UNPACK_ROW_LENGTH, width / 2);        // Update row stride to reflect post-downsampling dimensions of the target texture
-			//    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width / 2, height / 2, 0, GL_RGB, GL_UNSIGNED_BYTE, rgb.data());
-			//}
-			//break;
-			default:
-				throw std::runtime_error("The requested format is not supported for rendering");
-			}
-			
+            //case RS2_FORMAT_RAW10:
+            //{
+            //    // Visualize Raw10 by performing a naive down sample. Each 2x2 block contains one red pixel, two green pixels, and one blue pixel, so combine them into a single RGB triple.
+            //    rgb.clear(); rgb.resize(width / 2 * height / 2 * 3);
+            //    auto out = rgb.data(); auto in0 = reinterpret_cast<const uint8_t *>(data), in1 = in0 + width * 5 / 4;
+            //    for (auto y = 0; y<height; y += 2)
+            //    {
+            //        for (auto x = 0; x<width; x += 4)
+            //        {
+            //            *out++ = in0[0]; *out++ = (in0[1] + in1[0]) / 2; *out++ = in1[1]; // RGRG -> RGB RGB
+            //            *out++ = in0[2]; *out++ = (in0[3] + in1[2]) / 2; *out++ = in1[3]; // GBGB
+            //            in0 += 5; in1 += 5;
+            //        }
+            //        in0 = in1; in1 += width * 5 / 4;
+            //    }
+            //    glPixelStorei(GL_UNPACK_ROW_LENGTH, width / 2);        // Update row stride to reflect post-downsampling dimensions of the target texture
+            //    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width / 2, height / 2, 0, GL_RGB, GL_UNSIGNED_BYTE, rgb.data());
+            //}
+            //break;
+            default:
+                throw std::runtime_error("The requested format is not supported for rendering");
+            }
+            
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/examples/example.hpp
+++ b/examples/example.hpp
@@ -411,6 +411,9 @@ public:
         case RS2_FORMAT_Y8:
             glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, frame.get_data());
             break;
+        case RS2_FORMAT_Y10BPACK:
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_SHORT, frame.get_data());
+            break;
         default:
             throw std::runtime_error("The requested format is not supported by this demo!");
         }
@@ -659,6 +662,7 @@ private:
         case RS2_FORMAT_RGBA8:
         case RS2_FORMAT_Y8:
         case RS2_FORMAT_MOTION_XYZ32F:
+        case RS2_FORMAT_Y10BPACK:
             return true;
         default:
             return false;

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -73,6 +73,7 @@ extern "C" {
         RS2_OPTION_LLD_TEMPERATURE, /**< LLD temperature*/
         RS2_OPTION_MC_TEMPERATURE, /**< MC temperature*/
         RS2_OPTION_MA_TEMPERATURE, /**< MA temperature*/
+        RS2_OPTION_HARDWARE_PRESET, /**< Hardware stream configuration */
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 

--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -65,7 +65,7 @@ typedef enum rs2_format
     RS2_FORMAT_BGRA8           , /**< 8-bit blue, green, and red channels + constant alpha channel equal to FF */
     RS2_FORMAT_Y8              , /**< 8-bit per-pixel grayscale image */
     RS2_FORMAT_Y16             , /**< 16-bit per-pixel grayscale image */
-    RS2_FORMAT_RAW10           , /**< Four 10-bit luminance values encoded into a 5-byte macropixel */
+    RS2_FORMAT_RAW10           , /**< Four 10 bits per pixel luminance values packed into a 5-byte macropixel */
     RS2_FORMAT_RAW16           , /**< 16-bit raw image */
     RS2_FORMAT_RAW8            , /**< 8-bit raw image */
     RS2_FORMAT_UYVY            , /**< Similar to the standard YUYV pixel format, but packed in a different order */
@@ -74,7 +74,7 @@ typedef enum rs2_format
     RS2_FORMAT_GPIO_RAW        , /**< Raw data from the external sensors hooked to one of the GPIO's */
     RS2_FORMAT_6DOF            , /**< Pose data packed as floats array, containing translation vector, rotation quaternion and prediction velocities and accelerations vectors */
     RS2_FORMAT_DISPARITY32     , /**< 32-bit float-point disparity values. Depth->Disparity conversion : Disparity = Baseline*FocalLength/Depth */
-    RS2_FORMAT_Y10BPACK        , /**< 16-bit per-pixel grayscale image unpacked from 10 bits per pixel packed grey-scale image. The data is unpacked to LSB and padded with 6 zero bits */
+    RS2_FORMAT_Y10BPACK        , /**< 16-bit per-pixel grayscale image unpacked from 10 bits per pixel packed ([8:8:8:8:2222]) grey-scale image. The data is unpacked to LSB and padded with 6 zero bits */
     RS2_FORMAT_COUNT             /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_format;
 const char* rs2_format_to_string(rs2_format format);

--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -74,6 +74,7 @@ typedef enum rs2_format
     RS2_FORMAT_GPIO_RAW        , /**< Raw data from the external sensors hooked to one of the GPIO's */
     RS2_FORMAT_6DOF            , /**< Pose data packed as floats array, containing translation vector, rotation quaternion and prediction velocities and accelerations vectors */
     RS2_FORMAT_DISPARITY32     , /**< 32-bit float-point disparity values. Depth->Disparity conversion : Disparity = Baseline*FocalLength/Depth */
+    RS2_FORMAT_Y10BPACK        , /**< 16-bit per-pixel grayscale image unpacked from 10 bits per pixel packed grey-scale image. The data is unpacked to LSB and padded with 6 zero bits */
     RS2_FORMAT_COUNT             /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_format;
 const char* rs2_format_to_string(rs2_format format);

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -263,6 +263,8 @@ namespace librealsense
         virtual void tag_profiles(stream_profiles profiles) const = 0;
 
         virtual bool compress_while_record() const = 0;
+
+        virtual bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) = 0;
     };
 
     class depth_stereo_sensor;

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -264,7 +264,7 @@ namespace librealsense
 
         virtual bool compress_while_record() const = 0;
 
-        virtual bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) = 0;
+        virtual bool contradicts(const stream_profile_interface* a, const std::vector<stream_profile>& others) const = 0;
     };
 
     class depth_stereo_sensor;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -293,3 +293,24 @@ void librealsense::device::tag_profiles(stream_profiles profiles) const
         }
     }
 }
+
+bool librealsense::device::contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others)
+{
+    if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+    {
+        for (auto request : others)
+        {
+            if (a->get_framerate() != 0 && request.fps != 0 && (a->get_framerate() != request.fps))
+                return true;
+        }
+
+        for (auto request : others)
+        {
+            if (vid_a->get_width() != 0 && request.width != 0 && (vid_a->get_width() != request.width))
+                return true;
+            if (vid_a->get_height() != 0 && request.height != 0 && (vid_a->get_height() != request.height))
+                return true;
+        }
+    }
+    return false;
+}

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -294,18 +294,14 @@ void librealsense::device::tag_profiles(stream_profiles profiles) const
     }
 }
 
-bool librealsense::device::contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others)
+bool librealsense::device::contradicts(const stream_profile_interface* a, const std::vector<stream_profile>& others) const 
 {
-    if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+    if (auto vid_a = dynamic_cast<const video_stream_profile_interface*>(a))
     {
         for (auto request : others)
         {
             if (a->get_framerate() != 0 && request.fps != 0 && (a->get_framerate() != request.fps))
                 return true;
-        }
-
-        for (auto request : others)
-        {
             if (vid_a->get_width() != 0 && request.width != 0 && (vid_a->get_width() != request.width))
                 return true;
             if (vid_a->get_height() != 0 && request.height != 0 && (vid_a->get_height() != request.height))

--- a/src/device.h
+++ b/src/device.h
@@ -76,6 +76,7 @@ namespace librealsense
 
         virtual bool compress_while_record() const override { return true; }
 
+        virtual bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override;
     protected:
         int add_sensor(std::shared_ptr<sensor_interface> sensor_base);
         int assign_sensor(std::shared_ptr<sensor_interface> sensor_base, uint8_t idx);

--- a/src/device.h
+++ b/src/device.h
@@ -76,7 +76,7 @@ namespace librealsense
 
         virtual bool compress_while_record() const override { return true; }
 
-        virtual bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override;
+        virtual bool contradicts(const stream_profile_interface* a, const std::vector<stream_profile>& others) const override;
     protected:
         int add_sensor(std::shared_ptr<sensor_interface> sensor_base);
         int assign_sensor(std::shared_ptr<sensor_interface> sensor_base, uint8_t idx);

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -420,6 +420,13 @@ namespace librealsense
 
         auto pid_hex_str = hexify(pid);
 
+        if ((pid == RS416_PID) && _fw_version >= firmware_version("5.9.13.0"))
+        {
+            depth_ep.register_option(RS2_OPTION_HARDWARE_PRESET,
+                std::make_shared<uvc_xu_option<uint8_t>>(depth_ep, depth_xu, DS5_HARDWARE_PRESET,
+                    "Hardware pipe configuration"));
+        }
+
         std::string is_camera_locked{ "" };
         if (_fw_version >= firmware_version("5.6.3.0"))
         {

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -581,8 +581,6 @@ namespace librealsense
             return std::make_shared<rs410_device>(ctx, group, register_device_notifications);
         case RS415_PID:
             return std::make_shared<rs415_device>(ctx, group, register_device_notifications);
-        case RS416_PID:
-            return std::make_shared<rs416_device>(ctx, group, register_device_notifications);
         case RS420_PID:
             return std::make_shared<rs420_device>(ctx, group, register_device_notifications);
         case RS420_MM_PID:

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -91,21 +91,14 @@ namespace librealsense
             return tags;
         };
 
-        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override
+        bool contradicts(const stream_profile_interface* a, const std::vector<stream_profile>& others) const override
         {
-            if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+            if (auto vid_a = dynamic_cast<const video_stream_profile_interface*>(a))
             {
                 for (auto request : others)
                 {
                     if (a->get_framerate() != 0 && request.fps != 0 && (a->get_framerate() != request.fps))
                         return true;
-                }
-
-                for (auto request : others)
-                {
-                    // Patch for DS5U_S that allows different resolutions on multi-pin device
-                    if ((vid_a->get_height() == vid_a->get_width()) && (request.height == request.width))
-                        return false;
                 }
             }
             return false;
@@ -209,32 +202,26 @@ namespace librealsense
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 720, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 1, 1024, 1024, RS2_FORMAT_RAW10, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 2, 1024, 1024, RS2_FORMAT_RAW10, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1024, 1024, RS2_FORMAT_Y10BPACK, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1024, 1024, RS2_FORMAT_Y10BPACK, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 576, 576, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 1, 576, 576, RS2_FORMAT_RAW10, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 2, 576, 576, RS2_FORMAT_RAW10, 15, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 576, 576, RS2_FORMAT_Y10BPACK, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 576, 576, RS2_FORMAT_Y10BPACK, 15, profile_tag::PROFILE_TAG_SUPERSET });
             }
             return tags;
         };
 
-        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override
+        bool contradicts(const stream_profile_interface* a, const std::vector<stream_profile>& others) const override
         {
-            if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+            if (auto vid_a = dynamic_cast<const video_stream_profile_interface*>(a))
             {
                 for (auto request : others)
                 {
                     if (a->get_framerate() != 0 && request.fps != 0 && (a->get_framerate() != request.fps))
                         return true;
-                }
-
-                for (auto request : others)
-                {
-                    if ((vid_a->get_height() == vid_a->get_width()) && (request.height == request.width))
-                        return false;
                 }
             }
             return false;

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -90,6 +90,26 @@ namespace librealsense
             }
             return tags;
         };
+
+        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override
+        {
+            if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+            {
+                for (auto request : others)
+                {
+                    if (a->get_framerate() != 0 && request.fps != 0 && (a->get_framerate() != request.fps))
+                        return true;
+                }
+
+                for (auto request : others)
+                {
+                    // Patch for DS5U_S that allows different resolutions on multi-pin device
+                    if ((vid_a->get_height() == vid_a->get_width()) && (request.height == request.width))
+                        return false;
+                }
+            }
+            return false;
+        }
     };
 
     // ASR (D460)
@@ -165,6 +185,60 @@ namespace librealsense
             }
             return tags;
         };
+    };
+
+    class rs416_device : public ds5_rolling_shutter,
+        public ds5_active, public ds5_advanced_mode_base
+    {
+    public:
+        rs416_device(std::shared_ptr<context> ctx,
+            const platform::backend_device_group& group,
+            bool register_device_notifications)
+            : device(ctx, group, register_device_notifications),
+            ds5_device(ctx, group),
+            ds5_rolling_shutter(ctx, group),
+            ds5_active(ctx, group),
+            ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor()) {}
+
+        std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
+
+        std::vector<tagged_profile> get_profiles_tags() const override
+        {
+            std::vector<tagged_profile> tags;
+            auto usb_spec = get_usb_spec();
+            if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 720, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 1024, 1024, RS2_FORMAT_RAW10, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 1024, 1024, RS2_FORMAT_RAW10, 30, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            else
+            {
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 576, 576, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 576, 576, RS2_FORMAT_RAW10, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 576, 576, RS2_FORMAT_RAW10, 15, profile_tag::PROFILE_TAG_SUPERSET });
+            }
+            return tags;
+        };
+
+        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override
+        {
+            if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+            {
+                for (auto request : others)
+                {
+                    if (a->get_framerate() != 0 && request.fps != 0 && (a->get_framerate() != request.fps))
+                        return true;
+                }
+
+                for (auto request : others)
+                {
+                    if ((vid_a->get_height() == vid_a->get_width()) && (request.height == request.width))
+                        return false;
+                }
+            }
+            return false;
+        }
     };
 
     // PWGT
@@ -520,6 +594,8 @@ namespace librealsense
             return std::make_shared<rs410_device>(ctx, group, register_device_notifications);
         case RS415_PID:
             return std::make_shared<rs415_device>(ctx, group, register_device_notifications);
+        case RS416_PID:
+            return std::make_shared<rs416_device>(ctx, group, register_device_notifications);
         case RS420_PID:
             return std::make_shared<rs420_device>(ctx, group, register_device_notifications);
         case RS420_MM_PID:
@@ -666,6 +742,16 @@ namespace librealsense
         if (frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
         {
             return matcher_factory::create(RS2_MATCHER_DLR_C, streams);
+        }
+        return matcher_factory::create(RS2_MATCHER_DEFAULT, streams);
+    }
+
+    std::shared_ptr<matcher> rs416_device::create_matcher(const frame_holder& frame) const
+    {
+        std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get() };
+        if (frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
+        {
+            return matcher_factory::create(RS2_MATCHER_DLR, streams);
         }
         return matcher_factory::create(RS2_MATCHER_DEFAULT, streams);
     }

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -18,6 +18,7 @@ namespace librealsense
         const uint16_t RS400_PID        = 0x0ad1; // PSR
         const uint16_t RS410_PID        = 0x0ad2; // ASR
         const uint16_t RS415_PID        = 0x0ad3; // ASRC
+        const uint16_t RS416_PID        = 0x0b49;
         const uint16_t RS430_PID        = 0x0ad4; // AWG
         const uint16_t RS430I_PID       = 0x0b4b; // D430i
         const uint16_t RS430_MM_PID     = 0x0ad5; // AWGT
@@ -38,6 +39,7 @@ namespace librealsense
         const uint8_t DS5_DEPTH_EMITTER_ENABLED           = 2;
         const uint8_t DS5_EXPOSURE                        = 3;
         const uint8_t DS5_LASER_POWER                     = 4;
+        const uint8_t DS5_HARDWARE_PRESET                 = 6;
         const uint8_t DS5_ERROR_REPORTING                 = 7;
         const uint8_t DS5_EXT_TRIGGER                     = 8;
         const uint8_t DS5_ASIC_AND_PROJECTOR_TEMPERATURES = 9;
@@ -49,6 +51,7 @@ namespace librealsense
             ds::RS400_PID,
             ds::RS410_PID,
             ds::RS415_PID,
+            ds::RS416_PID,
             ds::RS430_PID,
             ds::RS430I_PID,
             ds::RS430_MM_PID,
@@ -95,6 +98,7 @@ namespace librealsense
             { RS410_PID,        "Intel RealSense D410"},
             { RS410_MM_PID,     "Intel RealSense D410 with Tracking Module"},
             { RS415_PID,        "Intel RealSense D415"},
+            { RS416_PID,        "Intel RealSense D416"},
             { RS420_PID,        "Intel RealSense D420"},
             { RS420_MM_PID,     "Intel RealSense D420 with Tracking Module"},
             { RS430_PID,        "Intel RealSense D430"},

--- a/src/ds5/ds5-rolling-shutter.cpp
+++ b/src/ds5/ds5-rolling-shutter.cpp
@@ -37,6 +37,7 @@ namespace librealsense
             // RS400 rolling-shutter Skus allow to get low-quality color image from the same viewport as the depth
             get_depth_sensor().register_pixel_format(pf_uyvyl);
             get_depth_sensor().register_pixel_format(pf_rgb888);
+            get_depth_sensor().register_pixel_format(pf_w10);
         }
 
         get_depth_sensor().unregister_option(RS2_OPTION_EMITTER_ON_OFF);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -69,6 +69,7 @@ namespace librealsense
         case RS2_FORMAT_Y8: return 8;
         case RS2_FORMAT_Y16: return 16;
         case RS2_FORMAT_RAW10: return 10;
+        case RS2_FORMAT_Y10BPACK: return 16;
         case RS2_FORMAT_RAW16: return 16;
         case RS2_FORMAT_RAW8: return 8;
         case RS2_FORMAT_UYVY: return 16;
@@ -228,8 +229,24 @@ namespace librealsense
 
     void copy_raw10(byte * const dest[], const byte * source, int width, int height)
     {
-        auto count = width * height;
-        librealsense::copy(dest[0], source, (5 * (count / 4)));
+        auto count = width * height; // num of pixels
+        librealsense::copy(dest[0], source, (5.0 * (count / 4.0)));
+    }
+
+    void unpack_y10bpack(byte * const dest[], const byte * source, int width, int height)
+    {
+         auto count = width * height / 4; // num of pixels
+         uint8_t  * from = (uint8_t*)(source);
+         uint16_t * to = (uint16_t*)(dest[0]);
+
+        // Put the 10 bit into the msb of uint16_t
+         for (int i = 0; i < count; i++, from +=5) // traverse macro-pixels
+         {
+            *to++ = ((from[0] << 2) | ( from[4] & 3)) << 6;
+            *to++ = ((from[1] << 2) | ((from[4] >> 2) & 3)) << 6;
+            *to++ = ((from[2] << 2) | ((from[4] >> 4) & 3)) << 6;
+            *to++ = ((from[3] << 2) | ((from[4] >> 6) & 3)) << 6;
+         }
     }
 
     template<class SOURCE, class UNPACK> void unpack_pixels(byte * const dest[], int count, const SOURCE * source, UNPACK unpack)
@@ -1027,8 +1044,8 @@ namespace librealsense
     const native_pixel_format pf_rw16                     = { 'RW16', 1, 2, {  { false,               &copy_pixels<2>,                               { { RS2_STREAM_COLOR,          RS2_FORMAT_RAW16 } } } } };
     const native_pixel_format pf_bayer16                  = { 'BYR2', 1, 2, {  { false,               &copy_pixels<2>,                               { { RS2_STREAM_COLOR,          RS2_FORMAT_RAW16 } } } } };
     const native_pixel_format pf_rw10                     = { 'pRAA', 1, 1, {  { false,               &copy_raw10,                                   { { RS2_STREAM_COLOR,          RS2_FORMAT_RAW10 } } } } };
-    // W10 development format will be exposed to the user via Y8
-    const native_pixel_format pf_w10                      = { 'W10 ', 1, 1, {  { true,                &unpack_y8_from_rw10,                        { { { RS2_STREAM_INFRARED, 1 },  RS2_FORMAT_Y8 } } } } };
+    const native_pixel_format pf_w10                      = { 'W10 ', 1, 2, {  { true,                &copy_raw10,                                   { { { RS2_STREAM_INFRARED, 1 },  RS2_FORMAT_RAW10 } } },
+                                                                               { true,                &unpack_y10bpack,                              { { { RS2_STREAM_INFRARED, 1 },  RS2_FORMAT_Y10BPACK } } } } };
 
     const native_pixel_format pf_yuy2                     = { 'YUY2', 1, 2, {  { true,                &unpack_yuy2<RS2_FORMAT_RGB8 >,                { { RS2_STREAM_COLOR,          RS2_FORMAT_RGB8 } } },
                                                                                { true,                &unpack_yuy2<RS2_FORMAT_Y16>,                  { { RS2_STREAM_COLOR,          RS2_FORMAT_Y16 } } },

--- a/src/media/playback/playback_device.h
+++ b/src/media/playback/playback_device.h
@@ -56,7 +56,7 @@ namespace librealsense
         }
 
         bool compress_while_record() const override { return true; }
-        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override { return false; }
+        bool contradicts(const stream_profile_interface* a, const std::vector<stream_profile>& others) const override { return false; }
 
     private:
         void update_time_base(device_serializer::nanoseconds base_timestamp);

--- a/src/media/playback/playback_device.h
+++ b/src/media/playback/playback_device.h
@@ -56,6 +56,7 @@ namespace librealsense
         }
 
         bool compress_while_record() const override { return true; }
+        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override { return false; }
 
     private:
         void update_time_base(device_serializer::nanoseconds base_timestamp);

--- a/src/media/record/record_device.h
+++ b/src/media/record/record_device.h
@@ -46,6 +46,8 @@ namespace librealsense
         std::vector<tagged_profile> get_profiles_tags() const override { return m_device->get_profiles_tags(); };
         void tag_profiles(stream_profiles profiles) const override { m_device->tag_profiles(profiles); }
         bool compress_while_record() const override { return true; }
+        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override { return m_device->contradicts(a, others); }
+
     private:
         template <typename T> void write_device_extension_changes(const T& ext);
         template <rs2_extension E, typename P> bool extend_to_aux(std::shared_ptr<P> p, void** ext);

--- a/src/media/record/record_device.h
+++ b/src/media/record/record_device.h
@@ -46,7 +46,7 @@ namespace librealsense
         std::vector<tagged_profile> get_profiles_tags() const override { return m_device->get_profiles_tags(); };
         void tag_profiles(stream_profiles profiles) const override { m_device->tag_profiles(profiles); }
         bool compress_while_record() const override { return true; }
-        bool contradicts(stream_profile_interface* a, const std::vector<stream_profile>& others) override { return m_device->contradicts(a, others); }
+        bool contradicts(const stream_profile_interface* a, const std::vector<stream_profile>& others) const override { return m_device->contradicts(a, others); }
 
     private:
         template <typename T> void write_device_extension_changes(const T& ext);

--- a/src/pipeline/config.cpp
+++ b/src/pipeline/config.cpp
@@ -16,7 +16,7 @@ namespace librealsense
         {
             std::lock_guard<std::mutex> lock(_mtx);
             _resolved_profile.reset();
-            _stream_requests[{stream, index}] = { stream, index, width, height, format, fps };
+            _stream_requests[{stream, index}] = { stream, index, width, height, fps, format };
         }
 
         void config::enable_all_stream()
@@ -118,7 +118,7 @@ namespace librealsense
             for (auto&& req : _stream_requests)
             {
                 auto r = req.second;
-                config.enable_stream(r.stream, r.stream_index, r.width, r.height, r.format, r.fps);
+                config.enable_stream(r.stream, r.index, r.width, r.height, r.format, r.fps);
             }
             return std::make_shared<profile>(dev, config, _device_request.record_output);
         }

--- a/src/pipeline/config.h
+++ b/src/pipeline/config.h
@@ -55,7 +55,7 @@ namespace librealsense
             std::shared_ptr<profile> resolve(std::shared_ptr<device_interface> dev);
 
             device_request _device_request;
-            std::map<std::pair<rs2_stream, int>, util::config::request_type> _stream_requests;
+            std::map<std::pair<rs2_stream, int>, stream_profile> _stream_requests;
             std::mutex _mtx;
             bool _enable_all_streams = false;
             std::shared_ptr<profile> _resolved_profile;

--- a/src/pipeline/resolver.h
+++ b/src/pipeline/resolver.h
@@ -75,7 +75,7 @@ namespace librealsense
                 return true;
             }
 
-            static bool match(stream_profile_interface* a, const stream_profile& b)
+            static bool match(const stream_profile_interface* a, const stream_profile& b)
             {
                 if (a->get_stream_type() != RS2_STREAM_ANY && b.stream != RS2_STREAM_ANY && (a->get_stream_type() != b.stream))
                     return false;
@@ -86,7 +86,7 @@ namespace librealsense
                 if (a->get_framerate() != 0 && b.fps != 0 && (a->get_framerate() != b.fps))
                     return false;
 
-                if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+                if (auto vid_a = dynamic_cast<const video_stream_profile_interface*>(a))
                 {
                     if (vid_a->get_width() != 0 && b.width != 0 && (vid_a->get_width() != b.width))
                         return false;
@@ -97,10 +97,10 @@ namespace librealsense
                 return true;
             }
 
-            static bool has_wildcards(stream_profile_interface* a)
+            static bool has_wildcards(const stream_profile_interface* a)
             {
                 if (a->get_framerate() == 0 || a->get_stream_type() == RS2_STREAM_ANY || a->get_stream_index() == -1 || a->get_format() == RS2_FORMAT_ANY) return true;
-                if (auto vid_a = dynamic_cast<video_stream_profile_interface*>(a))
+                if (auto vid_a = dynamic_cast<const video_stream_profile_interface*>(a))
                 {
                     if (vid_a->get_width() == 0 || vid_a->get_height() == 0) return true;
                 }
@@ -250,7 +250,7 @@ namespace librealsense
                 return false;
             }*/
 
-           bool can_enable_stream(device_interface* dev, rs2_stream stream, int index, int width, int height, rs2_format format, int fps)
+           bool can_enable_stream(const device_interface* dev, rs2_stream stream, int index, int width, int height, rs2_format format, int fps)
            {
                config c(*this);
                c.enable_stream(stream, index, width, height, format, fps);
@@ -346,7 +346,7 @@ namespace librealsense
                 return sort_highest_framerate(lhs, rhs);
             }
 
-            static void auto_complete(std::vector<stream_profile> &requests, stream_profiles candidates, device_interface* dev)
+            static void auto_complete(std::vector<stream_profile> &requests, stream_profiles candidates, const device_interface* dev)
             {
                 for (auto & request : requests)
                 {
@@ -384,7 +384,7 @@ namespace librealsense
                 return r;
             }
 
-            stream_profiles map_sub_device(stream_profiles profiles, std::set<index_type> satisfied_streams, device_interface* dev) const
+            stream_profiles map_sub_device(stream_profiles profiles, std::set<index_type> satisfied_streams, const device_interface* dev) const
             {
                 stream_profiles rv;
                 try
@@ -432,7 +432,7 @@ namespace librealsense
                 return rv;
             }
 
-            std::multimap<int, std::shared_ptr<stream_profile_interface>> map_streams(device_interface* dev) const
+            std::multimap<int, std::shared_ptr<stream_profile_interface>> map_streams(const device_interface* dev) const
             {
                 std::multimap<int, std::shared_ptr<stream_profile_interface>> out;
                 std::set<index_type> satisfied_streams;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -283,6 +283,7 @@ namespace librealsense
             CASE(LLD_TEMPERATURE)
             CASE(MC_TEMPERATURE)
             CASE(MA_TEMPERATURE)
+            CASE(HARDWARE_PRESET)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE
@@ -313,6 +314,7 @@ namespace librealsense
             CASE(MOTION_XYZ32F)
             CASE(GPIO_RAW)
             CASE(6DOF)
+            CASE(Y10BPACK)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/StreamFormat.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/StreamFormat.java
@@ -20,7 +20,8 @@ public enum StreamFormat {
     MOTION_XYZ32F(16),
     GPIO_RAW(17),
     POSE(18),
-    DISPARITY32(19);
+    DISPARITY32(19),
+    Y10BPACK(20);
 
     private final int mValue;
 


### PR DESCRIPTION
The new **W10** stream profile allows to stream IR and Depth streams with different resolutions and same frame rate.
Using wild cards is currently limited when streaming combinations of IR and Depth.
If both IR and Depth are required, both profiles should be configured without wildcards.

For example the following configuration will fail:
```
    cfg.enable_stream(RS2_STREAM_DEPTH);
    cfg.enable_stream(RS2_STREAM_INFRARED, 1, 1920, 1080, RS2_FORMAT_Y10BPACK, 30);
```

While this configuration is valid:
```
    cfg.enable_stream(RS2_STREAM_DEPTH, 0, 640, 480, RS2_FORMAT_Z16, 30);
    cfg.enable_stream(RS2_STREAM_INFRARED, 1, 1920, 1080, RS2_FORMAT_Y10BPACK, 30);
```

The Color sensor as no limitations and the following configuration is also valid:
```
    cfg.enable_stream(RS2_STREAM_COLOR);
    cfg.enable_stream(RS2_STREAM_DEPTH, 0, 640, 480, RS2_FORMAT_Z16, 30);
    cfg.enable_stream(RS2_STREAM_INFRARED, 1, 1920, 1080, RS2_FORMAT_Y10BPACK, 30);
```

If only IR is configured (on the Depth sensor) any wildcard is valid:
```
    cfg.enable_stream(RS2_STREAM_COLOR);
    cfg.enable_stream(RS2_STREAM_INFRARED, RS2_FORMAT_Y10BPACK);
```
