### PR TITLE
Add units transform processing block

### DIFF
--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -53,13 +53,20 @@ rs2_processing_block* rs2_create_pointcloud(rs2_error** error);
 */
 rs2_processing_block* rs2_create_yuy_decoder(rs2_error** error);
 
- /**
+/**
 * Creates depth thresholding processing block
 * By controlling min and max options on the block, one could filter out depth values
 * that are either too large or too small, as a software post-processing step
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
 rs2_processing_block* rs2_create_threshold(rs2_error** error);
+
+/**
+* Creates depth units transformation processing block
+* All of the pixels are transformed from depth units into meters.
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+rs2_processing_block* rs2_create_units_transform(rs2_error** error);
 
 /**
 * This method creates new custom processing block. This lets the users pass frames between module boundaries for processing

--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -75,6 +75,7 @@ typedef enum rs2_format
     RS2_FORMAT_6DOF            , /**< Pose data packed as floats array, containing translation vector, rotation quaternion and prediction velocities and accelerations vectors */
     RS2_FORMAT_DISPARITY32     , /**< 32-bit float-point disparity values. Depth->Disparity conversion : Disparity = Baseline*FocalLength/Depth */
     RS2_FORMAT_Y10BPACK        , /**< 16-bit per-pixel grayscale image unpacked from 10 bits per pixel packed ([8:8:8:8:2222]) grey-scale image. The data is unpacked to LSB and padded with 6 zero bits */
+	RS2_FORMAT_DISTANCE        , /**< 32-bit float-point depth distance value.  */
     RS2_FORMAT_COUNT             /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_format;
 const char* rs2_format_to_string(rs2_format format);

--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -75,7 +75,7 @@ typedef enum rs2_format
     RS2_FORMAT_6DOF            , /**< Pose data packed as floats array, containing translation vector, rotation quaternion and prediction velocities and accelerations vectors */
     RS2_FORMAT_DISPARITY32     , /**< 32-bit float-point disparity values. Depth->Disparity conversion : Disparity = Baseline*FocalLength/Depth */
     RS2_FORMAT_Y10BPACK        , /**< 16-bit per-pixel grayscale image unpacked from 10 bits per pixel packed ([8:8:8:8:2222]) grey-scale image. The data is unpacked to LSB and padded with 6 zero bits */
-	RS2_FORMAT_DISTANCE        , /**< 32-bit float-point depth distance value.  */
+    RS2_FORMAT_DISTANCE        , /**< 32-bit float-point depth distance value.  */
     RS2_FORMAT_COUNT             /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_format;
 const char* rs2_format_to_string(rs2_format format);

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -519,7 +519,30 @@ namespace rs2
             return block;
         }
     };
+
+    class units_transform : public filter
+    {
+    public:
+        /**
+        * Creates depth units to meters processing block.
+        */
+        units_transform() : filter(init(), 1) {}
+
+    protected:
+        units_transform(std::shared_ptr<rs2_processing_block> block) : filter(block, 1) {}
         
+    private:
+        std::shared_ptr<rs2_processing_block> init()
+        {
+            rs2_error* e = nullptr;
+            auto block = std::shared_ptr<rs2_processing_block>(
+                rs2_create_units_transform(&e),
+                rs2_delete_processing_block);
+            error::handle(e);
+
+            return block;
+        }
+    };
 
     class asynchronous_syncer : public processing_block
     {

--- a/src/proc/CMakeLists.txt
+++ b/src/proc/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/threshold.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/rates-printer.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/zero-order.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/units-transform.cpp"
 
         "${CMAKE_CURRENT_LIST_DIR}/processing-blocks-factory.h"
         "${CMAKE_CURRENT_LIST_DIR}/align.h"
@@ -43,4 +44,5 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/threshold.h"
         "${CMAKE_CURRENT_LIST_DIR}/rates-printer.h"
         "${CMAKE_CURRENT_LIST_DIR}/zero-order.h"
+        "${CMAKE_CURRENT_LIST_DIR}/units-transform.h"
 )

