### PR TITLE
IMU metadata attributes

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -156,7 +156,8 @@ namespace librealsense
         struct hid_header
         {
             uint8_t         length;             // HID report total size. Limited to 255
-            uint8_t         report_id;
+            uint8_t         report_type;        // Curently supported: IMU/Custom Temperature
+            uint64_t        timestamp;          // Driver-produced/FW-based timestamp. Note that currently only the lower 32bit are used
         };
 #pragma pack(pop)
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -152,19 +152,15 @@ namespace librealsense
             uint32_t        timestamp;
             uint8_t         source_clock[6];
         };
-#pragma pack(pop)
 
-        constexpr uint8_t uvc_header_size = sizeof(uvc_header);
-
-#pragma pack(push, 1)
         struct hid_header
         {
-            uint8_t         length;             // HID report metadata total length
-                                                // to be limited to 255 bytes
-            uint8_t        report_id;
+            uint8_t         length;             // HID report total size. Limited to 255
+            uint8_t         report_id;
         };
 #pragma pack(pop)
 
+        constexpr uint8_t uvc_header_size = sizeof(uvc_header);
         constexpr uint8_t hid_header_size = sizeof(hid_header);
 
         struct frame_object

--- a/src/backend.h
+++ b/src/backend.h
@@ -156,6 +156,17 @@ namespace librealsense
 
         constexpr uint8_t uvc_header_size = sizeof(uvc_header);
 
+#pragma pack(push, 1)
+        struct hid_header
+        {
+            uint8_t         length;             // HID report metadata total length
+                                                // to be limited to 255 bytes
+            uint8_t        report_id;
+        };
+#pragma pack(pop)
+
+        constexpr uint8_t hid_header_size = sizeof(hid_header);
+
         struct frame_object
         {
             size_t          frame_size;

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -321,7 +321,7 @@ namespace librealsense
                 register_info(RS2_CAMERA_INFO_FIRMWARE_VERSION, motion_module_fw_version);
 
             // attributes of md_hid_imu
-            auto md_prop_offset = offsetof(metadata_imu_raw, report_type) + offsetof(md_hid_report, imu_report);
+            auto md_prop_offset = offsetof(metadata_hid_raw, report_type) + offsetof(md_hid_report, imu_report);
 
             hid_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_attribute_parser(&md_imu_report::custom_timestamp, md_hid_imu_attributes::custom_timestamp_attirbute, md_prop_offset));
         }

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -320,10 +320,8 @@ namespace librealsense
             if (!motion_module_fw_version.empty())
                 register_info(RS2_CAMERA_INFO_FIRMWARE_VERSION, motion_module_fw_version);
 
-            // attributes of md_hid_imu
-            auto md_prop_offset = offsetof(metadata_hid_raw, report_type) + offsetof(md_hid_report, imu_report);
-
-            hid_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_attribute_parser(&md_imu_report::custom_timestamp, md_hid_imu_attributes::custom_timestamp_attirbute, md_prop_offset));
+            // HID metadata attributes
+            hid_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&platform::hid_header::timestamp));
         }
     }
 

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -319,6 +319,11 @@ namespace librealsense
 
             if (!motion_module_fw_version.empty())
                 register_info(RS2_CAMERA_INFO_FIRMWARE_VERSION, motion_module_fw_version);
+
+            // attributes of md_hid_imu
+            auto md_prop_offset = offsetof(metadata_imu_raw, report_type) + offsetof(md_hid_report, imu_report);
+
+            hid_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_attribute_parser(&md_imu_report::custom_timestamp, md_hid_imu_attributes::custom_timestamp_attirbute, md_prop_offset));
         }
     }
 

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -132,6 +132,9 @@ namespace librealsense
         {
             _motion_module_device_idx = add_sensor(hid_ep);
         }
+
+        // HID metadata attributes
+        hid_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_hid_header_parser(&platform::hid_header::timestamp));
     }
 
     std::vector<tagged_profile> l500_motion::get_profiles_tags() const

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -436,7 +436,7 @@ namespace librealsense
 
                 try
                 {
-                    int vid, pid, mi;
+                    uint16_t vid, pid, mi;
                     std::string busnum, devnum, devpath;
 
                     auto dev_name = "/dev/" + name;

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -205,7 +205,7 @@ namespace librealsense
         return static_cast<md_hid_imu_attributes>(static_cast<uint8_t>(l) | static_cast<uint8_t>(r));
     }
 
-    inline md_hid_imu_attributes& operator |=(md_hid_imu_attributes l, md_hid_imu_attributes r)
+    inline md_hid_imu_attributes operator |=(md_hid_imu_attributes l, md_hid_imu_attributes r)
     {
         return l = l | r;
     }
