### PR TITLE
Update t265_rpy.py

### DIFF
--- a/wrappers/python/examples/t265_rpy.py
+++ b/wrappers/python/examples/t265_rpy.py
@@ -42,7 +42,7 @@ try:
             # transform to aeronautic coordinates (body AND reference frame!)
             H_aeroRef_aeroBody = H_aeroRef_T265Ref.dot( H_T265Ref_T265body.dot( H_T265body_aeroBody ))
 
-            rpy_rad = np.array( tf.euler_from_matrix(H_aeroRef_aeroBody, 'rxyz') )
+            rpy_rad = np.array( tf.euler_from_matrix(H_aeroRef_aeroBody, 'sxyz') ) # Rz(yaw)*Ry(pitch)*Rx(roll) body w.r.t. reference frame
 
             print("Frame #{}".format(pose.frame_number))
             print("RPY [deg]: {}".format(rpy_rad*180/m.pi))


### PR DESCRIPTION
Fixed rotation matrix to roll-pitch-yaw conversion to comply with the following roll-pitch-yaw definition:
R_ref_body = Rz(yaw)*Ry(pitch)*Rx(roll) // body w.r.t. reference frame
where Ri denotes the rotation around axis i.

Additional info on orientation of coordinate frames:
https://en.wikipedia.org/wiki/Aircraft_principal_axes#/media/File:Yaw_Axis_Corrected.svg

Thanks, @radfordi!