### PR TITLE
Add software device python

### DIFF
--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -63,6 +63,7 @@ rs2_device* rs2_context_add_device(rs2_context* ctx, const char* file, rs2_error
  */
 void rs2_context_add_software_device(rs2_context* ctx, rs2_device* dev, rs2_error** error);
 
+    void rs2_context_add_emulated_device(rs2_context* ctx, rs2_device* dev, rs2_error** error);
 /**
  * Removes a playback device from the context, if exists
  * \param[in]  ctx       The context from which the device should be removed
@@ -93,6 +94,7 @@ rs2_device_list* rs2_query_devices(const rs2_context* context, rs2_error** error
 #define RS2_PRODUCT_LINE_NON_INTEL  0x01
 #define RS2_PRODUCT_LINE_D400       0x02
 #define RS2_PRODUCT_LINE_SR300      0x04
+#define RS2_PRODUCT_LINE_EMUDEV     0x08
 
 /**
 * create a static snapshot of all connected devices at the time of the call

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -153,6 +153,15 @@ rs2_context* rs2_create_mock_context_versioned(int api_version, const char* file
 rs2_device* rs2_create_software_device(rs2_error** error);
 
 /**
+ * Create software device to enable use librealsense logic without getting data from backend
+ * but inject the data from outside
+ * \param[in] ctx pointer to the context to add this device to.
+ * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+ * \return   software device object, should be released by rs2_delete_device
+ */
+rs2_device* rs2_create_software_device_with_context(rs2_context *ctx, rs2_error** error);
+
+/**
  * Add sensor to the software device
  * \param[in] dev the software device
  * \param[in] sensor_name the name of the sensor
@@ -203,6 +212,24 @@ void rs2_software_sensor_set_metadata(rs2_sensor* sensor, rs2_frame_metadata_val
 void rs2_software_device_create_matcher(rs2_device* dev, rs2_matchers matcher, rs2_error** error);
 
 /**
+ * Register a camera info value for the software device
+ * \param[in] dev the software device
+ * \param[in] info identifier for the camera info to add.
+ * \param[in] val string value for this new camera info.
+ * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+ */
+void rs2_software_device_register_info(rs2_device* dev, rs2_camera_info info, const char *val, rs2_error** error);
+
+/**
+ * Update an existing camera info value for the software device
+ * \param[in] dev the software device
+ * \param[in] info identifier for the camera info to add.
+ * \param[in] val string value for this new camera info.
+ * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+ */
+void rs2_software_device_update_info(rs2_device* dev, rs2_camera_info info, const char * val, rs2_error** error);
+
+/**
  * Add video stream to sensor
  * \param[in] sensor the software sensor
  * \param[in] video_stream all the stream components
@@ -225,6 +252,38 @@ rs2_stream_profile* rs2_software_sensor_add_motion_stream(rs2_sensor* sensor, rs
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
 rs2_stream_profile* rs2_software_sensor_add_pose_stream(rs2_sensor* sensor, rs2_pose_stream pose_stream, rs2_error** error);
+
+/**
+* Set a particular stream as the default stream for this sensor.
+* \param[in] sensor the software sensor
+* \param[in] stream_uid UID of the existing stream profile that we want to
+*    tag as default.
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+void rs2_software_sensor_set_default_profile(rs2_sensor* sensor, int stream_uid, rs2_error** error);
+
+/**
+ * Add writable option to sensor
+ * \param[in] sensor the software sensor
+ * \param[in] option the wanted option
+ * \param[in] desc Description string for this option.
+ * \param[in] min minimum value for range of the new option
+ * \param[in] max maximum value for range of the new option
+ * \param[in] step step size between values for the range of the new option.
+ * \param[in] def default value for the new option.
+ * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+ */
+void rs2_software_sensor_add_writable_option(rs2_sensor* sensor, rs2_option option, const char *desc, float min, float max, float step, float def, rs2_error** error);
+
+/**
+ * Update the writable option added to sensor
+ * \param[in] sensor the software sensor
+ * \param[in] option the wanted option
+ * \param[in] val the wanted value
+ * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+ */
+
+void rs2_software_sensor_update_writable_option(rs2_sensor* sensor, rs2_option option, float val, rs2_error** error);
 
 /**
  * Add read only option to sensor

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -121,7 +121,12 @@ namespace rs2
         * Checks if stream profile is marked/assigned as default, meaning that the profile will be selected when the user requests stream configuration using wildcards (RS2_DEPTH, -1,-1,...
         * \return bool - true or false.
         */
-        bool is_default() const { return _default; }
+        bool is_default() const {
+            rs2_error* e = nullptr;
+            auto ret = !!(rs2_is_stream_profile_default(_profile, &e));
+            error::handle(e);
+            return ret;
+        }
 
         /**
         * Checks if the profile is valid
@@ -172,9 +177,6 @@ namespace rs2
             rs2_get_stream_profile_data(_profile, &_type, &_format, &_index, &_uid, &_framerate, &e);
             error::handle(e);
 
-            _default = !!(rs2_is_stream_profile_default(_profile, &e));
-            error::handle(e);
-
         }
         operator const rs2_stream_profile*() { return _profile; }
         explicit operator std::shared_ptr<rs2_stream_profile>() { return _clone; }
@@ -194,7 +196,6 @@ namespace rs2
         rs2_format _format = RS2_FORMAT_ANY;
         rs2_stream _type = RS2_STREAM_ANY;
 
-        bool _default = false;
     };
 
     class video_stream_profile : public stream_profile

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -309,6 +309,21 @@ namespace rs2
         }
 
         /**
+        * Add emulated device to existing context
+        * Any future queries on the context
+        * Will return this device
+        * This operation cannot be undone (except for destroying the context)
+        *
+        * \param[in] ctx   context to add the device to
+        */
+        void add_emulated_to(context& ctx)
+        {
+            rs2_error* e = nullptr;
+            rs2_context_add_emulated_device(ctx._context.get(), _dev.get(), &e);
+            error::handle(e);
+        }
+
+        /**
         * Add a new camera info value, like serial number
         *
         * \param[in] info  Identifier of the camera info type

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -122,6 +122,18 @@ namespace rs2
         }
 
         /**
+         * Set the default stream for this sensor
+         * \param[in] stream_uid unique identifier for the stream to
+         *    tag as default.
+         */
+        void set_default_profile(int stream_uid)
+        {
+            rs2_error* e = nullptr;
+            rs2_software_sensor_set_default_profile(_sensor.get(), stream_uid, &e);
+            error::handle(e);
+        }
+
+        /**
         * Inject video frame into the sensor
         *
         * \param[in] frame   all the parameters that required to define video frame
@@ -169,6 +181,30 @@ namespace rs2
             error::handle(e);
         }
 
+        /**
+        * Add a read/writable option to the sensor
+        * \param[in] option option id
+        * \param[in] desc string description of this option.
+        * \param[in] rng range and default value for this option
+        */
+        void add_writable_option(rs2_option option, const std::string& desc, option_range rng)
+        {
+            rs2_error* e = nullptr;
+            rs2_software_sensor_add_writable_option(_sensor.get(), option, desc.c_str(), rng.min, rng.max, rng.step, rng.def, &e);
+            error::handle(e);
+        }
+
+        /**
+        * Update a read/writable option for this sensor
+        * \param[in] option option id
+        * \param[in] val desired value for the option.
+        */
+        void update_writable_option(rs2_option option, float val)
+        {
+            rs2_error* e = nullptr;
+            rs2_software_sensor_update_writable_option(_sensor.get(), option, val, &e);
+            error::handle(e);
+        }
         /**
         * Register option that will be supported by the sensor
         *
@@ -222,9 +258,23 @@ namespace rs2
             return dev;
         }
 
+        std::shared_ptr<rs2_device> create_device_ptr(context& ctx)
+        {
+            rs2_error* e = nullptr;
+            std::shared_ptr<rs2_device> dev(
+                rs2_create_software_device_with_context(ctx._context.get(), &e),
+                rs2_delete_device);
+            error::handle(e);
+            return dev;
+        }
+
     public:
         software_device()
             : device(create_device_ptr())
+        {}
+
+        software_device(context &ctx)
+            : device(create_device_ptr(ctx))
         {}
 
         /**
@@ -255,6 +305,32 @@ namespace rs2
         {
             rs2_error* e = nullptr;
             rs2_context_add_software_device(ctx._context.get(), _dev.get(), &e);
+            error::handle(e);
+        }
+
+        /**
+        * Add a new camera info value, like serial number
+        *
+        * \param[in] info  Identifier of the camera info type
+    * \param[in] val   string value to set to this camera info type
+        */
+        void register_info(rs2_camera_info info, const std::string& val)
+        {
+            rs2_error* e = nullptr;
+        rs2_software_device_register_info(_dev.get(), info, val.c_str(), &e);
+            error::handle(e);
+        }
+
+        /**
+        * Update an existing camera info value, like serial number
+        *
+        * \param[in] info  Identifier of the camera info type
+    * \param[in] val   string value to set to this camera info type
+        */
+        void update_info(rs2_camera_info info, const std::string& val)
+        {
+            rs2_error* e = nullptr;
+        rs2_software_device_update_info(_dev.get(), info, val.c_str(), &e);
             error::handle(e);
         }
 

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -82,9 +82,10 @@ namespace rs2
         {
             rs2_error* e = nullptr;
 
-            stream_profile stream(rs2_software_sensor_add_video_stream(_sensor.get(),video_stream, &e));
+            auto profile = rs2_software_sensor_add_video_stream(_sensor.get(),video_stream, &e);
             error::handle(e);
 
+            stream_profile stream(profile);
             return stream;
         }
 
@@ -97,9 +98,10 @@ namespace rs2
         {
             rs2_error* e = nullptr;
 
-            stream_profile stream(rs2_software_sensor_add_motion_stream(_sensor.get(), motion_stream, &e));
+            auto profile = rs2_software_sensor_add_motion_stream(_sensor.get(), motion_stream, &e);
             error::handle(e);
 
+            stream_profile stream(profile);
             return stream;
         }
 
@@ -112,9 +114,10 @@ namespace rs2
         {
             rs2_error* e = nullptr;
 
-            stream_profile stream(rs2_software_sensor_add_pose_stream(_sensor.get(), pose_stream, &e));
+            auto profile = rs2_software_sensor_add_pose_stream(_sensor.get(), pose_stream, &e);
             error::handle(e);
 
+            stream_profile stream(profile);
             return stream;
         }
 
@@ -239,7 +242,7 @@ namespace rs2
 
             return software_sensor(sensor);
         }
