### PR TITLE
Android - dynamic USB read buffer size

### DIFF
--- a/src/android/usb_host/android_uvc.cpp
+++ b/src/android/usb_host/android_uvc.cpp
@@ -20,7 +20,7 @@
 
 #define DEQUEUE_TIMEOUT 10
 #define STREAMING_BULK_TRANSFER_TIMEOUT 100
-#define UVC_PAYLOAD_HEADER_LENGTH 248
+#define UVC_PAYLOAD_HEADER_LENGTH 256
 
 // Data structures for Backend-Frontend queue:
 struct frame;
@@ -892,8 +892,11 @@ void stream_thread(usbhost_uvc_stream_context *strctx) {
                 break;
             case librealsense::platform::RS2_USB_STATUS_SUCCESS:
                 //we support only bulk transfer mode, so we expect the frame to arrive in a single payload
-                if(transferred == read_buff_length)
-                    usbhost_uvc_process_bulk_payload(std::move(fp), transferred, queue);
+                if(transferred > 0)
+                {
+                    if(transferred == (fp->pixels[0] + strctx->stream->cur_ctrl.dwMaxVideoFrameSize))
+                        usbhost_uvc_process_bulk_payload(std::move(fp), transferred, queue);
+                }
                 break;
             default:
                 break;

--- a/src/android/usb_host/android_uvc.cpp
+++ b/src/android/usb_host/android_uvc.cpp
@@ -18,8 +18,8 @@
 #include <atomic>
 #include <zconf.h>
 
-#define DEQUEUE_TIMEOUT 10
-#define STREAMING_BULK_TRANSFER_TIMEOUT 100
+#define DEQUEUE_TIMEOUT 50
+#define STREAMING_BULK_TRANSFER_TIMEOUT 1000
 #define UVC_PAYLOAD_HEADER_LENGTH 256
 
 // Data structures for Backend-Frontend queue:

--- a/src/android/usb_host/android_uvc.cpp
+++ b/src/android/usb_host/android_uvc.cpp
@@ -18,13 +18,14 @@
 #include <atomic>
 #include <zconf.h>
 
-#define DEQUEUE_TIMEOUT 50
-#define STREAMING_BULK_TRANSFER_TIMEOUT 1000
+#define DEQUEUE_TIMEOUT 10
+#define STREAMING_BULK_TRANSFER_TIMEOUT 100
+#define UVC_PAYLOAD_HEADER_LENGTH 248
 
 // Data structures for Backend-Frontend queue:
 struct frame;
 // We keep no more then 2 frames in between frontend and backend
-typedef librealsense::small_heap<frame, 2> frames_archive;
+typedef librealsense::small_heap<frame, 10> frames_archive;
 
 struct frame {
     frame() {}
@@ -799,111 +800,35 @@ uvc_frame_desc_t *usbhost_uvc_find_frame_desc_stream(usbhost_uvc_stream_handle_t
     return usbhost_uvc_find_frame_desc_stream_if(strmh->stream_if, format_id, frame_id);
 }
 
-
-void usbhost_uvc_swap_buffers(usbhost_uvc_stream_handle_t *strmh, size_t leftover = 0) {
-    uint8_t *tmp_buf;
-
-    //pthread_mutex_lock(&strmh->cb_mutex);
-
-    /* swap the buffers */
-    tmp_buf = strmh->holdbuf;
-    strmh->hold_bytes = strmh->got_bytes;
-    strmh->holdbuf = strmh->outbuf;
-    strmh->outbuf = tmp_buf;
-    strmh->hold_last_scr = strmh->last_scr;
-    strmh->hold_pts = strmh->pts;
-    strmh->hold_seq = strmh->seq;
-
-    //pthread_cond_broadcast(&strmh->cb_cond);
-    //pthread_mutex_unlock(&strmh->cb_mutex);
-
-    strmh->seq++;
-    strmh->got_bytes = leftover;
-    strmh->last_scr = 0;
-    strmh->pts = 0;
-}
-
-void usbhost_uvc_process_payload(usbhost_uvc_stream_handle_t *strmh,
-                                 frames_archive *archive,
-                                 frames_queue *queue) {
-    uint8_t header_info;
-    size_t payload_len = strmh->got_bytes;
-    uint8_t *payload = strmh->outbuf;
+void usbhost_uvc_process_bulk_payload(frame_ptr fp, size_t payload_len, frames_queue& queue) {
 
     /* ignore empty payload transfers */
-    if (payload_len == 0)
+    if (!fp || payload_len < 2)
         return;
-    uint8_t header_len = payload[0];
 
+    uint8_t header_len = fp->pixels[0];
+    uint8_t header_info = fp->pixels[1];
+
+    size_t data_len = payload_len - header_len;
+
+    if (header_info & 0x40)
+    {
+        LOG_ERROR("bad packet: error bit set");
+        return;
+    }
     if (header_len > payload_len)
     {
         LOG_ERROR("bogus packet: actual_len=" << payload_len << ", header_len=" << header_len);
         return;
     }
 
-    size_t data_len = strmh->got_bytes - header_len;
 
-    if (header_len < 2) {
-        header_info = 0;
-    }
-    else {
-        /** @todo we should be checking the end-of-header bit */
-        size_t variable_offset = 2;
+    LOG_DEBUG("Passing packet to user CB with size " << (data_len + header_len));
+    librealsense::platform::frame_object fo{ data_len, header_len,
+                                             fp->pixels.data() + header_len , fp->pixels.data() };
+    fp->fo = fo;
 
-        header_info = payload[1];
-
-        if (header_info & 0x40) {
-            LOG_ERROR("bad packet: error bit set");
-            return;
-        }
-
-        if (strmh->fid != (header_info & 1) && strmh->got_bytes != 0) {
-            /* The frame ID bit was flipped, but we have image data sitting
-            around from prior transfers. This means the camera didn't send
-            an EOF for the last transfer of the previous frame. */
-//            LOG_DEBUG("complete buffer : length " << strmh->got_bytes);
-            usbhost_uvc_swap_buffers(strmh);
-        }
-
-        strmh->fid = header_info & 1;
-
-        if (header_info & (1 << 2)) {
-            strmh->pts = DW_TO_INT(payload + variable_offset);
-            variable_offset += 4;
-        }
-
-        if (header_info & (1 << 3)) {
-            /** @todo read the SOF token counter */
-            strmh->last_scr = DW_TO_INT(payload + variable_offset);
-            variable_offset += 6;
-        }
-    }
-
-    if ((data_len > 0) && (strmh->cur_ctrl.dwMaxVideoFrameSize == (data_len)))
-    {
-        //if (header_info & (1 << 1)) { // Temp patch to allow old firmware
-        /* The EOF bit is set, so publish the complete frame */
-        usbhost_uvc_swap_buffers(strmh);
-
-        auto frame_p = archive->allocate();
-        if (frame_p)
-        {
-            frame_ptr fp(frame_p, &cleanup_frame);
-
-            memcpy(fp->pixels.data(), payload, data_len + header_len);
-
-            LOG_DEBUG("Passing packet to user CB with size " << (data_len + header_len));
-            librealsense::platform::frame_object fo{ data_len, header_len,
-                                                     fp->pixels.data() + header_len , fp->pixels.data() };
-            fp->fo = fo;
-
-            queue->enqueue(std::move(fp));
-        }
-        else
-        {
-            LOG_WARNING("usbhost backend is dropping a frame because librealsense wasn't fast enough");
-        }
-    }
+    queue.enqueue(std::move(fp));
 }
 
 void stream_thread(usbhost_uvc_stream_context *strctx) {
@@ -919,11 +844,14 @@ void stream_thread(usbhost_uvc_stream_context *strctx) {
     std::atomic_bool keep_sending_callbacks(true);
     frames_queue queue;
 
+    uint32_t read_buff_length = UVC_PAYLOAD_HEADER_LENGTH + strctx->stream->cur_ctrl.dwMaxVideoFrameSize;
+    LOG_INFO("endpoint " << (int)read_ep->get_address() << " read buffer size: " << read_buff_length);
+
     // Get all pointers from archive and initialize their content
     std::vector<frame *> frames;
     for (auto i = 0; i < frames_archive::CAPACITY; i++) {
         auto ptr = archive.allocate();
-        ptr->pixels.resize(strctx->maxVideoBufferSize, 0);
+        ptr->pixels.resize(read_buff_length, 0);
         ptr->owner = &archive;
         frames.push_back(ptr);
     }
@@ -941,27 +869,36 @@ void stream_thread(usbhost_uvc_stream_context *strctx) {
         }
     });
     LOG_DEBUG("Transfer thread started for endpoint address: " << strctx->endpoint);
-    bool disconnect = false;
+    bool fatal_error = false;
     do {
+        frame_ptr fp = frame_ptr(archive.allocate(), &cleanup_frame);
+        if(!fp)
+            continue;
         auto i = strctx->stream->stream_if->interface;
         uint32_t transferred = 0;
-        auto sts = messenger->bulk_transfer(read_ep, strctx->stream->outbuf, LIBUVC_XFER_BUF_SIZE, transferred, STREAMING_BULK_TRANSFER_TIMEOUT);
+        auto sts = messenger->bulk_transfer(read_ep, fp->pixels.data(), read_buff_length, transferred, STREAMING_BULK_TRANSFER_TIMEOUT);
+//        LOG_INFO("endpoint: " << (int)read_ep->get_address() << ", sts: " << (int)sts << ", expected: " << (int)read_buff_length << ", actual: " << (int)transferred);
         switch(sts)
         {
-            case librealsense::platform::RS2_USB_STATUS_NO_DEVICE:
-                disconnect = true;
-                break;
+            case librealsense::platform::RS2_USB_STATUS_NO_MEM:
+                LOG_ERROR("USB transfer failed, the max read buffer size is smaller than the current resolution requires, try to configure lower resolution");
             case librealsense::platform::RS2_USB_STATUS_OVERFLOW:
+            case librealsense::platform::RS2_USB_STATUS_NO_DEVICE:
+                fatal_error = true;
+                break;
+            case librealsense::platform::RS2_USB_STATUS_PIPE:
+            case librealsense::platform::RS2_USB_STATUS_INVALID_PARAM:
                 messenger->reset_endpoint(read_ep, reset_ep_timeout);
                 break;
             case librealsense::platform::RS2_USB_STATUS_SUCCESS:
-                strctx->stream->got_bytes = transferred;
-                usbhost_uvc_process_payload(strctx->stream, &archive, &queue);
+                //we support only bulk transfer mode, so we expect the frame to arrive in a single payload
+                if(transferred == read_buff_length)
+                    usbhost_uvc_process_bulk_payload(std::move(fp), transferred, queue);
                 break;
             default:
                 break;
         }
-    } while (!disconnect && strctx->stream->running);
+    } while (!fatal_error && strctx->stream->running);
 
     int ep = strctx->endpoint;
     messenger->reset_endpoint(read_ep, reset_ep_timeout);

--- a/src/usbhost/messenger-usbhost.cpp
+++ b/src/usbhost/messenger-usbhost.cpp
@@ -38,6 +38,7 @@ namespace librealsense
                 case EPROTO: return RS2_USB_STATUS_PIPE;
                 case EINVAL: return RS2_USB_STATUS_INVALID_PARAM;
                 case ENOMEM: return RS2_USB_STATUS_NO_MEM;
+                case ETIMEDOUT: return RS2_USB_STATUS_TIMEOUT;
                     //TODO:MK
                 default: return RS2_USB_STATUS_OTHER;
             }

--- a/src/usbhost/messenger-usbhost.cpp
+++ b/src/usbhost/messenger-usbhost.cpp
@@ -34,7 +34,9 @@ namespace librealsense
             {
                 case EBADF:
                 case ENODEV: return RS2_USB_STATUS_NO_DEVICE;
-                case EPROTO: return RS2_USB_STATUS_OVERFLOW; //protocol error seems to identify FW overflow
+                case EOVERFLOW: return RS2_USB_STATUS_OVERFLOW;
+                case EPROTO: return RS2_USB_STATUS_PIPE;
+                case EINVAL: return RS2_USB_STATUS_INVALID_PARAM;
                 case ENOMEM: return RS2_USB_STATUS_NO_MEM;
                     //TODO:MK
                 default: return RS2_USB_STATUS_OTHER;

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/Streamer.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/Streamer.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public class Streamer {
     private static final String TAG = "librs camera streamer";
 
-    private int mFirstFrameTimeout = 15000;
+    private final int mFirstFrameTimeout;
 
     interface Listener{
         void config(Config config);
@@ -40,6 +40,9 @@ public class Streamer {
         mContext = context;
         mListener = listener;
         mLoadConfig = loadConfig;
+        SharedPreferences sharedPref = mContext.getSharedPreferences(mContext.getString(R.string.app_settings), Context.MODE_PRIVATE);
+        boolean efft = sharedPref.getBoolean(mContext.getString(R.string.extended_first_frame_timeout), false);
+        mFirstFrameTimeout = efft ? 15000 : 3000;
     }
 
     private Runnable mStreaming = new Runnable() {
@@ -73,8 +76,6 @@ public class Streamer {
         }
 
         SharedPreferences sharedPref = mContext.getSharedPreferences(mContext.getString(R.string.app_settings), Context.MODE_PRIVATE);
-        boolean efft = sharedPref.getBoolean(mContext.getString(R.string.extended_first_frame_timeout), false);
-        mFirstFrameTimeout = efft ? 15000 : 3000;
 
         for(Map.Entry e : profilesMap.entrySet()){
             List<VideoStreamProfile> profiles = (List<VideoStreamProfile>) e.getValue();


### PR DESCRIPTION
This PR changes the bulk transfer buffer size from fixed size to the frame resolution size.
This change should allow streaming in lower resolutions in case of "out of memory" error as reported in: #3612, #4091, #4215 
In the few cases that I was able to reproduce the "out of memory" error, rebooting the phone eliminated the problem but the root cause is yet to be found.
