### PR TITLE
Software device pipeline

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Devices/SoftwareDevice.cs
+++ b/wrappers/csharp/Intel.RealSense/Devices/SoftwareDevice.cs
@@ -24,6 +24,12 @@ namespace Intel.RealSense
             return new SoftwareSensor(AddSoftwareSensor(name));
         }
 
+        public void AddTo(Context ctx)
+        {
+            object error;
+            NativeMethods.rs2_context_add_software_device(ctx.Handle, Handle, out error);
+        }
+
         public void SetMatcher(Matchers matcher)
         {
             object error;

--- a/wrappers/csharp/Intel.RealSense/NativeMethods.cs
+++ b/wrappers/csharp/Intel.RealSense/NativeMethods.cs
@@ -510,6 +510,8 @@ namespace Intel.RealSense
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void rs2_set_devices_changed_callback(IntPtr ctx, rs2_devices_changed_callback callback, IntPtr user_data, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
 
+        [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void rs2_context_add_software_device(IntPtr ctx, IntPtr device, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
 #endregion
 #region rs
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Added a C# wrapper for the software_device.add_to(context) function.
This enables the software device to create its own pipeline, as suggested in #3947 