### PR TITLE
Pybackend compilation hotfix

### DIFF
--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -86,7 +86,7 @@ PYBIND11_MODULE(NAME, m) {
 
     py::class_<platform::extension_unit> extension_unit(m, "extension_unit");
     extension_unit.def(py::init<>())
-                  .def("__init__", [](platform::extension_unit & xu, int s, int u, int n, platform::guid g)
+                  .def("__init__", [](platform::extension_unit & xu, int s, uint8_t u, int n, platform::guid g)
                       {
                           new (&xu) platform::extension_unit { s, u, n, g };
                       }, "subdevice"_a, "unit"_a, "node"_a, "guid"_a)


### PR DESCRIPTION
int32->uint8 narrowing conversion warning is interpreted as error with MSVC
Change-Id: I6689e5cba879a0a46df95c96a6486ce4d3a4bdda