### PR TITLE
Fix T265 Pose attributes in record/playback scenarios

### DIFF
--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -253,7 +253,7 @@ namespace rs2
     {
     public:
         /**
-        * Video stream profile instance which contans additional motion attributes
+        * Motion stream profile instance which contans IMU-specific intrinsic
         * \param[in] stream_profile sp - assign exisiting stream_profile to this instance.
         */
         explicit motion_stream_profile(const stream_profile& sp)
@@ -268,7 +268,7 @@ namespace rs2
         }
 
         /**
-        * Returns scale and bias of a the motion stream profile
+        * Returns scale/bias/covariances of a the motion sensors
         * \return rs2_motion_device_intrtinsic - stream motion intrinsics
         */
         rs2_motion_device_intrinsic get_motion_intrinsics() const
@@ -281,6 +281,24 @@ namespace rs2
         }
     };
 
+    class pose_stream_profile : public stream_profile
+    {
+    public:
+        /**
+        * Video stream profile instance which contans additional motion attributes
+        * \param[in] stream_profile sp - assign exisiting stream_profile to this instance.
+        */
+        explicit pose_stream_profile(const stream_profile& sp)
+            : stream_profile(sp)
+        {
+            rs2_error* e = nullptr;
+            if ((rs2_stream_profile_is(sp.get(), RS2_EXTENSION_POSE_PROFILE, &e) == 0 && !e))
+            {
+                _profile = nullptr;
+            }
+            error::handle(e);
+        }
+    };
 
     /**
     Interface for frame filtering functionality

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -285,7 +285,7 @@ namespace rs2
     {
     public:
         /**
-        * Video stream profile instance which contans additional motion attributes
+        * Pose stream profile instance with a designated extension type
         * \param[in] stream_profile sp - assign exisiting stream_profile to this instance.
         */
         explicit pose_stream_profile(const stream_profile& sp)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -516,7 +516,7 @@ namespace librealsense
         return results;
     }
 
