### PR TITLE
Fix IMU handling for D400 series

### DIFF
--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #define RS2_API_MAJOR_VERSION    2
 #define RS2_API_MINOR_VERSION    25
-#define RS2_API_PATCH_VERSION    0
+#define RS2_API_PATCH_VERSION    11
 #define RS2_API_BUILD_VERSION    0
 
 #ifndef STRINGIFY

--- a/src/ds5/advanced_mode/advanced_mode.cpp
+++ b/src/ds5/advanced_mode/advanced_mode.cpp
@@ -69,13 +69,13 @@ namespace librealsense
             {
             case ds::RS410_PID:
             case ds::RS415_PID:
-            case ds::RS465_PID:
                 default_410(p);
                 break;
             case ds::RS430_PID:
             case ds::RS430I_PID:
             case ds::RS435_RGB_PID:
             case ds::RS435I_PID:
+            case ds::RS465_PID:
                 default_430(p);
                 break;
             case ds::RS405_PID:

--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -60,14 +60,20 @@ namespace librealsense
         color_ep->register_pixel_format(pf_bayer16);
         color_ep->register_pixel_format(pf_uyvyc);
 
-        color_ep->register_pu(RS2_OPTION_BACKLIGHT_COMPENSATION);
         color_ep->register_pu(RS2_OPTION_BRIGHTNESS);
         color_ep->register_pu(RS2_OPTION_CONTRAST);
+        color_ep->register_pu(RS2_OPTION_SATURATION);
         color_ep->register_pu(RS2_OPTION_GAIN);
         color_ep->register_pu(RS2_OPTION_GAMMA);
-        color_ep->register_pu(RS2_OPTION_HUE);
-        color_ep->register_pu(RS2_OPTION_SATURATION);
         color_ep->register_pu(RS2_OPTION_SHARPNESS);
+
+        // Currently disabled for certain sensors
+        if (!val_in_range(color_devices_info.front().pid, { ds::RS465_PID }))
+        {
+            color_ep->register_pu(RS2_OPTION_HUE);
+            color_ep->register_pu(RS2_OPTION_BACKLIGHT_COMPENSATION);
+            color_ep->register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
+        }
 
         auto white_balance_option = std::make_shared<uvc_pu_option>(*color_ep, RS2_OPTION_WHITE_BALANCE);
         auto auto_white_balance_option = std::make_shared<uvc_pu_option>(*color_ep, RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE);
@@ -93,8 +99,6 @@ namespace librealsense
                 { 1.f, "50Hz" },
                 { 2.f, "60Hz" },
                 { 3.f, "Auto" }, }));
-
-        color_ep->register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
 
         color_ep->register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
         color_ep->register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS,  std::make_shared<ds5_md_attribute_actual_fps> (false, [](const rs2_metadata_type& param)

--- a/src/ds5/ds5-device.h
+++ b/src/ds5/ds5-device.h
@@ -62,7 +62,7 @@ namespace librealsense
 
         float get_stereo_baseline_mm() const;
 
-        ds::d400_caps  parse_device_capabilities() const;
+        ds::d400_caps  parse_device_capabilities(const uint16_t pid) const;
 
         void init(std::shared_ptr<context> ctx,
             const platform::backend_device_group& group);

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -257,8 +257,8 @@ namespace librealsense
             if (_fw_version >= firmware_version("5.10.4.0"))
             {
                 tags.push_back({ RS2_STREAM_FISHEYE, -1, 640, 480, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT});
-                tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 125, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             }
 
             return tags;
@@ -361,8 +361,8 @@ namespace librealsense
                 tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
             }
-            tags.push_back({ RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 
             return tags;
         };
@@ -407,8 +407,8 @@ namespace librealsense
             tags.push_back({ RS2_STREAM_FISHEYE, -1, 640, 480, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT});
             if (_fw_version >= firmware_version("5.10.4.0")) // Back-compat with records is required
             {
-                tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 125, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             }
 
             return tags;
@@ -526,8 +526,8 @@ namespace librealsense
             tags.push_back({ RS2_STREAM_COLOR, -1, width, height, RS2_FORMAT_RGB8, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_DEPTH, -1, width, height, RS2_FORMAT_Z16, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_INFRARED, -1, width, height, RS2_FORMAT_Y8, fps, profile_tag::PROFILE_TAG_SUPERSET });
-            tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 
             return tags;
         };
@@ -735,8 +735,8 @@ namespace librealsense
             tags.push_back({ RS2_STREAM_COLOR, -1, width, height, RS2_FORMAT_RGB8, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_DEPTH, -1, width, height, RS2_FORMAT_Z16, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_INFRARED, -1, width, height, RS2_FORMAT_Y8, fps, profile_tag::PROFILE_TAG_SUPERSET });
