### PR TITLE
Adding support for new calibration query command

### DIFF
--- a/src/ds5/ds5-device.h
+++ b/src/ds5/ds5-device.h
@@ -56,6 +56,7 @@ namespace librealsense
     protected:
 
         std::vector<uint8_t> get_raw_calibration_table(ds::calibration_table_id table_id) const;
+        std::vector<uint8_t> get_new_calibration_table() const;
 
         bool is_camera_in_advanced_mode() const;
 
@@ -80,6 +81,7 @@ namespace librealsense
         uint8_t _depth_device_idx;
 
         lazy<std::vector<uint8_t>> _coefficients_table_raw;
+        lazy<std::vector<uint8_t>> _new_calib_table_raw;
 
         std::unique_ptr<polling_error_handler> _polling_error_handler;
         std::shared_ptr<lazy<rs2_extrinsics>> _left_right_extrinsics;

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -165,6 +165,7 @@ namespace librealsense
             SETSUBPRESET    = 0x7B,     // Download sub-preset
             GETSUBPRESET    = 0x7C,     // Upload the current sub-preset
             GETSUBPRESETNAME= 0x7D,     // Retrieve sub-preset's name
+            RECPARAMSGET    = 0x7E,     // Retrieve depth calibration table in new format (fw >= 5.11.12.100)
         };
 
         #define TOSTRING(arg) #arg
@@ -312,6 +313,16 @@ namespace librealsense
             uint8_t             reserved1[88];
             float4              rect_params[max_ds5_rect_resolutions];
             uint8_t             reserved2[64];
+        };
+
+        struct new_calibration_item
+        {
+            uint16_t width;
+            uint16_t height;
+            float  fx;
+            float  fy;
+            float  ppx;
+            float  ppy;
         };
 
         template<class T>
@@ -619,6 +630,9 @@ namespace librealsense
 
 
         ds5_rect_resolutions width_height_to_ds5_rect_resolutions(uint32_t width, uint32_t height);
+
+        bool try_get_intrinsic_by_resolution_new(const std::vector<uint8_t>& raw_data,
+                uint32_t width, uint32_t height, rs2_intrinsics* result);
 
         rs2_intrinsics get_intrinsic_by_resolution(const std::vector<uint8_t>& raw_data, calibration_table_id table_id, uint32_t width, uint32_t height);
         rs2_intrinsics get_intrinsic_by_resolution_coefficients_table(const std::vector<uint8_t>& raw_data, uint32_t width, uint32_t height);


### PR DESCRIPTION
Starting with recent firmware versions, new method of querying depth stream intrinsics was introduced via RECPARAMSGET command. This PR takes advantage of this method when its available, since it is the official way moving forward. 