### PR TITLE
Fix for HID timestamp trimming

### DIFF
--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -15,6 +15,8 @@
 
 namespace librealsense
 {
+    static const float TIMESTAMP_USEC_TO_MSEC = 0.001;
+
     ds5_timestamp_reader_from_metadata::ds5_timestamp_reader_from_metadata(std::unique_ptr<frame_timestamp_reader> backup_timestamp_reader)
         :_backup_timestamp_reader(std::move(backup_timestamp_reader)), _has_metadata(pins), one_time_note(false)
     {
@@ -164,16 +166,16 @@ namespace librealsense
 
         if(has_metadata(mode, fo.metadata, fo.metadata_size))
         {
-            //  The timestamps conversions path is as follows :
-            //          FW TS (32bit) ->    USB Phy Layer (no changes)  -> Host Driver TS (Extend to 64bit) ->  LRS read as 64 bit
-            // This flow introduces discrepancy with UVC stream which timestamps aer not extended to 64 bit by host driver both for Win and v4l backends.
+            //  The timestamps conversions path comprise of:
+            // FW TS (32bit) ->    USB Phy Layer (no changes)  -> Host Driver TS (Extend to 64bit) ->  LRS read as 64 bit
+            // The flow introduces discrepancy with UVC stream which timestamps aer not extended to 64 bit by host driver both for Win and v4l backends.
             // In order to allow for hw timestamp-based synchronization of Depth and IMU streams the latter will be trimmed to 32 bit.
             // To revert to the extended 64 bit TS uncomment the next line instead
             //auto timestamp = *((uint64_t*)((const uint8_t*)fo.metadata));
             auto timestamp = *((uint32_t*)((const uint8_t*)fo.metadata));
 
-            // The FW timestamps for HID are converted to Nanosec in Linux kernel. This may produce conflicts with MS API.
-            return static_cast<rs2_time_t>(timestamp * HID_TIMESTAMP_MULTIPLIER);
+            // HID timestamps are aligned to FW Default - usec units
+            return static_cast<rs2_time_t>(timestamp * TIMESTAMP_USEC_TO_MSEC);
         }
 
         if (!started)

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -559,6 +559,12 @@ namespace librealsense
                             auto hid_data_size = channel_size - HID_METADATA_SIZE;
 
                             sens_data.fo = {hid_data_size, metadata?HID_METADATA_SIZE: uint8_t(0),  p_raw_data,  metadata?p_raw_data + hid_data_size:nullptr};
+                            //Linux HID provides timestamps in nanosec. Convert to usec (FW default)
+                            if (metadata)
+                            {
+                                auto* ts_nsec = reinterpret_cast<uint64_t*>(const_cast<void*>(sens_data.fo.metadata));
+                                *ts_nsec /=1000;
+                            }
 
                             this->_callback(sens_data);
                         }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -307,7 +307,6 @@ namespace librealsense
         std::unordered_set<std::shared_ptr<video_stream_profile>> results;
         std::set<uint32_t> unregistered_formats;
         std::set<uint32_t> supported_formats;
-        std::set<uint32_t> registered_formats;
 
         power on(std::dynamic_pointer_cast<uvc_sensor>(shared_from_this()));
         if (_uvc_profiles.empty()){}
@@ -354,7 +353,7 @@ namespace librealsense
             }
 
             ss << "]; Supported: [ ";
-            for (auto& elem : registered_formats)
+            for (auto& elem : supported_formats)
             {
                 uint32_t device_fourcc = reinterpret_cast<const big_endian<uint32_t>&>(elem);
                 char fourcc[sizeof(device_fourcc) + 1];

--- a/src/types.h
+++ b/src/types.h
@@ -68,16 +68,6 @@ template<typename T> T rad2deg(T val) { return T(val * r2d); }
 namespace librealsense
 {
     #define UNKNOWN_VALUE "UNKNOWN"
-    const double TIMESTAMP_USEC_TO_MSEC = 0.001;
-    const double TIMESTAMP_NSEC_TO_MSEC = 0.000001;
-
-#ifdef _WIN32
-/* The FW timestamps for HID are converted to Usec in Windows kernel */
-#define HID_TIMESTAMP_MULTIPLIER TIMESTAMP_USEC_TO_MSEC
-#else
-/* The FW timestamps for HID are converted to Nanosec in Linux kernel */
-#define HID_TIMESTAMP_MULTIPLIER TIMESTAMP_NSEC_TO_MSEC
-#endif // define HID_TIMESTAMP_MULTIPLIER
 
     ///////////////////////////////////
     // Utility types for general use //


### PR DESCRIPTION
- Adjusting HID timestamp units from nsec to usec before applying retrieving the original FW 32bit timestamp.
- Fix log message for unregistered formats.
Addresses #3675.
Tracked on: DSO-12084