### PR TITLE
Handle EBUSY as xu_query return type. Kernel 4.19+

### DIFF
--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -105,7 +105,7 @@ namespace librealsense
                 extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 }, { -0.00552f, 0.0051f, 0.01174f} };
             }
             return extr;
-        };
+        }
 
         ds::imu_intrinsic get_intrinsic(rs2_stream stream)
         {
@@ -138,7 +138,7 @@ namespace librealsense
     public:
         mm_calib_handler(std::shared_ptr<hw_monitor> hw_monitor);
         mm_calib_handler(const mm_calib_handler&);
-        ~mm_calib_handler() {};
+        ~mm_calib_handler() {}
 
         ds::imu_intrinsic get_intrinsic(rs2_stream);
         rs2_extrinsics get_extrinsic(rs2_stream);       // The extrinsic defined as Depth->Stream rigid-body transfom.

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -318,9 +318,9 @@ namespace librealsense
                                                                                  const option_range& opt_range,
                                                                                  const std::map<float, std::string>& description_per_value)
         : option_base(opt_range),
+          _description_per_value(description_per_value),
           _auto_exposure_state(auto_exposure_state),
-          _auto_exposure(auto_exposure),
-          _description_per_value(description_per_value)
+          _auto_exposure(auto_exposure)
     {}
 
     void auto_exposure_antiflicker_rate_option::set(float value)

--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -61,7 +61,7 @@ namespace librealsense
         {
             if (!one_time_note)
             {
-                LOG_WARNING("UVC metadata payloads not available. Please refer to installation chapter for details.");
+                LOG_WARNING("UVC metadata payloads not available. Please refer to the installation chapter for details.");
                 one_time_note = true;
             }
             return _backup_timestamp_reader->get_frame_timestamp(mode, fo);

--- a/src/gl/synthetic-stream-gl.cpp
+++ b/src/gl/synthetic-stream-gl.cpp
@@ -76,7 +76,7 @@ namespace librealsense
             std::lock_guard<std::mutex> lock(_data.mutex);
 
             gladLoadGLLoader((GLADloadproc)binding.glfwGetProcAddress);
-            LOG_WARNING("Initializing rendering, GLSL=" << use_glsl);
+            LOG_INFO("Initializing rendering, GLSL=" << use_glsl);
 
             for (auto&& obj : _data.objs)
             {
@@ -85,7 +85,7 @@ namespace librealsense
             _data.active = true;
             _data.use_glsl = use_glsl;
 
-            LOG_WARNING(" " << _data.objs.size() << " GPU objects initialized");
+            LOG_INFO(" " << _data.objs.size() << " GPU objects initialized");
 
             _rendering_thread = std::this_thread::get_id();
         }
@@ -93,13 +93,13 @@ namespace librealsense
         void rendering_lane::shutdown()
         {
             std::lock_guard<std::mutex> lock(_data.mutex);
-            LOG_WARNING("Shutting down rendering");
+            LOG_INFO("Shutting down rendering");
             for (auto&& obj : _data.objs)
             {
                 obj->update_gpu_resources(false);
             }
             _data.active = false;
-            LOG_WARNING(" " << _data.objs.size() << " GPU objects cleaned-up");
+            LOG_INFO(" " << _data.objs.size() << " GPU objects cleaned-up");
         }
 
         rendering_lane& rendering_lane::instance()
@@ -128,7 +128,7 @@ namespace librealsense
         {
             std::lock_guard<std::mutex> lock(_data.mutex);
 
-            LOG_WARNING("Initializing processing, GLSL=" << use_glsl);
+            LOG_INFO("Initializing processing, GLSL=" << use_glsl);
 
             _data.active = true;
             _data.use_glsl = use_glsl;
@@ -142,14 +142,14 @@ namespace librealsense
                 obj->update_gpu_resources(use_glsl);
             }
 
-            LOG_WARNING(" " << _data.objs.size() << " GPU objects initialized");
+            LOG_INFO(" " << _data.objs.size() << " GPU objects initialized");
         }
 
         void processing_lane::shutdown()
         {
             std::lock_guard<std::mutex> lock(_data.mutex);
 
-            LOG_WARNING("Shutting down processing");
+            LOG_INFO("Shutting down processing");
 
             _data.active = false;
             auto session = _ctx->begin_session();
@@ -160,7 +160,7 @@ namespace librealsense
                 obj->update_gpu_resources(false);
             }
 
-            LOG_WARNING(" " << _data.objs.size() << " GPU objects cleaned-up");
+            LOG_INFO(" " << _data.objs.size() << " GPU objects cleaned-up");
             
             _ctx.reset();
         }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -955,7 +955,7 @@ namespace librealsense
                                       static_cast<uint16_t>(size), const_cast<uint8_t *>(data)};
             if(xioctl(_fd, UVCIOC_CTRL_QUERY, &q) < 0)
             {
-                if (errno == EIO || errno == EAGAIN) // TODO: Log?
+                if (errno == EIO || errno == EAGAIN || errno == EBUSY) // TODO: Log?
                     return false;
 
                 throw linux_backend_exception("get_xu(...). xioctl(UVCIOC_CTRL_QUERY) failed");

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -899,7 +899,7 @@ namespace librealsense
                         }
                         else
                         {
-                            LOG_WARNING("FD_ISSET returned false - video node is not signalled (md only)");
+                            LOG_INFO("FD_ISSET returned false - video node is not signalled (md only)");
                         }
                     }
                 }

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -202,9 +202,9 @@ namespace librealsense
                     if (_data_buf && (!_managed))
                     {
                         //LOG_DEBUG("Enqueue buf " << _dq_buf.index << " for fd " << _file_desc);
-                        if (xioctl(_file_desc, (int)VIDIOC_QBUF, &_dq_buf) < 0)
+                        if ((_file_desc > 0) && (xioctl(_file_desc, (int)VIDIOC_QBUF, &_dq_buf) < 0))
                         {
-                            LOG_ERROR("xioctl(VIDIOC_QBUF) guard failed");
+                            LOG_INFO("xioctl(VIDIOC_QBUF) guard failed");
                         }
                     }
                 }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -364,7 +364,7 @@ namespace librealsense
                 ss << fourcc << " ";
             }
             ss << "]";
-            LOG_WARNING(ss.str());
+            LOG_INFO(ss.str());
         }
 
         // Sort the results to make sure that the user will receive predictable deterministic output from the API
@@ -1146,7 +1146,7 @@ namespace librealsense
 
         if (!started)
         {
-            LOG_WARNING("HID timestamp not found! please apply HID patch.");
+            LOG_WARNING("HID timestamp not found, switching to Host timestamps.");
             started = true;
         }
 


### PR DESCRIPTION
The change is due to media subsystems restrictions introduced in the kernel 4.19 (Reference): https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/diff/drivers/media/usb/uvc/uvc_video.c?id=71f3a82fab1b631ae9cb1feb677f498d4ca5007d
Cleanup logs by adjusting report level of some recurrent events
Fix inconsistent types

#2850
Tracked on: DSO-11696