### PR TITLE
UE4 Wrapper Update

### DIFF
--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -250,7 +250,7 @@ namespace rs2
         * \param[in] block - low level rs2_processing_block created before.
         */
         processing_block(std::shared_ptr<rs2_processing_block> block)
-            : _block(block), options((rs2_options*)block.get())
+            : options((rs2_options*)block.get()), _block(block)
         {
         }
 

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DepthColorizer.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DepthColorizer.cpp
@@ -1,3 +1,4 @@
+#include "DepthColorizer.h"
 #include "PCH.h"
 #include "ColorMap.inl"
 

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DepthColorizer.h
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DepthColorizer.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "RealSenseNative.h"
 
 namespace rs2_utils {
 

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DynamicTexture.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DynamicTexture.cpp
@@ -1,3 +1,4 @@
+#include "DynamicTexture.h"
 #include "PCH.h"
 
 FDynamicTexture::FDynamicTexture(FString Name, 

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DynamicTexture.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/DynamicTexture.cpp
@@ -15,12 +15,11 @@ FDynamicTexture::FDynamicTexture(FString Name,
 	this->Compression = Compression;
 
 	CommandCounter.Increment();
-	ENQUEUE_UNIQUE_RENDER_COMMAND_ONEPARAMETER(
-		CreateTextureCmd,
-		FDynamicTexture*, Context, this,
-	{
-		Context->RenderCmd_CreateTexture();
-	});
+	ENQUEUE_RENDER_COMMAND(CreateTextureCmd)(
+		[this](FRHICommandListImmediate& RHICmdList)
+		{
+			this->RenderCmd_CreateTexture();
+		});
 }
 
 FDynamicTexture::~FDynamicTexture()
@@ -97,12 +96,11 @@ void FDynamicTexture::EnqueUpdateCommand(FTextureUpdateData* Tud)
 	else if (TextureObject && TextureObject->Resource)
 	{
 		CommandCounter.Increment();
-		ENQUEUE_UNIQUE_RENDER_COMMAND_ONEPARAMETER(
-			UpdateTextureCmd,
-			FTextureUpdateData*, Tud, Tud,
-		{
-			Tud->Context->RenderCmd_UpdateTexture(Tud);
-		});
+		ENQUEUE_RENDER_COMMAND(UpdateTextureCmd)(
+			[Tud](FRHICommandListImmediate& RHICmdList)
+			{
+				Tud->Context->RenderCmd_UpdateTexture(Tud);
+			});
 	}
 }
 

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseContext.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseContext.cpp
@@ -1,3 +1,4 @@
+#include "RealSenseContext.h"
 #include "PCH.h"
 
 URealSenseContext::URealSenseContext(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseDetailCustomization.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseDetailCustomization.cpp
@@ -1,3 +1,4 @@
+#include "RealSenseDetailCustomization.h"
 #include "PCH.h"
 
 #if WITH_EDITOR

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseDevice.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseDevice.cpp
@@ -1,3 +1,4 @@
+#include "RealSenseDevice.h"
 #include "PCH.h"
 #include <librealsense2/rs_advanced_mode.hpp>
 

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseOption.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseOption.cpp
@@ -1,3 +1,4 @@
+#include "RealSenseOption.h"
 #include "PCH.h"
 
 URealSenseOption::URealSenseOption(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSensePluginImpl.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSensePluginImpl.cpp
@@ -1,5 +1,5 @@
-#include "PCH.h"
 #include "RealSensePluginImpl.h"
+#include "PCH.h"
 
 #if defined(PROF_ENABLED)
 #include "AllowWindowsPlatformTypes.h"

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseSensor.cpp
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Private/RealSenseSensor.cpp
@@ -1,3 +1,4 @@
+#include "RealSenseSensor.h"
 #include "PCH.h"
 
 URealSenseSensor::URealSenseSensor(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Public/RealSenseInspector.h
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/Public/RealSenseInspector.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "PCH.h"
 #include "RealSenseTypes.h"
 #include "RuntimeMeshComponent.h"
 #include "RealSenseInspector.generated.h"

--- a/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/RealSense.Build.cs
+++ b/wrappers/unrealengine4/Plugins/RealSense/Source/RealSense/RealSense.Build.cs
@@ -8,8 +8,10 @@ public class RealSense : ModuleRules
 		bEnableExceptions = true;
 		bUseRTTI = false;
 
-		PrivateIncludePaths.AddRange(new string[] { "RealSense/Private" });
-		PublicIncludePaths.AddRange(new string[] { "RealSense/Public" });
+		PrivateIncludePaths.AddRange(new string[] { Path.Combine( ModuleDirectory, "Private") });
+		PublicIncludePaths.AddRange(new string[] { Path.Combine(ModuleDirectory, "Public") });
+
+		PrivatePCHHeaderFile = "Private/PCH.h";
 
 		PublicDependencyModuleNames.AddRange(
 			new string[] {
@@ -37,7 +39,7 @@ public class RealSense : ModuleRules
 		}
 
 		//string RealSenseDirectory = Environment.GetEnvironmentVariable("RSSDK_DIR");
-		string RealSenseDirectory = "c:/Program Files (x86)/Intel RealSense SDK 2.0";
+		string RealSenseDirectory = "C:/Program Files (x86)/Intel RealSense SDK 2.0";
 
 		PublicIncludePaths.Add(Path.Combine(RealSenseDirectory, "include"));
 		PublicLibraryPaths.Add(Path.Combine(RealSenseDirectory, "lib", "x64"));

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMesh.cpp
@@ -116,7 +116,11 @@ void URuntimeMesh::Serialize(FArchive& Ar)
 
 	// Serialize the entire data object.
 	Ar.UsingCustomVersion(FRuntimeMeshVersion::GUID);
-	Ar << Data.Get();
+
+	if (Ar.CustomVer(FRuntimeMeshVersion::GUID) < FRuntimeMeshVersion::SerializationUpgradeToConfigurable || bShouldSerializeMeshData)
+	{
+		Ar << Data.Get();
+	}
 }
 
 void URuntimeMesh::PostLoad()
@@ -138,6 +142,11 @@ UMaterialInterface* URuntimeMesh::GetMaterialFromCollisionFaceIndex(int32 FaceIn
 	return nullptr;
 }
 
+int32 URuntimeMesh::GetSectionIdFromCollisionFaceIndex(int32 FaceIndex) const
+{
+	return GetRuntimeMeshData()->GetSectionFromCollisionFaceIndex(FaceIndex);
+}
+
 void URuntimeMesh::MarkCollisionDirty()
 {
 	// Flag the collision as dirty
@@ -149,6 +158,7 @@ void URuntimeMesh::MarkCollisionDirty()
 	}
 }
 
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 21
 UBodySetup* URuntimeMesh::CreateNewBodySetup()
 {
 	UBodySetup* NewBodySetup = NewObject<UBodySetup>(this, NAME_None, (IsTemplate() ? RF_Public : RF_NoFlags));
@@ -156,14 +166,7 @@ UBodySetup* URuntimeMesh::CreateNewBodySetup()
 
 	return NewBodySetup;
 }
-
-void URuntimeMesh::EnsureBodySetupCreated()
-{
-	if (BodySetup == nullptr)
-	{
-		BodySetup = CreateNewBodySetup();
-	}
-}
+#endif
 
 void URuntimeMesh::CopyCollisionElementsToBodySetup(UBodySetup* Setup)
 {
@@ -181,6 +184,13 @@ void URuntimeMesh::SetBasicBodySetupParameters(UBodySetup* Setup)
 
 void URuntimeMesh::UpdateCollision(bool bForceCookNow)
 {
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 21
+	DoForAllLinkedComponents([bForceCookNow](URuntimeMeshComponent* Mesh)
+	{
+		Mesh->UpdateCollision(bForceCookNow);
+	});
+
+#else
 	SCOPE_CYCLE_COUNTER(STAT_RuntimeMesh_CollisionUpdate);
 	check(IsInGameThread());
 	
@@ -189,14 +199,20 @@ void URuntimeMesh::UpdateCollision(bool bForceCookNow)
 
 	if (bShouldCookAsync)
 	{
-		UBodySetup* CurrentBodySetup = CreateNewBodySetup();
-		AsyncBodySetupQueue.Add(CurrentBodySetup);
+		// Abort all previous ones still standing
+		for (UBodySetup* OldBody : AsyncBodySetupQueue)
+		{
+			OldBody->AbortPhysicsMeshAsyncCreation();
+		}
 
-		SetBasicBodySetupParameters(CurrentBodySetup);
-		CopyCollisionElementsToBodySetup(CurrentBodySetup);
+		UBodySetup* NewBodySetup = CreateNewBodySetup();
+		AsyncBodySetupQueue.Add(NewBodySetup);
 
-		CurrentBodySetup->CreatePhysicsMeshesAsync(
-			FOnAsyncPhysicsCookFinished::CreateUObject(this, &URuntimeMesh::FinishPhysicsAsyncCook, CurrentBodySetup));
+		SetBasicBodySetupParameters(NewBodySetup);
+		CopyCollisionElementsToBodySetup(NewBodySetup);
+
+		NewBodySetup->CreatePhysicsMeshesAsync(
+			FOnAsyncPhysicsCookFinished::CreateUObject(this, &URuntimeMesh::FinishPhysicsAsyncCook, NewBodySetup));
 	}
 	else
 	{
@@ -217,9 +233,11 @@ void URuntimeMesh::UpdateCollision(bool bForceCookNow)
 		BodySetup = NewBodySetup;
 		FinalizeNewCookedData();
 	}
+#endif
 }
 
-void URuntimeMesh::FinishPhysicsAsyncCook(UBodySetup* FinishedBodySetup)
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 21
+void URuntimeMesh::FinishPhysicsAsyncCook(bool bSuccess, UBodySetup* FinishedBodySetup)
 {
 	SCOPE_CYCLE_COUNTER(STAT_RuntimeMesh_AsyncCollisionFinish);
 	check(IsInGameThread());
@@ -227,18 +245,26 @@ void URuntimeMesh::FinishPhysicsAsyncCook(UBodySetup* FinishedBodySetup)
 	int32 FoundIdx;
 	if (AsyncBodySetupQueue.Find(FinishedBodySetup, FoundIdx))
 	{
-		// The new body was found in the array meaning it's newer so use it
-		BodySetup = FinishedBodySetup;
+		if (bSuccess)
+		{			
+			// The new body was found in the array meaning it's newer so use it
+			BodySetup = FinishedBodySetup;
 
-		// Shift down all remaining body setups, removing any old setups
-		for (int32 Index = FoundIdx + 1; Index < AsyncBodySetupQueue.Num(); Index++)
-		{
-			AsyncBodySetupQueue[Index - (FoundIdx + 1)] = AsyncBodySetupQueue[Index];
-			AsyncBodySetupQueue[Index] = nullptr;
+			// Shift down all remaining body setups, removing any old setups
+			for (int32 Index = FoundIdx + 1; Index < AsyncBodySetupQueue.Num(); Index++)
+			{
+				AsyncBodySetupQueue[Index - (FoundIdx + 1)] = AsyncBodySetupQueue[Index];
+				AsyncBodySetupQueue[Index] = nullptr;
+			}
+			AsyncBodySetupQueue.SetNum(AsyncBodySetupQueue.Num() - (FoundIdx + 1));
+
+			FinalizeNewCookedData();
+
 		}
-		AsyncBodySetupQueue.SetNum(AsyncBodySetupQueue.Num() - (FoundIdx + 1));
-
-		FinalizeNewCookedData();
+		else
+		{
+			AsyncBodySetupQueue.RemoveAt(FoundIdx);
+		}
 	}
 }
 
@@ -259,6 +285,7 @@ void URuntimeMesh::FinalizeNewCookedData()
 		CollisionUpdated.Broadcast();
 	}
 }
+#endif
 
 void URuntimeMesh::UpdateLocalBounds()
 {

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshActor.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshActor.cpp
@@ -3,6 +3,8 @@
 #include "RuntimeMeshActor.h"
 #include "RuntimeMeshComponent.h"
 #include "RuntimeMeshComponentPlugin.h"
+#include "Engine/CollisionProfile.h"
+
 
 
 ARuntimeMeshActor::ARuntimeMeshActor(const FObjectInitializer& ObjectInitializer)
@@ -15,8 +17,12 @@ ARuntimeMeshActor::ARuntimeMeshActor(const FObjectInitializer& ObjectInitializer
 	RuntimeMeshComponent = CreateDefaultSubobject<URuntimeMeshComponent>(TEXT("RuntimeMeshComponent0"));
 	RuntimeMeshComponent->SetCollisionProfileName(UCollisionProfile::BlockAll_ProfileName);
 	RuntimeMeshComponent->Mobility = EComponentMobility::Static;
-	RuntimeMeshComponent->bGenerateOverlapEvents = false;
 
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 20
+	RuntimeMeshComponent->SetGenerateOverlapEvents(false);
+#else
+	RuntimeMeshComponent->bGenerateOverlapEvents = false;
+#endif
 	RootComponent = RuntimeMeshComponent;
 }
 
@@ -56,6 +62,8 @@ EComponentMobility::Type ARuntimeMeshActor::GetMobility()
 
 void ARuntimeMeshActor::OnConstruction(const FTransform& Transform)
 {
+	Super::OnConstruction(Transform);
+	
 	if (bRunGenerateMeshesOnConstruction)
 	{
 		GenerateMeshes();
@@ -64,6 +72,8 @@ void ARuntimeMeshActor::OnConstruction(const FTransform& Transform)
 
 void ARuntimeMeshActor::BeginPlay()
 {
+	Super::BeginPlay();
+	
 	bool bIsGameWorld = GetWorld() && GetWorld()->IsGameWorld() && !GetWorld()->IsPreviewWorld() && !GetWorld()->IsEditorWorld();
 
 	bool bHadSerializedMeshData = false;
@@ -72,7 +82,7 @@ void ARuntimeMeshActor::BeginPlay()
 		URuntimeMesh* Mesh = RuntimeMeshComponent->GetRuntimeMesh();
 		if (Mesh)
 		{
-			bHadSerializedMeshData = Mesh->HasSerializedMeshData();
+			bHadSerializedMeshData = Mesh->ShouldSerializeMeshData();
 		}
 	}
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintMeshBuilder.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshBlueprintMeshBuilder.cpp
@@ -1,0 +1,15 @@
+// Copyright 2016-2018 Chris Conway (Koderz). All Rights Reserved.
+
+#include "RuntimeMeshBlueprintMeshBuilder.h"
+
+
+
+
+
+URuntimeBlueprintMeshBuilder* URuntimeMeshBuilderFunctions::MakeRuntimeMeshBuilder(bool bWantsHighPrecisionTangents /*= false*/, bool bWantsHighPrecisionUVs /*= false*/, int32 NumUVs /*= 1*/, bool bUse16BitIndices /*= false*/)
+{
+	URuntimeBlueprintMeshBuilder* Builder = NewObject<URuntimeBlueprintMeshBuilder>();
+	Builder->MeshBuilder = ::MakeRuntimeMeshBuilder(bWantsHighPrecisionTangents, bWantsHighPrecisionUVs, NumUVs, !bUse16BitIndices);
+	Builder->MeshAccessor = Builder->MeshBuilder;
+	return Builder;
+}

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
@@ -13,7 +13,12 @@
 #include "RuntimeMesh.h"
 #include "RuntimeMeshComponentProxy.h"
 #include "RuntimeMeshLegacySerialization.h"
+
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 20
 #include "NavigationSystem.h"
+#else
+#include "AI/Navigation/NavigationSystem.h"
+#endif
 
 
 
@@ -71,14 +76,13 @@ void URuntimeMeshComponent::NewCollisionMeshReceived()
 #if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 20
 	FNavigationSystem::UpdateComponentData(*this);
 #else
- 	if (UNavigationSystemV1::ShouldUpdateNavOctreeOnComponentChange() && IsRegistered())
+ 	if (UNavigationSystem::ShouldUpdateNavOctreeOnComponentChange() && IsRegistered())
  	{
  		UWorld* MyWorld = GetWorld();
- 
- 		if (MyWorld != nullptr && FNavigationSystem::GetCurrent(MyWorld) != nullptr &&
- 			(FNavigationSystem::GetCurrent(MyWorld)->ShouldAllowClientSideNavigation() || !MyWorld->IsNetMode(ENetMode::NM_Client)))
+		if (MyWorld != nullptr && MyWorld->GetNavigationSystem() != nullptr &&
+			(MyWorld->GetNavigationSystem()->ShouldAllowClientSideNavigation() || !MyWorld->IsNetMode(ENetMode::NM_Client)))
  		{
-			UNavigationSystemV1::UpdateComponentInNavOctree(*this);
+			UNavigationSystem::UpdateComponentInNavOctree(*this);
  		}
  	}
 #endif

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponent.cpp
@@ -13,7 +13,7 @@
 #include "RuntimeMesh.h"
 #include "RuntimeMeshComponentProxy.h"
 #include "RuntimeMeshLegacySerialization.h"
-
+#include "NavigationSystem.h"
 
 
 
@@ -25,6 +25,10 @@ DECLARE_CYCLE_STAT(TEXT("RMC - New Collision Data Recieved"), STAT_RuntimeMeshCo
 
 URuntimeMeshComponent::URuntimeMeshComponent(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 21
+	, BodySetup(nullptr)
+#endif
+
 {
 	SetNetAddressable();
 }
@@ -67,14 +71,14 @@ void URuntimeMeshComponent::NewCollisionMeshReceived()
 #if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 20
 	FNavigationSystem::UpdateComponentData(*this);
 #else
- 	if (UNavigationSystem::ShouldUpdateNavOctreeOnComponentChange() && IsRegistered())
+ 	if (UNavigationSystemV1::ShouldUpdateNavOctreeOnComponentChange() && IsRegistered())
  	{
  		UWorld* MyWorld = GetWorld();
  
- 		if (MyWorld != nullptr && MyWorld->GetNavigationSystem() != nullptr &&
- 			(MyWorld->GetNavigationSystem()->ShouldAllowClientSideNavigation() || !MyWorld->IsNetMode(ENetMode::NM_Client)))
+ 		if (MyWorld != nullptr && FNavigationSystem::GetCurrent(MyWorld) != nullptr &&
+ 			(FNavigationSystem::GetCurrent(MyWorld)->ShouldAllowClientSideNavigation() || !MyWorld->IsNetMode(ENetMode::NM_Client)))
  		{
- 			UNavigationSystem::UpdateComponentInNavOctree(*this);
+			UNavigationSystemV1::UpdateComponentInNavOctree(*this);
  		}
  	}
 #endif
@@ -123,12 +127,16 @@ FPrimitiveSceneProxy* URuntimeMeshComponent::CreateSceneProxy()
 
 UBodySetup* URuntimeMeshComponent::GetBodySetup()
 {
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 21
+	return BodySetup;
+#else
 	if (GetRuntimeMesh())
 	{
 		return GetRuntimeMesh()->BodySetup;
 	}
 	
 	return nullptr;
+#endif
 }
 
 
@@ -165,6 +173,23 @@ UMaterialInterface* URuntimeMeshComponent::GetMaterial(int32 ElementIndex) const
 
 	// Had no RM/Section return null
 	return nullptr;
+}
+
+UMaterialInterface* URuntimeMeshComponent::GetOverrideMaterial(int32 ElementIndex) const
+{
+	return Super::GetMaterial(ElementIndex);
+}
+
+int32 URuntimeMeshComponent::GetSectionIdFromCollisionFaceIndex(int32 FaceIndex) const
+{
+	int32 SectionIndex = 0;
+
+	if (URuntimeMesh* Mesh = GetRuntimeMesh())
+	{
+		SectionIndex = Mesh->GetSectionIdFromCollisionFaceIndex(FaceIndex);
+	}
+
+	return SectionIndex;
 }
 
 UMaterialInterface* URuntimeMeshComponent::GetMaterialFromCollisionFaceIndex(int32 FaceIndex, int32& SectionIndex) const
@@ -211,4 +236,110 @@ void URuntimeMeshComponent::PostLoad()
 	{
 		RuntimeMeshReference->RegisterLinkedComponent(this);
 	}
+}
+
+
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 21
+
+bool URuntimeMeshComponent::GetPhysicsTriMeshData(struct FTriMeshCollisionData* CollisionData, bool InUseAllTriData)
+{
+	URuntimeMesh* RuntimeMesh = GetRuntimeMesh();
+	if (RuntimeMesh)
+	{
+		return RuntimeMesh->GetPhysicsTriMeshData(CollisionData, InUseAllTriData);
+	}
+
+	return false;
+}
+
+bool URuntimeMeshComponent::ContainsPhysicsTriMeshData(bool InUseAllTriData) const
+{
+	URuntimeMesh* RuntimeMesh = GetRuntimeMesh();
+	if (RuntimeMesh)
+	{
+		return RuntimeMesh->ContainsPhysicsTriMeshData(InUseAllTriData);
+	}
+	return false;
+}
+
+UBodySetup* URuntimeMeshComponent::CreateNewBodySetup()
+{
+	UBodySetup* NewBodySetup = NewObject<UBodySetup>(this, NAME_None, (IsTemplate() ? RF_Public : RF_NoFlags));
+	NewBodySetup->BodySetupGuid = FGuid::NewGuid();
+
+	return NewBodySetup;
+}
+
+void URuntimeMeshComponent::FinishPhysicsAsyncCook(UBodySetup* FinishedBodySetup)
+{
+	//SCOPE_CYCLE_COUNTER(STAT_RuntimeMesh_AsyncCollisionFinish);
+	check(IsInGameThread());
+
+	int32 FoundIdx;
+	if (AsyncBodySetupQueue.Find(FinishedBodySetup, FoundIdx))
+	{
+		// The new body was found in the array meaning it's newer so use it
+		BodySetup = FinishedBodySetup;
+
+		// Shift down all remaining body setups, removing any old setups
+		for (int32 Index = FoundIdx + 1; Index < AsyncBodySetupQueue.Num(); Index++)
+		{
+			AsyncBodySetupQueue[Index - (FoundIdx + 1)] = AsyncBodySetupQueue[Index];
+			AsyncBodySetupQueue[Index] = nullptr;
+		}
+		AsyncBodySetupQueue.SetNum(AsyncBodySetupQueue.Num() - (FoundIdx + 1));
+		
+		NewCollisionMeshReceived();
+	}
+}
+
+void URuntimeMeshComponent::UpdateCollision(bool bForceCookNow)
+{
+	//SCOPE_CYCLE_COUNTER(STAT_RuntimeMesh_CollisionUpdate);
+	check(IsInGameThread());
+	// HORU: workaround for a nullpointer
+	if (!GetRuntimeMesh())
+		return;
+	//check(GetRuntimeMesh());
+
+	UWorld* World = GetWorld();
+	const bool bShouldCookAsync = !bForceCookNow && World && World->IsGameWorld() && GetRuntimeMesh()->bUseAsyncCooking;
+
+	if (bShouldCookAsync)
+	{
+		UBodySetup* NewBodySetup = CreateNewBodySetup();
+		AsyncBodySetupQueue.Add(NewBodySetup);
+
+		GetRuntimeMesh()->SetBasicBodySetupParameters(NewBodySetup);
+		GetRuntimeMesh()->CopyCollisionElementsToBodySetup(NewBodySetup);
+
+		NewBodySetup->CreatePhysicsMeshesAsync(
+			FOnAsyncPhysicsCookFinished::CreateUObject(this, &URuntimeMeshComponent::FinishPhysicsAsyncCook, NewBodySetup));
+	}
+	else
+	{
+		AsyncBodySetupQueue.Empty();
+		UBodySetup* NewBodySetup = CreateNewBodySetup();
+
+		// Change body setup guid 
+		NewBodySetup->BodySetupGuid = FGuid::NewGuid();
+
+		GetRuntimeMesh()->SetBasicBodySetupParameters(NewBodySetup);
+		GetRuntimeMesh()->CopyCollisionElementsToBodySetup(NewBodySetup);
+
+		// Update meshes
+		NewBodySetup->bHasCookedCollisionData = true;
+		NewBodySetup->InvalidatePhysicsData();
+		NewBodySetup->CreatePhysicsMeshes();
+
+		BodySetup = NewBodySetup;
+		NewCollisionMeshReceived();
+	}
+}
+
+#endif
+
+bool URuntimeMeshComponent::IsAsyncCollisionCookingPending() const
+{
+	return AsyncBodySetupQueue.Num() != 0;
 }

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
@@ -5,6 +5,8 @@
 #include "RuntimeMeshComponent.h"
 #include "RuntimeMeshProxy.h"
 #include "PhysicsEngine/BodySetup.h"
+#include "TessellationRendering.h"
+#include "PrimitiveSceneProxy.h"
 
 FRuntimeMeshComponentSceneProxy::FRuntimeMeshComponentSceneProxy(URuntimeMeshComponent* Component) 
 	: FPrimitiveSceneProxy(Component)
@@ -86,8 +88,8 @@ void FRuntimeMeshComponentSceneProxy::CreateMeshBatch(FMeshBatch& MeshBatch, con
 	MeshBatch.ReverseCulling = IsLocalToWorldDeterminantNegative();
 	MeshBatch.bCanApplyViewModeOverrides = true;
 
-	FMeshBatchElement& BatchElement = MeshBatch.Elements[0];
-	BatchElement.PrimitiveUniformBufferResource = &GetUniformBuffer();
+	//HORU: 4.22 compat
+	//FMeshBatchElement& BatchElement = MeshBatch.Elements[0];
 }
 
 void FRuntimeMeshComponentSceneProxy::DrawStaticElements(FStaticPrimitiveDrawInterface* PDI)
@@ -98,7 +100,7 @@ void FRuntimeMeshComponentSceneProxy::DrawStaticElements(FStaticPrimitiveDrawInt
 		if (SectionRenderData.Contains(SectionEntry.Key) && Section.IsValid() && Section->ShouldRender() && Section->WantsToRenderInStaticPath())
 		{
 			const FRuntimeMeshSectionRenderData& RenderData = SectionRenderData[SectionEntry.Key];
-			FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy(false);
+			FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy();
 
 			FMeshBatch MeshBatch;
 			CreateMeshBatch(MeshBatch, Section, RenderData, Material, nullptr);
@@ -116,7 +118,7 @@ void FRuntimeMeshComponentSceneProxy::GetDynamicMeshElements(const TArray<const 
 	if (bWireframe)
 	{
 		WireframeMaterialInstance = new FColoredMaterialRenderProxy(
-			GEngine->WireframeMaterial ? GEngine->WireframeMaterial->GetRenderProxy(IsSelected()) : nullptr,
+			GEngine->WireframeMaterial ? GEngine->WireframeMaterial->GetRenderProxy() : nullptr,
 			FLinearColor(0, 0.5f, 1.f)
 		);
 
@@ -139,7 +141,7 @@ void FRuntimeMeshComponentSceneProxy::GetDynamicMeshElements(const TArray<const 
 					if (bForceDynamicPath || !Section->WantsToRenderInStaticPath())
 					{
 						const FRuntimeMeshSectionRenderData& RenderData = SectionRenderData[SectionEntry.Key];
-						FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy(IsSelected());
+						FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy();
 
 						FMeshBatch& MeshBatch = Collector.AllocateMesh();
 						CreateMeshBatch(MeshBatch, Section, RenderData, Material, WireframeMaterialInstance);

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
@@ -100,7 +100,12 @@ void FRuntimeMeshComponentSceneProxy::DrawStaticElements(FStaticPrimitiveDrawInt
 		if (SectionRenderData.Contains(SectionEntry.Key) && Section.IsValid() && Section->ShouldRender() && Section->WantsToRenderInStaticPath())
 		{
 			const FRuntimeMeshSectionRenderData& RenderData = SectionRenderData[SectionEntry.Key];
+
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 20
+			FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy(false);
+#else
 			FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy();
+#endif
 
 			FMeshBatch MeshBatch;
 			CreateMeshBatch(MeshBatch, Section, RenderData, Material, nullptr);
@@ -118,7 +123,11 @@ void FRuntimeMeshComponentSceneProxy::GetDynamicMeshElements(const TArray<const 
 	if (bWireframe)
 	{
 		WireframeMaterialInstance = new FColoredMaterialRenderProxy(
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 20
+			GEngine->WireframeMaterial ? GEngine->WireframeMaterial->GetRenderProxy(IsSelected()) : nullptr,
+#else
 			GEngine->WireframeMaterial ? GEngine->WireframeMaterial->GetRenderProxy() : nullptr,
+#endif
 			FLinearColor(0, 0.5f, 1.f)
 		);
 
@@ -141,7 +150,11 @@ void FRuntimeMeshComponentSceneProxy::GetDynamicMeshElements(const TArray<const 
 					if (bForceDynamicPath || !Section->WantsToRenderInStaticPath())
 					{
 						const FRuntimeMeshSectionRenderData& RenderData = SectionRenderData[SectionEntry.Key];
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 20
+						FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy(IsSelected());
+#else
 						FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy();
+#endif
 
 						FMeshBatch& MeshBatch = Collector.AllocateMesh();
 						CreateMeshBatch(MeshBatch, Section, RenderData, Material, WireframeMaterialInstance);

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshComponentProxy.cpp
@@ -101,7 +101,7 @@ void FRuntimeMeshComponentSceneProxy::DrawStaticElements(FStaticPrimitiveDrawInt
 		{
 			const FRuntimeMeshSectionRenderData& RenderData = SectionRenderData[SectionEntry.Key];
 
-#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 20
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 22
 			FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy(false);
 #else
 			FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy();
@@ -123,7 +123,7 @@ void FRuntimeMeshComponentSceneProxy::GetDynamicMeshElements(const TArray<const 
 	if (bWireframe)
 	{
 		WireframeMaterialInstance = new FColoredMaterialRenderProxy(
-#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 20
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 22
 			GEngine->WireframeMaterial ? GEngine->WireframeMaterial->GetRenderProxy(IsSelected()) : nullptr,
 #else
 			GEngine->WireframeMaterial ? GEngine->WireframeMaterial->GetRenderProxy() : nullptr,
@@ -150,7 +150,7 @@ void FRuntimeMeshComponentSceneProxy::GetDynamicMeshElements(const TArray<const 
 					if (bForceDynamicPath || !Section->WantsToRenderInStaticPath())
 					{
 						const FRuntimeMeshSectionRenderData& RenderData = SectionRenderData[SectionEntry.Key];
-#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 20
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 22
 						FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy(IsSelected());
 #else
 						FMaterialRenderProxy* Material = RenderData.Material->GetRenderProxy();

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshData.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshData.cpp
@@ -165,6 +165,14 @@ void FRuntimeMeshData::CheckBoundingBox(const FBox& Box) const
 
 
 
+void FRuntimeMeshData::EnterSerializedMode()
+{
+	if (!SyncRoot->IsThreadSafe())
+	{
+		SyncRoot = MakeUnique<FRuntimeMeshMutexLockProvider>();
+	}
+}
+
 void FRuntimeMeshData::CreateMeshSection(int32 SectionIndex, bool bWantsHighPrecisionTangents, bool bWantsHighPrecisionUVs, int32 NumUVs, bool bWants32BitIndices, bool bCreateCollision, EUpdateFrequency UpdateFrequency /*= EUpdateFrequency::Average*/)
 {
 	SCOPE_CYCLE_COUNTER(STAT_RuntimeMesh_CreateMeshSection_NoData);
@@ -326,7 +334,7 @@ void FRuntimeMeshData::CreateMeshSectionFromComponents(int32 SectionIndex, const
 	FRuntimeMeshScopeLock Lock(SyncRoot);
 
 	// Create the section
-	auto NewSection = CreateOrResetSectionForBlueprint(SectionIndex, false, bUseHighPrecisionTangents, bUseHighPrecisionUVs, UpdateFrequency);
+	auto NewSection = CreateOrResetSectionForBlueprint(SectionIndex, bWantsSecondUV, bUseHighPrecisionTangents, bUseHighPrecisionUVs, UpdateFrequency);
 
 	TSharedPtr<FRuntimeMeshAccessor> MeshData = NewSection->GetSectionMeshAccessor();
 
@@ -439,7 +447,30 @@ void FRuntimeMeshData::UpdateMeshSectionFromComponents(int32 SectionIndex, const
 	UpdateSectionInternal(SectionIndex, BuffersToUpdate, UpdateFlags);
 }
 
+void FRuntimeMeshData::UpdateMeshSectionColors(int32 SectionIndex, TArray<FColor>& Colors, ESectionUpdateFlags UpdateFlags /*= ESectionUpdateFlags::None*/)
+{
+	if (Colors.Num() == 0)
+		return;
 
+	check(DoesSectionExist(SectionIndex));
+
+	FRuntimeMeshScopeLock Lock(SyncRoot);
+	const FRuntimeMeshSectionPtr& Section = MeshSections[SectionIndex];
+	const ERuntimeMeshBuffersToUpdate BuffersToUpdate = ERuntimeMeshBuffersToUpdate::ColorBuffer;
+	TSharedPtr<FRuntimeMeshAccessor> MeshData = Section->GetSectionMeshAccessor();
+
+	for (int i = 0; i < Colors.Num(); i++)
+		MeshData->SetColor(i, Colors[i]);
+
+	if (RenderProxy.IsValid())
+		RenderProxy->UpdateSection_GameThread(SectionIndex, Section->GetSectionUpdateData(BuffersToUpdate));
+
+	const bool bRequireProxyRecreate = Section->GetUpdateFrequency() == EUpdateFrequency::Infrequent;
+	if (bRequireProxyRecreate)
+		MarkRenderStateDirty();
+
+	MarkChanged();
+}
 
 void FRuntimeMeshData::CreateMeshSection(int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 	const TArray<FVector2D>& UV0, const TArray<FColor>& Colors, const TArray<FRuntimeMeshTangent>& Tangents, bool bCreateCollision, EUpdateFrequency UpdateFrequency,
@@ -1048,7 +1079,7 @@ void FRuntimeMeshData::SetCollisionCapsules(const TArray<FRuntimeMeshCollisionCa
 
 FBoxSphereBounds FRuntimeMeshData::GetLocalBounds() const
 {
-	FRuntimeMeshScopeLock Lock(SyncRoot);
+	FRuntimeMeshScopeLock Lock(SyncRoot, false, true);
 	return LocalBounds;
 }
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshLibrary.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshLibrary.cpp
@@ -30,11 +30,11 @@ void URuntimeMeshLibrary::CalculateTangentsForMesh(const TArray<FVector>& Vertic
 		[&Vertices](int32 Index) -> FVector { return Vertices[Index]; },
 		[&UVs](int32 Index) -> FVector2D { return UVs[Index]; },
 		[&Normals, &Tangents](int32 Index, FVector TangentX, FVector TangentY, FVector TangentZ)
-	{
-		Normals[Index] = TangentZ;
-		Tangents[Index].TangentX = TangentX;
-		Tangents[Index].bFlipTangentY = GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0;
-	},
+		{
+			Normals[Index] = TangentZ;
+			Tangents[Index].TangentX = TangentX;
+			Tangents[Index].bFlipTangentY = GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0;
+		},
 		Vertices.Num(), UVs.Num(), Triangles.Num(), bCreateSmoothNormals);
 }
 
@@ -45,11 +45,11 @@ void URuntimeMeshLibrary::CalculateTangentsForMeshPacked(TArray<FRuntimeMeshBlue
 		[&Vertices](int32 Index) -> FVector { return Vertices[Index].Position; },
 		[&Vertices](int32 Index) -> FVector2D { return Vertices[Index].UV0; },
 		[&Vertices](int32 Index, FVector TangentX, FVector TangentY, FVector TangentZ)
-	{
-		Vertices[Index].Normal = TangentZ;
-		Vertices[Index].Tangent.TangentX = TangentX;
-		Vertices[Index].Tangent.bFlipTangentY = GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0;
-	},
+		{
+			Vertices[Index].Normal = TangentZ;
+			Vertices[Index].Tangent.TangentX = TangentX;
+			Vertices[Index].Tangent.bFlipTangentY = GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0;
+		},
 		Vertices.Num(), Vertices.Num(), Triangles.Num(), bCreateSmoothNormals);
 }
 
@@ -60,10 +60,10 @@ void URuntimeMeshLibrary::CalculateTangentsForMesh(TArray<FRuntimeMeshVertexSimp
 		[&Vertices](int32 Index) -> FVector { return Vertices[Index].Position; },
 		[&Vertices](int32 Index) -> FVector2D { return Vertices[Index].UV0; },
 		[&Vertices](int32 Index, FVector TangentX, FVector TangentY, FVector TangentZ)
-	{
-		Vertices[Index].Normal = TangentZ;
-		Vertices[Index].SetTangents(TangentX, TangentY, TangentZ);
-	},
+		{
+			Vertices[Index].Normal = TangentZ;
+			Vertices[Index].SetTangents(TangentX, TangentY, TangentZ);
+		},
 		Vertices.Num(), Vertices.Num(), Triangles.Num(), bCreateSmoothNormals);
 }
 
@@ -74,9 +74,9 @@ void URuntimeMeshLibrary::CalculateTangentsForMesh(const TSharedPtr<FRuntimeMesh
 		[MeshAccessor](int32 Index) -> FVector { return MeshAccessor->GetPosition(Index); },
 		[MeshAccessor](int32 Index) -> FVector2D { return MeshAccessor->GetUV(Index); },
 		[MeshAccessor](int32 Index, FVector TangentX, FVector TangentY, FVector TangentZ)
-	{
-		MeshAccessor->SetTangents(Index, TangentX, TangentY, TangentZ);
-	},
+		{
+			MeshAccessor->SetTangents(Index, TangentX, TangentY, TangentZ);
+		},
 		MeshAccessor->NumVertices(), MeshAccessor->NumVertices(), MeshAccessor->NumIndices(), bCreateSmoothNormals);
 }
 
@@ -167,28 +167,30 @@ void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODInd
 
 	GetStaticMeshSection(InMesh, LODIndex, SectionIndex, 1,
 		[&Vertices, &Normals, &Tangents](FVector Position, FVector TangentX, FVector TangentY, FVector TangentZ) -> int32
-	{
-		int32 NewIndex = Vertices.Add(Position);
-		Normals.Add(TangentZ);
-		Tangents.Add(FRuntimeMeshTangent(TangentX, GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0));
-		return NewIndex;
-	},
+		{
+			int32 NewIndex = Vertices.Add(Position);
+			Normals.Add(TangentZ);
+			Tangents.Add(FRuntimeMeshTangent(TangentX, GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0));
+			return NewIndex;
+		},
 		[&UVs](int32 Index, int32 UVIndex, FVector2D UV)
-	{
-		check(UVIndex == 0);
-		UVs[Index] = UV;
-	},
+		{
+			check(UVIndex == 0);
+			UVs.SetNum(Index + 1);
+			UVs[Index] = UV;
+		},
 		[&Colors](int32 Index, FColor Color)
-	{
-		Colors[Index] = Color;
-	},
+		{
+			Colors.SetNum(Index + 1);
+			Colors[Index] = Color;
+		},
 		[&Triangles](int32 Index)
-	{
-		Triangles.Add(Index);
-	},
+		{
+			Triangles.Add(Index);
+		},
 		[](int32 Index)
-	{
-	});
+		{
+		});
 }
 
 void URuntimeMeshLibrary::GetStaticMeshSectionPacked(UStaticMesh* InMesh, int32 LODIndex, int32 SectionIndex, TArray<FRuntimeMeshBlueprintVertexSimple>& Vertices, TArray<int32>& Triangles)
@@ -198,25 +200,25 @@ void URuntimeMeshLibrary::GetStaticMeshSectionPacked(UStaticMesh* InMesh, int32 
 
 	GetStaticMeshSection(InMesh, LODIndex, SectionIndex, 1,
 		[&Vertices](FVector Position, FVector TangentX, FVector TangentY, FVector TangentZ) -> int32
-	{
-		return Vertices.Add(FRuntimeMeshBlueprintVertexSimple(Position, TangentZ, FRuntimeMeshTangent(TangentX, GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0), FVector2D::ZeroVector));
-	},
+		{
+			return Vertices.Add(FRuntimeMeshBlueprintVertexSimple(Position, TangentZ, FRuntimeMeshTangent(TangentX, GetBasisDeterminantSign(TangentX, TangentY, TangentZ) < 0), FVector2D::ZeroVector));
+		},
 		[&Vertices](int32 Index, int32 UVIndex, FVector2D UV)
-	{
-		check(UVIndex == 0);
-		Vertices[Index].UV0 = UV;
-	},
+		{
+			check(UVIndex == 0);
+			Vertices[Index].UV0 = UV;
+		},
 		[&Vertices](int32 Index, FColor Color)
-	{
-		Vertices[Index].Color = Color;
-	},
+		{
+			Vertices[Index].Color = Color;
+		},
 		[&Triangles](int32 Index)
-	{
-		Triangles.Add(Index);
-	},
+		{
+			Triangles.Add(Index);
+		},
 		[](int32 Index)
-	{
-	});
+		{
+		});
 }
 
 void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODIndex, int32 SectionIndex, TArray<FRuntimeMeshVertexSimple>& Vertices, TArray<int32>& Triangles)
@@ -226,25 +228,25 @@ void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODInd
 
 	GetStaticMeshSection(InMesh, LODIndex, SectionIndex, 1,
 		[&Vertices](FVector Position, FVector TangentX, FVector TangentY, FVector TangentZ) -> int32
-	{
-		return Vertices.Add(FRuntimeMeshVertexSimple(Position, TangentX, TangentY, TangentZ));
-	},
+		{
+			return Vertices.Add(FRuntimeMeshVertexSimple(Position, TangentX, TangentY, TangentZ));
+		},
 		[&Vertices](int32 Index, int32 UVIndex, FVector2D UV)
-	{
-		check(UVIndex == 0);
-		Vertices[Index].UV0 = UV;
-	},
+		{
+			check(UVIndex == 0);
+			Vertices[Index].UV0 = UV;
+		},
 		[&Vertices](int32 Index, FColor Color)
-	{
-		Vertices[Index].Color = Color;
-	},
+		{
+			Vertices[Index].Color = Color;
+		},
 		[&Triangles](int32 Index)
-	{
-		Triangles.Add(Index);
-	},
+		{
+			Triangles.Add(Index);
+		},
 		[](int32 Index)
-	{
-	});
+		{
+		});
 }
 
 void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODIndex, int32 SectionIndex, TArray<FRuntimeMeshVertexSimple>& Vertices, TArray<int32>& Triangles, TArray<int32>& AdjacencyTriangles)
@@ -255,26 +257,26 @@ void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODInd
 
 	GetStaticMeshSection(InMesh, LODIndex, SectionIndex, 1,
 		[&Vertices](FVector Position, FVector TangentX, FVector TangentY, FVector TangentZ) -> int32
-	{
-		return Vertices.Add(FRuntimeMeshVertexSimple(Position, TangentX, TangentY, TangentZ));
-	},
+		{
+			return Vertices.Add(FRuntimeMeshVertexSimple(Position, TangentX, TangentY, TangentZ));
+		},
 		[&Vertices](int32 Index, int32 UVIndex, FVector2D UV)
-	{
-		check(UVIndex == 0);
-		Vertices[Index].UV0 = UV;
-	},
+		{
+			check(UVIndex == 0);
+			Vertices[Index].UV0 = UV;
+		},
 		[&Vertices](int32 Index, FColor Color)
-	{
-		Vertices[Index].Color = Color;
-	},
+		{
+			Vertices[Index].Color = Color;
+		},
 		[&Triangles](int32 Index)
-	{
-		Triangles.Add(Index);
-	},
+		{
+			Triangles.Add(Index);
+		},
 		[&AdjacencyTriangles](int32 Index)
-	{
-		AdjacencyTriangles.Add(Index);
-	});
+		{
+			AdjacencyTriangles.Add(Index);
+		});
 }
 
 void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODIndex, int32 SectionIndex, const TSharedPtr<FRuntimeMeshAccessor>& MeshAccessor)
@@ -284,26 +286,26 @@ void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODInd
 
 	GetStaticMeshSection(InMesh, LODIndex, SectionIndex, MeshAccessor->NumUVChannels(),
 		[&MeshAccessor](FVector Position, FVector TangentX, FVector TangentY, FVector TangentZ) -> int32
-	{
-		int32 NewIndex = MeshAccessor->AddVertex(Position);
-		MeshAccessor->SetTangents(NewIndex, TangentX, TangentY, TangentZ);
-		return NewIndex;
-	},
+		{
+			int32 NewIndex = MeshAccessor->AddVertex(Position);
+			MeshAccessor->SetTangents(NewIndex, TangentX, TangentY, TangentZ);
+			return NewIndex;
+		},
 		[&MeshAccessor](int32 Index, int32 UVIndex, FVector2D UV)
-	{
-		MeshAccessor->SetUV(Index, UVIndex, UV);
-	},
+		{
+			MeshAccessor->SetUV(Index, UVIndex, UV);
+		},
 		[&MeshAccessor](int32 Index, FColor Color)
-	{
-		MeshAccessor->SetColor(Index, Color);
-	},
+		{
+			MeshAccessor->SetColor(Index, Color);
+		},
 		[&MeshAccessor](int32 Index)
-	{
-		MeshAccessor->AddIndex(Index);
-	},
+		{
+			MeshAccessor->AddIndex(Index);
+		},
 		[](int32 Index)
-	{
-	});
+		{
+		});
 }
 
 void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODIndex, int32 SectionIndex, const TSharedPtr<FRuntimeMeshAccessor>& MeshAccessor, const TSharedPtr<FRuntimeMeshIndicesAccessor>& TessellationIndicesAccessor)
@@ -314,27 +316,27 @@ void URuntimeMeshLibrary::GetStaticMeshSection(UStaticMesh* InMesh, int32 LODInd
 
 	GetStaticMeshSection(InMesh, LODIndex, SectionIndex, MeshAccessor->NumUVChannels(),
 		[&MeshAccessor](FVector Position, FVector TangentX, FVector TangentY, FVector TangentZ) -> int32
-	{
-		int32 NewIndex = MeshAccessor->AddVertex(Position);
-		MeshAccessor->SetTangents(NewIndex, TangentX, TangentY, TangentZ);
-		return NewIndex;
-	},
+		{
+			int32 NewIndex = MeshAccessor->AddVertex(Position);
+			MeshAccessor->SetTangents(NewIndex, TangentX, TangentY, TangentZ);
+			return NewIndex;
+		},
 		[&MeshAccessor](int32 Index, int32 UVIndex, FVector2D UV)
-	{
-		MeshAccessor->SetUV(Index, UVIndex, UV);
-	},
+		{
+			MeshAccessor->SetUV(Index, UVIndex, UV);
+		},
 		[&MeshAccessor](int32 Index, FColor Color)
-	{
-		MeshAccessor->SetColor(Index, Color);
-	},
+		{
+			MeshAccessor->SetColor(Index, Color);
+		},
 		[&MeshAccessor](int32 Index)
-	{
-		MeshAccessor->AddIndex(Index);
-	},
+		{
+			MeshAccessor->AddIndex(Index);
+		},
 		[&TessellationIndicesAccessor](int32 Index)
-	{
-		TessellationIndicesAccessor->AddIndex(Index);
-	});
+		{
+			TessellationIndicesAccessor->AddIndex(Index);
+		});
 }
 
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshProxy.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshProxy.cpp
@@ -18,13 +18,11 @@ FRuntimeMeshProxy::~FRuntimeMeshProxy()
 
 void FRuntimeMeshProxy::CreateSection_GameThread(int32 SectionId, const FRuntimeMeshSectionCreationParamsPtr& SectionData)
 {
-	ENQUEUE_UNIQUE_RENDER_COMMAND_THREEPARAMETER(
-		FRuntimeMeshProxyCreateSection,
-		FRuntimeMeshProxy*, MeshProxy, this,
-		int32, SectionId, SectionId,
-		FRuntimeMeshSectionCreationParamsPtr, SectionData, SectionData,
+	// HORU: 4.22 rendering
+	ENQUEUE_RENDER_COMMAND(FRuntimeMeshProxyCreateSection)(
+		[this, SectionId, SectionData](FRHICommandListImmediate & RHICmdList)
 		{
-			MeshProxy->CreateSection_RenderThread(SectionId, SectionData);
+			CreateSection_RenderThread(SectionId, SectionData);
 		}
 	);
 }
@@ -46,13 +44,11 @@ void FRuntimeMeshProxy::CreateSection_RenderThread(int32 SectionId, const FRunti
 
 void FRuntimeMeshProxy::UpdateSection_GameThread(int32 SectionId, const FRuntimeMeshSectionUpdateParamsPtr& SectionData)
 {
-	ENQUEUE_UNIQUE_RENDER_COMMAND_THREEPARAMETER(
-		FRuntimeMeshProxyUpdateSection,
-		FRuntimeMeshProxy*, MeshProxy, this,
-		int32, SectionId, SectionId,
-		FRuntimeMeshSectionUpdateParamsPtr, SectionData, SectionData,
+	// HORU: 4.22 rendering
+	ENQUEUE_RENDER_COMMAND(FRuntimeMeshProxyUpdateSection)(
+		[this, SectionId, SectionData](FRHICommandListImmediate & RHICmdList)
 		{
-			MeshProxy->UpdateSection_RenderThread(SectionId, SectionData);
+			UpdateSection_RenderThread(SectionId, SectionData);
 		}
 	);
 }
@@ -74,13 +70,11 @@ void FRuntimeMeshProxy::UpdateSection_RenderThread(int32 SectionId, const FRunti
 
 void FRuntimeMeshProxy::UpdateSectionProperties_GameThread(int32 SectionId, const FRuntimeMeshSectionPropertyUpdateParamsPtr& SectionData)
 {
-	ENQUEUE_UNIQUE_RENDER_COMMAND_THREEPARAMETER(
-		FRuntimeMeshProxyUpdateSectionProperties,
-		FRuntimeMeshProxy*, MeshProxy, this,
-		int32, SectionId, SectionId,
-		FRuntimeMeshSectionPropertyUpdateParamsPtr, SectionData, SectionData,
+	// HORU: 4.22 rendering
+	ENQUEUE_RENDER_COMMAND(FRuntimeMeshProxyUpdateSectionProperties)(
+		[this, SectionId, SectionData](FRHICommandListImmediate & RHICmdList)
 		{
-			MeshProxy->UpdateSectionProperties_RenderThread(SectionId, SectionData);
+			UpdateSectionProperties_RenderThread(SectionId, SectionData);
 		}
 	);
 }
@@ -102,12 +96,11 @@ void FRuntimeMeshProxy::UpdateSectionProperties_RenderThread(int32 SectionId, co
 
 void FRuntimeMeshProxy::DeleteSection_GameThread(int32 SectionId)
 {
-	ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
-		FRuntimeMeshProxyDeleteSection,
-		FRuntimeMeshProxy*, MeshProxy, this,
-		int32, SectionId, SectionId,
+	// HORU: 4.22 rendering
+	ENQUEUE_RENDER_COMMAND(FRuntimeMeshProxyDeleteSection)(
+		[this, SectionId](FRHICommandListImmediate & RHICmdList)
 		{
-			MeshProxy->DeleteSection_RenderThread(SectionId);
+			DeleteSection_RenderThread(SectionId);
 		}
 	);
 }

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshProxy.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshProxy.h
@@ -19,9 +19,9 @@ struct FRuntimeMeshRenderThreadDeleter
 		}
 		else
 		{
-			ENQUEUE_UNIQUE_RENDER_COMMAND_ONEPARAMETER(
-				FRuntimeMeshProxyDeleterCommand,
-				void*, Object, Object,
+			// HORU: 4.22 rendering
+			ENQUEUE_RENDER_COMMAND(FRuntimeMeshProxyDeleterCommand)(
+				[Object](FRHICommandListImmediate & RHICmdList)
 				{
 					delete static_cast<Type*>(Object);
 				}

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.cpp
@@ -154,13 +154,13 @@ void FRuntimeMeshVertexFactory::Init(FLocalVertexFactory::FDataType VertexStruct
 	else
 	{
 		// Send the command to the render thread
-		ENQUEUE_UNIQUE_RENDER_COMMAND_TWOPARAMETER(
-			InitRuntimeMeshVertexFactory,
-			FRuntimeMeshVertexFactory*, VertexFactory, this,
-			FLocalVertexFactory::FDataType, VertexStructure, VertexStructure,
+		// HORU: 4.22 rendering
+		ENQUEUE_RENDER_COMMAND(InitRuntimeMeshVertexFactory)(
+			[this, VertexStructure](FRHICommandListImmediate & RHICmdList)
 			{
-				VertexFactory->Init(VertexStructure);
-			});
+				Init(VertexStructure);
+			}
+		);
 	}
 }
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshRendering.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "Engine.h"
+#include "Engine/Engine.h"
 #include "RuntimeMeshCore.h"
 #include "RuntimeMeshGenericVertex.h"
 
@@ -120,17 +120,22 @@ public:
 		}
 
 #if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 19
- 		DataType.TangentBasisComponents[1] = FVertexStreamComponent(this, TangentXOffset, TangentSizeInBytes, TangentElementType, EVertexStreamUsage::ManualFetch);
- 		DataType.TangentBasisComponents[0] = FVertexStreamComponent(this, TangentZOffset, TangentSizeInBytes, TangentElementType, EVertexStreamUsage::ManualFetch);
+ 		DataType.TangentBasisComponents[0] = FVertexStreamComponent(this, TangentXOffset, TangentSizeInBytes, TangentElementType, EVertexStreamUsage::ManualFetch);
+ 		DataType.TangentBasisComponents[1] = FVertexStreamComponent(this, TangentZOffset, TangentSizeInBytes, TangentElementType, EVertexStreamUsage::ManualFetch);
 		DataType.TangentsSRV = ShaderResourceView;
 #else
-		DataType.TangentBasisComponents[1] = FVertexStreamComponent(this, TangentXOffset, TangentSizeInBytes, TangentElementType);
-		DataType.TangentBasisComponents[0] = FVertexStreamComponent(this, TangentZOffset, TangentSizeInBytes, TangentElementType);
+		DataType.TangentBasisComponents[0] = FVertexStreamComponent(this, TangentXOffset, TangentSizeInBytes, TangentElementType);
+		DataType.TangentBasisComponents[1] = FVertexStreamComponent(this, TangentZOffset, TangentSizeInBytes, TangentElementType);
 #endif
 	}
 
 protected:
-#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 19
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 20
+	virtual void CreateSRV() override
+	{
+		ShaderResourceView = RHICreateShaderResourceView(VertexBufferRHI, bUseHighPrecision ? 8 : 4, bUseHighPrecision ? PF_R16G16B16A16_SNORM : PF_R8G8B8A8_SNORM);
+	}
+#elif ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 19
 	virtual void CreateSRV() override
 	{
 		ShaderResourceView = RHICreateShaderResourceView(VertexBufferRHI, bUseHighPrecision? 8 : 4, bUseHighPrecision? PF_A16B16G16R16 : PF_R8G8B8A8);

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshSectionProxy.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshSectionProxy.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "Engine.h"
+#include "Engine/Engine.h"
 #include "Components/MeshComponent.h"
 #include "RuntimeMeshRendering.h"
 #include "RuntimeMeshUpdateCommands.h"
@@ -62,6 +62,7 @@ public:
 	~FRuntimeMeshSectionProxy();
 
 	bool ShouldRender();
+	bool CanRender();
 
 	bool WantsToRenderInStaticPath() const;
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshSlicer.cpp
@@ -666,6 +666,7 @@ void URuntimeMeshSlicer::SliceRuntimeMesh(URuntimeMesh* InRuntimeMesh, FVector P
 					SourceMeshData->CopyTo(NewBuilder);
 
 					OutOtherHalf->CreateMeshSection(SectionIndex, MoveTemp(NewBuilder));
+					OutOtherHalf->SetSectionMaterial(SectionIndex, InRuntimeMesh->GetSectionMaterial(SectionIndex));
 				}
 
 				InRuntimeMesh->ClearMeshSection(SectionIndex);
@@ -727,6 +728,15 @@ void URuntimeMeshSlicer::SliceRuntimeMeshComponent(URuntimeMeshComponent* InRunt
 				OutOtherHalf->SetCollisionProfileName(InRuntimeMesh->GetCollisionProfileName());
 				OutOtherHalf->SetCollisionEnabled(InRuntimeMesh->GetCollisionEnabled());
 				OutOtherHalf->SetCollisionUseComplexAsSimple(InRuntimeMesh->IsCollisionUsingComplexAsSimple());
+
+				// Copy overridden materials
+				for (int32 Index = 0; Index < InRuntimeMesh->GetNumOverrideMaterials(); Index++)
+				{
+					if (UMaterialInterface* Material = InRuntimeMesh->GetOverrideMaterial(Index))
+					{
+						OutOtherHalf->SetMaterial(Index, Material);
+					}
+				}
 
 				OutOtherHalf->RegisterComponent();
 			}

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshUpdateCommands.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Private/RuntimeMeshUpdateCommands.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "Engine.h"
+#include "Engine/Engine.h"
 #include "Components/MeshComponent.h"
 
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMesh.h
@@ -8,6 +8,7 @@
 #include "RuntimeMeshData.h"
 #include "RuntimeMeshBlueprint.h"
 #include "RuntimeMeshCollision.h"
+#include "RuntimeMeshBlueprintMeshBuilder.h"
 #include "RuntimeMesh.generated.h"
 
 class UBodySetup;
@@ -43,7 +44,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE(FRuntimeMeshCollisionUpdatedDelegate);
 
 
 UCLASS(HideCategories = Object, BlueprintType)
-class RUNTIMEMESHCOMPONENT_API URuntimeMesh : public UObject, public IInterface_CollisionDataProvider/*, public IInterface_AssetUserData*/
+class RUNTIMEMESHCOMPONENT_API URuntimeMesh : public UObject, public IInterface_CollisionDataProvider
 {
 	GENERATED_UCLASS_BODY()
 
@@ -100,9 +101,16 @@ private:
 
 public:
 
-	bool HasSerializedMeshData() 
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	bool ShouldSerializeMeshData() 
 	{
 		return bShouldSerializeMeshData;			
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	void SetShouldSerializeMeshData(bool bShouldSerialize)
+	{
+		bShouldSerializeMeshData = bShouldSerialize;
 	}
 
 	/** Event called when the collision has finished updated, this works both with standard following frame synchronous updates, as well as async updates */
@@ -333,6 +341,13 @@ public:
 		GetRuntimeMeshData()->CreateMeshSectionByMove(SectionId, MeshData, bCreateCollision, UpdateFrequency, UpdateFlags);
 	}
 
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	void CreateMeshSectionFromBuilder(int32 SectionId, URuntimeBlueprintMeshBuilder* MeshData, bool bCreateCollision = false,
+		EUpdateFrequency UpdateFrequency = EUpdateFrequency::Average/*, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None*/)
+	{
+		check(IsInGameThread());
+		GetRuntimeMeshData()->CreateMeshSection(SectionId, MeshData->GetMeshBuilder(), bCreateCollision, UpdateFrequency/*, UpdateFlags*/);
+	}
 
 
 	FORCEINLINE void UpdateMeshSection(int32 SectionId, const TSharedPtr<FRuntimeMeshBuilder>& MeshData, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None)
@@ -345,6 +360,13 @@ public:
 	{
 		check(IsInGameThread());
 		GetRuntimeMeshData()->UpdateMeshSectionByMove(SectionId, MeshData, UpdateFlags);
+	}
+	
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	void UpdateMeshSectionFromBuilder(int32 SectionId, URuntimeBlueprintMeshBuilder* MeshData/*, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None*/)
+	{
+		check(IsInGameThread());
+		GetRuntimeMeshData()->UpdateMeshSection(SectionId, MeshData->GetMeshBuilder()/*, UpdateFlags*/);
 	}
 
 
@@ -790,10 +812,24 @@ public:
 	}
 
 	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	bool IsCollisionUsingAsyncCooking()
+	{
+		check(IsInGameThread());
+		return bUseAsyncCooking;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
 	void SetCollisionMode(ERuntimeMeshCollisionCookingMode NewMode)
 	{
 		check(IsInGameThread());
 		CollisionMode = NewMode;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	ERuntimeMeshCollisionCookingMode GetCollisionMode() const
+	{
+		check(IsInGameThread());
+		return CollisionMode;
 	}
 
 	FBoxSphereBounds GetLocalBounds() const 
@@ -852,26 +888,32 @@ private:
 		OutMaterials.Append(Materials.FilterByPredicate([](UMaterialInterface* Mat) -> bool { return Mat != nullptr; }));
 	}
 
-
-
 	//~ Begin Interface_CollisionDataProvider Interface
 	virtual bool GetPhysicsTriMeshData(struct FTriMeshCollisionData* CollisionData, bool InUseAllTriData) override;
 	virtual bool ContainsPhysicsTriMeshData(bool InUseAllTriData) const override;
 	virtual bool WantsNegXTriMesh() override { return false; }
 	//~ End Interface_CollisionDataProvider Interface
 
-	virtual void Serialize(FArchive& Ar) override; 
+	virtual void Serialize(FArchive& Ar) override;
 	void PostLoad();
 
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
 	UMaterialInterface* GetMaterialFromCollisionFaceIndex(int32 FaceIndex, int32& SectionIndex) const;
 
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	int32 GetSectionIdFromCollisionFaceIndex(int32 FaceIndex) const;
 
+
+private:
 	/** Triggers a rebuild of the collision data on the next tick */
 	void MarkCollisionDirty();
+
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 21
 	/** Helper to create new body setup objects */
 	UBodySetup* CreateNewBodySetup();
-	/** Ensure ProcMeshBodySetup is allocated and configured */
-	void EnsureBodySetupCreated();
+#endif
 	/** Copies the convex element geometry to a supplied body setup */
 	void CopyCollisionElementsToBodySetup(UBodySetup* Setup);
 	/** Sets all basic configuration on body setup */
@@ -879,9 +921,11 @@ private:
 	/** Mark collision data as dirty, and re-create on instance if necessary */
 	void UpdateCollision(bool bForceCookNow = false);
 	/** Once async physics cook is done, create needed state, and then call the user event */
-	void FinishPhysicsAsyncCook(UBodySetup* FinishedBodySetup);
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 21
+	void FinishPhysicsAsyncCook(bool bSuccess, UBodySetup* FinishedBodySetup);
 	/** Runs all post cook tasks like alerting the user event and alerting linked components */
 	void FinalizeNewCookedData();
+#endif
 
 
 	FRuntimeMeshProxyPtr EnsureProxyCreated(ERHIFeatureLevel::Type InFeatureLevel)

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshActor.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshActor.h
@@ -15,6 +15,7 @@ private:
 	UPROPERTY(Category = "RuntimeMeshActor", VisibleAnywhere, BlueprintReadOnly, Meta = (ExposeFunctionCategories = "Mesh,Rendering,Physics,Components|RuntimeMesh", AllowPrivateAccess = "true"))
 	class URuntimeMeshComponent* RuntimeMeshComponent;
 
+public:
 	UPROPERTY(Category = "RuntimeMeshActor", EditAnywhere, Meta = (AllowPrivateAccess = "true"))
 	bool bRunGenerateMeshesOnConstruction;
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshBlueprintMeshBuilder.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshBlueprintMeshBuilder.h
@@ -1,0 +1,261 @@
+// Copyright 2016-2018 Chris Conway (Koderz). All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RuntimeMeshCore.h"
+#include "RuntimeMeshBuilder.h"
+#include "RuntimeMeshBlueprintMeshBuilder.generated.h"
+
+/**
+ * 
+ */
+UCLASS(BlueprintType, Abstract)
+class RUNTIMEMESHCOMPONENT_API URuntimeBlueprintMeshAccessor : public UObject
+{
+	GENERATED_BODY()
+
+protected:
+
+	TSharedPtr<FRuntimeMeshAccessor> MeshAccessor;
+
+public:
+
+	
+	
+	friend class URuntimeMeshBuilderFunctions;
+};
+
+UCLASS(BlueprintType)
+class RUNTIMEMESHCOMPONENT_API URuntimeBlueprintMeshBuilder : public URuntimeBlueprintMeshAccessor
+{
+	GENERATED_BODY()
+
+	TSharedPtr<FRuntimeMeshBuilder> MeshBuilder;
+	friend class URuntimeMeshBuilderFunctions;
+	
+public:
+	TSharedPtr<FRuntimeMeshBuilder> GetMeshBuilder() { return MeshBuilder; }
+
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	bool IsUsingHighPrecisionTangents(URuntimeBlueprintMeshBuilder*& OutMeshBuilder)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->IsUsingHighPrecisionTangents();
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	bool IsUsingHighPrecisionUVs(URuntimeBlueprintMeshBuilder*& OutMeshBuilder)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->IsUsingHighPrecisionUVs();
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	bool IsUsing32BitIndices(URuntimeBlueprintMeshBuilder*& OutMeshBuilder)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->IsUsing32BitIndices();
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	bool IsReadonly(URuntimeBlueprintMeshBuilder*& OutMeshBuilder)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->IsReadonly();
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 NumVertices(URuntimeBlueprintMeshBuilder*& OutMeshBuilder)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->NumVertices();
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 NumUVChannels(URuntimeBlueprintMeshBuilder*& OutMeshBuilder)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->NumUVChannels();
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 NumIndices(URuntimeBlueprintMeshBuilder*& OutMeshBuilder)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->NumIndices();
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	void EmptyVertices(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Slack = 0)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->EmptyVertices(Slack);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	void SetNumVertices(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 NewNum)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetNumVertices(NewNum);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	void EmptyIndices(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Slack = 0)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->EmptyIndices(Slack);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	void SetNumIndices(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 NewNum)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetNumIndices(NewNum);
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 AddVertex(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, FVector InPosition, FVector Normal, FRuntimeMeshTangent Tangent, FVector2D UV0, FLinearColor Color)
+	{
+		OutMeshBuilder = this;
+		int32 Index = MeshAccessor->AddVertex(InPosition);
+		MeshAccessor->SetNormalTangent(Index, Normal, Tangent);
+		MeshAccessor->SetUV(Index, UV0);
+		MeshAccessor->SetColor(Index, Color.ToFColor(false));
+		return Index;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	FVector GetPosition(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->GetPosition(Index);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	FVector4 GetNormal(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->GetNormal(Index);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	FVector GetTangent(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->GetTangent(Index);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	FLinearColor GetColor(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index)
+	{
+		OutMeshBuilder = this;
+		return FLinearColor(MeshAccessor->GetColor(Index));
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	FVector2D GetUV(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, int32 Channel = 0)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->GetUV(Index, Channel);
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetVertex(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, FVector InPosition, FVector Normal, FRuntimeMeshTangent Tangent, FVector2D UV0, FLinearColor Color)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetPosition(Index, InPosition);
+		MeshAccessor->SetNormalTangent(Index, Normal, Tangent);
+		MeshAccessor->SetUV(Index, UV0);
+		MeshAccessor->SetColor(Index, Color.ToFColor(false));
+		return Index;
+	}
+
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetPosition(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, FVector Value)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetPosition(Index, Value);
+		return Index;
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetNormal(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, const FVector4& Value)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetNormal(Index, Value);
+		return Index;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetTangent(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, FRuntimeMeshTangent Value)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetTangent(Index, Value);
+		return Index;
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetColor(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, FLinearColor Value)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetColor(Index, Value.ToFColor(false));
+		return Index;
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetUV(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, FVector2D Value, int32 Channel = 0)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetUV(Index, Channel, Value);
+		return Index;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetNormalTangent(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, FVector Normal, FRuntimeMeshTangent Tangent)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetNormalTangent(Index, Normal, Tangent);
+		return Index;
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 SetTangents(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, FVector TangentX, FVector TangentY, FVector TangentZ)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetTangents(Index, TangentX, TangentY, TangentZ);
+		return Index;
+	}
+
+	//FRuntimeMeshAccessorVertex GetVertex(int32 Index) const;
+	//void SetVertex(int32 Index, const FRuntimeMeshAccessorVertex& Vertex);
+	//int32 AddVertex(const FRuntimeMeshAccessorVertex& Vertex);
+
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 AddIndex(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 NewIndex)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->AddIndex(NewIndex);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 AddTriangle(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index0, int32 Index1, int32 Index2)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->AddTriangle(Index0, Index1, Index2);
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	int32 GetIndex(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index)
+	{
+		OutMeshBuilder = this;
+		return MeshAccessor->GetIndex(Index);
+	}
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	void SetIndex(URuntimeBlueprintMeshBuilder*& OutMeshBuilder, int32 Index, int32 Value)
+	{
+		OutMeshBuilder = this;
+		MeshAccessor->SetIndex(Index, Value);
+	}
+};
+
+
+
+UCLASS()
+class RUNTIMEMESHCOMPONENT_API URuntimeMeshBuilderFunctions : public UBlueprintFunctionLibrary
+{
+
+	GENERATED_BODY()
+
+public:
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMeshBuilder")
+	static URuntimeBlueprintMeshBuilder* MakeRuntimeMeshBuilder(bool bWantsHighPrecisionTangents = false, bool bWantsHighPrecisionUVs = false, int32 NumUVs = 1, bool bUse16BitIndices = false);
+};

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshBuilder.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshBuilder.h
@@ -72,13 +72,50 @@ public:
 	FVector2D GetUV(int32 Index, int32 Channel = 0) const;
 
 
-	void SetPosition(int32 Index, FVector Value);
+	void SetPosition(int32 Index, const FVector& Value);
+	bool SetPositions(const int32 InsertAtIndex, const TArray<FVector>& Positions, const int32 Count, const bool bSizeToFit);
+	bool SetPositions(const int32 InsertAtIndex, const FVector *const Positions, const int32 Count, const bool bSizeToFit);
 	void SetNormal(int32 Index, const FVector4& Value);
-	void SetTangent(int32 Index, FVector Value);
-	void SetTangent(int32 Index, FRuntimeMeshTangent Value);
-	void SetColor(int32 Index, FColor Value);
-	void SetUV(int32 Index, FVector2D Value);
-	void SetUV(int32 Index, int32 Channel, FVector2D Value);
+	void SetTangent(int32 Index, const FVector& Value);
+	void SetTangent(int32 Index, const FRuntimeMeshTangent& Value);
+	void SetColor(int32 Index, const FColor& Value);
+	bool SetColors(const int32 InsertAtIndex, const TArray<FColor>& Colors, const int32 Count, const bool bSizeToFit);
+	bool SetColors(const int32 InsertAtIndex, const FColor *const Colors, const int32 Count, const bool bSizeToFit);
+	void SetUV(int32 Index, const FVector2D& Value);
+	void SetUV(int32 Index, int32 Channel, const FVector2D& Value);
+
+	/**
+	*	UV arrangement for 3 uv channels:
+	*	UVs[0]: vertex 0:uvChannel[0]
+	*	UVs[1]: vertex 0:uvChannel[1]
+	*	UVs[2]: vertex 0:uvChannel[2]
+	*	UVs[3]: vertex 1:uvChannel[0]
+	*	UVs[4]: vertex 1:uvChannel[1]
+	*	UVs[5]: vertex 1:uvChannel[2]
+	*	UVs[6]: vertex 2:uvChannel[0]
+	*	...
+	*
+	*	@param CountVertices			The number of vertices you want to add UV data for!
+	*/
+	bool SetUVs(const int32 InsertAtVertexIndex, const TArray<FVector2D>& UVs, const int32 CountVertices, const bool bSizeToFit);
+	bool SetUVs(const int32 InsertAtVertexIndex, const TArray<FVector2DHalf>& UVs, const int32 CountVertices, const bool bSizeToFit);
+
+	/**
+	*	UV arrangement for 3 uv channels:
+	*	UVs[0]: vertex 0:uvChannel[0]
+	*	UVs[1]: vertex 0:uvChannel[1]
+	*	UVs[2]: vertex 0:uvChannel[2]
+	*	UVs[3]: vertex 1:uvChannel[0]
+	*	UVs[4]: vertex 1:uvChannel[1]
+	*	UVs[5]: vertex 1:uvChannel[2]
+	*	UVs[6]: vertex 2:uvChannel[0]
+	*	...
+	*
+	*	@param UVs						Must point to the start of the uv data for a vertex!
+	*	@param CountVertices			The number of vertices you want to add UV data for!
+	*/
+	bool SetUVs(const int32 InsertAtVertexIndex, const FVector2D *const UVs, const int32 CountVertices, const bool bSizeToFit);
+	bool SetUVs(const int32 InsertAtVertexIndex, const FVector2DHalf *const UVs, const int32 CountVertices, const bool bSizeToFit);
 
 	void SetNormalTangent(int32 Index, FVector Normal, FRuntimeMeshTangent Tangent);
 	void SetTangents(int32 Index, FVector TangentX, FVector TangentY, FVector TangentZ);
@@ -375,6 +412,10 @@ public:
 
 	int32 GetIndex(int32 Index) const;
 	void SetIndex(int32 Index, int32 Value);
+	bool SetIndices(const int32 InsertAtIndex, const TArray<uint16>& Indices, const int32 Count, const bool bSizeToFit);
+	bool SetIndices(const int32 InsertAtIndex, const uint16 *const Indices, const int32 Count, const bool bSizeToFit);
+	bool SetIndices(const int32 InsertAtIndex, const TArray<int32>& Indices, const int32 Count, const bool bSizeToFit);
+	bool SetIndices(const int32 InsertAtIndex, const int32 *const Indices, const int32 Count, const bool bSizeToFit);
 
 protected:
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshCollision.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "Engine.h"
+#include "Engine/Engine.h"
 #include "Components/MeshComponent.h"
 #include "RuntimeMeshCollision.generated.h"
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -813,14 +813,12 @@ private:
 	UPROPERTY(Transient)
 	TArray<UBodySetup*> AsyncBodySetupQueue;
 
-#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 22
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 21
 	virtual bool GetPhysicsTriMeshData(struct FTriMeshCollisionData* CollisionData, bool InUseAllTriData) override;
 	virtual bool ContainsPhysicsTriMeshData(bool InUseAllTriData) const override;
 	virtual bool WantsNegXTriMesh() override { return false; }
 	//~ End Interface_CollisionDataProvider Interface
-#endif
 
-#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 21
 	UBodySetup* CreateNewBodySetup();
 	void FinishPhysicsAsyncCook(UBodySetup* FinishedBodySetup);
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -8,13 +8,14 @@
 #include "RuntimeMeshGenericVertex.h"
 #include "PhysicsEngine/ConvexElem.h"
 #include "RuntimeMesh.h"
+#include "Interfaces/Interface_CollisionDataProvider.h"
 #include "RuntimeMeshComponent.generated.h"
 
 /**
 *	Component that allows you to specify custom triangle mesh geometry for rendering and collision.
 */
 UCLASS(HideCategories = (Object, LOD), Meta = (BlueprintSpawnableComponent))
-class RUNTIMEMESHCOMPONENT_API URuntimeMeshComponent : public UMeshComponent
+class RUNTIMEMESHCOMPONENT_API URuntimeMeshComponent : public UMeshComponent, public IInterface_CollisionDataProvider
 {
 	GENERATED_BODY()
 
@@ -46,6 +47,18 @@ public:
 		EnsureHasRuntimeMesh();
 
 		return RuntimeMeshReference;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	bool ShouldSerializeMeshData()
+	{
+		return GetRuntimeMesh() ? GetRuntimeMesh()->ShouldSerializeMeshData() : false;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	void SetShouldSerializeMeshData(bool bShouldSerialize)
+	{
+		GetOrCreateRuntimeMesh()->SetShouldSerializeMeshData(bShouldSerialize);
 	}
 
 	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh", Meta = (AllowPrivateAccess = "true", DisplayName = "Get Mobility"))
@@ -209,7 +222,7 @@ public:
 
 	/** DEPRECATED! Use UpdateMeshSectionDualBuffer() instead.  Updates the dual buffer mesh section */
 	template<typename VertexType>
-	DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
+	UE_DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
 	void UpdateMeshSection(int32 SectionIndex, TArray<FVector>& VertexPositions, TArray<VertexType>& VertexData, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None)
 	{
 		UpdateMeshSectionDualBuffer(SectionIndex, VertexPositions, VertexData, UpdateFlags);
@@ -217,7 +230,7 @@ public:
 
 	/** DEPRECATED! Use UpdateMeshSectionDualBuffer() instead.  Updates the dual buffer mesh section */
 	template<typename VertexType>
-	DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
+	UE_DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
 	void UpdateMeshSection(int32 SectionIndex, TArray<FVector>& VertexPositions, TArray<VertexType>& VertexData, const FBox& BoundingBox, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None)
 	{
 		UpdateMeshSectionDualBuffer(SectionIndex, VertexPositions, VertexData, BoundingBox, UpdateFlags);
@@ -225,7 +238,7 @@ public:
 
 	/** DEPRECATED! Use UpdateMeshSectionDualBuffer() instead.  Updates the dual buffer mesh section */
 	template<typename VertexType>
-	DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
+	UE_DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
 	void UpdateMeshSection(int32 SectionIndex, TArray<FVector>& VertexPositions, TArray<VertexType>& VertexData, TArray<int32>& Triangles, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None)
 	{
 		UpdateMeshSectionDualBuffer(SectionIndex, VertexPositions, VertexData, Triangles, UpdateFlags);
@@ -233,7 +246,7 @@ public:
 
 	/** DEPRECATED! Use UpdateMeshSectionDualBuffer() instead.  Updates the dual buffer mesh section */
 	template<typename VertexType>
-	DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
+	UE_DEPRECATED(3.0, "UpdateMeshSection for dual buffer sections deprecated. Please use UpdateMeshSectionDualBuffer instead.")
 	void UpdateMeshSection(int32 SectionIndex, TArray<FVector>& VertexPositions, TArray<VertexType>& VertexData, TArray<int32>& Triangles, const FBox& BoundingBox, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None)
 	{
 		UpdateMeshSectionDualBuffer(SectionIndex, VertexPositions, VertexData, Triangles, BoundingBox, UpdateFlags);
@@ -287,6 +300,13 @@ public:
 		GetOrCreateRuntimeMesh()->CreateMeshSectionByMove(SectionId, MeshData, bCreateCollision, UpdateFrequency, UpdateFlags);
 	}
 
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	void CreateMeshSectionFromBuilder(int32 SectionId, URuntimeBlueprintMeshBuilder* MeshData, bool bCreateCollision = false,
+		EUpdateFrequency UpdateFrequency = EUpdateFrequency::Average/*, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None*/)
+	{
+		GetOrCreateRuntimeMesh()->CreateMeshSectionFromBuilder(SectionId, MeshData, bCreateCollision, UpdateFrequency/*, UpdateFlags*/);
+	}
+
 
 
 	FORCEINLINE void UpdateMeshSection(int32 SectionId, const TSharedPtr<FRuntimeMeshBuilder>& MeshData, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None)
@@ -297,6 +317,12 @@ public:
 	FORCEINLINE void UpdateMeshSectionByMove(int32 SectionId, const TSharedPtr<FRuntimeMeshBuilder>& MeshData, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None)
 	{
 		GetOrCreateRuntimeMesh()->UpdateMeshSectionByMove(SectionId, MeshData, UpdateFlags);
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	void UpdateMeshSectionFromBuilder(int32 SectionId, URuntimeBlueprintMeshBuilder* MeshData/*, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None*/)
+	{
+		GetOrCreateRuntimeMesh()->UpdateMeshSectionFromBuilder(SectionId, MeshData/*, UpdateFlags*/);
 	}
 
 	
@@ -709,6 +735,13 @@ public:
 	}
 
 	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	bool IsCollisionUsingAsyncCooking()
+	{
+		check(IsInGameThread());
+		return GetRuntimeMesh() != nullptr ? GetRuntimeMesh()->IsCollisionUsingAsyncCooking() : false;
+	}
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
 	void SetCollisionMode(ERuntimeMeshCollisionCookingMode NewMode)
 	{
 		GetOrCreateRuntimeMesh()->SetCollisionMode(NewMode);
@@ -728,15 +761,28 @@ private:
 	//~ Begin UPrimitiveComponent Interface.
 	virtual FPrimitiveSceneProxy* CreateSceneProxy() override;
 	virtual class UBodySetup* GetBodySetup() override;
+
+public:
+
+	// HORU: returns true if any async collision cooking is pending.
+	UFUNCTION(BlueprintCallable)
+	bool IsAsyncCollisionCookingPending() const;
+
+	UFUNCTION(BlueprintCallable, Category = "Components|RuntimeMesh")
+	int32 GetSectionIdFromCollisionFaceIndex(int32 FaceIndex) const;
+
 	virtual UMaterialInterface* GetMaterialFromCollisionFaceIndex(int32 FaceIndex, int32& SectionIndex) const override;
 	//~ End UPrimitiveComponent Interface.
 
+public:
 	//~ Begin UMeshComponent Interface.
 	virtual int32 GetNumMaterials() const override;
 	virtual void GetUsedMaterials(TArray<UMaterialInterface*>& OutMaterials, bool bGetDebugMaterials = false) const override;
 	virtual UMaterialInterface* GetMaterial(int32 ElementIndex) const override;
+	virtual UMaterialInterface* GetOverrideMaterial(int32 ElementIndex) const;
 	//~ End UMeshComponent Interface.
 
+private:
 
 	/* Serializes this component */
 	virtual void Serialize(FArchive& Ar) override;
@@ -754,6 +800,31 @@ private:
 
 	void SendSectionCreation(int32 SectionIndex);
 	void SendSectionPropertiesUpdate(int32 SectionIndex);
+
+	// This collision setup is only to support older engine versions where the BodySetup being owned by a non UActorComponent breaks runtime cooking
+
+	/** Collision data */
+	UPROPERTY(Instanced)
+	UBodySetup* BodySetup;
+
+	/** Queue of pending collision cooks */
+	UPROPERTY(Transient)
+	TArray<UBodySetup*> AsyncBodySetupQueue;
+
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 22
+	virtual bool GetPhysicsTriMeshData(struct FTriMeshCollisionData* CollisionData, bool InUseAllTriData) override;
+	virtual bool ContainsPhysicsTriMeshData(bool InUseAllTriData) const override;
+	virtual bool WantsNegXTriMesh() override { return false; }
+	//~ End Interface_CollisionDataProvider Interface
+#endif
+
+#if ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < 21
+	UBodySetup* CreateNewBodySetup();
+	void FinishPhysicsAsyncCook(UBodySetup* FinishedBodySetup);
+
+	void UpdateCollision(bool bForceCookNow);
+#endif
+
 
 
 	friend class URuntimeMesh;

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshComponent.h
@@ -218,7 +218,9 @@ public:
 	}
 
 
-
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION < 22
+#define UE_DEPRECATED(VERSION, MESSAGE) DEPRECATED(VERSION, MESSAGE)
+#endif
 
 	/** DEPRECATED! Use UpdateMeshSectionDualBuffer() instead.  Updates the dual buffer mesh section */
 	template<typename VertexType>

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshData.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshData.h
@@ -121,6 +121,14 @@ private:
 	void CheckBoundingBox(const FBox& Box) const;
 
 public:
+
+	/* 
+		This will put the RuntimeMesh into serialized mode where it becomes safe to access it from other threads. 
+		Don't do this if you don't need it as it will make interacting with it slighly slower as it incurs thread locks.
+	*/
+	void EnterSerializedMode();
+
+
 	void CreateMeshSection(int32 SectionIndex, bool bWantsHighPrecisionTangents, bool bWantsHighPrecisionUVs, int32 NumUVs, bool bWants32BitIndices, bool bCreateCollision, EUpdateFrequency UpdateFrequency = EUpdateFrequency::Average);
 	
 	template<typename VertexType0, typename IndexType>
@@ -865,6 +873,9 @@ private:
 
 public:
 
+	// HORU :)
+	void UpdateMeshSectionColors(int32 SectionIndex, TArray<FColor>& Colors, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None);
+
 	void CreateMeshSection(int32 SectionIndex, const TArray<FVector>& Vertices, const TArray<int32>& Triangles, const TArray<FVector>& Normals,
 		const TArray<FVector2D>& UV0, const TArray<FColor>& Colors, const TArray<FRuntimeMeshTangent>& Tangents, bool bCreateCollision = false,
 		EUpdateFrequency UpdateFrequency = EUpdateFrequency::Average, ESectionUpdateFlags UpdateFlags = ESectionUpdateFlags::None,
@@ -1102,7 +1113,7 @@ private:
 	{
 		SCOPE_CYCLE_COUNTER(STAT_RuntimeMesh_SerializationOperator);
 
-		//FRuntimeMeshScopeLock Lock(MeshData.SyncRoot);
+		FRuntimeMeshScopeLock Lock(MeshData.SyncRoot, false, true);
 
 		Ar << MeshData.MeshSections;
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshSection.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/Public/RuntimeMeshSection.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "Engine.h"
+#include "Engine/Engine.h"
 #include "RuntimeMeshCore.h"
 #include "RuntimeMeshBuilder.h"
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
@@ -8,23 +8,10 @@ public class RuntimeMeshComponent : ModuleRules
     {
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PublicIncludePaths.AddRange(
-            new string[] {
-                "RuntimeMeshComponent/Public"
-				// ... add public include paths required here ...
-			}
-            );
+		PrivateIncludePaths.AddRange(new string[] { Path.Combine(ModuleDirectory, "Private") });
+		PublicIncludePaths.AddRange(new string[] { Path.Combine(ModuleDirectory, "Public") });
 
-
-        PrivateIncludePaths.AddRange(
-            new string[] {
-                "RuntimeMeshComponent/Private",
-				// ... add other private include paths required here ...
-			}
-            );
-
-
-        PublicDependencyModuleNames.AddRange(
+		PublicDependencyModuleNames.AddRange(
             new string[]
             {
                 "Core",
@@ -40,8 +27,8 @@ public class RuntimeMeshComponent : ModuleRules
                 "Engine",
 				// ... add private dependencies that you statically link with here ...	
                 "RenderCore",
-                "ShaderCore",
                 "RHI",
+                "NavigationSystem"
             }
             );
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
@@ -28,8 +28,13 @@ public class RuntimeMeshComponent : ModuleRules
                 "Engine",
 				// ... add private dependencies that you statically link with here ...	
                 "RenderCore",
-                "RHI",
-                "NavigationSystem"
+#if !UE_4_22_OR_LATER
+				"ShaderCore",  // ShaderCore was Merged into RenderCore in 4.22
+#endif
+				"RHI",
+#if UE_4_20_OR_LATER
+				"NavigationSystem"
+#endif
             }
             );
 

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponent/RuntimeMeshComponent.Build.cs
@@ -1,6 +1,7 @@
 // Copyright 2016-2018 Chris Conway (Koderz). All Rights Reserved.
 
 using UnrealBuildTool;
+using System.IO;
 
 public class RuntimeMeshComponent : ModuleRules
 {

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentDetails.h
@@ -3,6 +3,8 @@
 #pragma once
 #include "IDetailCustomization.h"
 #include "DetailLayoutBuilder.h"
+#include "RuntimeMesh.h"
+#include "SlateEnums.h"
 
 class FRuntimeMeshComponentDetails : public IDetailCustomization
 {
@@ -23,5 +25,31 @@ public:
 	class URuntimeMeshComponent* GetFirstSelectedRuntimeMeshComp() const;
 
 	/** Cached array of selected objects */
-	TArray< TWeakObjectPtr<UObject> > SelectedObjectsList;
+	TArray<TWeakObjectPtr<UObject>> SelectedObjectsList;
+	TArray<URuntimeMesh*> RuntimeMeshesReferenced;
+
+	TArray<TSharedPtr<ERuntimeMeshCollisionCookingMode>> CookingModes;
+
+	ECheckBoxState UseComplexAsSimple() const;
+	void UseComplexAsSimpleCheckedStateChanged(ECheckBoxState InCheckboxState);
+
+	ECheckBoxState IsAsyncCollisionEnabled() const;
+	void AsyncCollisionCheckedStateChanged(ECheckBoxState InCheckboxState);
+
+	ECheckBoxState ShouldSerializeMeshData() const;
+	void ShouldSerializeMeshDataCheckedStateChanged(ECheckBoxState InCheckboxState);
+
+	FText GetModeText(const TSharedPtr<ERuntimeMeshCollisionCookingMode>& Mode) const;
+
+	FText GetSelectedModeText() const 
+	{
+		return GetModeText(GetCurrentCollisionCookingMode());
+	}
+
+	TSharedRef<SWidget> MakeCollisionModeComboItemWidget(TSharedPtr<ERuntimeMeshCollisionCookingMode> Mode);
+
+	TSharedPtr<ERuntimeMeshCollisionCookingMode> GetCurrentCollisionCookingMode() const;
+
+	void CollisionCookingModeSelectionChanged(TSharedPtr<ERuntimeMeshCollisionCookingMode> NewMode, ESelectInfo::Type SelectionType);
+
 };

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentEditorCommands.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentEditorCommands.cpp
@@ -1,0 +1,17 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#include "RuntimeMeshComponentEditorCommands.h"
+
+#define LOCTEXT_NAMESPACE "FRuntimeMeshComponentEditorModule"
+
+void FRuntimeMeshComponentEditorCommands::RegisterCommands()
+{
+	UI_COMMAND(DonateAction, "Donate to Support the RMC!", "Support the RMC by donating", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(HelpAction, "Help Documentation", "RMC Help Documentation", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(ForumsAction, "Forums", "RMC Forums", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(IssuesAction, "Issues", "RMC Issue Tracker", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(DiscordAction, "Discord Chat", "RMC Discord Chat", EUserInterfaceActionType::Button, FInputGesture());
+	UI_COMMAND(MarketplaceAction, "Marketplace Page", "RMC Marketplace Page", EUserInterfaceActionType::Button, FInputGesture());
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentEditorPlugin.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentEditorPlugin.cpp
@@ -4,14 +4,39 @@
 #include "PropertyEditorModule.h"
 #include "RuntimeMeshComponent.h"
 #include "RuntimeMeshComponentDetails.h"
+#include "RuntimeMeshComponentEditorStyle.h"
+#include "RuntimeMeshComponentEditorCommands.h"
 
+#include "ModuleManager.h"
+#include "LevelEditor.h"
 
+class FToolBarBuilder;
+class FMenuBuilder;
+
+#define LOCTEXT_NAMESPACE "FRuntimeMeshComponentEditorModule"
 
 class FRuntimeMeshComponentEditorPlugin : public IRuntimeMeshComponentEditorPlugin
 {
+public:
 	/** IModuleInterface implementation */
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
+
+	/** This function will be bound to Command. */
+	void DonateActionClicked();
+	void HelpActionClicked();
+	void ForumsActionClicked();
+	void IssuesActionClicked();
+	void DiscordActionClicked();
+	void MarketplaceActionClicked();
+
+private:
+
+	void AddMenuBarExtension(FMenuBarBuilder& Builder);
+	void AddMenuExtension(FMenuBuilder& Builder);
+
+private:
+	TSharedPtr<class FUICommandList> PluginCommands;
 };
 
 IMPLEMENT_MODULE(FRuntimeMeshComponentEditorPlugin, RuntimeMeshComponentEditor)
@@ -24,10 +49,113 @@ void FRuntimeMeshComponentEditorPlugin::StartupModule()
 		FPropertyEditorModule& PropertyModule = FModuleManager::LoadModuleChecked<FPropertyEditorModule>("PropertyEditor");
 		PropertyModule.RegisterCustomClassLayout(URuntimeMeshComponent::StaticClass()->GetFName(), FOnGetDetailCustomizationInstance::CreateStatic(&FRuntimeMeshComponentDetails::MakeInstance));
 	}
-}
 
+	FRuntimeMeshComponentEditorStyle::Initialize();
+	FRuntimeMeshComponentEditorStyle::ReloadTextures();
+
+	FRuntimeMeshComponentEditorCommands::Register();
+
+	PluginCommands = MakeShareable(new FUICommandList);
+
+	PluginCommands->MapAction(
+		FRuntimeMeshComponentEditorCommands::Get().DonateAction,
+		FExecuteAction::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::DonateActionClicked),
+		FCanExecuteAction());
+	PluginCommands->MapAction(
+		FRuntimeMeshComponentEditorCommands::Get().HelpAction,
+		FExecuteAction::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::HelpActionClicked),
+		FCanExecuteAction());
+	PluginCommands->MapAction(
+		FRuntimeMeshComponentEditorCommands::Get().ForumsAction,
+		FExecuteAction::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::ForumsActionClicked),
+		FCanExecuteAction());
+	PluginCommands->MapAction(
+		FRuntimeMeshComponentEditorCommands::Get().IssuesAction,
+		FExecuteAction::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::IssuesActionClicked),
+		FCanExecuteAction());
+	PluginCommands->MapAction(
+		FRuntimeMeshComponentEditorCommands::Get().DiscordAction,
+		FExecuteAction::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::DiscordActionClicked),
+		FCanExecuteAction());
+	PluginCommands->MapAction(
+		FRuntimeMeshComponentEditorCommands::Get().MarketplaceAction,
+		FExecuteAction::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::MarketplaceActionClicked),
+		FCanExecuteAction());
+
+	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+
+	{
+		TSharedPtr<FExtender> MenuExtender = MakeShareable(new FExtender());
+		MenuExtender->AddMenuBarExtension("Window", EExtensionHook::After, PluginCommands, FMenuBarExtensionDelegate::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::AddMenuBarExtension));
+		LevelEditorModule.GetMenuExtensibilityManager()->AddExtender(MenuExtender);
+	}
+}
 
 void FRuntimeMeshComponentEditorPlugin::ShutdownModule()
 {
+	FRuntimeMeshComponentEditorStyle::Shutdown();
+
+	FRuntimeMeshComponentEditorCommands::Unregister();
+}
+
+void FRuntimeMeshComponentEditorPlugin::DonateActionClicked()
+{
+	FPlatformProcess::LaunchURL(TEXT("https://github.com/Koderz/RuntimeMeshComponent/wiki/Support-the-development!"), NULL, NULL);
 
 }
+
+void FRuntimeMeshComponentEditorPlugin::HelpActionClicked()
+{
+	FPlatformProcess::LaunchURL(TEXT("https://github.com/Koderz/UE4RuntimeMeshComponent/wiki"), NULL, NULL);
+}
+
+void FRuntimeMeshComponentEditorPlugin::ForumsActionClicked()
+{
+	FPlatformProcess::LaunchURL(TEXT("https://github.com/Koderz/UE4RuntimeMeshComponent/wiki"), NULL, NULL);
+
+}
+
+void FRuntimeMeshComponentEditorPlugin::IssuesActionClicked()
+{
+	FPlatformProcess::LaunchURL(TEXT("https://github.com/Koderz/UE4RuntimeMeshComponent/issues"), NULL, NULL);
+
+}
+
+void FRuntimeMeshComponentEditorPlugin::DiscordActionClicked()
+{
+
+	FPlatformProcess::LaunchURL(TEXT("https://discord.gg/KGvBBTv"), NULL, NULL);
+}
+
+void FRuntimeMeshComponentEditorPlugin::MarketplaceActionClicked()
+{
+	FPlatformProcess::LaunchURL(TEXT("https://unrealengine.com/Marketplace/RuntimeMeshComponent"), NULL, NULL);
+
+}
+
+void FRuntimeMeshComponentEditorPlugin::AddMenuBarExtension(FMenuBarBuilder& Builder)
+{
+	Builder.AddPullDownMenu(
+		LOCTEXT("RuntimeMeshComponentMenu", "Runtime Mesh Component"),
+		LOCTEXT("RuntimeMeshComponentMenu_ToolTip", "Open Runtime Mesh Component Help and Documentation"),
+		FNewMenuDelegate::CreateRaw(this, &FRuntimeMeshComponentEditorPlugin::AddMenuExtension),
+		"Runtime Mesh Component");
+}
+
+void FRuntimeMeshComponentEditorPlugin::AddMenuExtension(FMenuBuilder& Builder)
+{
+	Builder.BeginSection("Help", LOCTEXT("RuntimeMeshComponentMenu_Help", "Help"));
+	Builder.AddMenuEntry(FRuntimeMeshComponentEditorCommands::Get().MarketplaceAction);
+	Builder.AddMenuEntry(FRuntimeMeshComponentEditorCommands::Get().ForumsAction);
+	Builder.AddMenuEntry(FRuntimeMeshComponentEditorCommands::Get().HelpAction);
+	Builder.AddMenuEntry(FRuntimeMeshComponentEditorCommands::Get().IssuesAction);
+	Builder.AddMenuEntry(FRuntimeMeshComponentEditorCommands::Get().DiscordAction);
+	Builder.EndSection();
+	
+	Builder.BeginSection("Support", LOCTEXT("RuntimeMeshComponentMenu_Support", "Support"));
+	Builder.AddMenuEntry(FRuntimeMeshComponentEditorCommands::Get().DonateAction);
+	Builder.EndSection();
+}
+
+
+#undef LOCTEXT_NAMESPACE

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentEditorStyle.cpp
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Private/RuntimeMeshComponentEditorStyle.cpp
@@ -1,0 +1,68 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#include "RuntimeMeshComponentEditorStyle.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Styling/SlateStyleRegistry.h"
+#include "SlateGameResources.h"
+#include "IPluginManager.h"
+
+TSharedPtr< FSlateStyleSet > FRuntimeMeshComponentEditorStyle::StyleInstance = NULL;
+
+void FRuntimeMeshComponentEditorStyle::Initialize()
+{
+	if (!StyleInstance.IsValid())
+	{
+		StyleInstance = Create();
+		FSlateStyleRegistry::RegisterSlateStyle(*StyleInstance);
+	}
+}
+
+void FRuntimeMeshComponentEditorStyle::Shutdown()
+{
+	FSlateStyleRegistry::UnRegisterSlateStyle(*StyleInstance);
+	ensure(StyleInstance.IsUnique());
+	StyleInstance.Reset();
+}
+
+FName FRuntimeMeshComponentEditorStyle::GetStyleSetName()
+{
+	static FName StyleSetName(TEXT("RuntimeMeshComponentEditorStyle"));
+	return StyleSetName;
+}
+
+#define IMAGE_BRUSH( RelativePath, ... ) FSlateImageBrush( Style->RootToContentDir( RelativePath, TEXT(".png") ), __VA_ARGS__ )
+#define BOX_BRUSH( RelativePath, ... ) FSlateBoxBrush( Style->RootToContentDir( RelativePath, TEXT(".png") ), __VA_ARGS__ )
+#define BORDER_BRUSH( RelativePath, ... ) FSlateBorderBrush( Style->RootToContentDir( RelativePath, TEXT(".png") ), __VA_ARGS__ )
+#define TTF_FONT( RelativePath, ... ) FSlateFontInfo( Style->RootToContentDir( RelativePath, TEXT(".ttf") ), __VA_ARGS__ )
+#define OTF_FONT( RelativePath, ... ) FSlateFontInfo( Style->RootToContentDir( RelativePath, TEXT(".otf") ), __VA_ARGS__ )
+
+const FVector2D Icon128x128(128.0f, 128.0f);
+
+TSharedRef< FSlateStyleSet > FRuntimeMeshComponentEditorStyle::Create()
+{
+	TSharedRef< FSlateStyleSet > Style = MakeShareable(new FSlateStyleSet("RuntimeMeshComponentEditorStyle"));
+	Style->SetContentRoot(IPluginManager::Get().FindPlugin("RuntimeMeshComponent")->GetBaseDir() / TEXT("Resources"));
+
+	Style->Set("RuntimeMeshComponentEditor.PluginAction", new IMAGE_BRUSH(TEXT("Icon128"), Icon128x128));
+
+	return Style;
+}
+
+#undef IMAGE_BRUSH
+#undef BOX_BRUSH
+#undef BORDER_BRUSH
+#undef TTF_FONT
+#undef OTF_FONT
+
+void FRuntimeMeshComponentEditorStyle::ReloadTextures()
+{
+	if (FSlateApplication::IsInitialized())
+	{
+		FSlateApplication::Get().GetRenderer()->ReloadTextureResources();
+	}
+}
+
+const ISlateStyle& FRuntimeMeshComponentEditorStyle::Get()
+{
+	return *StyleInstance;
+}

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Public/RuntimeMeshComponentEditorCommands.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Public/RuntimeMeshComponentEditorCommands.h
@@ -1,0 +1,28 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.RuntimeMeshComponentEditor
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Framework/Commands/Commands.h"
+#include "RuntimeMeshComponentEditorStyle.h"
+
+class FRuntimeMeshComponentEditorCommands : public TCommands<FRuntimeMeshComponentEditorCommands>
+{
+public:
+
+	FRuntimeMeshComponentEditorCommands()
+		: TCommands<FRuntimeMeshComponentEditorCommands>(TEXT("RuntimeMeshComponentEditor"), NSLOCTEXT("Contexts", "RuntimeMeshComponentEditor", "RuntimeMeshComponentEditor Plugin"), NAME_None, FRuntimeMeshComponentEditorStyle::GetStyleSetName())
+	{
+	}
+
+	// TCommands<> interface
+	virtual void RegisterCommands() override;
+
+public:
+	TSharedPtr<FUICommandInfo> DonateAction;
+	TSharedPtr<FUICommandInfo> HelpAction;
+	TSharedPtr<FUICommandInfo> ForumsAction;
+	TSharedPtr<FUICommandInfo> IssuesAction;
+	TSharedPtr<FUICommandInfo> DiscordAction;
+	TSharedPtr<FUICommandInfo> MarketplaceAction;
+};

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Public/RuntimeMeshComponentEditorStyle.h
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/Public/RuntimeMeshComponentEditorStyle.h
@@ -1,0 +1,31 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Styling/SlateStyle.h"
+
+class FRuntimeMeshComponentEditorStyle
+{
+public:
+
+	static void Initialize();
+
+	static void Shutdown();
+
+	/** reloads textures used by slate renderer */
+	static void ReloadTextures();
+
+	/** @return The Slate style set for the Shooter game */
+	static const ISlateStyle& Get();
+
+	static FName GetStyleSetName();
+
+private:
+
+	static TSharedRef< class FSlateStyleSet > Create();
+
+private:
+
+	static TSharedPtr< class FSlateStyleSet > StyleInstance;
+};

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
@@ -8,28 +8,16 @@ public class RuntimeMeshComponentEditor : ModuleRules
     {
         PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-        PublicIncludePaths.AddRange(
-            new string[] {
-                "RuntimeMeshComponentEditor/Public"
-				// ... add public include paths required here ...
-			}
-            );
+		PrivateIncludePaths.AddRange(new string[] { Path.Combine(ModuleDirectory, "Private") });
+		PublicIncludePaths.AddRange(new string[] { Path.Combine(ModuleDirectory, "Public") });
 
-
-        PrivateIncludePaths.AddRange(
-            new string[] {
-                "RuntimeMeshComponentEditor/Private",
-				// ... add other private include paths required here ...
-			}
-            );
-
-
-        PublicDependencyModuleNames.AddRange(
+		PublicDependencyModuleNames.AddRange(
             new string[]
             {
                 "Core",
 				// ... add other public dependencies that you statically link with here ...
-			}
+                
+            }
             );
 
 
@@ -37,18 +25,22 @@ public class RuntimeMeshComponentEditor : ModuleRules
             new string[]
             {
                 "CoreUObject",
-                "Engine",
                 // ... add private dependencies that you statically link with here ...	
-                "RenderCore",
-                "ShaderCore",
-                "RHI",
+                "Engine",
                 "Slate",
                 "SlateCore",
+                "RenderCore",
+                "RHI",
+                "NavigationSystem",
                 "UnrealEd",
+                "LevelEditor",
                 "PropertyEditor",
                 "RawMesh",
                 "AssetTools",
                 "AssetRegistry",
+                "Projects",
+                "EditorStyle",
+                "InputCore",
 
                 "RuntimeMeshComponent",
             }

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
@@ -31,8 +31,13 @@ public class RuntimeMeshComponentEditor : ModuleRules
                 "Slate",
                 "SlateCore",
                 "RenderCore",
-                "RHI",
-                "NavigationSystem",
+#if !UE_4_22_OR_LATER
+				"ShaderCore", // ShaderCore was Merged into RenderCore in 4.22
+#endif
+				"RHI",
+#if UE_4_20_OR_LATER
+				"NavigationSystem",
+#endif
                 "UnrealEd",
                 "LevelEditor",
                 "PropertyEditor",

--- a/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
+++ b/wrappers/unrealengine4/Plugins/RuntimeMeshComponent/Source/RuntimeMeshComponentEditor/RuntimeMeshComponentEditor.Build.cs
@@ -1,6 +1,7 @@
 // Copyright 2016-2018 Chris Conway (Koderz). All Rights Reserved.
 
 using UnrealBuildTool;
+using System.IO;
 
 public class RuntimeMeshComponentEditor : ModuleRules
 {

--- a/wrappers/unrealengine4/README.md
+++ b/wrappers/unrealengine4/README.md
@@ -19,9 +19,11 @@ UnrealEngine4 wrapper shows how to use RealSense features via Blueprints (UE4 ve
 
 Download and install [RealSense SDK 2.0](https://github.com/IntelRealSense/librealsense/releases)
 
-Download wrapper and [generate project](https://wiki.unrealengine.com/Generate_Visual_Studio_Project) for RealSenseUE.uproject
+Download wrapper and [generate project files](https://wiki.unrealengine.com/Generate_Visual_Studio_Project) for RealSenseUE.uproject
 
-Copy C:\Program Files (x86)\Intel RealSense SDK 2.0\bin\x64\realsense2.dll to engine bin folder C:\Program Files\Epic Games\UE_4.19\Engine\Binaries\Win64\
+Copy C:\Program Files (x86)\Intel RealSense SDK 2.0\bin\x64\realsense2.dll to either:
+* The engine bin folder C:\Program Files\Epic Games\UE_4.19\Engine\Binaries\Win64\ **OR**
+* The plugin build folder RealSense-UE4-Wrapper\Plugins\RealSense\Binaries\Win64\
 
 In case RealSense SDK was installed in custom folder:
 * edit file RealSense-UE4-Wrapper\Plugins\RealSense\Source\RealSense\RealSense.Build.cs
@@ -187,6 +189,7 @@ ARealSenseTestActor::ARealSenseTestActor()
 * ColorizedDepth is CPU bound
 * PointCloud (PCL) has sometimes texture corruptions at thhe egdes (RealSenseSDK issue)
 * PointCloud (PCL) update/rendering performance is somtime slow
+* rebuilding project files can sometimes fail after switching Unreal Engine versions. Cleaning the solution or Deleting the intermediate directory should fix this.
 
 ## License
 

--- a/wrappers/unrealengine4/Source/RealSenseUE/RealSenseTestActor.cpp
+++ b/wrappers/unrealengine4/Source/RealSenseUE/RealSenseTestActor.cpp
@@ -1,5 +1,5 @@
-#include "RealSenseUE.h"
 #include "RealSenseTestActor.h"
+#include "RealSenseUE.h"
 
 // wrapper headers
 #include "RealSensePlugin.h"

--- a/wrappers/unrealengine4/Source/RealSenseUE/RealSenseUE.Build.cs
+++ b/wrappers/unrealengine4/Source/RealSenseUE/RealSenseUE.Build.cs
@@ -7,6 +7,8 @@ public class RealSenseUE : ModuleRules
 		bEnableExceptions = true;
 		bUseRTTI = false;
 
+		PrivatePCHHeaderFile = "RealSenseUE.h";
+
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore" });
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 


### PR DESCRIPTION
This PR updates the Unreal Engine 4 wrapper to support up to version 4.22, while preserving backwards compatibility. Can be cleaned up further when older versions are no longer needed.

- Fixed C5038 error by swapping initialization order of `rs2::processing_block` constructor to match definition. Initializers run in the same order as they are defined, so this is functionally identical. Unreal Engine promotes the warning to an error at build time.
- RuntimeMeshComponent updated based off of [GlassBeaver's UE 4.22 Fork](https://github.com/GlassBeaver/RuntimeMeshComponent/tree/422_ready)
- Updated includes to fit Unreal's expected [IWYU](https://docs.unrealengine.com/en-us/Programming/BuildTools/UnrealBuildTool/IWYU) order. Maintaining backwards compatibility broke a lot of forward declarations.

Tested in Unreal Engine versions 4.19.2, 4.20.3, 4.21.2, and 4.22.1
Using the test scene with Realsense SDK 2.21.0 and a D435 Camera using Firmware 5.11.6.200