### PR TITLE
Change name of laser power to preset, enable sync mode in case of zero order, update l515 create matcher.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -887,11 +887,12 @@ namespace rs2
 
     subdevice_model::subdevice_model(
         device& dev,
-        std::shared_ptr<sensor> s, std::string& error_message, viewer_model& viewer)
+        std::shared_ptr<sensor> s, std::string& error_message, viewer_model* viewer)
         : s(s), dev(dev), tm2(), ui(), last_valid_ui(),
         streaming(false), _pause(false),
         depth_colorizer(std::make_shared<rs2::gl::colorizer>()),
-        yuy2rgb(std::make_shared<rs2::gl::yuy_decoder>())
+        yuy2rgb(std::make_shared<rs2::gl::yuy_decoder>()),
+        viewer(viewer)
     {
         restore_processing_block("colorizer", depth_colorizer);
         restore_processing_block("yuy2rgb", yuy2rgb);
@@ -944,7 +945,7 @@ namespace rs2
             if (shared_filter->is<zero_order_invalidation>())
             {
                 zero_order_artifact_fix = model;
-                viewer.zero_order_enabled = true;
+                viewer->num_of_zero_order_enabled++;
             }
 
             if (shared_filter->is<hole_filling_filter>())
@@ -1079,6 +1080,11 @@ namespace rs2
         }
     }
 
