### PR TITLE
Updates to zo and defaults stream of l500

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1518,7 +1518,7 @@ namespace rs2
         try {
             s->start([&, syncer](frame f)
             {
-                if (viewer.zo_sensors.load() > 0 || (viewer.synchronization_enable && is_synchronized_frame(viewer, f)))
+                if (viewer.synchronization_enable && is_synchronized_frame(viewer, f))
                 {
                     syncer->invoke(f);
                 }

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -107,9 +107,9 @@ namespace librealsense
     {
         std::vector<tagged_profile> tags;
 
-        tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 360, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-        tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 360, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-        tags.push_back({ RS2_STREAM_CONFIDENCE, -1, 640, 360, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+        tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_CONFIDENCE, -1, 640, 480, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET });
         
         return tags;
     }
@@ -135,19 +135,6 @@ namespace librealsense
         }
 
         return std::make_shared<timestamp_composite_matcher>(matchers);
-    }
-
-    std::pair<int, int> l500_depth_sensor::read_zo_point()
-    {
-        const int zo_point_address = 0xa00e1b8c;
-        command cmd(ivcam2::fw_cmd::MRD, zo_point_address, zo_point_address + 4);
-        auto res = _owner->_hw_monitor->send(cmd);
-        if (res.size() < 2)
-        {
-            throw std::runtime_error("Invalid result size!");
-        }
-        auto data = (uint16_t*)res.data();
-        return { data[0], data[1] };
     }
 
     int l500_depth_sensor::read_algo_version()
@@ -240,20 +227,10 @@ namespace librealsense
         return (has_metadata_ts(fo)) ? RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK : _backup_timestamp_reader->get_frame_timestamp_domain(mode, fo);
     }
 
-    float zo_point_option_x::query() const
-    {
-        return static_cast<float>(_zo_point->first);
-    }
-
-    float zo_point_option_y::query() const
-    {
-        return static_cast<float>(_zo_point->second);
-    }
-
-    processing_blocks l500_depth_sensor::get_l500_recommended_proccesing_blocks(std::shared_ptr<option> zo_point_x, std::shared_ptr<option> zo_point_y)
+    processing_blocks l500_depth_sensor::get_l500_recommended_proccesing_blocks()
     {
         processing_blocks res;
-        res.push_back(std::make_shared<zero_order>(zo_point_x, zo_point_y));
+        res.push_back(std::make_shared<zero_order>());
         auto depth_standart = get_depth_recommended_proccesing_blocks();
         res.insert(res.end(), depth_standart.begin(), depth_standart.end());
         res.push_back(std::make_shared<threshold>());

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -893,10 +893,7 @@ namespace librealsense
         {
             if (is_depth_sensor(sensor_name))
             {
-                auto zo_point_x = std::shared_ptr<option>(&options->get_option(RS2_OPTION_ZERO_ORDER_POINT_X), [](option*) {});
-                auto zo_point_y = std::shared_ptr<option>(&options->get_option(RS2_OPTION_ZERO_ORDER_POINT_Y), [](option*) {});
-
-                return std::make_shared<recommended_proccesing_blocks_snapshot>(l500_depth_sensor::get_l500_recommended_proccesing_blocks(zo_point_x, zo_point_y));
+                return std::make_shared<recommended_proccesing_blocks_snapshot>(l500_depth_sensor::get_l500_recommended_proccesing_blocks());
             }
             throw io_exception("Unrecognized sensor name");
         }
@@ -1369,7 +1366,7 @@ namespace librealsense
 
             zo_point_x = std::make_shared<const_value_option>("", zo_opt_x_val);
             zo_point_y = std::make_shared<const_value_option>("", zo_opt_y_val);
-            return std::make_shared<ExtensionToType<RS2_EXTENSION_ZERO_ORDER_FILTER>::type>(zo_point_x, zo_point_y);
+            return std::make_shared<ExtensionToType<RS2_EXTENSION_ZERO_ORDER_FILTER>::type>();
         default:
             return nullptr;
         }

--- a/src/proc/zero-order.h
+++ b/src/proc/zero-order.h
@@ -6,10 +6,11 @@
 #include "../include/librealsense2/hpp/rs_frame.hpp"
 #include "synthetic-stream.h"
 #include "option.h"
+#include "l500/l500-private.h"
 
 #define IR_THRESHOLD 115
 #define RTD_THRESHOLD 200
-#define BASELINE 31
+#define BASELINE -10
 #define PATCH_SIZE 5
 #define Z_MAX_VALUE 1200
 #define IR_MIN_VALUE 75
@@ -47,16 +48,18 @@ namespace librealsense
     class zero_order : public generic_processing_block
     {
     public:
-        zero_order(std::shared_ptr<option> zo_point_x = nullptr, std::shared_ptr<option> zo_point_y = nullptr);
+        zero_order();
 
         rs2::frame process_frame(const rs2::frame_source& source, const rs2::frame& f) override;
-        bool try_get_zo_point(const rs2::frame& f);
 
     private:
         bool should_process(const rs2::frame& frame) override;
         rs2::frame prepare_output(const rs2::frame_source& source, rs2::frame input, std::vector<rs2::frame> results) override;
         const char * get_option_name(rs2_option option) const override;
         bool try_read_baseline(const rs2::frame& frame);
+        ivcam2::intrinsic_params try_read_intrinsics(const rs2::frame& frame);
+
+        std::pair<int, int> get_zo_point(const rs2::frame& frame);
 
         rs2::stream_profile     _source_profile_depth;
         rs2::stream_profile     _target_profile_depth;
@@ -69,8 +72,7 @@ namespace librealsense
         bool                    _first_frame;
 
         zero_order_options      _options;
-        std::shared_ptr<option> _zo_point_x;
-        std::shared_ptr<option> _zo_point_y;
+        ivcam2::intrinsic_params _resolutions_depth;
     };
     MAP_EXTENSION(RS2_EXTENSION_ZERO_ORDER_FILTER, librealsense::zero_order);
 }


### PR DESCRIPTION
1. Read the zo point from calibration per resolution and remove zo option.
2. Change the default profiles to 640x480.
3. Do not use syncer automatically in case of zo sensors.