### PR TITLE
legacy: Compatibility fixes for recent Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if(UNIX)
       message( FATAL_ERROR "Failed to find libusb-1.0" )
     endif(LIBUSB1_FOUND)
 
-    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_BSD_SOURCE")
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_DEFAULT_SOURCE -D_BSD_SOURCE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pedantic -g -Ofast -Wno-missing-field-initializers")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar")
 

--- a/include/librealsense/rs.h
+++ b/include/librealsense/rs.h
@@ -16,7 +16,7 @@ extern "C" {
 
 #define RS_API_MAJOR_VERSION    1
 #define RS_API_MINOR_VERSION    12
-#define RS_API_PATCH_VERSION    3
+#define RS_API_PATCH_VERSION    4
 
 #define STRINGIFY(arg) #arg
 #define VAR_ARG_STRING(arg) STRINGIFY(arg)

--- a/src/f200.cpp
+++ b/src/f200.cpp
@@ -58,21 +58,21 @@ namespace rsimpl
         }
 
         // Depth and IR modes on subdevice 1
-        info.stream_subdevices[RS_STREAM_DEPTH] = 1;
-        info.stream_subdevices[RS_STREAM_INFRARED] = 1;
+        info.stream_subdevices[RS_STREAM_DEPTH] = 3;
+        info.stream_subdevices[RS_STREAM_INFRARED] = 3;
         for(auto & m : f200_ir_only_modes)
         {
             for(auto fps : m.fps)
             {
-                info.subdevice_modes.push_back({1, m.dims, pf_f200_invi, fps, MakeDepthIntrinsics(c, m.dims), {}, {0}});
+                info.subdevice_modes.push_back({3, m.dims, pf_f200_invi, fps, MakeDepthIntrinsics(c, m.dims), {}, {0}});
             }
         }
         for(auto & m : f200_depth_modes)
         {
             for(auto fps : m.fps)
             {
-                info.subdevice_modes.push_back({1, m.dims, pf_invz, fps, MakeDepthIntrinsics(c, m.dims), {}, {0}});
-                info.subdevice_modes.push_back({1, m.dims, pf_f200_inzi, fps, MakeDepthIntrinsics(c, m.dims), {}, {0}});
+                info.subdevice_modes.push_back({3, m.dims, pf_invz, fps, MakeDepthIntrinsics(c, m.dims), {}, {0}});
+                info.subdevice_modes.push_back({3, m.dims, pf_f200_inzi, fps, MakeDepthIntrinsics(c, m.dims), {}, {0}});
             }
         }
 

--- a/src/ivcam-device.cpp
+++ b/src/ivcam-device.cpp
@@ -227,7 +227,7 @@ namespace rsimpl
     std::vector<std::shared_ptr<frame_timestamp_reader>> iv_camera::create_frame_timestamp_readers() const
     {
         auto the_reader = std::make_shared<rolling_timestamp_reader>(); // single shared timestamp reader for all subdevices
-        return { the_reader, the_reader }; // clone the reference for color and depth
+        return { the_reader, the_reader, the_reader, the_reader, the_reader }; // clone the reference for color and depth
     }
 
 } // namespace rsimpl::f200


### PR DESCRIPTION
Most importantly, this PR restores functionality on recent Linux kernels by using the bundled libuvc instead of v4l2.
I'm not entirely sure when exactly the breakage occurred, but it must have been some changes to the uvcvideo driver between Linux 4.15 and 4.19. Unfortunately I can't test for the versions in between right now, but using libuvc from 4.16 onward should be fine.