### PR TITLE
Fix range for stream_index in filters.

### DIFF
--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -189,7 +189,7 @@ namespace librealsense
             _stream_filter.format = static_cast<rs2_format>((int)val);
         });
 
-        auto index_selector = std::make_shared<ptr_option<int>>(0, std::numeric_limits<int>::max(), 1, -1, &_stream_filter.index, "Stream index");
+        auto index_selector = std::make_shared<ptr_option<int>>(-1, std::numeric_limits<int>::max(), 1, -1, &_stream_filter.index, "Stream index");
         index_selector->on_set([this, index_selector](float val)
         {
             std::lock_guard<std::mutex> lock(_mutex);


### PR DESCRIPTION
(-1) is a valid value for stream_index in filters, often the default value. Therefor (-1) should be included in the range for the option.