-        
+
         /**
         * Add software device to existing context
         * Any future queries on the context

--- a/src/backend.h
+++ b/src/backend.h
@@ -282,6 +282,30 @@ namespace librealsense
             return (a.file_path == b.file_path);
         }
 
+        struct emulated_device_info
+        {
+            std::string name;
+            uint16_t vid;
+            int unique_id;
+            operator std::string() const
+            {
+                std::stringstream s;
+                s << "name- " << name <<
+                    "\nvid- " << std::hex << vid <<
+                    "\nunique_id- " << unique_id;
+                return s.str();
+            }
+
+        };
+
+        inline bool operator==(const emulated_device_info& a,
+            const emulated_device_info& b)
+        {
+            return (a.name == b.name) &&
+                (a.vid == b.vid) &&
+                (a.unique_id == b.unique_id);
+        }
+
         struct tm2_device_info
         {
             void* device_ptr;
@@ -549,18 +573,20 @@ namespace librealsense
                 :uvc_devices(uvc_devices), usb_devices(usb_devices) {}
 
             backend_device_group(const std::vector<playback_device_info>& playback_devices) : playback_devices(playback_devices) {}
+            backend_device_group(const std::vector<emulated_device_info>& emu_devices) : emulated_devices(emu_devices) {}
 
             std::vector<uvc_device_info> uvc_devices;
             std::vector<usb_device_info> usb_devices;
             std::vector<hid_device_info> hid_devices;
             std::vector<playback_device_info> playback_devices;
+            std::vector<emulated_device_info> emulated_devices;
             std::vector<tm2_device_info> tm2_devices;
 
             bool operator == (const backend_device_group& other)
             {
                 return !list_changed(uvc_devices, other.uvc_devices) &&
                     !list_changed(hid_devices, other.hid_devices) &&
-                    !list_changed(playback_devices, other.playback_devices) &&
+                    !list_changed(playback_devices, other.playback_devices) &&                    !list_changed(emulated_devices, other.emulated_devices) &&
                     !list_changed(tm2_devices, other.tm2_devices);
             }
 
@@ -592,6 +618,13 @@ namespace librealsense
                 for (auto playback_device : playback_devices)
                 {
                     s += playback_device;
+                    s += "\n\n";
+                }
+
+                s += emulated_devices.size()>0 ? "emulated devices: \n" : "";
+                for (auto emu_device : emulated_devices)
+                {
+                    s += emu_device;
                     s += "\n\n";
                 }
 

--- a/src/context.h
+++ b/src/context.h
@@ -125,12 +125,13 @@ namespace librealsense
         void set_devices_changed_callback(devices_changed_callback_ptr callback);
 
         std::vector<std::shared_ptr<device_info>> create_devices(platform::backend_device_group devices,
-            const std::map<std::string, std::weak_ptr<device_info>>& playback_devices, int mask) const;
+            const std::map<std::string, std::weak_ptr<device_info>>& playback_devices, const std::vector<std::shared_ptr<device_info>>& emulated_devices, int mask) const;
 
         std::shared_ptr<playback_device_info> add_device(const std::string& file);
         void remove_device(const std::string& file);
 
         void add_software_device(std::shared_ptr<device_info> software_device);
+        void add_emulated_device(std::shared_ptr<device_info> dev);
 
 #if WITH_TRACKING
         void unload_tracking_module();
@@ -140,7 +141,10 @@ namespace librealsense
         void on_device_changed(platform::backend_device_group old,
                                platform::backend_device_group curr,
                                const std::map<std::string, std::weak_ptr<device_info>>& old_playback_devices,
-                               const std::map<std::string, std::weak_ptr<device_info>>& new_playback_devices);
+                               const std::map<std::string, std::weak_ptr<device_info>>& new_playback_devices,
+                               const std::vector<std::shared_ptr<device_info>>& old_emu_devices = std::vector<std::shared_ptr<device_info>>(),
+                               const std::vector<std::shared_ptr<device_info>>& new_emu_devices = std::vector<std::shared_ptr<device_info>>()
+                               );
         void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
         int find_stream_profile(const stream_interface& p);
         std::shared_ptr<lazy<rs2_extrinsics>> fetch_edge(int from, int to);
@@ -151,6 +155,7 @@ namespace librealsense
 #endif
         std::shared_ptr<platform::device_watcher> _device_watcher;
         std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
+        std::vector<std::shared_ptr<device_info>> _emulated_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
 
         devices_changed_callback_ptr _devices_changed_callback;

--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -31,6 +31,14 @@ namespace librealsense
             // TODO: enable T265 filter by VID:PID via tm2_device_info
             if ((!filtered) && data.tm2_devices.size())
                 result.push_back(dev);
+
+            for (const auto& emu : data.emulated_devices)
+            {
+                if ( emu.vid == vid || vid == 0 )
+                {
+                    result.push_back(dev);
+                }
+            }
         }
         return result;
     }

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1209,6 +1209,16 @@ void rs2_context_add_software_device(rs2_context* ctx, rs2_device* dev, rs2_erro
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, ctx, dev)
 
+void rs2_context_add_emulated_device(rs2_context* ctx, rs2_device* dev, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(ctx);
+    VALIDATE_NOT_NULL(dev);
+    auto software_dev = VALIDATE_INTERFACE(dev->device, librealsense::software_device);
+
+    ctx->ctx->add_emulated_device(software_dev->get_emu_info());
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, ctx, dev)
+
 void rs2_context_remove_device(rs2_context* ctx, const char* file, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(ctx);

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -2028,6 +2028,13 @@ rs2_device* rs2_create_software_device(rs2_error** error) BEGIN_API_CALL
 }
 NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(0)
 
+rs2_device* rs2_create_software_device_with_context(rs2_context *ctx, rs2_error** error) BEGIN_API_CALL
+{
+    auto dev = std::make_shared<software_device>(ctx->ctx);
+    return new rs2_device{ dev->get_context(), std::make_shared<readonly_device_info>(dev), dev };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, ctx)
+
 void rs2_software_device_create_matcher(rs2_device* dev, rs2_matchers m, rs2_error** error)BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
@@ -2035,6 +2042,22 @@ void rs2_software_device_create_matcher(rs2_device* dev, rs2_matchers m, rs2_err
     df->set_matcher_type(m);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, dev, m)
+
+void rs2_software_device_register_info(rs2_device* dev, rs2_camera_info info, const char * val, rs2_error** error)BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(dev);
+    auto df = VALIDATE_INTERFACE(dev->device, librealsense::software_device);
+    df->register_info(info, val);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, dev, info, val)
+
+void rs2_software_device_update_info(rs2_device* dev, rs2_camera_info info, const char * val, rs2_error** error)BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(dev);
+    auto df = VALIDATE_INTERFACE(dev->device, librealsense::software_device);
+    df->update_info(info, val);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, dev, info, val)
 
 rs2_sensor* rs2_software_device_add_sensor(rs2_device* dev, const char* sensor_name, rs2_error** error) BEGIN_API_CALL
 {
@@ -2099,6 +2122,28 @@ rs2_stream_profile* rs2_software_sensor_add_pose_stream(rs2_sensor* sensor, rs2_
     return bs->add_pose_stream(pose_stream)->get_c_wrapper();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, sensor, pose_stream.type, pose_stream.index, pose_stream.fmt, pose_stream.uid)
+
+void rs2_software_sensor_set_default_profile(rs2_sensor* sensor, int stream_uid, rs2_error** error) BEGIN_API_CALL
+{
+    auto bs = VALIDATE_INTERFACE(sensor->sensor, librealsense::software_sensor);
+    bs->set_default_profile(stream_uid);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(,sensor, stream_uid)
+
+void rs2_software_sensor_add_writable_option(rs2_sensor* sensor, rs2_option option, const char *desc, float min, float max, float step, float def, rs2_error** error) BEGIN_API_CALL
+{
+    auto bs = VALIDATE_INTERFACE(sensor->sensor, librealsense::software_sensor);
+    option_range rng {min, max, step, def};
+    bs->add_writable_option(option, desc, rng);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, sensor, option, desc, min, max, step, def)
+
+void rs2_software_sensor_update_writable_option(rs2_sensor* sensor, rs2_option option, float val, rs2_error** error) BEGIN_API_CALL
+{
+    auto bs = VALIDATE_INTERFACE(sensor->sensor, librealsense::software_sensor);
+    bs->update_writable_option(option, val);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, sensor, option, val)
 
 void rs2_software_sensor_add_read_only_option(rs2_sensor* sensor, rs2_option option, float val, rs2_error** error) BEGIN_API_CALL
 {

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -68,12 +68,9 @@ namespace librealsense
 
     std::shared_ptr<stream_profile_interface> software_sensor::add_video_stream(rs2_video_stream video_stream)
     {
-        auto exist = (std::find_if(_profiles.begin(), _profiles.end(), [&](std::shared_ptr<stream_profile_interface> profile)
-        {
-            return profile->get_unique_id() == video_stream.uid;
-        } ) != _profiles.end());
 
-        if (exist)
+        auto currProfile = find_profile_by_uid(video_stream.uid);
+        if (currProfile)
         {
             LOG_WARNING("Video stream unique ID already exist!");
             throw rs2::error("Stream unique ID already exist!");
@@ -95,12 +92,8 @@ namespace librealsense
 
     std::shared_ptr<stream_profile_interface> software_sensor::add_motion_stream(rs2_motion_stream motion_stream)
     {
-        auto exist = (std::find_if(_profiles.begin(), _profiles.end(), [&](std::shared_ptr<stream_profile_interface> profile)
-        {
-            return profile->get_unique_id() == motion_stream.uid;
-        }) != _profiles.end());
-
-        if (exist)
+        auto currProfile = find_profile_by_uid(motion_stream.uid);
+        if (currProfile)
         {
             LOG_WARNING("Motion stream unique ID already exist!");
             throw rs2::error("Stream unique ID already exist!");
@@ -121,12 +114,8 @@ namespace librealsense
 
     std::shared_ptr<stream_profile_interface> software_sensor::add_pose_stream(rs2_pose_stream pose_stream)
     {
-        auto exist = (std::find_if(_profiles.begin(), _profiles.end(), [&](std::shared_ptr<stream_profile_interface> profile)
-        {
-            return profile->get_unique_id() == pose_stream.uid;
-        }) != _profiles.end());
-
-        if (exist)
+        auto currProfile = find_profile_by_uid(pose_stream.uid);
+        if (currProfile)
         {
             LOG_WARNING("Pose stream unique ID already exist!");
             throw rs2::error("Stream unique ID already exist!");
@@ -142,6 +131,21 @@ namespace librealsense
         _profiles.push_back(profile);
 
         return std::move(profile);
+    }
+
+    std::shared_ptr<stream_profile_interface> software_sensor::find_profile_by_uid(int uid)
+    {
+        auto filtFunc = [&](std::shared_ptr<stream_profile_interface> profile)
+        {
+            return profile->get_unique_id() == uid;
+        };
+
+        auto profile = std::find_if(_profiles.begin(), _profiles.end(), filtFunc);
+        if ( profile != _profiles.end() ) {
+            return *profile;
+        } else {
+            return std::shared_ptr<stream_profile_interface>();
+        }
     }
 
     bool software_sensor::extend_to(rs2_extension extension_type, void ** ptr)

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -43,6 +43,10 @@ namespace librealsense
         return _info;
     }
 
+    std::shared_ptr<emulated_device_info> software_device::get_emu_info() {
+        return std::make_shared<emulated_device_info>(std::dynamic_pointer_cast<software_device>(shared_from_this()));
+    }
+
     void software_device::set_matcher_type(rs2_matchers matcher)
     {
         _matcher = matcher;

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -138,6 +138,8 @@ namespace librealsense
         lazy<stereo_extension> _stereo_extension;
 
         software_recommended_proccesing_blocks _pbs;
+
+        std::shared_ptr<stream_profile_interface> find_profile_by_uid(int uid);
     };
     MAP_EXTENSION(RS2_EXTENSION_SOFTWARE_SENSOR, software_sensor);
     MAP_EXTENSION(RS2_EXTENSION_SOFTWARE_DEVICE, software_device);

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -14,7 +14,7 @@ namespace librealsense
     class software_device : public device
     {
     public:
-        software_device();
+        software_device(std::shared_ptr<context> ctx=nullptr);
 
         software_sensor& add_software_sensor(const std::string& name);
 
@@ -77,9 +77,22 @@ namespace librealsense
             return _blocks;
         }
         ~software_recommended_proccesing_blocks() override {}
-       
+
     private:
         processing_blocks _blocks;
+    };
+
+    class software_option : public float_option
+    {
+    public:
+        software_option(const std::string& desc, option_range rng);
+
+        const char* get_description() const override {
+            return _desc.c_str();
+        }
+
+    private:
+        std::string _desc;
     };
 
     class software_sensor : public sensor_base, public extendable_interface
@@ -90,6 +103,7 @@ namespace librealsense
         std::shared_ptr<stream_profile_interface> add_video_stream(rs2_video_stream video_stream);
         std::shared_ptr<stream_profile_interface> add_motion_stream(rs2_motion_stream motion_stream);
         std::shared_ptr<stream_profile_interface> add_pose_stream(rs2_pose_stream pose_stream);
+        void set_default_profile(int stream_uid);
 
         bool extend_to(rs2_extension extension_type, void** ptr) override;
 
@@ -104,9 +118,13 @@ namespace librealsense
         void on_video_frame(rs2_software_video_frame frame);
         void on_motion_frame(rs2_software_motion_frame frame);
         void on_pose_frame(rs2_software_pose_frame frame);
+        void add_writable_option(rs2_option option, const std::string& desc, option_range rng);
+        void update_writable_option(rs2_option option, float val);
         void add_read_only_option(rs2_option option, float val);
         void update_read_only_option(rs2_option option, float val);
         void set_metadata(rs2_frame_metadata_value key, rs2_metadata_type value);
+        int get_unique_id() const { return _unique_id; }
+
     private:
         friend class software_device;
         stream_profiles _profiles;


### PR DESCRIPTION
Hi, 

This PR is targeting issue #4197. This PR is not a merge candidate - I'm trying to get feedback about direction only. 

I've implement the functionality that allows me to emulate a D435i device on a `rs2.context` object. I can create a pipeline object and pass in a configuration that targets the emulated device by serial number. I can subsequently interrogate for camera_info, options, and grab frames. All of these settings are configured through the API. [Here is an example python session where I create a trivial emulated device](https://gist.github.com/callendorph/4b7c61808e11967dcd002cfd0bcee824). 

Keep in mind, that my goal here was to get something functional - not to have the end all, be all, perfect solution and API. I've also not added unit tests yet because I want to make sure that the direction I'm heading is reasonable before investing time and energy into that. 

I've primarily attempted to add this functionality by adding to the API only - not modifying it. There are very clearly ways that we could make the API for the software device more concise if we changed the signature of certain methods. For example, `rs2_software_sensor_add_writable_option` and `rs2_software_sensor_add_read_only_option` are redundantly and could probably be combined into a single method with a `readonly` argument. Are you accepting of this kind of consolidation of the software device API or would you prefer to have maximum backward compatibility?

The current implementation adds a new `emulated` device backend because I didn't want to break functionality related to the `playback` devices. I would appreciate any feedback on this approach and how it integrates with the rest of the project. Specifically, in the `context` object I have added a vector of emulated devices, and this has caused the `context::create_devices` and `context::on_device_change` method signatures to expand and become rather ugly. I could integrate this into the `platform::backend_device_group` object but I wasn't sure because the `playback` devices are stored separately from this group object. Thoughts?

I did not see any unit tests for the python wrapper. Do you have a preferred platform for python unit tests if I were to try and add some ? 


