### PR TITLE
libuvc: fix undefined behavior caused by capture-by-reference of local variable

### DIFF
--- a/src/libuvc/stream.cpp
+++ b/src/libuvc/stream.cpp
@@ -1152,7 +1152,7 @@ uvc_error_t uvc_stream_start(
    * with the contents of each frame.
    */
   if (cb) {
-      strmh->cb_thread = std::thread([&]() {_uvc_user_caller((void*)strmh); });
+      strmh->cb_thread = std::thread([strmh]() {_uvc_user_caller((void*)strmh); });
   }
 
   for (transfer_id = 0; transfer_id < LIBUVC_NUM_TRANSFER_BUFS;


### PR DESCRIPTION
"&" captures all used variables by reference; as mentioned in [this Stack Overflow question](https://stackoverflow.com/questions/27775233/lambdas-and-capture-by-reference-local-variables-accessing-after-the-scope), that causes undefined behavior if the lambda is invoked after the function's stack frame is deallocated.

This means that the child thread was dereferencing a pointer from the other thread's stack frame -- sometimes it would happen to work because that data was still there, and other times it wouldn't and the process would segfault.

It appears this was introduced in 9d17956c82e79e72f4e12df40bd0f8848bec11a5.