### PR TITLE
Fix for D435i loosing RGB-depth extrinsic calibration after firmware update

### DIFF
--- a/src/ds5/ds5-color.h
+++ b/src/ds5/ds5-color.h
@@ -22,6 +22,7 @@ namespace librealsense
 
     private:
         friend class ds5_color_sensor;
+        friend class rs435i_device;
 
         uint8_t _color_device_idx = -1;
 

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -511,7 +511,11 @@ namespace librealsense
               ds5_active(ctx, group),
               ds5_color(ctx,  group),
               ds5_motion(ctx, group),
-              ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor()) {}
+              ds5_advanced_mode_base(ds5_device::_hw_monitor, get_depth_sensor()) 
+        {
+            if (!validate_color_stream_extrinsic(*_color_calib_table_raw))
+                restore_color_stream_extrinsic();
+        }
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;
 
@@ -534,6 +538,114 @@ namespace librealsense
             return tags;
         };
         bool compress_while_record() const override { return false; }
+
+    private:
+        bool validate_color_stream_extrinsic(const std::vector<uint8_t>& raw_data)
+        {
+            try
+            {
+                // verify extrinsic calibration table structure
+                auto table = ds::check_calib<ds::rgb_calibration_table>(raw_data);
+                float3 trans_vector = table->translation_rect;
+                float3x3 rect_rot_mat = table->rotation_matrix_rect;
+
+                // check that data rotation and translation are not zero
+                for (auto i = 0; i < 3; i++)
+                {
+                    if (std::fabs(trans_vector[i]) > std::numeric_limits<float>::epsilon())
+                    {
+                        for (auto j = 0; j < 3; i++)
+                        {
+                            if (std::fabs(rect_rot_mat(i, j)) > std::numeric_limits<float>::epsilon())
+                                return true;
+                        }
+                    }
+                }
+                return false;
+            }
+            catch (...)
+            {
+                return false;
+            }
+        }
+
+        void restore_color_stream_extrinsic(const std::vector<byte>& calib)
+        {
+            //write the calibration to its correct address
+            command cmd(ds::fw_cmd::SETINTCALNEW, 0x20, 0x2);
+            cmd.data = calib;
+            auto res = ds5_device::_hw_monitor->send(cmd);
+
+            _color_calib_table_raw = [this]() { return get_raw_calibration_table(ds::rgb_calibration_id); };
+            _color_extrinsic = std::make_shared<lazy<rs2_extrinsics>>([this]() { return from_pose(ds::get_color_stream_extrinsic(*_color_calib_table_raw)); });
+            environment::get_instance().get_extrinsics_graph().register_extrinsics(*_color_stream, *_depth_stream, _color_extrinsic);
+        }
+
+        bool restore_from_address(const uint32_t address)
+        {
+            const uint32_t bytes_to_read = 0x100;
+
+            //read the calibration from the address
+            command cmd(ds::fw_cmd::FRB, address, bytes_to_read);
+            auto calib = ds5_device::_hw_monitor->send(cmd);
+            if (validate_color_stream_extrinsic(calib))
+            {
+                restore_color_stream_extrinsic(calib);
+                return true;
+            }
+            LOG_WARNING("Restoring RGB Extrinsic from address" << address << " failed");
+            return false;
+        }
+
+        bool restore_color_stream_extrinsic_from_gold_sector()
+        {
+            command cmd(ds::fw_cmd::LOADINTCAL, 0x20, 0x1);
+            auto calib = ds5_device::_hw_monitor->send(cmd);
+            if (validate_color_stream_extrinsic(calib))
+            {
+                restore_color_stream_extrinsic(calib);
+                return true;
+            }
+            LOG_WARNING("Restore from gold_sector failed");
+            return false;
+        }
+
+        bool restore_color_stream_extrinsic()
+        {
+            try
+            {
+                LOG_WARNING("invalid RGB extrinsic was identified, recovery routine was invoked");
+
+                const uint32_t gold_address = 0x17c49c;
+                const uint32_t dynamic_address = 0x17b49c;
+
+                if (!restore_color_stream_extrinsic_from_gold_sector())
+                {
+                    LOG_WARNING("RGB extrinsic recovery - Gold calibration is invalid, restore from an alternative sector");
+
+                    if (!restore_from_address(gold_address))
+                    {
+                        LOG_WARNING("RGB extrinsic recovery - Gold calibration from address " << gold_address << " is invalid, restore from an alternative sector");
+
+                        if (!restore_from_address(dynamic_address))
+                        {
+                            LOG_WARNING("RGB extrinsic recovery - Dynamic calibration from address " << dynamic_address << " is invalid, recovery routine failed");
+
+                            _color_extrinsic.reset();
+                            return false;
+                        }
+                    }
+                }
+
+                LOG_DEBUG("Suceeded to restore color stream extrinsic");
+                return true;
+            }
+            catch (...)
+            {
+                LOG_WARNING("RGB Extrinsic recovery routine failed");
+                return false;
+            }
+        }
     };
 
 

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -574,7 +574,7 @@ namespace librealsense
             //write the calibration to its correct address
             command cmd(ds::fw_cmd::SETINTCALNEW, 0x20, 0x2);
             cmd.data = calib;
-            auto res = ds5_device::_hw_monitor->send(cmd);
+            ds5_device::_hw_monitor->send(cmd);
 
             _color_calib_table_raw = [this]() { return get_raw_calibration_table(ds::rgb_calibration_id); };
             _color_extrinsic = std::make_shared<lazy<rs2_extrinsics>>([this]() { return from_pose(ds::get_color_stream_extrinsic(*_color_calib_table_raw)); });

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -129,9 +129,11 @@ namespace librealsense
         enum fw_cmd : uint8_t
         {
             MRD             = 0x01,     // Read Register
+            FRB             = 0x09,     // Read from flash
             GLD             = 0x0f,     // FW logs
             GVD             = 0x10,     // camera details
             GETINTCAL       = 0x15,     // Read calibration table
+            LOADINTCAL      = 0x1D,     //Get Internal sub calibration table
             HWRST           = 0x20,     // hardware reset
             OBW             = 0x29,     // OVT bypass write
             SET_ADV         = 0x2B,     // set advanced mode control
@@ -142,6 +144,7 @@ namespace librealsense
             GETAEROI        = 0x45,     // get auto-exposure region of interest
             MMER            = 0x4F,     // MM EEPROM read ( from DS5 cache )
             GET_EXTRINSICS  = 0x53,     // get extrinsics
+            SETINTCALNEW    = 0x62,     // Set Internal sub calibration table
             SET_CAM_SYNC    = 0x69,     // set Inter-cam HW sync mode [0-default, 1-master, 2-slave]
             GET_CAM_SYNC    = 0x6A,     // fet Inter-cam HW sync mode
             SETRGBAEROI     = 0x75,     // set RGB auto-exposure region of interest


### PR DESCRIPTION
Fix FW calibration tables location that potentially disable alignment/texture mapping use-cases with D435i model.
The affected FW versions generate the RGB calibration table in the memory reserved for another SKU.
This PR provides a rectification method that restores the RGB calibration data on the affected units using either factory or improperly-located data sets.
This method is invoked and applied automatically on the device’s start and does not require user actions.
Addresses #3474, #3788, #3201
Tracked on: DSO-12587


 