### PR TITLE
Fix D435i IMU Extrinsics

### DIFF
--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -95,17 +95,9 @@ namespace librealsense
             }
             else
             {
-                LOG_INFO("IMU Extrinsic table error, switch to default calibration");
+                LOG_INFO("IMU extrinsic table not found; using CAD values");
                 // D435i specific - BMI055 assembly transformation based on mechanical drawing (mm)
-                //    ([[ -1.  ,   0.  ,   0.  ,   5.52],
-                //      [  0.  ,   1.  ,   0.  ,   5.1 ],
-                //      [  0.  ,   0.  ,  -1.  , -11.74],
-                //      [  0.  ,   0.  ,   0.  ,   1.  ]])
-                // The orientation matrix will be integrated into the IMU stream data
-                extr = { {-1.f,     0.f,    0.f,
-                           0.f,     1.f,    0.f,
-                           0.f,     0.f,   -1.f},
-                    { 0.00552f, -0.0051f, -0.01174f} };
+                extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 }, { -0.00552f, 0.0051f, 0.01174f} };
             }
             return extr;
         };
@@ -185,7 +177,6 @@ namespace librealsense
         lazy<ds::imu_intrinsic>                 _gyro_intrinsic;
         lazy<std::vector<uint8_t>>              _fisheye_calibration_table_raw;
         std::shared_ptr<lazy<rs2_extrinsics>>   _depth_to_imu;                  // Mechanical installation pose
-        std::shared_ptr<lazy<rs2_extrinsics>>   _depth_to_imu_aligned;          // Translation component
 
 #ifdef _WIN32
         // Bandwidth parameters from BOSCH BMI 055 spec'

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -159,7 +159,7 @@ namespace librealsense
                                 return inverse(back_edge->operator*());
                         }();
 
-                        auto pose = to_pose(local) * to_pose(*extr);
+                        auto pose = to_pose(*extr) * to_pose(local);
                         *extr = from_pose(pose);
                         return true;
                     }


### PR DESCRIPTION
Previously (the rotational part of) `_depth_to_imu` was applied to the IMU data to put them in depth coordinates when we should have applied the inverse.  In addition the translational part of the extrinsics had the wrong sign.

To clean this up, the aligning of the IMU with the depth camera is separated from the exported-to-user/eeprom-stored extrinsics such that the stored and default extrinsics now are with respect to the depth-aligned IMU.  This has the effect of completely hiding the coarse aligning of the IMU to depth camera from users.

This is based on the extrinsics graph fix, #3900, without which the extrinsics would still be wrong.

CC @dperox, @dmirota, @schmidtp1.