-    std::shared_ptr<device_interface> context::add_device(const std::string& file)
+    std::shared_ptr<playback_device_info> context::add_device(const std::string& file)
     {
         auto it = _playback_devices.find(file);
         if (it != _playback_devices.end() && it->second.lock())
@@ -529,7 +529,7 @@ namespace librealsense
         auto prev_playback_devices = _playback_devices;
         _playback_devices[file] = dinfo;
         on_device_changed({}, {}, prev_playback_devices, _playback_devices);
-        return std::move(playback_dev);
+        return std::move(dinfo);
     }
 
     void context::add_software_device(std::shared_ptr<device_info> dev)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -318,7 +318,7 @@ namespace librealsense
     }
 
     std::vector<std::shared_ptr<device_info>> context::create_devices(platform::backend_device_group devices,
-                                                                      const std::map<std::string, std::weak_ptr<device_info>>& playback_devices,
+                                                                      const std::map<std::string, std::shared_ptr<device_info>>& playback_devices,
                                                                       int mask) const
     {
         std::vector<std::shared_ptr<device_info>> list;
@@ -361,8 +361,7 @@ namespace librealsense
 
         for (auto&& item : playback_devices)
         {
-            if (auto dev = item.second.lock())
-                list.push_back(dev);
+                list.push_back(item.second);
         }
 
         return list;
@@ -371,8 +370,8 @@ namespace librealsense
 
     void context::on_device_changed(platform::backend_device_group old,
                                     platform::backend_device_group curr,
-                                    const std::map<std::string, std::weak_ptr<device_info>>& old_playback_devices,
-                                    const std::map<std::string, std::weak_ptr<device_info>>& new_playback_devices)
+                                    const std::map<std::string, std::shared_ptr<device_info>>& old_playback_devices,
+                                    const std::map<std::string, std::shared_ptr<device_info>>& new_playback_devices)
     {
         auto old_list = create_devices(old, old_playback_devices, RS2_PRODUCT_LINE_ANY);
         auto new_list = create_devices(curr, new_playback_devices, RS2_PRODUCT_LINE_ANY);
@@ -519,7 +518,7 @@ namespace librealsense
     std::shared_ptr<device_interface> context::add_device(const std::string& file)
     {
         auto it = _playback_devices.find(file);
-        if (it != _playback_devices.end() && it->second.lock())
+        if (it != _playback_devices.end())
         {
             //Already exists
             throw librealsense::invalid_value_exception(to_string() << "File \"" << file << "\" already loaded to context");
@@ -529,15 +528,15 @@ namespace librealsense
         auto prev_playback_devices = _playback_devices;
         _playback_devices[file] = dinfo;
         on_device_changed({}, {}, prev_playback_devices, _playback_devices);
-        return playback_dev;
+        return std::move(playback_dev);
     }
-    
+
     void context::add_software_device(std::shared_ptr<device_info> dev)
     {
         auto file = dev->get_device_data().playback_devices.front().file_path;
         
         auto it = _playback_devices.find(file);
-        if (it != _playback_devices.end() && it->second.lock())
+        if (it != _playback_devices.end())
         {
             //Already exists
             throw librealsense::invalid_value_exception(to_string() << "File \"" << file << "\" already loaded to context");
@@ -550,7 +549,7 @@ namespace librealsense
     void context::remove_device(const std::string& file)
     {
         auto it = _playback_devices.find(file);
-        if (!it->second.lock() || it == _playback_devices.end())
+        if (it == _playback_devices.end())
         {
             //Not found
             return;

--- a/src/context.h
+++ b/src/context.h
@@ -127,7 +127,7 @@ namespace librealsense
         std::vector<std::shared_ptr<device_info>> create_devices(platform::backend_device_group devices,
             const std::map<std::string, std::weak_ptr<device_info>>& playback_devices, int mask) const;
 
-        std::shared_ptr<device_interface> add_device(const std::string& file);
+        std::shared_ptr<playback_device_info> add_device(const std::string& file);
         void remove_device(const std::string& file);
 
         void add_software_device(std::shared_ptr<device_info> software_device);

--- a/src/context.h
+++ b/src/context.h
@@ -125,7 +125,7 @@ namespace librealsense
         void set_devices_changed_callback(devices_changed_callback_ptr callback);
 
         std::vector<std::shared_ptr<device_info>> create_devices(platform::backend_device_group devices,
-            const std::map<std::string, std::shared_ptr<device_info>>& playback_devices, int mask) const;
+            const std::map<std::string, std::weak_ptr<device_info>>& playback_devices, int mask) const;
 
         std::shared_ptr<device_interface> add_device(const std::string& file);
         void remove_device(const std::string& file);
@@ -139,8 +139,8 @@ namespace librealsense
     private:
         void on_device_changed(platform::backend_device_group old,
                                platform::backend_device_group curr,
-                               const std::map<std::string, std::shared_ptr<device_info>>& old_playback_devices,
-                               const std::map<std::string, std::shared_ptr<device_info>>& new_playback_devices);
+                               const std::map<std::string, std::weak_ptr<device_info>>& old_playback_devices,
+                               const std::map<std::string, std::weak_ptr<device_info>>& new_playback_devices);
         void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
         int find_stream_profile(const stream_interface& p);
         std::shared_ptr<lazy<rs2_extrinsics>> fetch_edge(int from, int to);
@@ -150,7 +150,7 @@ namespace librealsense
         std::shared_ptr<tm2_context> _tm2_context;
 #endif
         std::shared_ptr<platform::device_watcher> _device_watcher;
-        std::map<std::string, std::shared_ptr<device_info>> _playback_devices;
+        std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
 
         devices_changed_callback_ptr _devices_changed_callback;

--- a/src/context.h
+++ b/src/context.h
@@ -125,7 +125,7 @@ namespace librealsense
         void set_devices_changed_callback(devices_changed_callback_ptr callback);
 
         std::vector<std::shared_ptr<device_info>> create_devices(platform::backend_device_group devices,
-            const std::map<std::string, std::weak_ptr<device_info>>& playback_devices, int mask) const;
+            const std::map<std::string, std::shared_ptr<device_info>>& playback_devices, int mask) const;
 
         std::shared_ptr<device_interface> add_device(const std::string& file);
         void remove_device(const std::string& file);
@@ -139,8 +139,8 @@ namespace librealsense
     private:
         void on_device_changed(platform::backend_device_group old,
                                platform::backend_device_group curr,
-                               const std::map<std::string, std::weak_ptr<device_info>>& old_playback_devices,
-                               const std::map<std::string, std::weak_ptr<device_info>>& new_playback_devices);
+                               const std::map<std::string, std::shared_ptr<device_info>>& old_playback_devices,
+                               const std::map<std::string, std::shared_ptr<device_info>>& new_playback_devices);
         void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
         int find_stream_profile(const stream_interface& p);
         std::shared_ptr<lazy<rs2_extrinsics>> fetch_edge(int from, int to);
@@ -150,7 +150,7 @@ namespace librealsense
         std::shared_ptr<tm2_context> _tm2_context;
 #endif
         std::shared_ptr<platform::device_watcher> _device_watcher;
-        std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
+        std::map<std::string, std::shared_ptr<device_info>> _playback_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
 
         devices_changed_callback_ptr _devices_changed_callback;

--- a/src/core/extension.h
+++ b/src/core/extension.h
@@ -15,7 +15,7 @@
     template<> struct TypeToExtension<T> {                       \
         static constexpr rs2_extension value = E;                \
         static constexpr const char* to_string() { return #T; }; \
-    }
+    }                                                            \
 
 namespace librealsense
 {

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -12,14 +12,14 @@
 using namespace librealsense;
 
 playback_device::playback_device(std::shared_ptr<context> ctx, std::shared_ptr<device_serializer::reader> serializer) :
+    m_read_thread([]() {return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max()); }),
     m_context(ctx),
     m_is_started(false),
     m_is_paused(false),
     m_sample_rate(1),
     m_real_time(true),
     m_prev_timestamp(0),
-    m_last_published_timestamp(0),
-    m_read_thread([]() {return std::make_shared<dispatcher>(std::numeric_limits<unsigned int>::max()); })
+    m_last_published_timestamp(0)
 {
     if (serializer == nullptr)
     {

--- a/src/media/playback/playback_device.h
+++ b/src/media/playback/playback_device.h
@@ -76,6 +76,7 @@ namespace librealsense
 
     private:
         lazy<std::shared_ptr<dispatcher>> m_read_thread;
+        std::shared_ptr<context> m_context;
         std::shared_ptr<device_serializer::reader> m_reader;
         device_serializer::device_snapshot m_device_description;
         std::atomic_bool m_is_started;
@@ -87,7 +88,6 @@ namespace librealsense
         std::atomic<double> m_sample_rate;
         std::atomic_bool m_real_time;
         device_serializer::nanoseconds m_prev_timestamp;
-        std::shared_ptr<context> m_context;
         std::vector<std::shared_ptr<lazy<rs2_extrinsics>>> m_extrinsics_fetchers;
         std::map<int, std::pair<uint32_t, rs2_extrinsics>> m_extrinsics_map;
         device_serializer::nanoseconds m_last_published_timestamp;

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -250,7 +250,7 @@ device_serializer::snapshot_collection librealsense::record_device::get_extensio
             case RS2_EXTENSION_COUNT           : break;
             case RS2_EXTENSION_UNKNOWN         : break;
             default:
-                LOG_WARNING("Extensions type is unhandled: " << ext);
+                LOG_WARNING("Extensions type is unhandled: " << get_string(ext));
         }
     }
     return snapshots;
@@ -359,7 +359,7 @@ bool librealsense::record_device::extend_to(rs2_extension extension_type, void**
     case RS2_EXTENSION_DEBUG           : return extend_to_aux<RS2_EXTENSION_DEBUG          >(m_device, ext);
     //Other cases are not extensions that we expect a device to have.
     default:
-        LOG_WARNING("Extensions type is unhandled: " << extension_type);
+        LOG_WARNING("Extensions type is unhandled: " << get_string(extension_type));
         return false;
     }
 }

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -163,7 +163,7 @@ bool librealsense::record_sensor::extend_to(rs2_extension extension_type, void**
     case RS2_EXTENSION_DEPTH_STEREO_SENSOR: return extend_to_aux<RS2_EXTENSION_DEPTH_STEREO_SENSOR   >(&m_sensor, ext);
     //Other extensions are not expected to be extensions of a sensor
     default:
-        LOG_WARNING("Extensions type is unhandled: " << extension_type);
+        LOG_WARNING("Extensions type is unhandled: " << get_string(extension_type));
         return false;
     }
 }

