### PR TITLE
Promote T265 Firmware to 0.0.18.5715

### DIFF
--- a/third-party/libtm/fw/CMakeLists.txt
+++ b/third-party/libtm/fw/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 cmake_minimum_required(VERSION 3.1.3)
 
-set( FW_VERSION "0.0.18.5502")
-set( FW_SHA1 46ba18af9907841da8a0a599f719c89fbb2515e3)
+set( FW_VERSION "0.0.18.5715")
+set( FW_SHA1 cc12cf05f387d80f65e98c4d41fc883725124a08)
 set(APP_VERSION "2.0.19.271")
 set(APP_SHA1 cab0011e9e18edc8bcca20afb2f944399ac8b81c)
 set( BL_VERSION "1.0.1.112")


### PR DESCRIPTION
WW19-RC0
Change-Id: Id063c2a903180d18610be29d0c7e765dd61103c5