--- a/src/proc/units-transform.cpp
+++ b/src/proc/units-transform.cpp
@@ -1,0 +1,80 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#include "../include/librealsense2/hpp/rs_sensor.hpp"
+#include "../include/librealsense2/hpp/rs_processing.hpp"
+
+#include "proc/synthetic-stream.h"
+#include "context.h"
+#include "environment.h"
+#include "option.h"
+#include "units-transform.h"
+#include "image.h"
+
+namespace librealsense
+{
+    units_transform::units_transform() : stream_filter_processing_block("Units Transform")
+    {
+        _stream_filter.format = RS2_FORMAT_DISTANCE;
+        _stream_filter.stream = RS2_STREAM_DEPTH;
+    }
+
+    void units_transform::update_configuration(const rs2::frame& f)
+    {
+        if (f.get_profile().get() != _source_stream_profile.get())
+        {
+            _source_stream_profile = f.get_profile();
+            _target_stream_profile = f.get_profile().clone(RS2_STREAM_DEPTH, 0, RS2_FORMAT_DISTANCE);
+
+            if (!_depth_units)
+            {
+                auto sensor = ((frame_interface*)f.get())->get_sensor().get();
+                _depth_units = sensor->get_option(RS2_OPTION_DEPTH_UNITS).query();
+            }
+
+            auto vf = f.as<rs2::depth_frame>();
+            _width = vf.get_width();
+            _height = vf.get_height();
+            _stride = sizeof(float) * _width;
+            _bpp = sizeof(float);
+        }
+    }
+
+    rs2::frame units_transform::process_frame(const rs2::frame_source& source, const rs2::frame& f)
+    {
+		if (!f.is<rs2::depth_frame>()) return f;
+
+        update_configuration(f);
+
+		auto new_f = source.allocate_video_frame(_target_stream_profile, f,
+			_bpp, _width, _height, _stride, RS2_EXTENSION_DEPTH_FRAME);
+
+        if (new_f)
+        {
+            auto ptr = dynamic_cast<librealsense::depth_frame*>((librealsense::frame_interface*)new_f.get());
+            auto orig = dynamic_cast<librealsense::depth_frame*>((librealsense::frame_interface*)f.get());
+
+            auto depth_data = (uint16_t*)orig->get_frame_data();
+            auto new_data = (float*)ptr->get_frame_data();
+
+            ptr->set_sensor(orig->get_sensor());
+
+            memset(new_data, 0, _width * _height * sizeof(float));
+            for (int i = 0; i < _width * _height; i++)
+            {
+                float dist = *_depth_units * depth_data[i];
+                new_data[i] = dist;
+            }
+
+            return new_f;
+        }
+
+        return f;
+    }
+
+	bool units_transform::should_process(const rs2::frame& frame)
+	{
+		if (!frame.is<rs2::depth_frame>()) return false;
+		return true;
+	}
+}

--- a/src/proc/units-transform.cpp
+++ b/src/proc/units-transform.cpp
@@ -32,7 +32,8 @@ namespace librealsense
                 }
                 catch (...)
                 {
-                    // reset depth_units in case of garbage value.
+                    // reset stream profile in case of failure.
+                    _source_stream_profile = rs2::stream_profile();
                     _depth_units = optional_value<float>();
                     LOG_ERROR("Failed obtaining depth units option");
                 }
@@ -53,7 +54,7 @@ namespace librealsense
         auto new_f = source.allocate_video_frame(_target_stream_profile, f,
             _bpp, _width, _height, _stride, RS2_EXTENSION_DEPTH_FRAME);
 