@@ -663,7 +663,7 @@ namespace librealsense
         uint8_t     usb_counter;        // USB-layer internal counter
     };
 
-    REGISTER_MD_TYPE(md_imu_report, md_type::META_DATA_HID_IMU_REPORT_ID);
+    REGISTER_MD_TYPE(md_imu_report, md_type::META_DATA_HID_IMU_REPORT_ID)
 
     constexpr uint8_t metadata_imu_report_size = sizeof(md_imu_report);
 

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -182,13 +182,22 @@ namespace librealsense
     };
 
     /**\brief md_hid_imu_attributes - bit mask to designate the enabled attributed,
+*  md_imu_report struct */
+    enum md_hid_report_type : uint8_t
+    {
+        hid_report_unknown,
+        hid_report_imu,
+        hid_report_custom_temperature,
+        hid_report_max,
+    };
+
+    /**\brief md_hid_imu_attributes - bit mask to designate the enabled attributed,
  *  md_imu_report struct */
     enum class md_hid_imu_attributes : uint8_t
     {
-        timestamp_attirbute         = (1u << 0),
-        custom_timestamp_attirbute  = (1u << 1),
-        imu_counter_attribute       = (1u << 2),
-        usb_counter_attribute       = (1u << 3)
+        custom_timestamp_attirbute  = (1u << 0),
+        imu_counter_attribute       = (1u << 1),
+        usb_counter_attribute       = (1u << 2)
     };
 
     inline md_hid_imu_attributes operator |(md_hid_imu_attributes l, md_hid_imu_attributes r)
@@ -649,7 +658,6 @@ namespace librealsense
     {
         md_header   header;
         uint8_t     flags;              // Bit array to specify attributes that are valid (limited to 7 fields)
-        uint64_t    timestamp;          // Driver-produced Timestamp
         uint64_t    custom_timestamp;   // HW Timestamp
         uint8_t     imu_counter;        // IMU internal counter
         uint8_t     usb_counter;        // USB-layer internal counter
@@ -663,10 +671,10 @@ namespace librealsense
     {
         md_header   header;
         uint8_t     flags;              // Bit array to specify attributes that are valid (limited to 7 fields)
-        uint8_t     source_id;
         uint64_t    custom_timestamp;   // HW Timestamp
         uint8_t     imu_counter;        // IMU internal counter
         uint8_t     usb_counter;        // USB-layer internal counter
+        uint8_t     source_id;
     };
 
     REGISTER_MD_TYPE(md_custom_tmp_report, md_type::META_DATA_HID_CUSTOM_TEMP_REPORT_ID)
@@ -679,15 +687,15 @@ namespace librealsense
         md_custom_tmp_report    temperature_report;
     };
 
-    /**\brief metadata_imu_raw - HID metadata structure
+    /**\brief metadata_hid_raw - HID metadata structure
  *  layout populated by backend */
-    struct metadata_imu_raw
+    struct metadata_hid_raw
     {
         platform::hid_header   header;
         md_hid_report          report_type;
     };
 
-    constexpr uint8_t metadata_imu_raw_size = sizeof(metadata_imu_raw);
+    constexpr uint8_t metadata_hid_raw_size = sizeof(metadata_hid_raw);
 
 #pragma pack(pop)
 }

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -191,6 +191,16 @@ namespace librealsense
         usb_counter_attribute       = (1u << 3)
     };
 
+    inline md_hid_imu_attributes operator |(md_hid_imu_attributes l, md_hid_imu_attributes r)
+    {
+        return static_cast<md_hid_imu_attributes>(static_cast<uint8_t>(l) | static_cast<uint8_t>(r));
+    }
+
+    inline md_hid_imu_attributes& operator |=(md_hid_imu_attributes l, md_hid_imu_attributes r)
+    {
+        return l = l | r;
+    }
+
     /**\brief md_hid_imu_attributes - bit mask to designate the enabled attributed,
 *  md_imu_report struct */
     enum class md_hid_custom_temp_attributes : uint8_t
@@ -645,6 +655,10 @@ namespace librealsense
         uint8_t     usb_counter;        // USB-layer internal counter
     };
 
+    REGISTER_MD_TYPE(md_imu_report, md_type::META_DATA_HID_IMU_REPORT_ID);
+
+    constexpr uint8_t metadata_imu_report_size = sizeof(md_imu_report);
+
     struct md_custom_tmp_report
     {
         md_header   header;
@@ -655,7 +669,8 @@ namespace librealsense
         uint8_t     usb_counter;        // USB-layer internal counter
     };
 