-            tags.push_back({ RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_100, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 
             return tags;
         };
@@ -759,8 +759,8 @@ namespace librealsense
         std::vector<tagged_profile> get_profiles_tags() const override
         {
             std::vector<tagged_profile> tags;
-            tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, 63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 
             return tags;
         };

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -195,7 +195,7 @@ namespace librealsense
 
         uint16_t pid = static_cast<uint16_t>(strtoul(all_hid_infos.front().pid.data(), nullptr, 16));
 
-        if ((camera_fw_version >= firmware_version(custom_sensor_fw_ver)) && (!val_in_range(pid, { ds::RS400_IMU_PID, ds::RS435I_PID, ds::RS430I_PID })))
+        if ((camera_fw_version >= firmware_version(custom_sensor_fw_ver)) && (!val_in_range(pid, { ds::RS400_IMU_PID, ds::RS435I_PID, ds::RS430I_PID, ds::RS465_PID })))
         {
             hid_ep->register_option(RS2_OPTION_MOTION_MODULE_TEMPERATURE,
                                     std::make_shared<motion_module_temperature_option>(*hid_ep));

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -263,7 +263,7 @@ namespace librealsense
     {
         using namespace ds;
 
-        _mm_calib = std::make_shared<mm_calib_handler>(_hw_monitor);
+        _mm_calib = std::make_shared<mm_calib_handler>(_hw_monitor,_device_capabilities);
 
         _accel_intrinsic = [this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); };
         _gyro_intrinsic = [this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); };
@@ -459,7 +459,8 @@ namespace librealsense
         //});
     }
 
-    mm_calib_handler::mm_calib_handler(std::shared_ptr<hw_monitor> hw_monitor) :  _hw_monitor(hw_monitor)
+    mm_calib_handler::mm_calib_handler(std::shared_ptr<hw_monitor> hw_monitor, ds::d400_caps dev_cap) :
+        _hw_monitor(hw_monitor), _dev_cap(dev_cap)
     {
         _imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
 
@@ -484,8 +485,8 @@ namespace librealsense
             switch (calib_id)
             {
                 case ds::dm_v2_eeprom_id: // DM V2 id
-                    prs = std::make_shared<dm_v2_imu_calib_parser>(raw,valid); break;
-                case ds::tm1_eeprom_id:// TM1 id
+                    prs = std::make_shared<dm_v2_imu_calib_parser>(raw, _dev_cap, valid); break;
+                case ds::tm1_eeprom_id: // TM1 id
                     prs = std::make_shared<tm1_imu_calib_parser>(raw); break;
                 default:
                     throw recoverable_exception(to_string() << "Motion Intrinsics unresolved - "

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -35,11 +35,11 @@ namespace librealsense
     static const std::string accel_sensor_name = "accel_3d";
     static const std::map<IMU_OUTPUT_DATA_RATES, unsigned> hid_fps_translation =
     {  //FPS   Value to send to the Driver
-        {IMU_FPS_63,   1},
-        {IMU_FPS_100,  1},
-        {IMU_FPS_200,  2},
-        {IMU_FPS_250,  3},
-        {IMU_FPS_400,  4} };
+        {odr::IMU_FPS_63,   1},
+        {odr::IMU_FPS_100,  1},
+        {odr::IMU_FPS_200,  2},
+        {odr::IMU_FPS_250,  3},
+        {odr::IMU_FPS_400,  4} };
 #endif
 
     class mm_calib_parser
@@ -56,9 +56,9 @@ namespace librealsense
         tm1_imu_calib_parser(const std::vector<uint8_t>& raw_data)
         {
             calib_table = *(ds::check_calib<ds::tm1_eeprom>(raw_data));
-        };
+        }
         tm1_imu_calib_parser(const tm1_imu_calib_parser&);
-        ~tm1_imu_calib_parser(){};
+        virtual ~tm1_imu_calib_parser(){}
 
         float3x3 imu_to_depth_alignment() { return {{1,0,0},{0,1,0},{0,0,1}}; }
 
@@ -72,14 +72,16 @@ namespace librealsense
             auto rot = fe_calib.fisheye_to_imu.rotation;
             auto trans = fe_calib.fisheye_to_imu.translation;
 
-            pose ex = { { rot(0,0), rot(1,0),rot(2,0),rot(0,1), rot(1,1),rot(2,1),rot(0,2), rot(1,2),rot(2,2) },
-            { trans[0], trans[1], trans[2] } };
+            pose ex = { { { rot(0,0), rot(1,0),rot(2,0)},
+                          { rot(0,1), rot(1,1),rot(2,1) },
+                          { rot(0,2), rot(1,2),rot(2,2) } },
+                          { trans[0], trans[1], trans[2] } };
 
             if (RS2_STREAM_FISHEYE == stream)
                 return inverse(from_pose(ex));
             else
                 return from_pose(ex);
-        };
+        }
 
         ds::imu_intrinsic get_intrinsic(rs2_stream stream)
         {
@@ -116,9 +118,9 @@ namespace librealsense
             // default parser to be applied when no FW calibration is available
             if (valid)
                 calib_table = *(ds::check_calib<ds::dm_v2_eeprom>(raw_data));
-        };
+        }
         dm_v2_imu_calib_parser(const dm_v2_imu_calib_parser&);
