### PR TITLE
Silence OpenGL deprecation warnings on macos 10.14

### DIFF
--- a/examples/example.hpp
+++ b/examples/example.hpp
@@ -5,6 +5,7 @@
 
 #include <librealsense2/rs.hpp>
 
+#define GL_SILENCE_DEPRECATION
 #define GLFW_INCLUDE_GLU
 #include <GLFW/glfw3.h>
 


### PR DESCRIPTION
This PR silences warnings like:

>  warning: 'glRotatef' is deprecated: first deprecated in macOS 10.14 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Wdeprecated-declarations]

on macOS 10.14