-    
+    REGISTER_MD_TYPE(md_custom_tmp_report, md_type::META_DATA_HID_CUSTOM_TEMP_REPORT_ID)
+
     /**\brief md_hid_types - aggrevative structure that represents the supported HID
  * metadata struct types to be handled */
     union md_hid_report
@@ -672,8 +687,7 @@ namespace librealsense
         md_hid_report          report_type;
     };
 
-#pragma pack(pop)
-    REGISTER_MD_TYPE(md_imu_report, md_type::META_DATA_HID_IMU_REPORT_ID);
-    REGISTER_MD_TYPE(md_custom_tmp_report, md_type::META_DATA_HID_CUSTOM_TEMP_REPORT_ID)
+    constexpr uint8_t metadata_imu_raw_size = sizeof(metadata_imu_raw);
 
+#pragma pack(pop)
 }

--- a/src/mf/mf-hid.cpp
+++ b/src/mf/mf-hid.cpp
@@ -122,13 +122,6 @@ namespace librealsense
                 auto customTimestampHigh = var.ulVal;
 
                 // Parse additional custom fields
-                //std::vector<unsigned long> props;
-                /*CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE3, &var));
-                props.push_back(var.ulVal);
-                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE4, &var));
-                props.push_back(var.ulVal);
-                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE5, &var));
-                props.push_back(var.ulVal);*/
                 CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE6, &var));
                 uint8_t imu_count = var.bVal;
                 CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE7, &var));
@@ -204,12 +197,6 @@ namespace librealsense
                 meta_data.report_type.imu_report.custom_timestamp = customTimestampLow | (customTimestampHigh < 32);
                 meta_data.report_type.imu_report.imu_counter = imu_count;
                 meta_data.report_type.imu_report.usb_counter = usb_count;
-
-                std::cout << "IMU Metadata: flags :" << int(meta_data.report_type.imu_report.flags)
-                        << " custom ts: " << (unsigned long long)(meta_data.report_type.imu_report.custom_timestamp)
-                        << " imu_counter: " << (int)(meta_data.report_type.imu_report.imu_counter)
-                        << " usb_counter: " << (int)(meta_data.report_type.imu_report.usb_counter)
-                    << std::endl;
 
                 data.x = static_cast<int16_t>(rawX);
                 data.y = static_cast<int16_t>(rawY);

--- a/src/mf/mf-hid.cpp
+++ b/src/mf/mf-hid.cpp
@@ -190,10 +190,12 @@ namespace librealsense
 
                 sensor_data d{};
                 hid_sensor_data data{};
-                // Populate HID IMU data
-                metadata_imu_raw meta_data{};
-                meta_data.header.report_id = 0; //  TBD
+                // Populate HID IMU data - Header
+                metadata_hid_raw meta_data{};
+                meta_data.header.report_type = md_hid_report_type::hid_report_imu;
                 meta_data.header.length = hid_header_size + metadata_imu_report_size;
+                meta_data.header.timestamp = customTimestampLow | (customTimestampHigh < 32);
+                // Payload:
                 meta_data.report_type.imu_report.header.md_type_id = md_type::META_DATA_HID_IMU_REPORT_ID;
                 meta_data.report_type.imu_report.header.md_size = metadata_imu_report_size;
                 meta_data.report_type.imu_report.flags = static_cast<uint8_t>( md_hid_imu_attributes::custom_timestamp_attirbute |
@@ -220,7 +222,7 @@ namespace librealsense
 
                 d.fo.pixels = &data;
                 d.fo.metadata = &meta_data;
-                d.fo.metadata_size = metadata_imu_raw_size;
+                d.fo.metadata_size = metadata_hid_raw_size;
                 d.fo.frame_size = sizeof(data);
                 d.fo.backend_time = 0;
                 if (SystemTimeToFileTime(&sys_time, &file_time))

--- a/src/mf/mf-hid.cpp
+++ b/src/mf/mf-hid.cpp
@@ -27,7 +27,7 @@
 #pragma comment(lib, "Sensorsapi.lib")
 #pragma comment(lib, "PortableDeviceGuids.lib")
 
-const uint8_t HID_METADATA_SIZE = 8; // bytes
+const uint8_t HID_METADATA_SIZE = 4; // bytes
 // Windows Filetime is represented in 64 - bit number of 100 - nanosecond intervals since midnight Jan 1, 1601
 // To convert to the Unix epoch, subtract 116444736000000000LL to reach Jan 1, 1970.
 constexpr uint64_t WIN_FILETIME_2_UNIX_SYSTIME = 116444736000000000LL;

--- a/src/mf/mf-hid.cpp
+++ b/src/mf/mf-hid.cpp
@@ -12,6 +12,7 @@
 #include "../types.h"
 #include "mf-hid.h"
 #include "win/win-helpers.h"
+#include "metadata.h"
 
 #include <PortableDeviceTypes.h>
 //#include <PortableDeviceClassExtension.h>
@@ -27,7 +28,6 @@
 #pragma comment(lib, "Sensorsapi.lib")
 #pragma comment(lib, "PortableDeviceGuids.lib")
 
-const uint8_t HID_METADATA_SIZE = 4; // bytes
 // Windows Filetime is represented in 64 - bit number of 100 - nanosecond intervals since midnight Jan 1, 1601
 // To convert to the Unix epoch, subtract 116444736000000000LL to reach Jan 1, 1970.
 constexpr uint64_t WIN_FILETIME_2_UNIX_SYSTIME = 116444736000000000LL;
@@ -121,6 +121,19 @@ namespace librealsense
                 CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE2, &var));
                 auto customTimestampHigh = var.ulVal;
 
