### PR TITLE
Handle disconnect events

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -96,7 +96,7 @@ namespace librealsense
         {
         public:
             virtual double get_time() const = 0;
-            ~time_service() = default;
+            virtual ~time_service() = default;
         };
 
         class os_time_service: public time_service
@@ -110,7 +110,7 @@ namespace librealsense
 
         struct guid { uint32_t data1; uint16_t data2, data3; uint8_t data4[8]; };
         // subdevice and node fields are assigned by Host driver; unit and GUID are hard-coded in camera firmware
-        struct extension_unit { int subdevice, unit, node; guid id; };
+        struct extension_unit { int subdevice; uint8_t unit; int node; guid id; };
 
         enum power_state
         {

--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -38,12 +38,12 @@ namespace librealsense
     device_hub::device_hub(std::shared_ptr<librealsense::context> ctx, int mask, int vid,
                            bool register_device_notifications)
         : _ctx(ctx), _vid(vid),
-          _register_device_notifications(register_device_notifications),
-         _device_changes_callback_id(0)
+          _device_changes_callback_id(0),
+          _register_device_notifications(register_device_notifications)
     {
         _device_list = filter_by_vid(_ctx->query_devices(mask), _vid);
 
-        auto cb = new hub_devices_changed_callback([&](rs2::event_information& info)
+        auto cb = new hub_devices_changed_callback([&,mask](rs2::event_information&)
                    {
                         std::unique_lock<std::mutex> lock(_mutex);
 

--- a/src/linux/backend-hid.h
+++ b/src/linux/backend-hid.h
@@ -118,8 +118,8 @@ namespace librealsense
 
             void signal_stop();
 
-            int _stop_pipe_fd[2]; // write to _stop_pipe_fd[1] and read from _stop_pipe_fd[0]
             int _fd;
+            int _stop_pipe_fd[2]; // write to _stop_pipe_fd[1] and read from _stop_pipe_fd[0]
             std::map<std::string, std::string> _reports;
             std::string _custom_device_path;
             std::string _custom_sensor_name;

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -610,7 +610,7 @@ namespace librealsense
         v4l_uvc_device::~v4l_uvc_device()
         {
             _is_capturing = false;
-            if (_thread) _thread->join();
+            if (_thread && _thread->joinable()) _thread->join();
             for (auto&& fd : _fds)
             {
                 try { if (fd) ::close(fd);} catch (...) {}

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -111,6 +111,11 @@ namespace librealsense
         {
         }
 
+        named_mutex::~named_mutex()
+        {
+            unlock();
+        }
+
         void named_mutex::lock()
         {
             std::lock_guard<std::mutex> lock(_mutex);
@@ -170,7 +175,7 @@ namespace librealsense
             _fildes = -1;
         }
 
-        static int xioctl(int fh, int request, void *arg)
+        static int xioctl(int fh, unsigned long request, void *arg)
         {
             int r=0;
             do {
@@ -179,7 +184,7 @@ namespace librealsense
             return r;
         }
 
-        buffer::buffer(int fd, v4l2_buf_type type, bool use_memory_map, int index)
+        buffer::buffer(int fd, v4l2_buf_type type, bool use_memory_map, uint32_t index)
             : _type(type), _use_memory_map(use_memory_map), _index(index)
         {
             v4l2_buffer buf = {};
@@ -190,13 +195,13 @@ namespace librealsense
                 throw linux_backend_exception("xioctl(VIDIOC_QUERYBUF) failed");
 
             // Prior to kernel 4.16 metadata payload was attached to the end of the video payload
-            auto md_extra = (V4L2_BUF_TYPE_VIDEO_CAPTURE==type) ? MAX_META_DATA_SIZE : 0;
+            uint8_t md_extra = (V4L2_BUF_TYPE_VIDEO_CAPTURE==type) ? MAX_META_DATA_SIZE : 0;
             _original_length = buf.length;
             _length = _original_length + md_extra;
 
             if (use_memory_map)
             {
-                _start = static_cast<uint8_t*>(mmap(NULL, buf.length,
+                _start = static_cast<uint8_t*>(mmap(nullptr, buf.length,
                                                     PROT_READ | PROT_WRITE, MAP_SHARED,
                                                     fd, buf.m.offset));
                 if(_start == MAP_FAILED)
@@ -221,7 +226,7 @@ namespace librealsense
 
             if ( !_use_memory_map )
             {
-                buf.m.userptr = (unsigned long)_start;
+                buf.m.userptr = reinterpret_cast<unsigned long>(_start);
             }
             if(xioctl(fd, VIDIOC_QBUF, &buf) < 0)
                 throw linux_backend_exception("xioctl(VIDIOC_QBUF) failed");
@@ -307,7 +312,6 @@ namespace librealsense
             };
         }
 
-
         static std::tuple<std::string,uint16_t>  get_usb_descriptors(libusb_device* usb_device)
         {
             auto usb_bus = std::to_string(libusb_get_bus_number(usb_device));
@@ -318,11 +322,10 @@ namespace librealsense
             std::stringstream port_path;
             auto port_count = libusb_get_port_numbers(usb_device, usb_ports, max_usb_depth);
             auto usb_dev = std::to_string(libusb_get_device_address(usb_device));
-            auto speed = libusb_get_device_speed(usb_device);
             libusb_device_descriptor dev_desc;
-            auto r= libusb_get_device_descriptor(usb_device,&dev_desc);
+            libusb_get_device_descriptor(usb_device,&dev_desc);
 
-            for (size_t i = 0; i < port_count; ++i)
+            for (auto i = 0; i < port_count; ++i)
             {
                 port_path << std::to_string(usb_ports[i]) << (((i+1) < port_count)?".":"");
             }
@@ -338,7 +341,7 @@ namespace librealsense
             usb_spec res{usb_undefined};
 
             char usb_actual_path[PATH_MAX] = {0};
-            if (realpath(path.c_str(), usb_actual_path) != NULL)
+            if (realpath(path.c_str(), usb_actual_path) != nullptr)
             {
                 path = std::string(usb_actual_path);
                 std::string val;
@@ -391,7 +394,7 @@ namespace librealsense
         void req_io_buff(int fd, uint32_t count, std::string dev_name,
                         v4l2_memory mem_type, v4l2_buf_type type)
         {
-            struct v4l2_requestbuffers req = { count, type, mem_type};
+            struct v4l2_requestbuffers req = { count, type, mem_type, {}};
 
             if(xioctl(fd, VIDIOC_REQBUFS, &req) < 0)
             {
@@ -427,7 +430,7 @@ namespace librealsense
                 std::string path = "/sys/class/video4linux/" + name;
                 std::string real_path{};
                 char buff[PATH_MAX] = {0};
-                if (realpath(path.c_str(), buff) != NULL)
+                if (realpath(path.c_str(), buff) != nullptr)
                 {
                     real_path = std::string(buff);
                     if (real_path.find("virtual") != std::string::npos)
@@ -453,7 +456,7 @@ namespace librealsense
                     std::ostringstream ss; ss << "/sys/dev/char/" << major(st.st_rdev) << ":" << minor(st.st_rdev) << "/device/";
                     auto path = ss.str();
                     auto valid_path = false;
-                    for(auto i=0; i < MAX_DEV_PARENT_DIR; ++i)
+                    for(auto i=0U; i < MAX_DEV_PARENT_DIR; ++i)
                     {
                         if(std::ifstream(path + "busnum") >> busnum)
                         {
@@ -608,7 +611,10 @@ namespace librealsense
         {
             _is_capturing = false;
             if (_thread) _thread->join();
-            _fds.clear();
+            for (auto&& fd : _fds)
+            {
+                try { if (fd) ::close(fd);} catch (...) {}
+            }
         }
 
         void v4l_uvc_device::probe_and_commit(stream_profile profile, frame_callback callback, int buffers)
@@ -677,8 +683,8 @@ namespace librealsense
                     throw linux_backend_exception("xioctl(VIDIOC_S_PARM) failed");
 
                 // Init memory mapped IO
-                negotiate_kernel_buffers(buffers);
-                allocate_io_buffers(buffers);
+                negotiate_kernel_buffers(static_cast<size_t>(buffers));
+                allocate_io_buffers(static_cast<size_t>(buffers));
 
                 _profile =  profile;
                 _callback = callback;
@@ -796,7 +802,7 @@ namespace librealsense
                 struct timeval current_time = { mono_time.tv_sec, mono_time.tv_nsec / 1000 };
                 timersub(&expiration_time, &current_time, &remaining);
                 if (timercmp(&current_time, &expiration_time, <)) {
-                    val = select(_max_fd + 1, &fds, NULL, NULL, &remaining);
+                    val = select(_max_fd + 1, &fds, nullptr, nullptr, &remaining);
                 }
                 else {
                     val = 0;
@@ -913,7 +919,7 @@ namespace librealsense
             }
         }
 
-        void v4l_uvc_device::acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds)
+        void v4l_uvc_device::acquire_metadata(buffers_mgr & buf_mgr,fd_set &)
         {
             if (has_metadata())
                 buf_mgr.set_md_from_video_node();

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -92,6 +92,8 @@ namespace librealsense
 
             named_mutex(const named_mutex&) = delete;
 
+            ~named_mutex();
+
             void lock();
 
             void unlock();
@@ -108,12 +110,12 @@ namespace librealsense
             std::mutex _mutex;
         };
 
-        static int xioctl(int fh, int request, void *arg);
+        static int xioctl(int fh, unsigned long request, void *arg);
 
         class buffer
         {
         public:
-            buffer(int fd, v4l2_buf_type type, bool use_memory_map, int index);
+            buffer(int fd, v4l2_buf_type type, bool use_memory_map, uint32_t index);
 
             void prepare_for_streaming(int fd);
 
@@ -125,8 +127,8 @@ namespace librealsense
 
             void request_next_frame(int fd);
 
-            size_t get_full_length() const { return _length; }
-            size_t get_length_frame_only() const { return _original_length; }
+            uint32_t get_full_length() const { return _length; }
+            uint32_t get_length_frame_only() const { return _original_length; }
 
             uint8_t* get_frame_start() const { return _start; }
 
@@ -135,10 +137,10 @@ namespace librealsense
         private:
             v4l2_buf_type _type;
             uint8_t* _start;
-            size_t _length;
-            size_t _original_length;
+            uint32_t _length;
+            uint32_t _original_length;
             bool _use_memory_map;
-            int _index;
+            uint32_t _index;
             v4l2_buffer _buf;
             std::mutex _mutex;
             bool _must_enqueue = false;
@@ -160,17 +162,17 @@ namespace librealsense
                 _md_start(nullptr),
                 _md_size(0),
                 _mmap_bufs(memory_mapped_buf)
-                {};
+                {}
 
-            ~buffers_mgr(){};
+            ~buffers_mgr(){}
 
             void    request_next_frame();
             void    handle_buffer(supported_kernel_buf_types buf_type, int file_desc,
                                    v4l2_buffer buf= v4l2_buffer(),
                                    std::shared_ptr<platform::buffer> data_buf=nullptr);
 
-            uint8_t metadata_size() const { return _md_size; };
-            void*   metadata_start() const { return _md_start; };
+            uint8_t metadata_size() const { return _md_size; }
+            void*   metadata_start() const { return _md_start; }
 
             void    set_md_attributes(uint8_t md_size, void* md_start)
                     { _md_start = md_start; _md_size = md_size; }
@@ -202,7 +204,7 @@ namespace librealsense
                     if (_data_buf && (!_managed))
                     {
                         //LOG_DEBUG("Enqueue buf " << _dq_buf.index << " for fd " << _file_desc);
-                        if (xioctl(_file_desc, (int)VIDIOC_QBUF, &_dq_buf) < 0)
+                        if (xioctl(_file_desc, VIDIOC_QBUF, &_dq_buf) < 0)
                         {
                             LOG_ERROR("xioctl(VIDIOC_QBUF) guard failed");
                         }
@@ -246,7 +248,7 @@ namespace librealsense
 
             v4l_uvc_device(const uvc_device_info& info, bool use_memory_map = false);
 
-            ~v4l_uvc_device();
+            ~v4l_uvc_device() override;
 
             void probe_and_commit(stream_profile profile, frame_callback callback, int buffers) override;
 
@@ -267,7 +269,7 @@ namespace librealsense
             void set_power_state(power_state state) override;
             power_state get_power_state() const override { return _state; }
 
-            void init_xu(const extension_unit& xu) override {}
+            void init_xu(const extension_unit&) override {}
             bool set_xu(const extension_unit& xu, uint8_t control, const uint8_t* data, int size) override;
             bool get_xu(const extension_unit& xu, uint8_t control, uint8_t* data, int size) const override;
             control_range get_xu_range(const extension_unit& xu, uint8_t control, int len) const override;
@@ -289,21 +291,21 @@ namespace librealsense
         protected:
             static uint32_t get_cid(rs2_option option);
 
-            virtual void capture_loop();
+            virtual void capture_loop() override;
 
-            virtual bool has_metadata() const;
+            virtual bool has_metadata() const override;
 
-            virtual void streamon() const;
-            virtual void streamoff() const;
-            virtual void negotiate_kernel_buffers(size_t num) const;
+            virtual void streamon() const override;
+            virtual void streamoff() const override;
+            virtual void negotiate_kernel_buffers(size_t num) const override;
 
-            virtual void allocate_io_buffers(size_t num);
-            virtual void map_device_descriptor();
-            virtual void unmap_device_descriptor();
-            virtual void set_format(stream_profile profile);
-            virtual void prepare_capture_buffers();
-            virtual void stop_data_capture();
-            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds);
+            virtual void allocate_io_buffers(size_t num) override;
+            virtual void map_device_descriptor() override;
+            virtual void unmap_device_descriptor() override;
+            virtual void set_format(stream_profile profile) override;
+            virtual void prepare_capture_buffers() override;
+            virtual void stop_data_capture() override;
+            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds) override;
 
             power_state _state = D3;
             std::string _name = "";
@@ -369,7 +371,7 @@ namespace librealsense
             std::vector<hid_device_info> query_hid_devices() const override;
 
             std::shared_ptr<time_service> create_time_service() const override;
-            std::shared_ptr<device_watcher> create_device_watcher() const;
+            std::shared_ptr<device_watcher> create_device_watcher() const override;
         };
     }
 }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -612,7 +612,11 @@ namespace librealsense
 
         for (auto& profile : _internal_config)
         {
-            _device->close(profile);
+            try // Handle disconnect event
+            {
+                _device->close(profile);
+            }
+            catch (...) {}
         }
         reset_streaming();
         if (Is<librealsense::global_time_interface>(_owner))

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -37,6 +37,7 @@ namespace librealsense
         explicit sensor_base(std::string name,
                              device* device, 
                              recommended_proccesing_blocks_interface* owner);
+        virtual ~sensor_base() override { _source.flush(); }
 
         virtual stream_profiles init_stream_profiles() = 0;
 
@@ -55,8 +56,6 @@ namespace librealsense
         {
             return _is_streaming;
         }
-
-        virtual ~sensor_base() { _source.flush(); }
 
         void register_metadata(rs2_frame_metadata_value metadata, std::shared_ptr<md_attribute_parser_base> metadata_parser) const;
 
@@ -202,7 +201,7 @@ namespace librealsense
         explicit uvc_sensor(std::string name, std::shared_ptr<platform::uvc_device> uvc_device,
                             std::unique_ptr<frame_timestamp_reader> timestamp_reader, device* dev);
 
-        ~uvc_sensor();
+        virtual ~uvc_sensor();
 
         void open(const stream_profiles& requests) override;
 

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -20,7 +20,15 @@
 #include <functional>
 #include <core/debug.h>
 
-#define rs_fourcc(a, b, c, d) (((unsigned int)(a) << 24) | ((unsigned int)(b) << 16) | ((unsigned int)(c) << 8) | ((unsigned int)(d) << 0))
+template<typename T>
+uint32_t rs_fourcc(const T a, const T b, const  T c, const T d)
+{
+    static_assert((std::is_integral<T>::value), "rs_fourcc supports integral built-in types only");
+    return ((static_cast<uint32_t>(a) << 24) |
+            (static_cast<uint32_t>(b) << 16) |
+            (static_cast<uint32_t>(c) << 8) |
+            (static_cast<uint32_t>(d) << 0));
+}
 
 namespace librealsense
 {
@@ -153,7 +161,7 @@ namespace librealsense
                             std::vector<std::pair<std::string, stream_profile>> sensor_name_and_hid_profiles,
                             device* dev);
 
-        ~hid_sensor();
+        ~hid_sensor() override;
 
         void open(const stream_profiles& requests) override;
 
@@ -201,7 +209,7 @@ namespace librealsense
         explicit uvc_sensor(std::string name, std::shared_ptr<platform::uvc_device> uvc_device,
                             std::unique_ptr<frame_timestamp_reader> timestamp_reader, device* dev);
 
-        virtual ~uvc_sensor();
+        virtual ~uvc_sensor() override;
 
         void open(const stream_profiles& requests) override;
 


### PR DESCRIPTION
Enforce releasing the allocated file descriptors for v4l and hid sensors in case of device disconnect event
Fix `device_hub` - passed by ref parameter goes out of scope
Handle GCC warnings in v4l backend

Can be related to #3538
Tracked on: DSO-12768