### PR TITLE
Fixed typo line 82 "cd protbuf"

### DIFF
--- a/doc/installation_raspbian.md
+++ b/doc/installation_raspbian.md
@@ -79,7 +79,7 @@ $ source ~/.zshrc
 ```
 $ cd ~
 $ git clone --depth=1 -b v3.5.1 https://github.com/google/protobuf.git
-$ cd protbuf
+$ cd protobuf
 $ ./autogen.sh
 $ ./configure
 $ make -j1


### PR DESCRIPTION
Typo on line 82

$ git clone --depth=1 -b v3.5.1 https://github.com/google/protobuf.git
$ "cd protbuf" -- should be --> "cd protobuf"