### PR TITLE
Fix config resolution issue on initial T265 plug in

### DIFF
--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1671,7 +1671,23 @@ rs2_pipeline_profile* rs2_config_resolve(rs2_config* config, rs2_pipeline* pipe,
 {
     VALIDATE_NOT_NULL(config);
     VALIDATE_NOT_NULL(pipe);
-    return new rs2_pipeline_profile{ config->config->resolve(pipe->pipeline) };
+
+    const int NUM_TIMES_TO_RETRY = 3;
+    rs2_pipeline_profile *profile = nullptr;
+    for (int i = 1; i <= NUM_TIMES_TO_RETRY; i++)
+    {
+        try
+        {
+            profile = new rs2_pipeline_profile{config->config->resolve(pipe->pipeline, std::chrono::seconds(5))};
+            break;
+        }
+        catch (...)
+        {
+            if (i == NUM_TIMES_TO_RETRY)
+                throw;
+        }
+    }
+    return profile;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, config, pipe)
 


### PR DESCRIPTION
If you plug in your T265 camera and run the following code you will get a "No device connected" exception:

```c++
#include <librealsense2/rs.hpp>

int main()
{
    auto pipeline = rs2::pipeline();
    auto config = rs2::config();
    config.enable_stream(RS2_STREAM_POSE, RS2_FORMAT_6DOF);
    config.resolve(pipeline); // "No device connected exception" gets thrown from here
}
```

The program will work fine on all subsequent runs until you disconnect and reconnect the T265 camera. If you attempt to add code to retry the `config.resolve` step you will still encounter this failure.

This bug was consistently reproducible on librealsense v2.24.0 on my system (Linux 5.1.16-200.fc29.x86_64) and another more exotic (and unsupported) armv7 system I am cross compiling to.

After some light debugging it became clear that you could resolve your config on the initial plug in of the T265 *if* you had already started streaming from a `rs2::pipeline`. Further inspection of the librealsense source made it clear that `rs2::pipeline::start` and `rs2::config::resolve` were calling the internal [`librealsense::pipeline::config::resolve`](https://github.com/IntelRealSense/librealsense/blob/1f2a0e7c3de973e15223bc988d1c36de82382386/src/pipeline/config.cpp#L126) method in all the same ways, *except* that `rs2::pipeline::start` (i.e. one that worked) [called resolve with a 5 second timeout and would retry 3 times](https://github.com/IntelRealSense/librealsense/blob/1f2a0e7c3de973e15223bc988d1c36de82382386/src/pipeline/pipeline.cpp#L67).

That meant that the most minimal fix was copying the retry code to `rs2_config_resolve`. That is what is included in this PR.

Another less minimal fix that I would be happy to submit instead would be to factor all the retrying code into `librealsense::pipeline::config::resolve`, and always use a timeout of 5 seconds. This may be better because a) it reduces code duplication, and b) it means that you can no longer call `librealsense::pipeline::config::resolve` in a buggy way. You can preview this change **[here](https://github.com/pietroglyph/librealsense/commit/4c9aae8db32e4e5347ffc5efd4db035911b63420)**.

Let me know if you have any questions or comments, and please review the two possible fixes and indicate which you would prefer I submit. (Note that all of the options to fix this that I've presented still don't fix the root of this issue; it may be more appropriate to fix this at a lower level instead of propagating the retry hack included in this PR.)

Thanks!