--- a/src/media/ros/ros_file_format.h
+++ b/src/media/ros/ros_file_format.h
@@ -42,116 +42,63 @@ namespace librealsense
     {
         switch (source)
         {
-        case RS2_FORMAT_Z16: target = sensor_msgs::image_encodings::MONO16;     return;
-        case RS2_FORMAT_RGB8: target = sensor_msgs::image_encodings::RGB8;       return;
-        case RS2_FORMAT_BGR8: target = sensor_msgs::image_encodings::BGR8;       return;
-        case RS2_FORMAT_RGBA8: target = sensor_msgs::image_encodings::RGBA8;      return;
-        case RS2_FORMAT_BGRA8: target = sensor_msgs::image_encodings::BGRA8;      return;
-        case RS2_FORMAT_Y8: target = sensor_msgs::image_encodings::TYPE_8UC1;  return;
-        case RS2_FORMAT_Y16: target = sensor_msgs::image_encodings::TYPE_16UC1; return;
-        case RS2_FORMAT_RAW8: target = sensor_msgs::image_encodings::MONO8;      return;
-        case RS2_FORMAT_UYVY: target = sensor_msgs::image_encodings::YUV422;     return;
+        case RS2_FORMAT_Z16: target = sensor_msgs::image_encodings::MONO16;     break;
+        case RS2_FORMAT_RGB8: target = sensor_msgs::image_encodings::RGB8;      break;
+        case RS2_FORMAT_BGR8: target = sensor_msgs::image_encodings::BGR8;      break;
+        case RS2_FORMAT_RGBA8: target = sensor_msgs::image_encodings::RGBA8;    break;
+        case RS2_FORMAT_BGRA8: target = sensor_msgs::image_encodings::BGRA8;    break;
+        case RS2_FORMAT_Y8: target = sensor_msgs::image_encodings::TYPE_8UC1;   break;
+        case RS2_FORMAT_Y16: target = sensor_msgs::image_encodings::TYPE_16UC1; break;
+        case RS2_FORMAT_RAW8: target = sensor_msgs::image_encodings::MONO8;     break;
+        case RS2_FORMAT_UYVY: target = sensor_msgs::image_encodings::YUV422;    break;
         default: target = rs2_format_to_string(source);
         }
     }
 
-    inline void convert(const std::string& source, rs2_format& target)
-    {
-        if (source == sensor_msgs::image_encodings::MONO16) { target = RS2_FORMAT_Z16; return; }
-        if (source == sensor_msgs::image_encodings::RGB8) { target = RS2_FORMAT_RGB8; return; }
-        if (source == sensor_msgs::image_encodings::BGR8) { target = RS2_FORMAT_BGR8; return; }
-        if (source == sensor_msgs::image_encodings::RGBA8) { target = RS2_FORMAT_RGBA8; return; }
-        if (source == sensor_msgs::image_encodings::BGRA8) { target = RS2_FORMAT_BGRA8; return; }
-        if (source == sensor_msgs::image_encodings::TYPE_8UC1) { target = RS2_FORMAT_Y8; return; }
-        if (source == sensor_msgs::image_encodings::TYPE_16UC1) { target = RS2_FORMAT_Y16; return; }
-        if (source == sensor_msgs::image_encodings::MONO8) { target = RS2_FORMAT_RAW8; return; }
-        if (source == sensor_msgs::image_encodings::YUV422) { target = RS2_FORMAT_UYVY; return; }
-        if (!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_format");
-        }
-    }
-
-    inline void convert(const std::string& source, rs2_stream& target)
-    {
-        if(!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_stream");
-        }
-    }
-
-    inline void convert(const std::string& source, rs2_distortion& target)
+    template <typename T>
+    inline bool convert(const std::string& source, T& target)
     {
         if (!try_parse(source, target))
         {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_distortion");
+            LOG_INFO("Failed to convert source: " << source << " to matching " << typeid(T).name());
+            return false;
         }
+        return true;
     }
 