-        ~dm_v2_imu_calib_parser() {};
+        virtual ~dm_v2_imu_calib_parser() {}
 
         float3x3 imu_to_depth_alignment() { return {{-1,0,0},{0,1,0},{0,0,-1}}; } //Reference spec : Bosch BMI055
 

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -91,6 +91,15 @@ namespace librealsense
             ds::RS465_PID
         };
 
+        static const std::set<std::uint16_t> hid_bmi_055_pid = {
+            ds::RS435I_PID,
+            ds::RS430I_PID
+        };
+
+        static const std::set<std::uint16_t> hid_bmi_085_pid = {
+            RS465_PID
+        };
+
         static const std::set<std::uint16_t> fisheye_pid = {
             ds::RS400_MM_PID,
             ds::RS410_MM_PID,
@@ -240,6 +249,8 @@ namespace librealsense
             CAP_IMU_SENSOR              = (1u << 3),
             CAP_GLOBAL_SHUTTER          = (1u << 4),
             CAP_ROLLING_SHUTTER         = (1u << 5),
+            CAP_BMI_055                 = (1u << 6),
+            CAP_BMI_085                 = (1u << 7),
             CAP_MAX
         };
 
@@ -250,7 +261,9 @@ namespace librealsense
             { d400_caps::CAP_FISHEYE_SENSOR,   "Fisheye Sensor"    },
             { d400_caps::CAP_IMU_SENSOR,       "IMU Sensor"        },
             { d400_caps::CAP_GLOBAL_SHUTTER,   "Global Shutter"    },
-            { d400_caps::CAP_ROLLING_SHUTTER,  "Rolling Shutter"   }
+            { d400_caps::CAP_ROLLING_SHUTTER,  "Rolling Shutter"   },
+            { d400_caps::CAP_BMI_055,          "IMU BMI_055"       },
+            { d400_caps::CAP_BMI_085,          "IMU BMI_085"       }
         };
 
         inline d400_caps operator &(const d400_caps lhs, const d400_caps rhs)
@@ -268,11 +281,17 @@ namespace librealsense
             return lhs = lhs | rhs;
         }
 
+        inline bool operator &&(d400_caps l, d400_caps r)
+        {
+            return !!(static_cast<uint8_t>(l) & static_cast<uint8_t>(r));
+        }
+
         inline std::ostream& operator <<(std::ostream& stream, const d400_caps& cap)
         {
             for (auto i : { d400_caps::CAP_ACTIVE_PROJECTOR,d400_caps::CAP_RGB_SENSOR,
                             d400_caps::CAP_FISHEYE_SENSOR,  d400_caps::CAP_IMU_SENSOR,
-                            d400_caps::CAP_GLOBAL_SHUTTER,  d400_caps::CAP_ROLLING_SHUTTER })
+                            d400_caps::CAP_GLOBAL_SHUTTER,  d400_caps::CAP_ROLLING_SHUTTER,
+                            d400_caps::CAP_BMI_055,         d400_caps::CAP_BMI_085 })
             {
                 if (i==(i&cap))
                     stream << d400_capabilities_names.at(i) << " ";

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -790,6 +790,7 @@ namespace librealsense
     {
         register_metadata(RS2_FRAME_METADATA_BACKEND_TIMESTAMP, make_additional_data_parser(&frame_additional_data::backend_timestamp));
 
+
         std::map<std::string, uint32_t> frequency_per_sensor;
         for (auto& elem : sensor_name_and_hid_profiles)
             frequency_per_sensor.insert(make_pair(elem.first, elem.second.fps));


### PR DESCRIPTION
Differentiate for BMI_055 and BMI_085 units
Select the actual rate according to the sensor type at run-time
Add the IMU sensor type to the capabilities vector
Disable IMU Temperature sensor
Assign IMU default intrinsic/extrinsic according to the SKU type.
Update defauly IMU profiles for supported SKUs

Fix default preset assignment for  SKU 0d4b
Tracked on: DSO-13325