### PR TITLE
Fix IMU timestamps precision

### DIFF
--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -15,7 +15,7 @@
 
 namespace librealsense
 {
-    static const float TIMESTAMP_USEC_TO_MSEC = 0.001;
+    static const double TIMESTAMP_USEC_TO_MSEC = 0.001;
 
     ds5_timestamp_reader_from_metadata::ds5_timestamp_reader_from_metadata(std::unique_ptr<frame_timestamp_reader> backup_timestamp_reader)
         :_backup_timestamp_reader(std::move(backup_timestamp_reader)), _has_metadata(pins), one_time_note(false)


### PR DESCRIPTION
Converting the timestamp units using floating point scale factor results in loss of actual precision on a scale of 0.01%. This round up does become  noticeable when profiling timestamp distribution and persistence.

The patch fixes the conversion discrepancy (double/float) and allows to preserve the original timestamps precision

Change-Id: I8d55bf94f2d73e7820d111200be251bbc88bb96f
Signed-off-by: Evgeni Raikhel <evgeni.raikhel@intel.com>