### PR TITLE
Add frame timestamp attribute and USB descriptor for L500

### DIFF
--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -87,6 +87,7 @@ namespace librealsense
         auto md_prop_offset = offsetof(metadata_raw, mode) +
             offsetof(md_l500_depth, intel_capture_timing);
 
+        get_depth_sensor().register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
         get_depth_sensor().register_metadata(RS2_FRAME_METADATA_FRAME_COUNTER, make_attribute_parser(&l500_md_capture_timing::frame_counter, md_capture_timing_attributes::frame_counter_attribute, md_prop_offset));
         get_depth_sensor().register_metadata(RS2_FRAME_METADATA_SENSOR_TIMESTAMP, make_attribute_parser(&l500_md_capture_timing::sensor_timestamp, md_capture_timing_attributes::sensor_timestamp_attribute, md_prop_offset));
         get_depth_sensor().register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS, make_attribute_parser(&l500_md_capture_timing::exposure_time, md_capture_timing_attributes::sensor_timestamp_attribute, md_prop_offset));

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -66,6 +66,17 @@ namespace librealsense
 
         auto pid_hex_str = hexify(group.uvc_devices.front().pid);
 
+        using namespace platform;
+
+        auto usb_mode = usb3_type;
+        std::string usb_type_str(usb_spec_names.at(usb_mode));
+        usb_mode = get_depth_sensor().get_usb_specification();
+        if (usb_spec_names.count(usb_mode) && (usb_undefined != usb_mode))
+        {
+            usb_type_str = usb_spec_names.at(usb_mode);
+            register_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR, usb_type_str);
+        }
+
         register_info(RS2_CAMERA_INFO_NAME, device_name);
         register_info(RS2_CAMERA_INFO_SERIAL_NUMBER, serial);
         register_info(RS2_CAMERA_INFO_FIRMWARE_VERSION, fw_version);


### PR DESCRIPTION
Added usb type for L500 camera info (RS5-4465)
Added support for frame number on L500 metadata (RS5-4427)
