### PR TITLE
Add missing include to uvc_types

### DIFF
--- a/src/libuvc/uvc_types.h
+++ b/src/libuvc/uvc_types.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 /* UVC_COLOR_FORMAT_* have been replaced with UVC_FRAME_FORMAT_*. Please use
  * UVC_FRAME_FORMAT_* instead of using these. */
 #define UVC_COLOR_FORMAT_UNKNOWN UVC_FRAME_FORMAT_UNKNOWN


### PR DESCRIPTION
DSO-12927

- Easy logging disablement lead to a missing include in uvc_types.h.