### PR TITLE
C# wrapper: add PoseSensor to expose localization map and static node api

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Devices/Device.cs
+++ b/wrappers/csharp/Intel.RealSense/Devices/Device.cs
@@ -54,13 +54,13 @@ namespace Intel.RealSense
         /// create a static snapshot of all connected devices at the time of the call
         /// </summary>
         /// <returns>The list of sensors</returns>
-        public ReadOnlyCollection<Sensor> QuerySensors()
+        public ReadOnlyCollection<T> QuerySensors<T>()  where T: Sensor
         {
             object error;
             var ptr = NativeMethods.rs2_query_sensors(Handle, out error);
-            using (var sl = new SensorList(ptr))
+            using (var sl = new SensorList<T>(ptr))
             {
-                var a = new Sensor[sl.Count];
+                var a = new T[sl.Count];
                 sl.CopyTo(a, 0);
                 return Array.AsReadOnly(a);
             }
@@ -70,7 +70,7 @@ namespace Intel.RealSense
         /// Gets a static snapshot of all connected devices at the time of the call
         /// </summary>
         /// <value>The list of sensors</value>
-        public ReadOnlyCollection<Sensor> Sensors => QuerySensors();
+        public ReadOnlyCollection<Sensor> Sensors => QuerySensors<Sensor>();
 
         /// <summary>
         /// Send hardware reset request to the device. The actual reset is asynchronous.

--- a/wrappers/csharp/Intel.RealSense/Sensors/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/Sensors/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(${LRS_DOTNET_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/Sensor.cs"
         "${CMAKE_CURRENT_LIST_DIR}/SensorList.cs"
         "${CMAKE_CURRENT_LIST_DIR}/SoftwareSensor.cs"
+		"${CMAKE_CURRENT_LIST_DIR}/PoseSensor.cs"
 )

--- a/wrappers/csharp/Intel.RealSense/Sensors/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/Sensors/CMakeLists.txt
@@ -3,5 +3,5 @@ target_sources(${LRS_DOTNET_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/Sensor.cs"
         "${CMAKE_CURRENT_LIST_DIR}/SensorList.cs"
         "${CMAKE_CURRENT_LIST_DIR}/SoftwareSensor.cs"
-		"${CMAKE_CURRENT_LIST_DIR}/PoseSensor.cs"
+        "${CMAKE_CURRENT_LIST_DIR}/PoseSensor.cs"
 )

--- a/wrappers/csharp/Intel.RealSense/Sensors/PoseSensor.cs
+++ b/wrappers/csharp/Intel.RealSense/Sensors/PoseSensor.cs
@@ -1,0 +1,68 @@
+namespace Intel.RealSense
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Runtime.InteropServices;
+
+    public class PoseSensor : Sensor
+    {
+        internal PoseSensor(IntPtr ptr) : base(ptr)
+        { }
+
+        public static PoseSensor FromSensor(Sensor sensor)
+        {
+            if (!sensor.Is(Extension.PoseSensor))
+            {
+                throw new ArgumentException($"Sensor does not support {nameof(Extension.PoseSensor)}");
+            }
+            return Create<PoseSensor>(sensor.Handle);
+        }
+
+        public byte[] ExportLocalizationMap()
+        {
+            object error;
+            IntPtr rawDataBuffer = NativeMethods.rs2_export_localization_map(Handle, out error);
+
+            IntPtr start = NativeMethods.rs2_get_raw_data(rawDataBuffer, out error);
+            int size = NativeMethods.rs2_get_raw_data_size(rawDataBuffer, out error);
+
+            byte[] managedBytes = new byte[size];
+            Marshal.Copy(start, managedBytes, 0, size);
+            NativeMethods.rs2_delete_raw_data(rawDataBuffer);
+
+            return managedBytes;
+        }
+
+        public bool ImportLocalizationMap(byte[] mapBytes)
+        {
+            IntPtr nativeBytes = Marshal.AllocHGlobal(mapBytes.Length);
+            Marshal.Copy(mapBytes, 0, nativeBytes, mapBytes.Length);
+
+            object error;
+            var res = NativeMethods.rs2_import_localization_map(Handle, nativeBytes, (uint)mapBytes.Length, out error);
+
+            Marshal.FreeHGlobal(nativeBytes);
+            nativeBytes = IntPtr.Zero;
+
+            return !(res == 0);
+        }
+
+        public bool SetStaticNode(string guid, Math.Vector position, Math.Quaternion rotation)
+        {
+            object error;
+            var res = NativeMethods.rs2_set_static_node(Handle, guid, position, rotation, out error);
+            return !(res == 0);
+        }
+
+        public bool GetStaticNode(string guid, out Math.Vector position, out Math.Quaternion rotation)
+        {
+            object error;
+            var res = NativeMethods.rs2_get_static_node(Handle, guid, out position, out rotation, out error);
+            return !(res == 0);
+        }
+    }
+}

--- a/wrappers/csharp/Intel.RealSense/Sensors/PoseSensor.cs
+++ b/wrappers/csharp/Intel.RealSense/Sensors/PoseSensor.cs
@@ -1,3 +1,6 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
 namespace Intel.RealSense
 {
     using System;

--- a/wrappers/csharp/Intel.RealSense/Sensors/SensorList.cs
+++ b/wrappers/csharp/Intel.RealSense/Sensors/SensorList.cs
@@ -13,7 +13,7 @@ namespace Intel.RealSense
     /// <summary>
     /// List of adjacent devices, sharing the same physical parent composite device
     /// </summary>
-    internal sealed class SensorList : Base.Object, IEnumerable<Sensor>, ICollection
+    internal sealed class SensorList<T> : Base.Object, IEnumerable<T>, ICollection where T : Sensor
     {
         internal SensorList(IntPtr ptr)
             : base(ptr, NativeMethods.rs2_delete_sensor_list)
@@ -21,7 +21,7 @@ namespace Intel.RealSense
         }
 
         /// <inheritdoc/>
-        public IEnumerator<Sensor> GetEnumerator()
+        public IEnumerator<T> GetEnumerator()
         {
             object error;
 
@@ -29,7 +29,7 @@ namespace Intel.RealSense
             for (int i = 0; i < sensorCount; i++)
             {
                 var ptr = NativeMethods.rs2_create_sensor(Handle, i, out error);
-                yield return Sensor.Create<Sensor>(ptr);
+                yield return Sensor.Create<T>(ptr);
             }
         }
 
@@ -80,7 +80,7 @@ namespace Intel.RealSense
             {
                 object error;
                 var ptr = NativeMethods.rs2_create_sensor(Handle, index, out error);
-                return Sensor.Create<Sensor>(ptr);
+                return Sensor.Create<T>(ptr);
             }
         }
     }

--- a/wrappers/csharp/cs-tutorial-1-depth/Program.cs
+++ b/wrappers/csharp/cs-tutorial-1-depth/Program.cs
@@ -21,7 +21,7 @@ namespace Intel.RealSense
                 Console.WriteLine("    Serial number: {0}", dev.Info[CameraInfo.SerialNumber]);
                 Console.WriteLine("    Firmware version: {0}", dev.Info[CameraInfo.FirmwareVersion]);
 
-                var depthSensor = dev.Sensors[0];
+                var depthSensor = dev.QuerySensors<Sensor>()[0];
 
                 var sp = depthSensor.StreamProfiles
                                     .Where(p => p.Stream == Stream.Depth)

--- a/wrappers/csharp/cs-tutorial-3-processing/Window.xaml.cs
+++ b/wrappers/csharp/cs-tutorial-3-processing/Window.xaml.cs
@@ -55,7 +55,7 @@ namespace Intel.RealSense
                 var pp = pipeline.Start(cfg);
 
                 // Get the recommended processing blocks for the depth sensor
-                var sensor = pp.Device.Sensors.First(s => s.Is(Extension.DepthSensor));
+                var sensor = pp.Device.QuerySensors<Sensor>().First(s => s.Is(Extension.DepthSensor));
                 var blocks = sensor.ProcessingBlocks.ToList();
 
                 // Allocate bitmaps for rendring.


### PR DESCRIPTION
Add a PoseSensor.cs to expose the localization map import/export and static node api to c# users.  This patch makes SensorList generic as the only way I saw to create a new sensor is from a sensor list handle.

Thanks.  