+    subdevice_model::~subdevice_model()
+    {
+        if(zero_order_artifact_fix)
+            viewer->num_of_zero_order_enabled--;
+    }
 
     bool subdevice_model::is_there_common_fps()
     {
@@ -1518,7 +1524,7 @@ namespace rs2
         try {
             s->start([&, syncer](frame f)
             {
-                if (viewer.zero_order_enabled || (viewer.synchronization_enable && is_synchronized_frame(viewer, f)))
+                if (viewer.num_of_zero_order_enabled.load() > 0 || (viewer.synchronization_enable && is_synchronized_frame(viewer, f)))
                 {
                     syncer->invoke(f);
                 }
@@ -2463,7 +2469,7 @@ namespace rs2
     viewer_model::viewer_model()
             : ppf(*this), 
               synchronization_enable(true),
-              zero_order_enabled(false)
+              num_of_zero_order_enabled(0)
     {
         syncer = std::make_shared<syncer_model>();
         reset_camera();
@@ -3394,7 +3400,7 @@ namespace rs2
     {
         for (auto&& sub : dev.query_sensors())
         {
-            auto model = std::make_shared<subdevice_model>(dev, std::make_shared<sensor>(sub), error_message, viewer);
+            auto model = std::make_shared<subdevice_model>(dev, std::make_shared<sensor>(sub), error_message, &viewer);
             subdevices.push_back(model);
         }
 
@@ -3916,7 +3922,7 @@ namespace rs2
         {
             try
             {
-                if(viewer.synchronization_enable || viewer.zero_order_enabled)
+                if(viewer.synchronization_enable || viewer.num_of_zero_order_enabled.load() >0)
                 {
                     auto frames = viewer.syncer->try_wait_for_frames();
                     for(auto f:frames)

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -887,7 +887,7 @@ namespace rs2
 
     subdevice_model::subdevice_model(
         device& dev,
-        std::shared_ptr<sensor> s, std::string& error_message)
+        std::shared_ptr<sensor> s, std::string& error_message, viewer_model& viewer)
         : s(s), dev(dev), tm2(), ui(), last_valid_ui(),
         streaming(false), _pause(false),
         depth_colorizer(std::make_shared<rs2::gl::colorizer>()),
@@ -942,7 +942,10 @@ namespace rs2
                 model->visible = false;
 
             if (shared_filter->is<zero_order_invalidation>())
+            {
                 zero_order_artifact_fix = model;
+                viewer.zero_order_enabled = true;
+            }
 
             if (shared_filter->is<hole_filling_filter>())
                 model->enabled = false;
@@ -1515,7 +1518,7 @@ namespace rs2
         try {
             s->start([&, syncer](frame f)
             {
-                if (viewer.synchronization_enable && is_synchronized_frame(viewer, f))
+                if (viewer.zero_order_enabled || (viewer.synchronization_enable && is_synchronized_frame(viewer, f)))
                 {
                     syncer->invoke(f);
                 }
@@ -2459,7 +2462,8 @@ namespace rs2
 
     viewer_model::viewer_model()
             : ppf(*this), 
-              synchronization_enable(true)
+              synchronization_enable(true),
+              zero_order_enabled(false)
     {
         syncer = std::make_shared<syncer_model>();
         reset_camera();
@@ -3390,7 +3394,7 @@ namespace rs2
     {
         for (auto&& sub : dev.query_sensors())
         {
-            auto model = std::make_shared<subdevice_model>(dev, std::make_shared<sensor>(sub), error_message);
+            auto model = std::make_shared<subdevice_model>(dev, std::make_shared<sensor>(sub), error_message, viewer);
             subdevices.push_back(model);
         }
 
@@ -3912,7 +3916,7 @@ namespace rs2
         {
             try
             {
-                if(viewer.synchronization_enable)
+                if(viewer.synchronization_enable || viewer.zero_order_enabled)
                 {
                     auto frames = viewer.syncer->try_wait_for_frames();
                     for(auto f:frames)

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -515,7 +515,7 @@ namespace rs2
             bool* options_invalidated,
             std::string& error_message);
 
-        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message);
+        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message, viewer_model& viewer);
         bool is_there_common_fps() ;
         bool draw_stream_selection();
         bool is_selected_combination_supported();
@@ -1031,6 +1031,7 @@ namespace rs2
         bool draw_frustrum = true;
         bool support_non_syncronized_mode = true;
         std::atomic<bool> synchronization_enable;
+        std::atomic<bool> zero_order_enabled;
 
         int selected_depth_source_uid = -1;
         int selected_tex_source_uid = -1;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -515,7 +515,9 @@ namespace rs2
             bool* options_invalidated,
             std::string& error_message);
 
-        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message, viewer_model& viewer);
+        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message, viewer_model* viewer);
+        ~subdevice_model();
+
         bool is_there_common_fps() ;
         bool draw_stream_selection();
         bool is_selected_combination_supported();
@@ -565,6 +567,7 @@ namespace rs2
             return false;
         }
 
+        viewer_model* viewer;
         std::function<void()> on_frame = []{};
         std::shared_ptr<sensor> s;
         device dev;
@@ -1031,7 +1034,7 @@ namespace rs2
         bool draw_frustrum = true;
         bool support_non_syncronized_mode = true;
         std::atomic<bool> synchronization_enable;
-        std::atomic<bool> zero_order_enabled;
+        std::atomic<int> num_of_zero_order_enabled;
 
         int selected_depth_source_uid = -1;
         int selected_tex_source_uid = -1;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -515,7 +515,7 @@ namespace rs2
             bool* options_invalidated,
             std::string& error_message);
 
-        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message, viewer_model* viewer);
+        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::string& error_message, viewer_model& viewer);
         ~subdevice_model();
 
         bool is_there_common_fps() ;
@@ -567,7 +567,7 @@ namespace rs2
             return false;
         }
 
-        viewer_model* viewer;
+        viewer_model& viewer;
         std::function<void()> on_frame = []{};
         std::shared_ptr<sensor> s;
         device dev;
@@ -1034,7 +1034,7 @@ namespace rs2
         bool draw_frustrum = true;
         bool support_non_syncronized_mode = true;
         std::atomic<bool> synchronization_enable;
-        std::atomic<int> num_of_zero_order_enabled;
+        std::atomic<int> zo_sensors;
 
         int selected_depth_source_uid = -1;
         int selected_tex_source_uid = -1;

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -75,6 +75,7 @@ extern "C" {
         RS2_OPTION_MA_TEMPERATURE, /**< MA temperature*/
         RS2_OPTION_HARDWARE_PRESET, /**< Hardware stream configuration */
         RS2_OPTION_GLOBAL_TIME_ENABLED, /**< disable global time  */
+        RS2_OPTION_APD_TEMPERATURE, /**< APD temperature*/
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -67,6 +67,9 @@ namespace librealsense
         get_depth_sensor().register_option(RS2_OPTION_MA_TEMPERATURE,
             std::make_shared <l500_temperature_options>(_hw_monitor.get(), RS2_OPTION_MA_TEMPERATURE));
 
+        get_depth_sensor().register_option(RS2_OPTION_APD_TEMPERATURE,
+            std::make_shared <l500_temperature_options>(_hw_monitor.get(), RS2_OPTION_APD_TEMPERATURE));
+
         environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_depth_stream, *_ir_stream);
         environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_depth_stream, *_confidence_stream);
 

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -132,7 +132,7 @@ namespace librealsense
                 else if (model_raw.height == profile.height && model_raw.width == profile.width)
                     cam_model = model_raw;
                 else
-                    throw std::runtime_error(to_string() << "intrinsics for resolution " << profile.width << "," << profile.height << " doesn't exist");
+                    continue;
 
                 rs2_intrinsics intrinsics;
                 intrinsics.width = cam_model.width;
@@ -143,7 +143,7 @@ namespace librealsense
                 intrinsics.ppy = cam_model.ipm.principal_point.y;
                 return intrinsics;
             }
-
+            throw std::runtime_error(to_string() << "intrinsics for resolution " << profile.width << "," << profile.height << " doesn't exist");
         }
 
         stream_profiles init_stream_profiles() override

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -111,7 +111,9 @@ namespace librealsense
             std::make_shared<uvc_xu_option<int>>(
                 *depth_ep,
                 ivcam2::depth_xu,
-                ivcam2::L500_DEPTH_VISUAL_PRESET, "Preset to calibrate the camera to short or long range. 1 is long range and 2 is short range"));
+                ivcam2::L500_DEPTH_VISUAL_PRESET, "Preset to calibrate the camera to short or long range. 1 is long range and 2 is short range",
+                std::map<float, std::string>{ { 1, "Long range"},
+                { 2, "Short range" }}));
 
         return depth_ep;
     }

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -68,12 +68,10 @@ namespace librealsense
 
         using namespace platform;
 
