### PR TITLE
Udev-rules validation fix

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -491,6 +491,7 @@ namespace rs2
                                  std::istreambuf_iterator<char>());
 
                 std::string udev = realsense_udev_rules;
+                udev.erase(udev.find_last_of("\n") + 1);
 
                 if (udev != str)
                 {


### PR DESCRIPTION
Work-around for inconsistent char* -> string conversion.
It is still unclear why  `std::string(char* array)` produces different results in optimized build in  case `array` ends with a new-line `\n` character (`0xA`). Reproduced on GCC 7.4.
#4350