### PR TITLE
Add t265 options to Python wrapper

### DIFF
--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -141,6 +141,9 @@ PYBIND11_MODULE(NAME, m) {
         .value("filter_holes_fill", RS2_OPTION_HOLES_FILL)
         .value("stereo_baseline", RS2_OPTION_STEREO_BASELINE)
         .value("global_time_enabled", RS2_OPTION_GLOBAL_TIME_ENABLED)
+        .value("enable_mapping", RS2_OPTION_ENABLE_MAPPING)
+        .value("enable_pose_jumping", RS2_OPTION_ENABLE_POSE_JUMPING)
+        .value("enable_relocalization", RS2_OPTION_ENABLE_RELOCALIZATION)
         .value("count", RS2_OPTION_COUNT);
 
     py::enum_<platform::power_state> power_state(m, "power_state");


### PR DESCRIPTION
This exposes the options `enable_mapping`, `enable_pose_jumping`, and `enable_relocalization` from https://github.com/IntelRealSense/librealsense/pull/4321 to Python under `pyrealsense2.option.*`.