-        if (new_f)
+        if (new_f && _depth_units)
         {
             auto ptr = dynamic_cast<librealsense::depth_frame*>((librealsense::frame_interface*)new_f.get());
             auto orig = dynamic_cast<librealsense::depth_frame*>((librealsense::frame_interface*)f.get());

--- a/src/proc/units-transform.cpp
+++ b/src/proc/units-transform.cpp
@@ -42,12 +42,12 @@ namespace librealsense
 
     rs2::frame units_transform::process_frame(const rs2::frame_source& source, const rs2::frame& f)
     {
-		if (!f.is<rs2::depth_frame>()) return f;
+        if (!f.is<rs2::depth_frame>()) return f;
 
         update_configuration(f);
 
-		auto new_f = source.allocate_video_frame(_target_stream_profile, f,
-			_bpp, _width, _height, _stride, RS2_EXTENSION_DEPTH_FRAME);
+        auto new_f = source.allocate_video_frame(_target_stream_profile, f,
+            _bpp, _width, _height, _stride, RS2_EXTENSION_DEPTH_FRAME);
 
         if (new_f)
         {
@@ -72,9 +72,9 @@ namespace librealsense
         return f;
     }
 
-	bool units_transform::should_process(const rs2::frame& frame)
-	{
-		if (!frame.is<rs2::depth_frame>()) return false;
-		return true;
-	}
+    bool units_transform::should_process(const rs2::frame& frame)
+    {
+        if (!frame.is<rs2::depth_frame>()) return false;
+        return true;
+    }
 }

--- a/src/proc/units-transform.h
+++ b/src/proc/units-transform.h
@@ -20,7 +20,7 @@ namespace librealsense
     protected:
         void update_configuration(const rs2::frame& f);
         rs2::frame process_frame(const rs2::frame_source& source, const rs2::frame& f) override;
-		bool should_process(const rs2::frame& frame) override;
+	    bool should_process(const rs2::frame& frame) override;
 
     private:
         rs2::stream_profile     _target_stream_profile;

--- a/src/proc/units-transform.h
+++ b/src/proc/units-transform.h
@@ -20,7 +20,7 @@ namespace librealsense
     protected:
         void update_configuration(const rs2::frame& f);
         rs2::frame process_frame(const rs2::frame_source& source, const rs2::frame& f) override;
-	    bool should_process(const rs2::frame& frame) override;
+        bool should_process(const rs2::frame& frame) override;
 
     private:
         rs2::stream_profile     _target_stream_profile;

--- a/src/proc/units-transform.h
+++ b/src/proc/units-transform.h
@@ -1,0 +1,33 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "synthetic-stream.h"
+
+namespace rs2
+{
+    class stream_profile;
+}
+
+namespace librealsense 
+{
+    class units_transform : public stream_filter_processing_block
+    {
+    public:
+        units_transform();
+
+    protected:
+        void update_configuration(const rs2::frame& f);
+        rs2::frame process_frame(const rs2::frame_source& source, const rs2::frame& f) override;
+		bool should_process(const rs2::frame& frame) override;
+
+    private:
+        rs2::stream_profile     _target_stream_profile;
+        rs2::stream_profile     _source_stream_profile;
+
+        optional_value<float>   _depth_units;
+        size_t                  _width, _height, _stride;
+        size_t                  _bpp;
+    };
+}

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -170,6 +170,7 @@ EXPORTS
     rs2_create_colorizer
     rs2_create_yuy_decoder
     rs2_create_threshold
+    rs2_create_units_transform
     rs2_create_decimation_filter_block
     rs2_create_temporal_filter_block
     rs2_create_spatial_filter_block

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -21,6 +21,7 @@
 #include "proc/colorizer.h"
 #include "proc/pointcloud.h"
 #include "proc/threshold.h"
+#include "proc/units-transform.h"
 #include "proc/disparity-transform.h"
 #include "proc/syncer-processing-block.h"
 #include "proc/decimation-filter.h"
@@ -1846,6 +1847,12 @@ NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(nullptr)
 rs2_processing_block* rs2_create_threshold(rs2_error** error) BEGIN_API_CALL
 {
     return new rs2_processing_block { std::make_shared<threshold>() };
+}
+NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(nullptr)
+
+rs2_processing_block* rs2_create_units_transform(rs2_error** error) BEGIN_API_CALL
+{
+    return new rs2_processing_block { std::make_shared<units_transform>() };
 }
 NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(nullptr)
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -304,7 +304,7 @@ namespace librealsense
             CASE(GPIO_RAW)
             CASE(6DOF)
             CASE(Y10BPACK)
-			CASE(DISTANCE)
+            CASE(DISTANCE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -304,6 +304,7 @@ namespace librealsense
             CASE(GPIO_RAW)
             CASE(6DOF)
             CASE(Y10BPACK)
+			CASE(DISTANCE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -4780,6 +4780,72 @@ TEST_CASE("Syncer clean_inactive_streams by frame number with software-device de
     }
 }
 
+TEST_CASE("Unit transform test", "[live][software-device]") {
+	rs2::context ctx;
+
+	if (!make_context(SECTION_FROM_TEST_NAME, &ctx))
+		return;
+
+	log_to_file(RS2_LOG_SEVERITY_DEBUG);
+	const int W = 640;
+	const int H = 480;
+	const int BPP = 2;
+	int expected_frames = 1;
+	int fps = 60;
+	float depth_unit = 1.5;
+	units_transform ut;
+	rs2_intrinsics intrinsics{ W, H, 0, 0, 0, 0, RS2_DISTORTION_NONE ,{ 0,0,0,0,0 } };
+
+	std::shared_ptr<software_device> dev = std::make_shared<software_device>();
+	auto s = dev->add_sensor("software_sensor");
+	s.add_read_only_option(RS2_OPTION_DEPTH_UNITS, depth_unit);
+	s.add_video_stream({ RS2_STREAM_DEPTH, 0, 0, W, H, fps, BPP, RS2_FORMAT_Z16, intrinsics });
+
+	auto profiles = s.get_stream_profiles();
+	auto depth = profiles[0];
+
+	syncer sync;
+	s.open(profiles);
+	s.start(sync);
+
+	std::vector<uint16_t> pixels(W * H, 0);
+	for (int i = 0; i < W * H; i++) {
+		pixels[i] = i % 10;
+	}
+
+	std::weak_ptr<rs2::software_device> weak_dev(dev);
+	std::thread t([s, weak_dev, &pixels, depth, expected_frames]() mutable {
+		auto shared_dev = weak_dev.lock();
+		if (shared_dev == nullptr)
+			return;
+		for (int i = 1; i <= expected_frames; i++)
+			s.on_video_frame({ pixels.data(), [](void*) {}, 0,0,rs2_time_t(i * 100), RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK, i, depth });
+	});
+	t.detach();
+
+	for (auto i = 0; i < expected_frames; i++)
+	{
+		frame f;
+		REQUIRE_NOTHROW(f = sync.wait_for_frames(5000));
+
+		auto f_format = f.get_profile().format();
+		REQUIRE(RS2_FORMAT_Z16 == f_format);
+
+		auto depth_distance = ut.process(f);
+		auto depth_distance_format = depth_distance.get_profile().format();
+		REQUIRE(RS2_FORMAT_DISTANCE == depth_distance_format);
+
+		auto frame_data = reinterpret_cast<const uint16_t*>(f.get_data());
+		auto depth_distance_data = reinterpret_cast<const float*>(depth_distance.get_data());
+
+		for (size_t i = 0; i < W*H; i++)
+		{
+			auto frame_data_units_transformed = (frame_data[i] * depth_unit);
+			REQUIRE(depth_distance_data[i] == frame_data_units_transformed);
+		}
+	}
+}
+
 #define ADD_ENUM_TEST_CASE(rs2_enum_type, RS2_ENUM_COUNT)                                  \
 TEST_CASE(#rs2_enum_type " enum test", "[live]") {                                         \
     int last_item_index = static_cast<int>(RS2_ENUM_COUNT);                                \

--- a/wrappers/csharp/Intel.RealSense/NativeMethods.cs
+++ b/wrappers/csharp/Intel.RealSense/NativeMethods.cs
@@ -174,6 +174,9 @@ namespace Intel.RealSense
         internal static extern IntPtr rs2_create_threshold([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
 
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr rs2_create_units_transform([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
+
+        [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr rs2_create_zero_order_invalidation_block([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
 
 #endregion

--- a/wrappers/csharp/Intel.RealSense/Processing/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/Processing/CMakeLists.txt
@@ -15,4 +15,5 @@ target_sources(${LRS_DOTNET_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/ZeroOrderInvalidationFilter.cs"
         "${CMAKE_CURRENT_LIST_DIR}/ProcessingBlockList.cs"
         "${CMAKE_CURRENT_LIST_DIR}/ThresholdFilter.cs"
+	"${CMAKE_CURRENT_LIST_DIR}/UnitsTransform.cs"
 )

--- a/wrappers/csharp/Intel.RealSense/Processing/UnitsTransform.cs
+++ b/wrappers/csharp/Intel.RealSense/Processing/UnitsTransform.cs
@@ -1,0 +1,35 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+namespace Intel.RealSense
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.InteropServices;
+
+    public class UnitsTransform : ProcessingBlock
+    {
+        private static IntPtr Create()
+        {
+            object error;
+            return NativeMethods.rs2_create_units_transform(out error);
+        }
+
+        internal UnitsTransform(IntPtr ptr)
+            : base(ptr)
+        {
+        }
+
+        public UnitsTransform()
+            : base(Create())
+        {
+        }
+
+        [Obsolete("This method is obsolete. Use Process method instead")]
+        public VideoFrame ApplyFilter(Frame original, FramesReleaser releaser = null)
+        {
+            return Process(original).DisposeWith(releaser) as VideoFrame;
+        }
+    }
+}

--- a/wrappers/csharp/Intel.RealSense/Types/Enums/Format.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/Enums/Format.cs
@@ -67,5 +67,12 @@ namespace Intel.RealSense
 
         /// <summary>32-bit float-point disparity values. Depth->Disparity conversion : Disparity = Baseline*FocalLength/Depth</summary>
         Disparity32 = 19,
+
+        /// <summary>16-bit per-pixel grayscale image unpacked from 10 bits per pixel packed ([8:8:8:8:2222]) grey-scale image. The data is unpacked to LSB and padded with 6 zero bits</summary>
+        Y10BPack = 20,
+
+        /// <summary>32-bit float-point depth distance value.</summary>
+        Distance = 21,
+
     }
 }

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -622,6 +622,8 @@ PYBIND11_MODULE(NAME, m) {
     threshold.def(py::init<>())
 		.def(py::init<float, float>(), "min_dist"_a, "max_dist"_a);
 
+	py::class_<rs2::units_transform, rs2::filter> units_transform(m, "units_transform");
+	units_transform.def(py::init<>());
 
     py::class_<rs2::colorizer, rs2::filter> colorizer(m, "colorizer");
     colorizer.def(py::init<>())


### PR DESCRIPTION
- RS5-4269
- Add the capability to process depth units into meters by units transform
  processing block (cpp, c#, python).