-    inline void convert(const std::string& source, rs2_option& target)
+    // Specialized methods for selected types
+    template <>
+    inline bool convert(const std::string& source, rs2_format& target)
     {
-        if (!try_parse(source, target))
+        bool ret = true;
+        if (source == sensor_msgs::image_encodings::MONO16)     target = RS2_FORMAT_Z16;
+        if (source == sensor_msgs::image_encodings::RGB8)       target = RS2_FORMAT_RGB8;
+        if (source == sensor_msgs::image_encodings::BGR8)       target = RS2_FORMAT_BGR8;
+        if (source == sensor_msgs::image_encodings::RGBA8)      target = RS2_FORMAT_RGBA8;
+        if (source == sensor_msgs::image_encodings::BGRA8)      target = RS2_FORMAT_BGRA8;
+        if (source == sensor_msgs::image_encodings::TYPE_8UC1)  target = RS2_FORMAT_Y8;
+        if (source == sensor_msgs::image_encodings::TYPE_16UC1) target = RS2_FORMAT_Y16;
+        if (source == sensor_msgs::image_encodings::MONO8)      target = RS2_FORMAT_RAW8;
+        if (source == sensor_msgs::image_encodings::YUV422)     target = RS2_FORMAT_UYVY;
+        if (!(ret = try_parse(source, target)))
         {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_option");
+            LOG_INFO("Failed to convert source: " << source << " to matching rs2_format");
         }
+        return ret;
     }
 
-    inline void convert(const std::string& source, rs2_extension& target)
-    {
-        if (!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_extension");
-        }
-    }
-
-    inline void convert(const std::string& source, rs2_frame_metadata_value& target)
-    {
-        if (!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_frame_metadata");
-        }
-    }
-
-    inline void convert(const std::string& source, rs2_camera_info& target)
-    {
-        if (!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_camera_info");
-        }
-    }
-
-    inline void convert(const std::string& source, rs2_timestamp_domain& target)
-    {
-        if (!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_timestamp_domain");
-        }
-    }
-
-    inline void convert(const std::string& source, rs2_notification_category& target)
-    {
-        if (!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_notification_category");
-        }
-    }
-
-    inline void convert(const std::string& source, rs2_log_severity& target)
-    {
-        if (!try_parse(source, target))
-        {
-            throw std::runtime_error(to_string() << "Failed to convert source: \"" << "\" to matching rs2_log_severity");
-        }
-    }
-
-    inline void convert(const std::string& source, double& target)
+    template <>
+    inline bool convert(const std::string& source, double& target)
     {
         target = std::stod(source);
+        return std::isfinite(target);
     }
 
