### PR TITLE
Tm2 timestamp domain

### DIFF
--- a/src/tm2/tm-device.cpp
+++ b/src/tm2/tm-device.cpp
@@ -994,7 +994,7 @@ namespace librealsense
         {
             auto pose_frame = static_cast<librealsense::pose_frame*>(frame.frame);
             frame->set_timestamp(system_ts_ms.count());
-            frame->set_timestamp_domain(RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME);
+            frame->set_timestamp_domain(RS2_TIMESTAMP_DOMAIN_GLOBAL_TIME);
             frame->set_stream(profile);
 
             auto info = reinterpret_cast<librealsense::pose_frame::pose_info*>(pose_frame->data.data());
@@ -1131,7 +1131,7 @@ namespace librealsense
         {
             auto motion_frame = static_cast<librealsense::motion_frame*>(frame.frame);
             frame->set_timestamp(system_ts_ms.count());
-            frame->set_timestamp_domain(RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME);
+            frame->set_timestamp_domain(RS2_TIMESTAMP_DOMAIN_GLOBAL_TIME);
             frame->set_stream(profile);
             auto data = reinterpret_cast<float*>(motion_frame->data.data());
             data[0] = imu_data[0];

--- a/src/tm2/tm-device.cpp
+++ b/src/tm2/tm-device.cpp
@@ -913,7 +913,7 @@ namespace librealsense
             auto video = (video_frame*)(frame.frame);
             video->assign(tm_frame.profile.width, tm_frame.profile.height, tm_frame.profile.stride, bpp);
             frame->set_timestamp(system_ts_ms.count());
-            frame->set_timestamp_domain(RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME);
+            frame->set_timestamp_domain(RS2_TIMESTAMP_DOMAIN_GLOBAL_TIME);
             frame->set_stream(profile);
             frame->set_sensor(this->shared_from_this()); //TODO? uvc doesn't set it?
             video->data.assign(tm_frame.data, tm_frame.data + (tm_frame.profile.height * tm_frame.profile.stride));


### PR DESCRIPTION
Timestamps returned by T265 are synced between hw timestamps and system timestamps. 
They match the GLOBAL_TIME_STAMP_DOMAIN definition.
address Jira: TM2-4496