+                // Parse additional custom fields
+                //std::vector<unsigned long> props;
+                /*CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE3, &var));
+                props.push_back(var.ulVal);
+                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE4, &var));
+                props.push_back(var.ulVal);
+                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE5, &var));
+                props.push_back(var.ulVal);*/
+                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE6, &var));
+                uint8_t imu_count = var.bVal;
+                CHECK_HR(report->GetSensorValue(SENSOR_DATA_TYPE_CUSTOM_VALUE7, &var));
+                uint8_t usb_count = var.bVal;
+
                 /* Retrieve sensor type - Sensor types are more specific groupings than sensor categories. Sensor type IDs are GUIDs that are defined in Sensors.h */
 
                 SENSOR_TYPE_ID type{};
@@ -175,8 +188,26 @@ namespace librealsense
 
                 PropVariantClear(&var);
 
-                sensor_data d;
-                hid_sensor_data data;
+                sensor_data d{};
+                hid_sensor_data data{};
+                // Populate HID IMU data
+                metadata_imu_raw meta_data{};
+                meta_data.header.report_id = 0; //  TBD
+                meta_data.header.length = hid_header_size + metadata_imu_report_size;
+                meta_data.report_type.imu_report.header.md_type_id = md_type::META_DATA_HID_IMU_REPORT_ID;
+                meta_data.report_type.imu_report.header.md_size = metadata_imu_report_size;
+                meta_data.report_type.imu_report.flags = static_cast<uint8_t>( md_hid_imu_attributes::custom_timestamp_attirbute |
+                                                                                md_hid_imu_attributes::imu_counter_attribute |
+                                                                                md_hid_imu_attributes::usb_counter_attribute);
+                meta_data.report_type.imu_report.custom_timestamp = customTimestampLow | (customTimestampHigh < 32);
+                meta_data.report_type.imu_report.imu_counter = imu_count;
+                meta_data.report_type.imu_report.usb_counter = usb_count;
+
+                std::cout << "IMU Metadata: flags :" << int(meta_data.report_type.imu_report.flags)
+                        << " custom ts: " << (unsigned long long)(meta_data.report_type.imu_report.custom_timestamp)
+                        << " imu_counter: " << (int)(meta_data.report_type.imu_report.imu_counter)
+                        << " usb_counter: " << (int)(meta_data.report_type.imu_report.usb_counter)
+                    << std::endl;
 
                 data.x = static_cast<int16_t>(rawX);
                 data.y = static_cast<int16_t>(rawY);
@@ -188,8 +219,8 @@ namespace librealsense
                 d.sensor.name = CW2A(fName);
 
                 d.fo.pixels = &data;
-                d.fo.metadata = &data.ts_low;
-                d.fo.metadata_size = HID_METADATA_SIZE;
+                d.fo.metadata = &meta_data;
+                d.fo.metadata_size = metadata_imu_raw_size;
                 d.fo.frame_size = sizeof(data);
                 d.fo.backend_time = 0;
                 if (SystemTimeToFileTime(&sys_time, &file_time))

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -964,13 +964,19 @@ namespace librealsense
             auto frame_counter = timestamp_reader->get_frame_counter(mode, sensor_data.fo);
             auto ts_domain = timestamp_reader->get_frame_timestamp_domain(mode, sensor_data.fo);
             std::cout << "HID timestamp : " << std::fixed << timestamp << std::endl;