-    inline void convert(const std::string& source, long long& target)
+    template <>
+    inline bool convert(const std::string& source, long long& target)
     {
         target = std::stoll(source);
+        return true;
     }
     /*
     quat2rot(), rot2quat()
@@ -186,22 +133,25 @@ namespace librealsense
         q.z = (r[1] - r[3]) / (4 * q.w);         // qz = (m10 - m01)/( 4 *qw)
     }
 
-    inline void convert(const geometry_msgs::Transform& source, rs2_extrinsics& target)
+    inline bool convert(const geometry_msgs::Transform& source, rs2_extrinsics& target)
     {
         target.translation[0] = source.translation.x;
         target.translation[1] = source.translation.y;
         target.translation[2] = source.translation.z;
         quat2rot(source.rotation, target.rotation);
+        return true;
     }
 
-    inline void convert(const rs2_extrinsics& source, geometry_msgs::Transform& target)
+    inline bool convert(const rs2_extrinsics& source, geometry_msgs::Transform& target)
     {
         target.translation.x = source.translation[0];
         target.translation.y = source.translation[1];
         target.translation.z = source.translation[2];
         rot2quat(source.rotation, target.rotation);
+        return true;
     }
 
+    constexpr const char* FRAME_NUMBER_MD_STR = "Frame number";
     constexpr const char* TIMESTAMP_DOMAIN_MD_STR = "timestamp_domain";
     constexpr const char* SYSTEM_TIME_MD_STR = "system_time";
     constexpr const char* MAPPER_CONFIDENCE_MD_STR = "Mapper Confidence";

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -91,7 +91,7 @@ namespace librealsense
         std::shared_ptr<info_container> read_legacy_info_snapshot(uint32_t sensor_index) const;
         std::shared_ptr<info_container> read_info_snapshot(const std::string& topic) const;
         std::set<uint32_t> read_sensor_indices(uint32_t device_index) const;
-        static std::shared_ptr<stream_profile_base> create_pose_profile(uint32_t stream_index, uint32_t fps);
+        static std::shared_ptr<pose_stream_profile> create_pose_profile(uint32_t stream_index, uint32_t fps);
         static std::shared_ptr<motion_stream_profile> create_motion_stream(rs2_stream stream_type, uint32_t stream_index, uint32_t fps, rs2_format format, rs2_motion_device_intrinsic intrinsics);
         static std::shared_ptr<video_stream_profile> create_video_stream_profile(const platform::stream_profile& sp,
             const sensor_msgs::CameraInfo& ci,
@@ -109,6 +109,7 @@ namespace librealsense
         static std::shared_ptr<options_container> read_sensor_options(const rosbag::Bag& file, device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, uint32_t file_version);
         static std::vector<std::string> get_topics(std::unique_ptr<rosbag::View>& view);
 
+        std::shared_ptr<metadata_parser_map>    m_metadata_parser_map;
         device_snapshot                         m_initial_device_description;
         nanoseconds                             m_total_duration;
         std::string                             m_file_path;
@@ -117,7 +118,6 @@ namespace librealsense
         std::unique_ptr<rosbag::View>           m_samples_view;
         rosbag::View::iterator                  m_samples_itrator;
         std::vector<std::string>                m_enabled_streams_topics;
-        std::shared_ptr<metadata_parser_map>    m_metadata_parser_map;
         std::shared_ptr<context>                m_context;
         uint32_t                                m_version;
     };

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -54,7 +54,7 @@ namespace librealsense
             bool ret{ false };
             try
             {
-                bool ret = convert(key, val);
+                ret = convert(key, val);
             }
             catch (const std::exception& e)
             {

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -51,16 +51,16 @@ namespace librealsense
         template <typename T>
         static bool safe_convert(const std::string& key, T& val)
         {
+            bool ret{ false };
             try
             {
-                convert(key, val);
+                bool ret = convert(key, val);
             }
             catch (const std::exception& e)
             {
                 LOG_ERROR(e.what());
-                return false;
             }
-            return true;
+            return ret;
         }
 
         static std::map<std::string, std::string> get_frame_metadata(const rosbag::Bag& bag,

--- a/src/media/ros/ros_writer.cpp
+++ b/src/media/ros/ros_writer.cpp
@@ -153,7 +153,7 @@ namespace librealsense
         }
         catch (std::exception const& e)
         {
-            LOG_WARNING("Failed to write frame metadata for " << stream_id << ". Exception: " << e.what());
+            LOG_WARNING("Failed to write frame metadata for " << stream_id.stream_type << ". Exception: " << e.what());
         }
 
         try
@@ -162,7 +162,7 @@ namespace librealsense
         }
         catch (std::exception const& e)
         {
-            LOG_WARNING("Failed to write stream extrinsics for " << stream_id << ". Exception: " << e.what());
+            LOG_WARNING("Failed to write stream extrinsics for " << stream_id.stream_type << ". Exception: " << e.what());
         }
     }
 
@@ -270,7 +270,7 @@ namespace librealsense
         std::string accel_topic = ros_topic::pose_accel_topic(stream_id);
         std::string twist_topic = ros_topic::pose_twist_topic(stream_id);
 
-        //Write the the pose frame as 3 seperate messages (each with different topic)
+        //Write the the pose frame as 3 separate messages (each with different topic)
         write_message(transform_topic, timestamp, transform);
         write_message(accel_topic, timestamp, accel);
         write_message(twist_topic, timestamp, twist);
@@ -291,8 +291,14 @@ namespace librealsense
         //Write frame's timestamp as metadata
         diagnostic_msgs::KeyValue frame_timestamp_msg;
         frame_timestamp_msg.key = FRAME_TIMESTAMP_MD_STR;
-        frame_timestamp_msg.value = to_string() << std::hexfloat << pose->get_frame_timestamp();
+        frame_timestamp_msg.value = to_string() << std::hexfloat << std::fixed << pose->get_frame_timestamp();
         write_message(md_topic, timestamp, frame_timestamp_msg);
+
+        //Write frame's number as external param
+        diagnostic_msgs::KeyValue frame_num_msg;
+        frame_num_msg.key = FRAME_NUMBER_MD_STR;
+        frame_num_msg.value = to_string() << pose->get_frame_number();
+        write_message(md_topic, timestamp, frame_num_msg);
 
         // Write the rest of the frame metadata and stream extrinsics
         write_additional_frame_messages(stream_id, timestamp, frame);

--- a/src/pipeline/config.cpp
+++ b/src/pipeline/config.cpp
@@ -199,7 +199,7 @@ namespace librealsense
                 }
             }
 
-            return ctx->add_device(file);
+            return ctx->add_device(file)->create_device(false);
         }
 
         std::shared_ptr<device_interface> config::resolve_device_requests(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout)

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1182,7 +1182,8 @@ rs2_device* rs2_context_add_device(rs2_context* ctx, const char* file, rs2_error
     VALIDATE_NOT_NULL(ctx);
     VALIDATE_NOT_NULL(file);
 
-    return new rs2_device{ ctx->ctx, nullptr, ctx->ctx->add_device(file) };
+    auto dev_info = ctx->ctx->add_device(file);
+    return new rs2_device{ ctx->ctx, dev_info, dev_info->create_device(false) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, ctx, file)
 

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -116,7 +116,7 @@ namespace librealsense
         profile->set_intrinsics([=]() {return motion_stream.intrinsics; });
         _profiles.push_back(profile);
 
-        return profile;
+        return std::move(profile);
     }
 
     std::shared_ptr<stream_profile_interface> software_sensor::add_pose_stream(rs2_pose_stream pose_stream)
@@ -141,7 +141,7 @@ namespace librealsense
         profile->set_unique_id(pose_stream.uid);
         _profiles.push_back(profile);
 
-        return profile;
+        return std::move(profile);
     }
 
     bool software_sensor::extend_to(rs2_extension extension_type, void ** ptr)

--- a/src/tm2/tm-device.cpp
+++ b/src/tm2/tm-device.cpp
@@ -309,6 +309,13 @@ namespace librealsense
             environment::get_instance().get_extrinsics_graph().register_extrinsics(*profile, *(profile_map[current_reference]), current_extrinsics);
         }
 
+        auto accel_it = std::find_if(results.begin(), results.end(),
+            [](std::shared_ptr<stream_profile_interface> spi) { return RS2_STREAM_ACCEL == spi->get_stream_type(); });
+        auto gyro_it = std::find_if(results.begin(), results.end(),
+            [](std::shared_ptr<stream_profile_interface> spi) { return RS2_STREAM_GYRO == spi->get_stream_type(); });
+        if ((accel_it != results.end()) && (gyro_it != results.end()))
+            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*(accel_it->get()), *(gyro_it->get()));
+
         return results;
     }
 
@@ -1268,6 +1275,11 @@ namespace librealsense
 
         _sensor->register_option(rs2_option::RS2_OPTION_ASIC_TEMPERATURE, std::make_shared<asic_temperature_option>(*_sensor));
         _sensor->register_option(rs2_option::RS2_OPTION_MOTION_MODULE_TEMPERATURE, std::make_shared<motion_temperature_option>(*_sensor));
+
+        // Assing the extrinsic nodes to the default group
+        auto tm2_profiles = _sensor->get_stream_profiles();
+        for (auto && pf : tm2_profiles)
+            register_stream_to_extrinsic_group(*pf, 0);
 
         //For manual testing: enable_loopback("C:\\dev\\recording\\tm2.bag");
     }

--- a/src/tm2/tm-device.cpp
+++ b/src/tm2/tm-device.cpp
@@ -504,8 +504,6 @@ namespace librealsense
             LOG_ERROR("Failed to convert lrs stream " << lrs_stream << " to tm stream");
             return;
         }
-        //auto time_of_arrival = get_md_or_default(RS2_FRAME_METADATA_TIME_OF_ARRIVAL);
-
 
         //Pass frames to firmware
         if (auto vframe = As<video_frame>(fref.frame))

--- a/src/tm2/tm-device.h
+++ b/src/tm2/tm-device.h
@@ -23,7 +23,7 @@ namespace librealsense
             perc::TrackingDevice* dev,
             std::shared_ptr<context> ctx,
             const platform::backend_device_group& group);
-        ~tm2_device();
+        virtual ~tm2_device();
 
         void enable_loopback(const std::string& source_file) override;
         void disable_loopback() override;
@@ -51,7 +51,7 @@ namespace librealsense
     {
     public:
         tm2_sensor(tm2_device* owner, perc::TrackingDevice* dev);
-        ~tm2_sensor();
+        virtual ~tm2_sensor();
 
         // sensor interface
         ////////////////////

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -200,12 +200,13 @@ int main(int argc, char** argv) try
     bool show_options           = show_options_arg.getValue();
     bool show_calibration_data  = show_calibration_data_arg.getValue();
     bool show_modes             = !compact_view;
-    auto playback_dev_file = show_playback_device_arg.getValue();
+    auto playback_dev_file      = show_playback_device_arg.getValue();
 
     // Obtain a list of devices currently present on the system
     context ctx;
+    rs2::device d;
     if (!playback_dev_file.empty())
-        ctx.load_device(playback_dev_file.data());
+        d = ctx.load_device(playback_dev_file.data());
 
     auto devices = ctx.query_devices();
     size_t device_count = devices.size();

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -56,14 +56,14 @@ void print(const rs2_extrinsics& extrinsics)
 void print(const rs2_motion_device_intrinsic& intrinsics)
 {
     stringstream ss;
-     ss << "Bias Variances: ";
+     ss << "Bias Variances: \t";
 
     for (auto i = 0 ; i < sizeof(intrinsics.bias_variances)/sizeof(intrinsics.bias_variances[0]) ; ++i)
-        ss << setprecision(15) << intrinsics.bias_variances[i] << "  ";
+        ss << setprecision(15) << std::fixed << intrinsics.bias_variances[i] << "  ";
 
-    ss << "\nNoise Variances: ";
+    ss << "\nNoise Variances: \t";
     for (auto i = 0 ; i < sizeof(intrinsics.noise_variances)/sizeof(intrinsics.noise_variances[0]) ; ++i)
-        ss << setprecision(15) << intrinsics.noise_variances[i] << "  ";
+        ss << setprecision(15) << std::fixed << intrinsics.noise_variances[i] << "  ";
 
     ss << "\nSensitivity : " << std::endl;
     for (auto i = 0 ; i < sizeof(intrinsics.data)/sizeof(intrinsics.data[0]) ; ++i)
@@ -363,13 +363,13 @@ int main(int argc, char** argv) try
                     {
                         if (motion_stream_profile motion = profile.as<motion_stream_profile>())
                         {
-                            if (streams.find(stream_and_index{profile.stream_type(), profile.stream_index()}) == streams.end())
+                            if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
                             {
-                                streams[stream_and_index{profile.stream_type(), profile.stream_index()}] = profile;
+                                streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
                             }
 
                             rs2_motion_device_intrinsic motion_intrinsics{};
-                            stream_and_resolution stream_res{profile.stream_type(), profile.stream_index(), motion.stream_type(), motion.stream_index(), profile.stream_name()};
+                            stream_and_resolution stream_res{ profile.stream_type(), profile.stream_index(), motion.stream_type(), motion.stream_index(), profile.stream_name() };
                             if (safe_get_motion_intrinsics(motion, motion_intrinsics))
                             {
                                 auto it = std::find_if((motion_intrinsics_map[stream_res]).begin(), (motion_intrinsics_map[stream_res]).end(),
@@ -387,11 +387,20 @@ int main(int argc, char** argv) try
                                 }
                             }
                         }
+                        else if (pose_stream_profile pose = profile.as<pose_stream_profile>())
+                        {
+                            if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
+                            {
+                                streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
+                            }
+                        }
+                        else
+                            cout << " Unhandled profile encountered: " << profile.stream_name() << "/" << profile.format() << std::endl;
                     }
                 }
             }
 
-            cout << "Provided Intrinsic:" << endl;
+            cout << "Provided Intrinsic:\n" << endl;
             for (auto& kvp : intrinsics_map)
             {
                 auto stream_res = kvp.first;
@@ -411,7 +420,7 @@ int main(int argc, char** argv) try
                 }
             }
 
-            cout << "Provided Motion Intrinsic:" << endl;
+            cout << "Provided Motion Intrinsic:\n" << endl;
             for (auto& kvp : motion_intrinsics_map)
             {
                 auto stream_res = kvp.first;

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -7,6 +7,8 @@
 #include <map>
 #include <set>
 #include <cstring>
+#include <cmath>
+#include <limits>
 
 #include "tclap/CmdLine.h"
 
@@ -47,7 +49,7 @@ void print(const rs2_extrinsics& extrinsics)
     }
 
     ss << "\n Translation Vector: ";
-    for (auto i = 0 ; i < sizeof(extrinsics.translation)/sizeof(extrinsics.translation[0]) ; ++i)
+    for (auto i = 0u ; i < sizeof(extrinsics.translation)/sizeof(extrinsics.translation[0]) ; ++i)
         ss << setprecision(15) << extrinsics.translation[i] << "  ";
 
     cout << ss.str() << endl << endl;
@@ -58,17 +60,17 @@ void print(const rs2_motion_device_intrinsic& intrinsics)
     stringstream ss;
      ss << "Bias Variances: \t";
 
-    for (auto i = 0 ; i < sizeof(intrinsics.bias_variances)/sizeof(intrinsics.bias_variances[0]) ; ++i)
+    for (auto i = 0u ; i < sizeof(intrinsics.bias_variances)/sizeof(intrinsics.bias_variances[0]) ; ++i)
         ss << setprecision(15) << std::fixed << intrinsics.bias_variances[i] << "  ";
 
     ss << "\nNoise Variances: \t";
-    for (auto i = 0 ; i < sizeof(intrinsics.noise_variances)/sizeof(intrinsics.noise_variances[0]) ; ++i)
+    for (auto i = 0u ; i < sizeof(intrinsics.noise_variances)/sizeof(intrinsics.noise_variances[0]) ; ++i)
         ss << setprecision(15) << std::fixed << intrinsics.noise_variances[i] << "  ";
 
     ss << "\nSensitivity : " << std::endl;
-    for (auto i = 0 ; i < sizeof(intrinsics.data)/sizeof(intrinsics.data[0]) ; ++i)
+    for (auto i = 0u ; i < sizeof(intrinsics.data)/sizeof(intrinsics.data[0]) ; ++i)
     {
-        for (auto j = 0 ; j < sizeof(intrinsics.data[0])/sizeof(intrinsics.data[0][0]) ; ++j)
+        for (auto j = 0u ; j < sizeof(intrinsics.data[0])/sizeof(intrinsics.data[0][0]) ; ++j)
             ss << std::right << std::setw(13) << setprecision(6) << intrinsics.data[i][j] << "  ";
         ss << "\n";
     }
@@ -88,7 +90,7 @@ void print(const rs2_intrinsics& intrinsics)
            left << setw(14) << "  Distortion: " << "\t" << rs2_distortion_to_string(intrinsics.model) << endl <<
            left << setw(14) << "  Coeffs: ";
 
-    for (auto i = 0 ; i < sizeof(intrinsics.coeffs)/sizeof(intrinsics.coeffs[0]) ; ++i)
+    for (auto i = 0u ; i < sizeof(intrinsics.coeffs)/sizeof(intrinsics.coeffs[0]) ; ++i)
         ss << "\t" << setprecision(15) << intrinsics.coeffs[i] << "  ";
 
     cout << ss.str() << endl << endl;
@@ -147,14 +149,14 @@ struct stream_and_index{
 bool operator ==(const rs2_intrinsics& lhs,
                  const rs2_intrinsics& rhs)
 {
-    return lhs.width == rhs.width &&
-           lhs.height == rhs.height &&
-           lhs.ppx == rhs.ppx &&
-           lhs.ppy == rhs.ppy &&
-           lhs.fx == rhs.fx &&
-           lhs.fy == rhs.fy &&
-           lhs.model == rhs.model &&
-           !std::memcmp(lhs.coeffs, rhs.coeffs, sizeof(rhs.coeffs));
+    return  lhs.width == rhs.width &&
+            lhs.height == rhs.height &&
+            (fabs(lhs.ppx - rhs.ppx) < std::numeric_limits<float>::min()) &&
+            (fabs(lhs.ppy - rhs.ppy) < std::numeric_limits<float>::min()) &&
+            (fabs(lhs.fx - rhs.fx) < std::numeric_limits<float>::min()) &&
+            (fabs(lhs.fy - rhs.fy) < std::numeric_limits<float>::min()) &&
+            lhs.model == rhs.model &&
+            !std::memcmp(lhs.coeffs, rhs.coeffs, sizeof(rhs.coeffs));
 }
 
 bool operator ==(const rs2_motion_device_intrinsic& lhs,
@@ -212,7 +214,7 @@ int main(int argc, char** argv) try
             << setw(20) << "Firmware Version"
             << endl;
 
-        for (auto i = 0; i < device_count; ++i)
+        for (auto i = 0u; i < device_count; ++i)
         {
             auto dev = devices[i];
 
@@ -231,7 +233,7 @@ int main(int argc, char** argv) try
 
     log_to_console(RS2_LOG_SEVERITY_FATAL);
 
-    for (auto i = 0; i < device_count; ++i)
+    for (auto i = 0u; i < device_count; ++i)
     {
         auto dev = devices[i];
 

--- a/unit-tests/unit-tests-common.h
+++ b/unit-tests/unit-tests-common.h
@@ -321,7 +321,7 @@ inline bool make_context(const char* id, rs2::context* ctx, std::string min_api_
     std::string base_filename;
     bool record = false;
     bool playback = false;
-    for (auto i = 0; i < argc; i++)
+    for (auto i = 0u; i < argc; i++)
     {
         std::string param(argv[i]);
         if (param == "into")

--- a/unit-tests/unit-tests-post-processing-from-bag.cpp
+++ b/unit-tests/unit-tests-post-processing-from-bag.cpp
@@ -68,8 +68,9 @@ public:
     }
 
 private:
-    rs2_stream _align_from;
     rs2::align _align;
+    rs2_stream _align_from;
+
 };
 
 class pointcloud_record_block : public processing_recordable_block

--- a/unit-tests/unit-tests-post-processing-from-bag.cpp
+++ b/unit-tests/unit-tests-post-processing-from-bag.cpp
@@ -347,7 +347,7 @@ void validate_ppf_results(const rs2::frame& result_frame, const rs2::frame& refe
     REQUIRE(result_profile.width() == reference_profile.width());
     REQUIRE(result_profile.height() == reference_profile.height());
 
-    auto pixels_as_bytes = reference_frame.as<rs2::video_frame>().get_bytes_per_pixel() * result_profile.width() * result_profile.height();
+    size_t pixels_as_bytes = reference_frame.as<rs2::video_frame>().get_bytes_per_pixel() * result_profile.width() * result_profile.height();
 
     // Pixel-by-pixel comparison of the resulted filtered depth vs data ercorded with external tool
     auto v1 = reinterpret_cast<const uint8_t*>(result_frame.get_data());

--- a/wrappers/matlab/CMakeLists.txt
+++ b/wrappers/matlab/CMakeLists.txt
@@ -5,6 +5,11 @@ project(RealsenseMatlabWrappers)
 
 find_package(Matlab COMPONENTS MX_LIBRARY MAT_LIBRARY REQUIRED)
 set(DEPENDENCIES realsense2 ${Matlab_MAT_LIBRARY})
+# Workaround for https://github.com/IntelRealSense/librealsense/pull/3611/files CMAKE_DEBUG_SUFFIX
+# With MSVC2017 the realsense2 dependency without the suffix is still added to the debug build
+# via the /DEFAULTLIB:realsense2.lib entry
+# A similar report exist dated in 2011 https://cmake.org/pipermail/cmake/2011-April/043808.html
+SET( CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} " /NODEFAULTLIB:realsense2" )
 
 set(MATLAB_CPP librealsense_mex.cpp Factory.cpp)
 set(MATLAB_H Factory.h MatlabParamParser.h rs2_type_traits.h types.h)


### PR DESCRIPTION
- Fix Pose record/playback flow to provide frame metadata - ts, fps, f.num
- Record and provide T265 Pose stream extrinsic parameters.
- Add `rs-enumerate-devices` functionality to parse playback device's info
>rs-enumerate-devices -f realsense_device_record.bag

- Fix the playback device context persistence, as requested by `ctx.load_device` API.

Derived on analysis of #3837
Tracked On: TM2-4344