### PR TITLE
Cancel the check of the algo version before reading the zero order point.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -944,7 +944,7 @@ namespace rs2
             if (shared_filter->is<zero_order_invalidation>())
                 zero_order_artifact_fix = model;
 
-            if (shared_filter->is<hole_filling_filter>() || shared_filter->is<zero_order_invalidation>())
+            if (shared_filter->is<hole_filling_filter>())
                 model->enabled = false;
 
             post_processing.push_back(model);

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -135,19 +135,15 @@ namespace librealsense
 
     std::pair<int, int> l500_depth_sensor::read_zo_point()
     {
-        if (auto ver = read_algo_version() >= 115)
+        const int zo_point_address = 0xa00e1b8c;
+        command cmd(ivcam2::fw_cmd::MRD, zo_point_address, zo_point_address + 4);
+        auto res = _owner->_hw_monitor->send(cmd);
+        if (res.size() < 2)
         {
-            const int zo_point_address = 0xa00e1b8c;
-            command cmd(ivcam2::fw_cmd::MRD, zo_point_address, zo_point_address + 4);
-            auto res = _owner->_hw_monitor->send(cmd);
-            if (res.size() < 2)
-            {
-                throw std::runtime_error("Invalid result size!");
-            }
-            auto data = (uint16_t*)res.data();
-            return { data[0], data[1] };
+            throw std::runtime_error("Invalid result size!");
         }
-        return { 0, 0 };
+        auto data = (uint16_t*)res.data();
+        return { data[0], data[1] };
     }
 
     int l500_depth_sensor::read_algo_version()


### PR DESCRIPTION
Read zero order without checking the algo version.
Enable by default the zero order validation filter on viewer. 