### PR TITLE
#3803 Removed the requirement of additional hid devices

### DIFF
--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -578,6 +578,7 @@ namespace librealsense
             }
 
 
+#if !defined(ANDROID) && !defined(__APPLE__) // Not supported by android & macos
             auto is_pid_of_hid_sensor_device = [](int pid) { return std::find(std::begin(ds::hid_sensors_pid), std::end(ds::hid_sensors_pid), pid) != std::end(ds::hid_sensors_pid); };
             bool is_device_hid_sensor = false;
             for (auto&& uvc : devices)
@@ -592,6 +593,7 @@ namespace librealsense
             {
                 all_sensors_present &= (hids.capacity() >= 2);
             }
+#endif
 
             if (!devices.empty() && all_sensors_present)
             {


### PR DESCRIPTION
The IMU is a great part of the camera, but not so required to actually connect the camera and get the depth stream from it.
Removing this HID requirement will help to use this cameras on the android devices right now.