### PR TITLE
Make legacy librealsense compatible with recent kernel

### DIFF
--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -777,6 +777,8 @@ namespace rsimpl
                 {
                     if(sub->busnum == dev->subdevices[0]->busnum && sub->devnum == dev->subdevices[0]->devnum)
                     {
+                        if (sub->is_metastream)  // avoid inserting metadata streamer
+                            continue;
                         dev->subdevices.push_back(move(sub));
                         is_new_device = false;
                         break;
@@ -811,6 +813,8 @@ namespace rsimpl
 
                 for(auto & dev : devices)
                 {
+                    if (sub->is_metastream)  // avoid inserting metadata streamer
+                        continue;
                     if (dev->subdevices[0]->vid == VID_INTEL_CAMERA && dev->subdevices[0]->pid == ZR300_CX3_PID && 
                         sub->vid == VID_INTEL_CAMERA && sub->pid == ZR300_FISHEYE_PID && dev->subdevices[0]->parent_devnum == sub->parent_devnum)
                     {

--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -35,7 +35,6 @@
 #include <linux/uvcvideo.h>
 #include <linux/videodev2.h>
 
-#include <iostream>
 #pragma GCC diagnostic ignored "-Wpedantic"
 #include <libusb.h>
 #pragma GCC diagnostic pop
@@ -157,7 +156,6 @@ namespace rsimpl
                 if(!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE)) throw std::runtime_error(dev_name + " is no video capture device");
                 if(!(cap.capabilities & V4L2_CAP_STREAMING)) throw std::runtime_error(dev_name + " does not support streaming I/O");
                 if((cap.device_caps & V4L2_CAP_META_CAPTURE)){
-                    std::cout << dev_name << " is a metadata stream" << std::endl;
                     is_metastream=true;
                 }
 


### PR DESCRIPTION
This should make it work with 4.16+ kernel
Tested with a R200, not sure about the behavior with other cams