-            frame_additional_data additional_data{};
+            frame_additional_data additional_data(timestamp,
+                frame_counter,
+                system_time,
+                static_cast<uint8_t>(sensor_data.fo.metadata_size),
+                (const uint8_t*)sensor_data.fo.metadata,
+                sensor_data.fo.backend_time,
+                last_timestamp,
+                last_frame_number,
+                false);
 
-            additional_data.timestamp = timestamp;
-            additional_data.frame_number = frame_counter;
             additional_data.timestamp_domain = ts_domain;
-            additional_data.system_time = system_time;
             additional_data.backend_timestamp = sensor_data.fo.backend_time;
+
             LOG_DEBUG("FrameAccepted," << get_string(request->get_stream_type())
                     << ",Counter," << std::dec << frame_counter << ",Index,0"
                     << ",BackEndTS," << std::fixed << sensor_data.fo.backend_time

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -12,6 +12,7 @@
 #include "stream.h"
 #include "sensor.h"
 #include "proc/decimation-filter.h"
+#include "metadata.h"
 
 namespace librealsense
 {
@@ -962,7 +963,7 @@ namespace librealsense
             auto timestamp = timestamp_reader->get_frame_timestamp(mode, sensor_data.fo);
             auto frame_counter = timestamp_reader->get_frame_counter(mode, sensor_data.fo);
             auto ts_domain = timestamp_reader->get_frame_timestamp_domain(mode, sensor_data.fo);
-
+            std::cout << "HID timestamp : " << std::fixed << timestamp << std::endl;
             frame_additional_data additional_data{};
 
             additional_data.timestamp = timestamp;
@@ -1113,7 +1114,8 @@ namespace librealsense
             // In order to allow for hw timestamp-based synchronization of Depth and IMU streams the latter will be trimmed to 32 bit.
             // To revert to the extended 64 bit TS uncomment the next line instead
             //auto timestamp = *((uint64_t*)((const uint8_t*)fo.metadata));
-            auto timestamp = *((uint32_t*)((const uint8_t*)fo.metadata));
+            auto timestamp = (fo.metadata_size >= platform::hid_header_size) ?
+                static_cast<uint32_t>(((platform::hid_header*)(fo.metadata))->timestamp) : *((uint32_t*)((const uint8_t*)fo.metadata));
 
             // HID timestamps are aligned to FW Default - usec units
             return static_cast<rs2_time_t>(timestamp * TIMESTAMP_USEC_TO_MSEC);

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -963,7 +963,7 @@ namespace librealsense
             auto timestamp = timestamp_reader->get_frame_timestamp(mode, sensor_data.fo);
             auto frame_counter = timestamp_reader->get_frame_counter(mode, sensor_data.fo);
             auto ts_domain = timestamp_reader->get_frame_timestamp_domain(mode, sensor_data.fo);
-            std::cout << "HID timestamp : " << std::fixed << timestamp << std::endl;
+
             frame_additional_data additional_data(timestamp,
                 frame_counter,
                 system_time,

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -774,6 +774,8 @@ namespace librealsense
       _hid_iio_timestamp_reader(move(hid_iio_timestamp_reader)),
       _custom_hid_timestamp_reader(move(custom_hid_timestamp_reader))
     {
+        register_metadata(RS2_FRAME_METADATA_BACKEND_TIMESTAMP, make_additional_data_parser(&frame_additional_data::backend_timestamp));
+
         std::map<std::string, uint32_t> frequency_per_sensor;
         for (auto& elem : sensor_name_and_hid_profiles)
             frequency_per_sensor.insert(make_pair(elem.first, elem.second.fps));
@@ -781,7 +783,6 @@ namespace librealsense
         std::vector<platform::hid_profile> profiles_vector;
         for (auto& elem : frequency_per_sensor)
             profiles_vector.push_back(platform::hid_profile{elem.first, elem.second});
-
 
         _hid_device->open(profiles_vector);
         for (auto& elem : _hid_device->get_sensors())
@@ -968,6 +969,7 @@ namespace librealsense
             additional_data.frame_number = frame_counter;
             additional_data.timestamp_domain = ts_domain;
             additional_data.system_time = system_time;
+            additional_data.backend_timestamp = sensor_data.fo.backend_time;
             LOG_DEBUG("FrameAccepted," << get_string(request->get_stream_type())
                     << ",Counter," << std::dec << frame_counter << ",Index,0"
                     << ",BackEndTS," << std::fixed << sensor_data.fo.backend_time


### PR DESCRIPTION
Generate and push IMU reports metadata into the SDK core.
Allows querying the IMU HW timestamp (when IMU global timestamp state in enabled).
Tracked on: DSO-12860