-        auto usb_mode = usb3_type;
-        std::string usb_type_str(usb_spec_names.at(usb_mode));
-        usb_mode = get_depth_sensor().get_usb_specification();
+        auto usb_mode = get_depth_sensor().get_usb_specification();
         if (usb_spec_names.count(usb_mode) && (usb_undefined != usb_mode))
         {
-            usb_type_str = usb_spec_names.at(usb_mode);
+            auto usb_type_str = usb_spec_names.at(usb_mode);
             register_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR, usb_type_str);
         }
 
@@ -109,11 +107,11 @@ namespace librealsense
         depth_ep->register_pixel_format(pf_confidence_l500);
         depth_ep->register_pixel_format(pf_y8_l500);
 
-        depth_ep->register_option(RS2_OPTION_LASER_POWER,
+        depth_ep->register_option(RS2_OPTION_VISUAL_PRESET,
             std::make_shared<uvc_xu_option<int>>(
                 *depth_ep,
                 ivcam2::depth_xu,
-                ivcam2::L500_DEPTH_LASER_POWER, "Power of the l500 projector, with 0 meaning projector off"));
+                ivcam2::L500_DEPTH_VISUAL_PRESET, "Preset to calibrate the camera to short or long range. 1 is long range and 2 is short range"));
 
         return depth_ep;
     }

--- a/src/l500/l500-factory.cpp
+++ b/src/l500/l500-factory.cpp
@@ -141,8 +141,11 @@ namespace librealsense
 
     std::shared_ptr<matcher> rs515_device::create_matcher(const frame_holder & frame) const
     {
+        std::vector<stream_interface*> mm_streams = { _accel_stream.get(), _gyro_stream.get() };
+
         std::vector<std::shared_ptr<matcher>> matchers = { l500_depth::create_matcher(frame),
-            std::make_shared<identity_matcher>(_color_stream->get_unique_id(), _color_stream->get_stream_type()) };
+            std::make_shared<identity_matcher>(_color_stream->get_unique_id(), _color_stream->get_stream_type()), 
+            matcher_factory::create(RS2_MATCHER_DEFAULT, mm_streams) };
 
         return std::make_shared<timestamp_composite_matcher>(matchers);
 

