### PR TITLE
Example: Stereo from T265 images using OpenCV

### DIFF
--- a/doc/t265.md
+++ b/doc/t265.md
@@ -87,6 +87,10 @@ No, the T265 does not offer any Depth information. It can provide position and o
 ### Can I use it together with a depth camera?
 Yes, this device can be used with RealSense (and most likely any 3rd-party) depth cameras. It is passive and comes with an IR-cut filter.
 
+### How can I use the camera intrinsics and extrinsics?
+
+The T265 uses the [Kanalla-Brandt distortion model](http://www.ee.oulu.fi/research/mvmp/mvg/files/pdf/pdf_697.pdf). This model is supported in OpenCV as part of the fisheye model. There is a python example which uses the camera intrinsics and extrinsics to [compute depth from T265 images on the host using OpenCV](../wrappers/python/examples/t265_stereo.py).
+
 ### What platforms are supported?
 At launch the T265 will be supported via librealsense on Windows and Linux, and via ros-realsense. Mac-OS and Android support are planned but not scheduled yet, as well as OpenVR integration.
 

--- a/wrappers/python/examples/readme.md
+++ b/wrappers/python/examples/readme.md
@@ -12,6 +12,9 @@ These Examples demonstrate how to use the python wrapper of the SDK.
 5. [Realsense Backend](./pybackend_example_1_general.py) - Example of controlling devices using the backend interface
 6. [Read bag file](./read_bag_example.py) - Example on how to read bag file and use colorizer to show recorded depth stream in jet colormap.
 7. [Box Dimensioner Multicam](./box_dimensioner_multicam/box_dimensioner_multicam_demo.py) - Simple demonstration for calculating the length, width and height of an object using multiple cameras.
+8. [T265 Basic](./t265_example.py) - Demonstrates how to retrieve pose data from a T265
+9. [T265 Coordinates](./t265_rpy.py) - This example shows how to change coordinate systems of a T265 pose
+10. [T265 Stereo](./t265_stereo.py) - This example shows how to use T265 intrinsics and extrinsics in OpenCV to asynchronously compute depth maps from T265 fisheye images on the host.
 
 ## Pointcloud Visualization
 

--- a/wrappers/python/examples/t265_stereo.py
+++ b/wrappers/python/examples/t265_stereo.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+## License: Apache 2.0. See LICENSE file in root directory.
+## Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+# Python 2/3 compatibility
+from __future__ import print_function
+
+"""
+This example shows how to use T265 intrinsics and extrinsics in OpenCV to
+asynchronously compute depth maps from T265 fisheye images on the host.
+
+T265 is not a depth camera and the quality of passive-only depth options will
+always be limited compared to (e.g.) the D4XX series cameras. However, T265 does
+have two global shutter cameras in a stereo configuration, and in this example
+we show how to set up OpenCV to undistort the images and compute stereo depth
+from them.
+
+Getting started with python3, OpenCV and T265 on Ubuntu 16.04:
+
+First, set up the virtual enviroment:
+
+$ apt-get install python3-venv  # install python3 built in venv support
+$ python3 -m venv py3librs      # create a virtual environment in pylibrs
+$ source py3librs/bin/activate  # activate the venv, do this from every terminal
+$ pip install opencv-python     # install opencv 4.1 in the venv
+$ pip install pyrealsense2      # install librealsense python bindings
+
+Then, for every new terminal:
+
+$ source py3librs/bin/activate  # Activate the virtual environment
+$ python3 t265_stereo.py        # Run the example
+"""
+
+# First import the library
+import pyrealsense2 as rs
+
+# Import OpenCV and numpy
+import cv2
+import numpy as np
+
+"""
+In this section, we will set up the functions that will translate the camera
+intrinsics and extrinsics from librealsense into parameters that can be used
+with OpenCV.
+
+The T265 uses very wide angle lenses, so the distortion is modeled using a four
+parameter distortion model known as Kanalla-Brandt. OpenCV supports this
+distortion model in their "fisheye" module, more details can be found here:
+
+https://docs.opencv.org/3.4/db/d58/group__calib3d__fisheye.html
+"""
+
+"""
+Returns R, T transform from src to dst
+"""
+def get_extrinsics(src, dst):
+    extrinsics = src.get_extrinsics_to(dst)
+    R = np.reshape(extrinsics.rotation, [3,3]).T
+    T = np.array(extrinsics.translation)
+    return (R, T)
+
+"""
+Returns a camera matrix K from librealsense intrinsics
+"""
+def camera_matrix(intrinsics):
+    return np.array([[intrinsics.fx,             0, intrinsics.ppx],
+                     [            0, intrinsics.fy, intrinsics.ppy],
+                     [            0,             0,              1]])
+
+"""
+Returns the fisheye distortion from librealsense intrinsics
+"""
+def fisheye_distortion(intrinsics):
+    return np.array(intrinsics.coeffs[:4])
+
+# Set up a mutex to share data between threads 
+from threading import Lock
+frame_mutex = Lock()
+frame_data = {"left"  : None,
+              "right" : None,
+              "timestamp_ms" : None
+              }
+
+"""
+This callback is called on a separate thread, so we must use a mutex
+to ensure that data is synchronized properly. We should also be
+careful not to do much work on this thread to avoid data backing up in the
+callback queue.
+"""
+def callback(frame):
+    global frame_data
+    if frame.is_frameset():
+        frameset = frame.as_frameset()
+        f1 = frameset.get_fisheye_frame(1).as_video_frame()
+        f2 = frameset.get_fisheye_frame(2).as_video_frame()
+        left_data = np.asanyarray(f1.get_data())
+        right_data = np.asanyarray(f2.get_data())
+        ts = frameset.get_timestamp()
+        frame_mutex.acquire()
+        frame_data["left"] = left_data
+        frame_data["right"] = right_data
+        frame_data["timestamp_ms"] = ts
+        frame_mutex.release()
+
+# Declare RealSense pipeline, encapsulating the actual device and sensors
+pipe = rs.pipeline()
+
+# Build config object and stream everything
+cfg = rs.config()
+
+# Start streaming with our callback
+pipe.start(cfg, callback)
+
+try:
+    # Retreive the stream and intrinsic properties for both cameras
+    profiles = pipe.get_active_profile()
+    streams = {"left"  : profiles.get_stream(rs.stream.fisheye, 1).as_video_stream_profile(),
+               "right" : profiles.get_stream(rs.stream.fisheye, 2).as_video_stream_profile()}
+    intrinsics = {"left"  : streams["left"].get_intrinsics(),
+                  "right" : streams["right"].get_intrinsics()}
+
+    # Set up an OpenCV window to visualize the results
+    WINDOW_TITLE = 'Realsense'
+    cv2.namedWindow(WINDOW_TITLE, cv2.WINDOW_NORMAL)
+
+    # Print information about both cameras
+    print("Left camera:",  intrinsics["left"])
+    print("Right camera:", intrinsics["right"])
+
+    # Translate the intrinsics from librealsense into OpenCV
+    K_left  = camera_matrix(intrinsics["left"])
+    D_left  = fisheye_distortion(intrinsics["left"])
+    K_right = camera_matrix(intrinsics["right"])
+    D_right = fisheye_distortion(intrinsics["right"])
+    (width, height) = (intrinsics["left"].width, intrinsics["left"].height)
+
+    # Get thre relative extrinsics between the left and right camera
+    (R, T) = get_extrinsics(streams["left"], streams["right"])
+
+    # Use OpenCV stereoRectify to compute a rectifying transform composed of two
+    # rotations, two projection matrices, and a Q matrix that transforms
+    # disparity to 3D points
+    (R_left, R_right, P_left, P_right, Q) = \
+    cv2.fisheye.stereoRectify(K1 = K_left, 
+                              D1 = D_left, 
+                              K2 = K_right,
+                              D2 = D_right,
+                              imageSize = (width, height),
+                              R = R,
+                              tvec = T,
+                              flags = cv2.CALIB_ZERO_DISPARITY,
+                              newImageSize = (width, height),
+                              balance = 0,
+                              fov_scale = 1.0)[0:5]
+
+    # Make sure the undisorted principal point is in the center of the image 
+    P_left[0][2] = P_right[0][2] = width/2
+    P_left[1][2] = P_right[1][2] = height/2
+
+    # Create an undistortion map for the left and right camera which applies the
+    # rectification and undoes the camera distortion. This only has to be done
+    # once
+    m1type = cv2.CV_32FC1
+    (lm1, lm2) = cv2.fisheye.initUndistortRectifyMap(K_left, D_left, R_left, P_left, (width, height), m1type)
+    (rm1, rm2) = cv2.fisheye.initUndistortRectifyMap(K_right, D_right, R_right, P_right, (width, height), m1type)
+    undistort_rectify = {"left"  : (lm1, lm2),
+                         "right" : (rm1, rm2)}
+
+    # Configure the OpenCV stereo algorithm. See
+    # https://docs.opencv.org/3.4/d2/d85/classcv_1_1StereoSGBM.html for a
+    # description of the parameters
+    window_size = 3
+    min_disp = 0
+    # must be divisible by 16
+    num_disp = 112 - min_disp
+    max_disp = min_disp + num_disp
+    stereo = cv2.StereoSGBM_create(minDisparity = min_disp,
+                                   numDisparities = num_disp,
+                                   blockSize = 16,
+                                   P1 = 8*3*window_size**2,
+                                   P2 = 32*3*window_size**2,
+                                   disp12MaxDiff = 1,
+                                   uniquenessRatio = 10,
+                                   speckleWindowSize = 100,
+                                   speckleRange = 32)
+
+    # Since the field of view of T265 is very wide, stereo computed on the edges
+    # of the images are not very informative. So, here we set up a region to
+    # crop in the center of the image. We also need to modify Q since we have
+    # adjusted the center of the disparity image
+    half_center_size = int((height/3)/2)
+    (rs,re) = (int(height/2 - half_center_size), int(height/2 + half_center_size))
+    (cs,ce) = (int( width/2 - half_center_size), int( width/2 + half_center_size))
+    (Q[0][3], Q[1][3]) = (-half_center_size, -half_center_size)
+
+    # Calculate the undistorted field of view
+    import math
+    focal_length = Q[2][3]
+    normalized_half_height = (re - rs)/focal_length/2
+    normalized_half_width  = (ce - cs)/focal_length/2
+    horizontal_fov = 2*math.atan(normalized_half_width)*180/math.pi
+    vertical_fov   = 2*math.atan(normalized_half_height)*180/math.pi
+    print("Undistorted FOV: %.1fdeg wide, %.1fdeg high" % (horizontal_fov, vertical_fov))
+
+    # start with max_disp more pixels if possible, since SGBM leaves an empty max_disp pixels on the left
+    cs_offset = min(max_disp,cs)
+    cs -= cs_offset
+
+    mode = "stack"
+    while True:
+        # Check if the camera has acquired any frames
+        frame_mutex.acquire()
+        valid = frame_data["timestamp_ms"] is not None
+        frame_mutex.release()
+
+        # If frames are ready to process
+        if valid:
+            # Hold the mutex only long enough to copy the stereo frames
+            frame_mutex.acquire()
+            frame_copy = {"left"  : frame_data["left"].copy(),
+                          "right" : frame_data["right"].copy()}
+            frame_mutex.release()
+
+            # Undistort and crop the center of the frames
+            center_undistorted = {"left" : cv2.remap(src = frame_copy["left"],
+                                          map1 = undistort_rectify["left"][0],
+                                          map2 = undistort_rectify["left"][1],
+                                          interpolation = cv2.INTER_LINEAR)[rs:re, cs:ce],
+                                  "right" : cv2.remap(src = frame_copy["right"],
+                                          map1 = undistort_rectify["right"][0],
+                                          map2 = undistort_rectify["right"][1],
+                                          interpolation = cv2.INTER_LINEAR)[rs:re, cs:ce]}
+
+            # compute the disparity on the center of the frames and convert it to a pixel disparity (divide by DISP_SCALE=16)
+            disparity = stereo.compute(center_undistorted["left"], center_undistorted["right"]).astype(np.float32) / 16.0
+
+            # re-crop just the valid part of the disparity
+            disparity = disparity[:,cs_offset:]
+
+            # convert disparity to 0-255 and color it
+            disp_vis = 255*(disparity - min_disp)/ num_disp
+            disp_color = cv2.applyColorMap(cv2.convertScaleAbs(disp_vis,1), cv2.COLORMAP_JET)
+            color_image = cv2.cvtColor(center_undistorted["left"][:,cs_offset:], cv2.COLOR_GRAY2RGB)
+
+            if mode == "stack":
+                cv2.imshow(WINDOW_TITLE, np.hstack((color_image, disp_color)))
+            if mode == "overlay":
+                ind = disparity >= min_disp
+                color_image[ind, 0] = disp_color[ind, 0]
+                color_image[ind, 1] = disp_color[ind, 1]
+                color_image[ind, 2] = disp_color[ind, 2]
+                cv2.imshow(WINDOW_TITLE, color_image)
+        key = cv2.waitKey(1)
+        if key == ord('s'): mode = "stack"
+        if key == ord('o'): mode = "overlay"
+        if key == ord('q') or cv2.getWindowProperty(WINDOW_TITLE, cv2.WND_PROP_VISIBLE) < 1:
+            break
+finally:
+    pipe.stop()


### PR DESCRIPTION
This example shows how to use T265 intrinsics and extrinsics in OpenCV to asynchronously compute depth maps from T265 fisheye images on the host.

T265 is not a depth camera and the quality of passive-only depth options will always be limited compared to (e.g.) the D4XX series cameras. However, T265 does have two global shutter cameras in a stereo configuration, and in this example we show how to set up OpenCV to undistort the images using OpenCV's fisheye model and compute stereo depth from them.