### PR TITLE
Enalbe RGB undistort for certain modes

### DIFF
--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -22,7 +22,8 @@ static void rs2_project_point_to_pixel(float pixel[2], const struct rs2_intrinsi
 
     float x = point[0] / point[2], y = point[1] / point[2];
 
-    if(intrin->model == RS2_DISTORTION_MODIFIED_BROWN_CONRADY)
+    if ((intrin->model == RS2_DISTORTION_MODIFIED_BROWN_CONRADY) ||
+        (intrin->model == RS2_DISTORTION_BROWN_CONRADY))
     {
 
         float r2  = x*x + y*y;

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -18,12 +18,10 @@
 /* Given a point in 3D space, compute the corresponding pixel coordinates in an image with no distortion or forward distortion coefficients produced by the same camera */
 static void rs2_project_point_to_pixel(float pixel[2], const struct rs2_intrinsics * intrin, const float point[3])
 {
-    //assert(intrin->model != RS2_DISTORTION_INVERSE_BROWN_CONRADY); // Cannot project to an inverse-distorted image
-
     float x = point[0] / point[2], y = point[1] / point[2];
 
     if ((intrin->model == RS2_DISTORTION_MODIFIED_BROWN_CONRADY) ||
-        (intrin->model == RS2_DISTORTION_BROWN_CONRADY))
+        (intrin->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY))
     {
 
         float r2  = x*x + y*y;

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -704,11 +704,10 @@ namespace librealsense
         }
     };
 
-    class rs465_device : public ds5_rolling_shutter,
-        public ds5_active,
-        public ds5_color,
-        public ds5_motion,
-        public ds5_advanced_mode_base
+    class rs465_device : public ds5_active,
+                         public ds5_color,
+                         public ds5_motion,
+                         public ds5_advanced_mode_base
     {
     public:
         rs465_device(std::shared_ptr<context> ctx,
@@ -716,7 +715,6 @@ namespace librealsense
             bool register_device_notifications)
             : device(ctx, group, register_device_notifications),
             ds5_device(ctx, group),
-            ds5_rolling_shutter(ctx, group),
             ds5_active(ctx, group),
             ds5_color(ctx, group),
             ds5_motion(ctx, group),

--- a/src/ds5/ds5-private.cpp
+++ b/src/ds5/ds5-private.cpp
@@ -131,9 +131,16 @@ namespace librealsense
         {
              auto table = check_calib<ds::rgb_calibration_table>(raw_data);
 
-             // Compensate for aspect ratio as the normalized intrinsic is calculated with 16/9 factor
+             // Compensate for aspect ratio as the normalized intrinsic is calculated with a single resolution
              float3x3 intrin = table->intrinsic;
-             static const float base_aspect_ratio_factor = 16.f / 9.f;
+             float base_aspect_ratio_factor = 16.f / 9.f; // shall be overwritten with the actual calib resolution
+
+             if (table->calib_width && table->calib_height)
+                 base_aspect_ratio_factor = float(table->calib_width) / float(table->calib_height);
+             else
+             {
+                 LOG_WARNING("RGB Calibration resolution is not specified, using default 16/9 Aspect ratio");
+             }
 
              // Compensate for aspect ratio
              intrin(0, 0) *= base_aspect_ratio_factor * (height / (float)width);

--- a/src/ds5/ds5-private.cpp
+++ b/src/ds5/ds5-private.cpp
@@ -227,11 +227,8 @@ namespace librealsense
             auto table = check_calib<rgb_calibration_table>(raw_data);
             float3 trans_vector = table->translation_rect;
             float3x3 rect_rot_mat = table->rotation_matrix_rect;
-            float trans_scale = 0.001f; // Convert units from mm to meter
-            if (table->translation.x > 0.f) // Extrinsic of color is referenced to the Depth Sensor CS
-            {
-                trans_scale *= -1;
-            }
+            float trans_scale = -0.001f; // Convert units from mm to meter. Extrinsic of color is referenced to the Depth Sensor CS
+
             trans_vector.x *= trans_scale;
             trans_vector.y *= trans_scale;
             trans_vector.z *= trans_scale;

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -528,8 +528,8 @@ namespace librealsense
             float3              translation;                // RGB translation vector, mm
             // RGB Projection
             float               projection[12];             // Projection matrix from depth to RGB [3 X 4]
-            uint16_t            width;                      // original calibrated resolution
-            uint16_t            height;
+            uint16_t            calib_width;                // original calibrated resolution
+            uint16_t            calib_height;
             // RGB Rectification Coefficients
             float3x3            intrinsic_matrix_rect;      // RGB intrinsic matrix after rectification
             float3x3            rotation_matrix_rect;       // Rotation matrix for rectification of RGB

--- a/src/proc/sse/sse-pointcloud.cpp
+++ b/src/proc/sse/sse-pointcloud.cpp
@@ -177,7 +177,7 @@ namespace librealsense
         auto ppy = _mm_set_ps1(other_intrinsics.ppy);
         auto w = _mm_set_ps1(other_intrinsics.width);
         auto h = _mm_set_ps1(other_intrinsics.height);
-        auto mask_brown_conrady = _mm_set_ps1(RS2_DISTORTION_MODIFIED_BROWN_CONRADY);
+        auto mask_inv_brown_conrady = _mm_set_ps1(RS2_DISTORTION_INVERSE_BROWN_CONRADY);
         auto zero = _mm_set_ps1(0);
         auto one = _mm_set_ps1(1);
         auto two = _mm_set_ps1(2);
@@ -221,7 +221,7 @@ namespace librealsense
             auto r5 = _mm_mul_ps(c[2], _mm_add_ps(r2, _mm_mul_ps(two, _mm_mul_ps(y_f, y_f))));
             auto d_y = _mm_add_ps(y_f, _mm_add_ps(_mm_mul_ps(two, _mm_mul_ps(c[3], _mm_mul_ps(x_f, y_f))), r4));
 
-            auto cmp = _mm_cmpeq_ps(mask_brown_conrady, dist);
+            auto cmp = _mm_cmpeq_ps(mask_inv_brown_conrady, dist);
 
             p_x = _mm_or_ps(_mm_and_ps(cmp, d_x), _mm_andnot_ps(cmp, p_x));
             p_y = _mm_or_ps(_mm_and_ps(cmp, d_y), _mm_andnot_ps(cmp, p_y));


### PR DESCRIPTION
RGB undistort shall  be enabled for the supported devices in the following configurations:

|  Functionality\Implementations | CPU | SSE | GLSL | CUDA |
|---|---|---|---|---|
| Align Depth->Color      |   V |  x |  wip  | wip |
| Align Color -> Depth    |   V | x    |        wip  |  wip |
| Pointcloud                     |   V | V    | V  | wip |
| Free Functions               |  V | n/a    |   n/a   | n/a |

Additional functionality:
Fix base class hierarchy for D465