--- a/src/l500/l500-private.cpp
+++ b/src/l500/l500-private.cpp
@@ -54,6 +54,7 @@ namespace librealsense
                 double LLD_temperature;
                 double MC_temperature;
                 double MA_temperature;
+                double APD_temperature;
             };
 #pragma pack(pop)
 
@@ -74,6 +75,8 @@ namespace librealsense
                 return float(temperature_data.MC_temperature);
             case RS2_OPTION_MA_TEMPERATURE:
                 return float(temperature_data.MA_temperature);
+            case RS2_OPTION_APD_TEMPERATURE:
+                return float(temperature_data.APD_temperature);
             default:
                 throw invalid_value_exception(to_string() << _option << " is not temperature option!");
             }

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -19,7 +19,7 @@ namespace librealsense
     {
         // L500 depth XU identifiers
         const uint8_t L500_HWMONITOR = 1;
-        const uint8_t L500_DEPTH_LASER_POWER = 2;
+        const uint8_t L500_DEPTH_VISUAL_PRESET = 2;
         const uint8_t L500_ERROR_REPORTING = 3;
 
         const platform::extension_unit depth_xu = { 0, 3, 2,

--- a/src/option.h
+++ b/src/option.h
@@ -281,6 +281,10 @@ namespace librealsense
             : _ep(ep), _xu(xu), _id(id), _desciption(std::move(description))
         {}
 
+        uvc_xu_option(uvc_sensor& ep, platform::extension_unit xu, uint8_t id, std::string description, const std::map<float, std::string>& description_per_value)
+            : _ep(ep), _xu(xu), _id(id), _desciption(std::move(description)), _description_per_value(description_per_value)
+        {}
+
         const char* get_description() const override
         {
             return _desciption.c_str();
@@ -289,12 +293,19 @@ namespace librealsense
         {
             _recording_function = record_action;
         }
+        const char* get_value_description(float val) const override
+        {
+            if (_description_per_value.find(val) != _description_per_value.end())
+                return _description_per_value.at(val).c_str();
+            return nullptr;
+        }
     protected:
         uvc_sensor&       _ep;
         platform::extension_unit _xu;
         uint8_t             _id;
         std::string         _desciption;
         std::function<void(const option&)> _recording_function = [](const option&) {};
+        const std::map<float, std::string> _description_per_value;
     };
 
     template<class T, class R, class W, class U>

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -272,6 +272,7 @@ namespace librealsense
             CASE(LLD_TEMPERATURE)
             CASE(MC_TEMPERATURE)
             CASE(MA_TEMPERATURE)
+            CASE(APD_TEMPERATURE)
             CASE(HARDWARE_PRESET)
             CASE(GLOBAL_TIME_ENABLED)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -770,7 +770,7 @@ namespace rs2
             _device_model->show_depth_only = true;
             _device_model->show_stream_selection = false;
             _depth_sensor_model = std::shared_ptr<rs2::subdevice_model>(
-                new subdevice_model(dev, dpt_sensor, _error_message));
+                new subdevice_model(dev, dpt_sensor, _error_message, _viewer_model));
 
             _depth_sensor_model->draw_streams_selector = false;
             _depth_sensor_model->draw_fps_selector = true;

--- a/wrappers/csharp/Intel.RealSense/Types/Enums/Option.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/Enums/Option.cs
@@ -165,6 +165,9 @@ namespace Intel.RealSense
         MCTemperature = 50,
 
         /// <summary>MA temperature</summary>
-        MATemperature = 51
+        MATemperature = 51,
+
+        /// <summary>APD temperature</summary>
+        APDTemperature = 54,
     }
 }


### PR DESCRIPTION
1. Change the name and description of laser power control to visual preset.
2. Enable synchronized mode on viewer if zero order processing block exist.
3. Added the motion module streams to l515 matcher. 