### PR TITLE
Android UVC backend - Out of memory error fix

### DIFF
--- a/src/android/jni/frame.cpp
+++ b/src/android/jni/frame.cpp
@@ -46,6 +46,29 @@ Java_com_intel_realsense_librealsense_Frame_nGetData(JNIEnv *env, jclass type, j
     handle_error(env, e);
 }
 
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_intel_realsense_librealsense_Points_nGetData(JNIEnv *env, jclass type, jlong handle,
+                                                      jfloatArray data_) {
+    jsize length = env->GetArrayLength(data_);
+    rs2_error *e = NULL;
+    env->SetFloatArrayRegion(data_, 0, length, static_cast<const jfloat *>(rs2_get_frame_data(
+            reinterpret_cast<const rs2_frame *>(handle), &e)));
+    handle_error(env, e);
+}
+
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_intel_realsense_librealsense_Points_nGetTextureCoordinates(JNIEnv *env, jclass type,
+                                                                    jlong handle,
+                                                                    jfloatArray data_) {
+    jsize length = env->GetArrayLength(data_);
+    rs2_error *e = NULL;
+    env->SetFloatArrayRegion(data_, 0, length, reinterpret_cast<const jfloat *>(rs2_get_frame_texture_coordinates(
+            reinterpret_cast<const rs2_frame *>(handle), &e)));
+    handle_error(env, e);
+}
+
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_intel_realsense_librealsense_Frame_nIsFrameExtendableTo(JNIEnv *env, jclass type,
                                                                  jlong handle, jint extension) {

--- a/src/android/usb_host/android_uvc.cpp
+++ b/src/android/usb_host/android_uvc.cpp
@@ -12,15 +12,20 @@
 #include "../../libuvc/utlist.h"
 #include "../../usb/usb-types.h"
 #include "../../usb/usb-device.h"
+#include "../../usbhost/messenger-usbhost.h"
 
 #include <vector>
 #include <thread>
 #include <atomic>
 #include <zconf.h>
 
+#define USE_URB true
 #define DEQUEUE_TIMEOUT 50
+#define STREAMING_WATCHER_TIMEOUT 1000
 #define STREAMING_BULK_TRANSFER_TIMEOUT 1000
-#define UVC_PAYLOAD_HEADER_LENGTH 256
+#define UVC_PAYLOAD_MAX_HEADER_LENGTH 256
+
+using namespace librealsense;
 
 // Data structures for Backend-Frontend queue:
 struct frame;
@@ -831,7 +836,7 @@ void usbhost_uvc_process_bulk_payload(frame_ptr fp, size_t payload_len, frames_q
     queue.enqueue(std::move(fp));
 }
 
-void stream_thread(usbhost_uvc_stream_context *strctx) {
+void stream_thread_bulk(usbhost_uvc_stream_context *strctx) {
     auto inf = strctx->stream->stream_if->interface;
     auto dev = strctx->stream->devh->device;
     auto messenger = dev->open();
@@ -844,7 +849,7 @@ void stream_thread(usbhost_uvc_stream_context *strctx) {
     std::atomic_bool keep_sending_callbacks(true);
     frames_queue queue;
 
-    uint32_t read_buff_length = UVC_PAYLOAD_HEADER_LENGTH + strctx->stream->cur_ctrl.dwMaxVideoFrameSize;
+    uint32_t read_buff_length = UVC_PAYLOAD_MAX_HEADER_LENGTH + strctx->stream->cur_ctrl.dwMaxVideoFrameSize;
     LOG_INFO("endpoint " << (int)read_ep->get_address() << " read buffer size: " << read_buff_length);
 
     // Get all pointers from archive and initialize their content
@@ -918,6 +923,152 @@ void stream_thread(usbhost_uvc_stream_context *strctx) {
     LOG_DEBUG("Transfer thread stopped for endpoint address: " << ep);
 };
 
+void stream_thread_urb(usbhost_uvc_stream_context *strctx) {
+    auto inf = strctx->stream->stream_if->interface;
+    auto dev = strctx->stream->devh->device;
+    auto messenger = std::static_pointer_cast<platform::usb_messenger_usbhost>(dev->open());
+
+    auto read_ep = std::static_pointer_cast<platform::usb_endpoint_usbhost>
+            (inf->first_endpoint(platform::RS2_USB_ENDPOINT_DIRECTION_READ));
+
+    uint32_t reset_ep_timeout = 100;
+    messenger->reset_endpoint(read_ep, reset_ep_timeout);
+
+    frames_archive archive;
+    std::atomic_bool keep_sending_callbacks(true);
+    frames_queue queue;
+
+    uint32_t read_buff_length = UVC_PAYLOAD_MAX_HEADER_LENGTH + strctx->stream->cur_ctrl.dwMaxVideoFrameSize;
+    LOG_INFO("endpoint " << (int)read_ep->get_address() << " read buffer size: " << read_buff_length);
+
+    // Get all pointers from archive and initialize their content
+    std::vector<frame *> frames;
+    for (auto i = 0; i < frames_archive::CAPACITY; i++) {
+        auto ptr = archive.allocate();
+        ptr->pixels.resize(read_buff_length, 0);
+        ptr->owner = &archive;
+        frames.push_back(ptr);
+    }
+
+    for (auto ptr : frames) {
+        archive.deallocate(ptr);
+    }
+
+    std::thread t([&]() {
+        while (keep_sending_callbacks) {
+            frame_ptr fp(nullptr, [](frame *) {});
+            if (queue.dequeue(&fp, DEQUEUE_TIMEOUT)) {
+                strctx->stream->user_cb(&fp->fo, strctx->stream->user_ptr);
+            }
+        }
+    });
+
+    frame_ptr fp = frame_ptr(archive.allocate(), &cleanup_frame);
+
+    auto desc = read_ep->get_descriptor();
+    std::shared_ptr<usb_request> request = std::shared_ptr<usb_request>(usb_request_new(dev->get_handle(),
+                                                                                        &desc), [](usb_request* req) {usb_request_free(req);});
+    if(!request)
+    {
+        LOG_ERROR("invalid USB request");
+        return;
+    }
+
+    bool fatal_error = false;
+    uint32_t frame_count = 0;
+    int active_request_count = 0;
+    uint32_t zero_response = 0;
+    auto callback = std::make_shared<platform::usb_request_callback>([&](usb_request* r)
+    {
+     if(r)
+     {
+         active_request_count--;
+         if(r->actual_length == 0){
+             LOG_WARNING("read_ep: " << r->endpoint << ", zero response");
+             zero_response++;
+             if(zero_response > 10)
+             {
+                 messenger->reset_endpoint(read_ep, reset_ep_timeout);
+                 zero_response = 0;
+             }
+         }
+         if(r->actual_length >= strctx->stream->cur_ctrl.dwMaxVideoFrameSize){
+             zero_response = 0;
+             frame_count++;
+             usbhost_uvc_process_bulk_payload(std::move(fp), r->actual_length, queue);
+         }
+     }
+
+     if(!strctx->stream->running){
+         return;
+     }
+
+     fp = frame_ptr(archive.allocate(), &cleanup_frame);
+     if(!fp)
+         return;
+     request->buffer = fp->pixels.data();
+     request->buffer_length = fp->pixels.size();
+
+     auto sts =  messenger->submit_request(request);
+     switch(sts)
+     {
+         case platform::RS2_USB_STATUS_SUCCESS:
+             active_request_count++;
+             return;
+         case platform::RS2_USB_STATUS_OVERFLOW:
+         case platform::RS2_USB_STATUS_NO_DEVICE:
+         case platform::RS2_USB_STATUS_NO_MEM:
+             fatal_error = true;
+             return;
+         default:
+             messenger->reset_endpoint(read_ep, reset_ep_timeout);
+             break;
+     }
+    });
+
+    request->client_data = callback.get();
+
+    while(!fatal_error && strctx->stream->running)
+    {
+        if(frame_count == 0){
+            if(active_request_count > 0)
+            {
+                messenger->cancel_request(request);
+                active_request_count--;
+            }
+            callback->callback(nullptr);
+        }
+        frame_count = 0;
+        std::this_thread::sleep_for(std::chrono::milliseconds(STREAMING_WATCHER_TIMEOUT));
+    }
+
+    if(active_request_count > 0)
+    {
+        messenger->cancel_request(request);
+        active_request_count--;
+    }
+    LOG_INFO("read endpoint: " << (int)read_ep->get_address() <<", active requests count: " << active_request_count);
+
+    callback->cancel();
+    messenger->reset_endpoint(read_ep, reset_ep_timeout);
+    free(strctx);
+    queue.clear();
+    archive.stop_allocation();
+    fp.reset();
+    archive.wait_until_empty();
+    keep_sending_callbacks = false;
+
+    LOG_INFO("start join stream_thread");
+    t.join();
+    LOG_INFO("Transfer thread stopped for endpoint address: " << (int)read_ep->get_address());
+};
+
+void stream_thread(usbhost_uvc_stream_context *strctx){
+    if(USE_URB)
+        stream_thread_urb(strctx);
+    else
+        stream_thread_bulk(strctx);
+}
 uvc_error_t usbhost_uvc_stream_start(
         usbhost_uvc_stream_handle_t *strmh,
         usbhost_uvc_frame_callback_t *cb,
@@ -959,8 +1110,6 @@ uvc_error_t usbhost_uvc_stream_start(
 
     usbhost_uvc_stream_context *streamctx = new usbhost_uvc_stream_context;
 
-    //printf("Starting stream on EP = 0x%X, interface 0x%X\n", format_desc->parent->bEndpointAddress, iface);
-
     streamctx->stream = strmh;
     streamctx->endpoint = format_desc->parent->bEndpointAddress;
     streamctx->iface = iface;
@@ -1001,7 +1150,7 @@ void usbhost_uvc_stream_close(usbhost_uvc_stream_handle_t *strmh) {
 }
 
 uvc_error_t usbhost_uvc_stream_open_ctrl(usbhost_uvc_device *devh, usbhost_uvc_stream_handle_t **strmhp,
-                             uvc_stream_ctrl_t *ctrl);
+                                         uvc_stream_ctrl_t *ctrl);
 
 uvc_error_t usbhost_start_streaming(usbhost_uvc_device *devh, uvc_stream_ctrl_t *ctrl,
                                     usbhost_uvc_frame_callback_t *cb, void *user_ptr,

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLFrame.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLFrame.java
@@ -23,4 +23,12 @@ public abstract class GLFrame implements AutoCloseable {
         GLES10.glMatrixMode(GLES10.GL_PROJECTION);
         GLES10.glOrthof(0, r.width(), r.height(), 0, -1, +1);
     }
+
+    public String getLabel() {
+        if(mFrame == null)
+            return "";
+        try(StreamProfile sp = mFrame.getProfile()){
+            return sp.getType() + " - " + sp.getFormat();
+        }
+    }
 }

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLMotionFrame.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLMotionFrame.java
@@ -189,6 +189,18 @@ public class GLMotionFrame extends GLFrame {
     }
 
     @Override
+    public synchronized String getLabel() {
+        MotionFrame mf = mFrame.as(Extension.MOTION_FRAME);
+        Float3 d = mf.getMotionData();
+        try(StreamProfile sp = mFrame.getProfile()){
+            return sp.getType().name() +
+                    " [ X: " + String.format("%+.2f", d.x) +
+                    ", Y: " + String.format("%+.2f", d.y) +
+                    ", Z: " + String.format("%+.2f", d.z) + " ]";
+        }
+    }
+
+    @Override
     public synchronized void close() {
         if(mFrame != null)
             mFrame.close();

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLPointsFrame.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLPointsFrame.java
@@ -1,0 +1,133 @@
+package com.intel.realsense.librealsense;
+
+import android.graphics.Rect;
+import android.opengl.GLES10;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+
+public class GLPointsFrame extends GLFrame {
+    private Frame mTexture;
+    private IntBuffer mGlTexture;
+    private float mDeltaX = 0;
+    private float mDeltaY = 0;
+    private float mRotationFactor = 0.1f;
+
+    public synchronized void setTextureFrame(Frame frame) {
+        if(mTexture != null)
+            mTexture.close();
+        mTexture = frame.clone();
+    }
+    public int getTexture() { return mGlTexture.array()[0]; }
+
+    private void drawPoints(float[] verArray, byte[] colorArray)
+    {
+        if(colorArray != null){
+            ByteBuffer tex = ByteBuffer.allocateDirect(colorArray.length);
+            tex.order(ByteOrder.nativeOrder());
+            tex.put(colorArray);
+            tex.position(0);
+
+            GLES10.glEnableClientState(GLES10.GL_COLOR_ARRAY);
+            GLES10.glColorPointer(4, GLES10.GL_UNSIGNED_BYTE, 0, tex);
+        }
+
+        ByteBuffer ver = ByteBuffer.allocateDirect(verArray.length * 4);
+        ver.order(ByteOrder.nativeOrder());
+        ver.asFloatBuffer().put(verArray);
+
+        GLES10.glEnableClientState(GLES10.GL_VERTEX_ARRAY);
+        GLES10.glVertexPointer(3, GLES10.GL_FLOAT, 0, ver);
+        GLES10.glDrawArrays(GLES10.GL_POINTS,0,verArray.length / 3);
+
+        GLES10.glDisableClientState(GLES10.GL_VERTEX_ARRAY);
+        if(colorArray != null)
+            GLES10.glDisableClientState(GLES10.GL_COLOR_ARRAY);
+    }
+
+    @Override
+    public synchronized void draw(Rect rect)
+    {
+        if (mFrame == null || !(mFrame.is(Extension.POINTS)))
+            return;
+
+        setViewport(rect);
+
+        GLES10.glMatrixMode(GLES10.GL_PROJECTION);
+        GLES10.glPushMatrix();
+        GLES10.glLoadIdentity();
+
+        GLES10.glOrthof(-1f, 1f, -1f, 1f, -7f, 0f);
+
+        GLES10.glRotatef(180, 0.0f, 0.0f, 1.0f);
+        GLES10.glRotatef(-mDeltaY * mRotationFactor, 1.0f, 0.0f, 0.0f);
+        GLES10.glRotatef(-mDeltaX * mRotationFactor, 0.0f, 1.0f, 0.0f);
+
+        Points points = mFrame.as(Extension.POINTS);
+        float[] data = points.getVertices();
+        byte[] tex = mTexture == null ? createTexture(data, 1.2f) : createTexture(points);
+        drawPoints(data, tex);
+
+        GLES10.glMatrixMode(GLES10.GL_PROJECTION);
+        GLES10.glPopMatrix();
+    }
+
+    //fallback to gray scale if no texture is available
+    private byte[] createTexture(float[] data, float maxRange){
+        int size = data.length / 3;
+        byte[] texture = new byte[size * 4];
+        for(int i = 0; i < size; i++){
+            float z = data[i * 3 + 2];
+            byte val = (byte) (z / maxRange * 255);
+            for(int j = 0; j < 3; j++)
+                texture[i*4+j] = val;
+            texture[i*4+3] = (byte) 255;
+        }
+        return texture;
+    }
+
+    public byte[] createTexture(Points points){
+        if(mTexture == null)
+            return null;
+
+        VideoFrame vf = mTexture.as(Extension.VIDEO_FRAME);
+        int textureSize = vf.getWidth() * vf.getHeight();
+        int pointCount = points.getCount();
+        float[] pointsData = points.getVertices();
+        byte[] textureData = new byte[textureSize * 3];
+        byte[] texture = new byte[pointCount * 4];
+        float[] textureCoordinates = points.getTextureCoordinates();
+
+        vf.getData(textureData);
+        int w = vf.getWidth();
+        int h = vf.getHeight();
+        for(int i = 0; i < pointCount; i++){
+            if(pointsData[i * 3 + 2] == 0)
+                continue;
+            float x = (float) Math.round(textureCoordinates[2 * i] * w);
+            float y = (float) Math.round(textureCoordinates[2 * i + 1] * h);
+            if(x <= 0 || y <= 0 || x >= w || y >= h)
+                continue;
+            long texIndex = (long) (x + y * w);
+            for(int j = 0; j < 3; j++)
+                texture[i*4+j] = textureData[(int) (texIndex * 3 + j)];
+            texture[i*4+3] = (byte) 255;
+        }
+        return texture;
+    }
+
+    @Override
+    public synchronized void close() {
+        if(mFrame != null)
+            mFrame.close();
+        if(mGlTexture != null)
+            GLES10.glDeleteTextures(1, mGlTexture);
+        mGlTexture = null;
+    }
+
+    public synchronized void rotate(float deltaX, float deltaY) {
+        mDeltaX += deltaX;
+        mDeltaY += deltaY;
+    }
+}

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLRenderer.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLRenderer.java
@@ -4,8 +4,11 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.opengl.GLES10;
 import android.opengl.GLSurfaceView;
+import android.util.Pair;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.microedition.khronos.egl.EGLConfig;
@@ -17,39 +20,113 @@ public class GLRenderer implements GLSurfaceView.Renderer{
     private int mWindowHeight = 0;
     private int mWindowWidth = 0;
     private boolean mIsDirty = true;
+    private float mDeltaX = 0;
+    private float mDeltaY = 0;
+    private Frame mPointsTexture;
+    private boolean mHasColorRbg8 = false;
+    private Colorizer mColorizer = new Colorizer();
+    private Map<StreamType,Pointcloud> mPointcloud = null;
+    private boolean mHasColorizedDepth = false;
 
-    public Map<Integer, Rect> getRectangles() {
+    public Map<Integer, Pair<String,Rect>> getRectangles() {
         return calcRectangles();
     }
 
+    private boolean showPoints(){
+        return mPointcloud != null;
+    }
+
+    private List<FilterInterface> createProcessingPipe(){
+        List<FilterInterface> rv = new ArrayList<>();
+        if(!mHasColorizedDepth && !showPoints())
+            rv.add(mColorizer);
+        if(showPoints()){
+            if(mHasColorRbg8)
+                rv.add(mPointcloud.get(StreamType.COLOR));
+            else
+                rv.add(mPointcloud.get(StreamType.DEPTH));
+        }
+        return rv;
+    }
+
+    private FrameSet applyFilters(FrameSet frameSet, List<FilterInterface> filters){
+        frameSet = frameSet.clone();
+        for(FilterInterface f : filters){
+            FrameSet newSet = frameSet.applyFilter(f);
+            frameSet.close();
+            frameSet = newSet;
+        }
+        return frameSet;
+    }
+
     public void upload(FrameSet frameSet) {
+        mHasColorRbg8 = mHasColorizedDepth = false;
         frameSet.foreach(new FrameCallback() {
             @Override
             public void onFrame(Frame f) {
-                addFrame(f);
+                getTexture(f);
             }
         });
-        frameSet.foreach(new FrameCallback() {
-            @Override
-            public void onFrame(Frame f) {
-                upload(f);
+
+        List<FilterInterface> filters = createProcessingPipe();
+        try(FrameSet processed = applyFilters(frameSet, filters)){
+            choosePointsTexture(processed);
+            processed.foreach(new FrameCallback() {
+                @Override
+                public void onFrame(Frame f) {
+                    addFrame(f);
+                }
+            });
+            processed.foreach(new FrameCallback() {
+                @Override
+                public void onFrame(Frame f) {
+                    upload(f);
+                }
+            });
+        }
+    }
+
+    private void choosePointsTexture(FrameSet frameSet){
+        if(!showPoints())
+            return;
+        if(mHasColorRbg8)
+            mPointsTexture = frameSet.first(StreamType.COLOR, StreamFormat.RGB8);
+        else{
+            try (Frame d = frameSet.first(StreamType.DEPTH, StreamFormat.Z16)) {
+                if(d != null)
+                    mPointsTexture = mColorizer.process(d);
             }
-        });
+        }
+    }
+
+    private void getTexture(Frame f){
+        try(StreamProfile sp = f.getProfile()){
+            if(sp.getType() == StreamType.COLOR && sp.getFormat() == StreamFormat.RGB8) {
+                mHasColorRbg8 = true;
+            }
+            if(sp.getType() == StreamType.DEPTH && sp.getFormat() == StreamFormat.RGB8) {
+                mHasColorizedDepth = true;
+            }
+        }
     }
 
     private void addFrame(Frame f){
         if(!isFormatSupported(f.getProfile().getFormat()))
             return;
 
-        int uid = f.getProfile().getUniqueId();
-        if(!mFrames.containsKey(uid)){
-            synchronized (mFrames) {
-                if(f.is(Extension.VIDEO_FRAME))
-                    mFrames.put(uid, new GLVideoFrame());
-                if(f.is(Extension.MOTION_FRAME))
-                    mFrames.put(uid, new GLMotionFrame());
+        try(StreamProfile sp = f.getProfile()){
+            int uid = sp.getUniqueId();
+            if(!mFrames.containsKey(uid)){
+                synchronized (mFrames) {
+                    if(f.is(Extension.VIDEO_FRAME) && !showPoints())
+                        mFrames.put(uid, new GLVideoFrame());
+                    if(f.is(Extension.MOTION_FRAME) && !showPoints())
+                        mFrames.put(uid, new GLMotionFrame());
+                    if(f.is(Extension.POINTS))
+                        mFrames.put(uid, new GLPointsFrame());
+                }
+                mIsDirty = true;
             }
-            mIsDirty = true;
         }
     }
 
@@ -57,24 +134,40 @@ public class GLRenderer implements GLSurfaceView.Renderer{
         if(f == null)
             return;
 
-        if(!isFormatSupported(f.getProfile().getFormat()))
-            return;
+        try(StreamProfile sp = f.getProfile()){
+            if(!isFormatSupported(sp.getFormat()))
+                return;
 
-        addFrame(f);
-        int uid = f.getProfile().getUniqueId();
+            addFrame(f);
+            int uid = sp.getUniqueId();
 
-        mFrames.get(uid).setFrame(f);
+            GLFrame curr = mFrames.get(uid);
+            if(curr == null)
+                return;
+            curr.setFrame(f);
+
+            if(mPointsTexture != null && curr instanceof GLPointsFrame){
+                ((GLPointsFrame) curr).setTextureFrame(mPointsTexture);
+                mPointsTexture.close();
+                mPointsTexture = null;
+            }
+        }
     }
 
     public void clear() {
         synchronized (mFrames) {
             mFrames.clear();
+            mIsDirty = true;
+            mDeltaX = 0;
+            mDeltaY = 0;
+            mPointcloud = null;
+            if(mPointsTexture != null) mPointsTexture.close();
+            mPointsTexture = null;
         }
-        mIsDirty = true;
     }
 
-    private Map<Integer, Rect> calcRectangles(){
-        Map<Integer, Rect> rv = new HashMap<>();
+    private Map<Integer, Pair<String,Rect>> calcRectangles(){
+        Map<Integer, Pair<String,Rect>> rv = new HashMap<>();
 
         int i = 0;
         for (Map.Entry<Integer, GLFrame> entry : mFrames.entrySet()){
@@ -84,8 +177,7 @@ public class GLRenderer implements GLSurfaceView.Renderer{
             Point pos = mWindowWidth > mWindowHeight ?
                     new Point(i++ * size.x, 0) :
                     new Point(0, i++ * size.y);
-//                    new Point(0, (mWindowHeight-size.y) -  i++ * size.y);
-            rv.put(entry.getKey(), new Rect(pos.x, pos.y, pos.x + size.x, pos.y + size.y));
+            rv.put(entry.getKey(), new Pair<>(entry.getValue().getLabel(), new Rect(pos.x, pos.y, pos.x + size.x, pos.y + size.y)));
         }
         return rv;
     }
@@ -114,16 +206,21 @@ public class GLRenderer implements GLSurfaceView.Renderer{
             if (mFrames.size() == 0)
                 return;
 
-            Map<Integer, Rect> rects = calcRectangles();
+            Map<Integer, Pair<String, Rect>> rects = calcRectangles();
 
             for(Integer uid : mFrames.keySet()){
                 GLFrame fl = mFrames.get(uid);
-                Rect r = rects.get(uid);
+                Rect r = rects.get(uid).second;
                 if(mWindowHeight > mWindowWidth){// TODO: remove, w/a for misaligned labels
                     int newTop = mWindowHeight - r.height() - r.top;
                     r = new Rect(r.left, newTop, r.right, newTop + r.height());
                 }
                 fl.draw(r);
+                if(fl instanceof GLPointsFrame){
+                    ((GLPointsFrame)fl).rotate(mDeltaX, mDeltaY);
+                    mDeltaX = 0;
+                    mDeltaY = 0;
+                }
             }
         }
     }
@@ -133,8 +230,34 @@ public class GLRenderer implements GLSurfaceView.Renderer{
             case RGB8:
             case RGBA8:
             case Y8:
-            case MOTION_XYZ32F: return true;
+            case MOTION_XYZ32F:
+            case XYZ32F: return true;
             default: return false;
+        }
+    }
+
+    public void onTouchEvent(float dx, float dy) {
+        synchronized (mFrames) {
+            mDeltaX = dx;
+            mDeltaY = dy;
+        }
+    }
+
+    public void showPointcloud(boolean showPoints) {
+        if(showPoints){
+            if(mPointcloud != null)
+                return;
+            mPointcloud = new HashMap<>();
+            mPointcloud.put(StreamType.COLOR, new Pointcloud(StreamType.COLOR));
+            mPointcloud.put(StreamType.DEPTH, new Pointcloud(StreamType.DEPTH));
+        }
+        else {
+            if(mPointcloud == null)
+                return;
+            for(Pointcloud pc : mPointcloud.values()){
+                pc.close();
+            }
+            mPointcloud = null;
         }
     }
 }

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLRsSurfaceView.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLRsSurfaceView.java
@@ -4,12 +4,16 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.opengl.GLSurfaceView;
 import android.util.AttributeSet;
+import android.util.Pair;
+import android.view.MotionEvent;
 
 import java.util.Map;
 
 public class GLRsSurfaceView extends GLSurfaceView {
 
     private final GLRenderer mRenderer;
+    private float mPreviousX = 0;
+    private float mPreviousY = 0;
 
     public GLRsSurfaceView(Context context) {
         super(context);
@@ -23,7 +27,7 @@ public class GLRsSurfaceView extends GLSurfaceView {
         setRenderer(mRenderer);
     }
 
-    public Map<Integer, Rect> getRectangles() {
+    public Map<Integer, Pair<String,Rect>> getRectangles() {
         return mRenderer.getRectangles();
     }
 
@@ -37,5 +41,27 @@ public class GLRsSurfaceView extends GLSurfaceView {
 
     public void clear() {
         mRenderer.clear();
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent e) {
+        float x = e.getX();
+        float y = e.getY();
+
+        switch (e.getAction()) {
+            case MotionEvent.ACTION_MOVE:
+
+                float dx = x - mPreviousX;
+                float dy = y - mPreviousY;
+                mRenderer.onTouchEvent(dx, dy);
+        }
+
+        mPreviousX = x;
+        mPreviousY = y;
+        return true;
+    }
+
+    public void showPointcloud(boolean showPoints) {
+        mRenderer.showPointcloud(showPoints);
     }
 }

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Points.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Points.java
@@ -1,18 +1,48 @@
 package com.intel.realsense.librealsense;
 
 public class Points extends Frame {
+    private float[] mData;
+    private float[] mTextureCoordinates;
+
     protected Points(long handle) {
         super(handle);
         mOwner = false;
     }
 
+    public float[] getVertices(){
+        if(mData == null){
+            mData = new float[getCount() * 3];
+            getData(mData);
+        }
+        return mData;
+    }
+
+    public float[] getTextureCoordinates(){
+        if(mTextureCoordinates == null){
+            mTextureCoordinates = new float[getCount() * 2];
+            getTextureCoordinates(mTextureCoordinates);
+        }
+        return mTextureCoordinates;
+    }
+
+    public void getTextureCoordinates(float[] data) {
+        nGetTextureCoordinates(mHandle, data);
+    }
+
+    public void getData(float[] data) {
+        nGetData(mHandle, data);
+    }
+
     public int getCount(){
         return nGetCount(mHandle);
     }
+
     public void exportToPly(String filePath, VideoFrame texture) {
         nExportToPly(mHandle, filePath, texture.getHandle());
     }
 
     private static native int nGetCount(long handle);
+    private static native void nGetData(long handle, float[] data);
+    private static native void nGetTextureCoordinates(long handle, float[] data);
     private static native void nExportToPly(long handle, String filePath, long textureHandle);
 }

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/InfoActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/InfoActivity.java
@@ -2,6 +2,7 @@ package com.intel.realsense.camera;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -39,6 +40,10 @@ public class InfoActivity extends AppCompatActivity {
             message.setText("Device info:");
 
             try(final Device device = devices.createDevice(0)){
+                if(device == null){
+                    Log.e(TAG, "failed to create device");
+                    return;
+                }
                 for(CameraInfo ci : CameraInfo.values()){
                     if(device.supportsInfo(ci))
                         infoMap.put(ci, device.getInfo(ci));

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PlaybackActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PlaybackActivity.java
@@ -1,16 +1,26 @@
 package com.intel.realsense.camera;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Pair;
+import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
 
-import com.intel.realsense.librealsense.Colorizer;
 import com.intel.realsense.librealsense.Config;
 import com.intel.realsense.librealsense.FrameSet;
 import com.intel.realsense.librealsense.GLRsSurfaceView;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public class PlaybackActivity extends AppCompatActivity {
     private static final String TAG = "librs camera pb";
@@ -21,7 +31,11 @@ public class PlaybackActivity extends AppCompatActivity {
     private String mFilePath;
     private Streamer mStreamer;
     private GLRsSurfaceView mGLSurfaceView;
-    private Colorizer mColorizer = new Colorizer();
+
+    private Map<Integer, TextView> mLabels;
+
+    private boolean mShow3D = false;
+    private TextView m3dButton;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -30,6 +44,25 @@ public class PlaybackActivity extends AppCompatActivity {
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
         mGLSurfaceView = findViewById(R.id.playbackGlSurfaceView);
+        m3dButton = findViewById(R.id.playback_3d_button);
+        m3dButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mGLSurfaceView.setVisibility(View.GONE);
+                mGLSurfaceView.clear();
+                clearLables();
+                mShow3D = !mShow3D;
+                m3dButton.setTextColor(mShow3D ? Color.YELLOW : Color.WHITE);
+                mGLSurfaceView.setVisibility(View.VISIBLE);
+                SharedPreferences sharedPref = getSharedPreferences(getString(R.string.app_settings), Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = sharedPref.edit();
+                editor.putBoolean(getString(R.string.show_3d), mShow3D);
+                editor.commit();
+            }
+        });
+        SharedPreferences sharedPref = getSharedPreferences(getString(R.string.app_settings), Context.MODE_PRIVATE);
+        mShow3D = sharedPref.getBoolean(getString(R.string.show_3d), false);
+        m3dButton.setTextColor(mShow3D ? Color.YELLOW : Color.WHITE);
     }
 
     @Override
@@ -51,9 +84,10 @@ public class PlaybackActivity extends AppCompatActivity {
 
                 @Override
                 public void onFrameset(FrameSet frameSet) {
-                    try (FrameSet processed = frameSet.applyFilter(mColorizer)) {
-                        mGLSurfaceView.upload(processed);
-                    }
+                    mGLSurfaceView.showPointcloud(mShow3D);
+                    mGLSurfaceView.upload(frameSet);
+                    Map<Integer, Pair<String, Rect>> rects = mGLSurfaceView.getRectangles();
+                    printLables(rects);
                 }
             });
             try {
@@ -68,6 +102,8 @@ public class PlaybackActivity extends AppCompatActivity {
     @Override
     protected void onPause() {
         super.onPause();
+
+        clearLables();
 
         if(mStreamer != null)
             mStreamer.stop();
@@ -98,5 +134,60 @@ public class PlaybackActivity extends AppCompatActivity {
     protected void onRestoreInstanceState(final Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);
         mFilePath = savedInstanceState.getString(FILE_PATH_KEY);
+    }
+
+    private synchronized Map<Integer, TextView> createLabels(Map<Integer, Pair<String, Rect>> rects){
+        if(rects == null)
+            return null;
+        mLabels = new HashMap<>();
+
+        final RelativeLayout rl = findViewById(R.id.labels_layout);
+        for(Map.Entry<Integer, Pair<String, Rect>> e : rects.entrySet()){
+            TextView tv = new TextView(getApplicationContext());
+            ViewGroup.LayoutParams lp = new RelativeLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+            tv.setLayoutParams(lp);
+            tv.setTextColor(Color.parseColor("#ffffff"));
+            tv.setTextSize(14);
+            rl.addView(tv);
+            mLabels.put(e.getKey(), tv);
+        }
+        return mLabels;
+    }
+
+    private void printLables(final Map<Integer, Pair<String, Rect>> rects){
+        if(rects == null)
+            return;
+        final Map<Integer, String> lables = new HashMap<>();
+        if(mLabels == null)
+            mLabels = createLabels(rects);
+        for(Map.Entry<Integer, Pair<String, Rect>> e : rects.entrySet()){
+            lables.put(e.getKey(), e.getValue().first);
+        }
+
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                for(Map.Entry<Integer,TextView> e : mLabels.entrySet()){
+                    Integer uid = e.getKey();
+                    if(rects.get(uid) == null)
+                        continue;
+                    Rect r = rects.get(uid).second;
+                    TextView tv = e.getValue();
+                    tv.setX(r.left);
+                    tv.setY(r.top);
+                    tv.setText(lables.get(uid));
+                }
+            }
+        });
+    }
+
+    private void clearLables(){
+        if(mLabels != null){
+            for(Map.Entry<Integer, TextView> label : mLabels.entrySet())
+                label.getValue().setVisibility(View.GONE);
+            mLabels = null;
+        }
     }
 }

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PresetsActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PresetsActivity.java
@@ -65,7 +65,7 @@ public class PresetsActivity extends AppCompatActivity {
                         finish();
                     }
                     try(Device device = devices.createDevice(0)){
-                        if(!device.isInAdvancedMode()){
+                        if(device == null || !device.isInAdvancedMode()){
                             Log.e(TAG, "failed to set preset, device not in advanced mode");
                             finish();
                         }

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PreviewActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PreviewActivity.java
@@ -1,13 +1,15 @@
 package com.intel.realsense.camera;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.Rect;
 import android.os.Bundle;
-import android.renderscript.Float3;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.util.Pair;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -15,15 +17,9 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.intel.realsense.librealsense.Colorizer;
 import com.intel.realsense.librealsense.Config;
-import com.intel.realsense.librealsense.Extension;
-import com.intel.realsense.librealsense.Frame;
-import com.intel.realsense.librealsense.FrameCallback;
 import com.intel.realsense.librealsense.FrameSet;
 import com.intel.realsense.librealsense.GLRsSurfaceView;
-import com.intel.realsense.librealsense.MotionFrame;
-import com.intel.realsense.librealsense.StreamProfile;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,16 +32,16 @@ public class PreviewActivity extends AppCompatActivity {
     private TextView mPlaybackButton;
     private TextView mSettingsButton;
     private TextView mStatisticsButton;
+    private TextView m3dButton;
 
     private TextView mStatsView;
     private Map<Integer, TextView> mLabels;
 
     private Streamer mStreamer;
-    private Colorizer mColorizer = new Colorizer();
-
     private StreamingStats mStreamingStats;
 
     private boolean statsToggle = false;
+    private boolean mShow3D = false;
 
     public synchronized void toggleStats(){
         statsToggle = !statsToggle;
@@ -73,6 +69,7 @@ public class PreviewActivity extends AppCompatActivity {
         mPlaybackButton = findViewById(R.id.preview_playback_button);
         mSettingsButton = findViewById(R.id.preview_settings_button);
         mStatisticsButton = findViewById(R.id.preview_stats_button);
+        m3dButton = findViewById(R.id.preview_3d_button);
 
         mStartRecordFab.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -96,66 +93,70 @@ public class PreviewActivity extends AppCompatActivity {
                 startActivity(intent);
             }
         });
+        m3dButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                mGLSurfaceView.setVisibility(View.GONE);
+                mGLSurfaceView.clear();
+                clearLables();
+                mShow3D = !mShow3D;
+                m3dButton.setTextColor(mShow3D ? Color.YELLOW : Color.WHITE);
+                mGLSurfaceView.setVisibility(View.VISIBLE);
+                SharedPreferences sharedPref = getSharedPreferences(getString(R.string.app_settings), Context.MODE_PRIVATE);
+                SharedPreferences.Editor editor = sharedPref.edit();
+                editor.putBoolean(getString(R.string.show_3d), mShow3D);
+                editor.commit();
+            }
+        });
         mStatisticsButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 toggleStats();
             }
         });
+        SharedPreferences sharedPref = getSharedPreferences(getString(R.string.app_settings), Context.MODE_PRIVATE);
+        mShow3D = sharedPref.getBoolean(getString(R.string.show_3d), false);
+        m3dButton.setTextColor(mShow3D ? Color.YELLOW : Color.WHITE);
     }
 
-    private synchronized Map<Integer, TextView> createLabels(FrameSet frameSet){
+    private synchronized Map<Integer, TextView> createLabels(Map<Integer, Pair<String, Rect>> rects){
+        if(rects == null)
+            return null;
         mLabels = new HashMap<>();
 
         final RelativeLayout rl = findViewById(R.id.labels_layout);
-
-        frameSet.foreach(new FrameCallback() {
-            @Override
-            public void onFrame(Frame f) {
-                TextView tv = new TextView(getApplicationContext());
-                ViewGroup.LayoutParams lp = new RelativeLayout.LayoutParams(
-                        ViewGroup.LayoutParams.WRAP_CONTENT,
-                        ViewGroup.LayoutParams.WRAP_CONTENT);
-                tv.setLayoutParams(lp);
-                tv.setTextColor(Color.parseColor("#ffffff"));
-                tv.setTextSize(14);
-                rl.addView(tv);
-                StreamProfile p = f.getProfile();
-                mLabels.put(p.getUniqueId(), tv);
-            }
-        });
+        for(Map.Entry<Integer, Pair<String, Rect>> e : rects.entrySet()){
+            TextView tv = new TextView(getApplicationContext());
+            ViewGroup.LayoutParams lp = new RelativeLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+            tv.setLayoutParams(lp);
+            tv.setTextColor(Color.parseColor("#ffffff"));
+            tv.setTextSize(14);
+            rl.addView(tv);
+            mLabels.put(e.getKey(), tv);
+        }
         return mLabels;
     }
 
-    private void printLables(FrameSet frames, final Map<Integer, Rect> rects){
+    private void printLables(final Map<Integer, Pair<String, Rect>> rects){
+        if(rects == null)
+            return;
         final Map<Integer, String> lables = new HashMap<>();
         if(mLabels == null)
-            mLabels = createLabels(frames);
-        frames.foreach(new FrameCallback() {
-            @Override
-            public void onFrame(Frame f) {
-                StreamProfile p = f.getProfile();
-                if(f.is(Extension.MOTION_FRAME)) {
-                    MotionFrame mf = f.as(Extension.MOTION_FRAME);
-                    Float3 d = mf.getMotionData();
-                    lables.put(p.getUniqueId(),p.getType().name() +
-                            " [ X: " + String.format("%+.2f", d.x) +
-                            ", Y: " + String.format("%+.2f", d.y) +
-                            ", Z: " + String.format("%+.2f", d.z) + " ]");
-                }
-                else{
-                    lables.put(p.getUniqueId(), p.getType().name());
-                }
-            }
-        });
+            mLabels = createLabels(rects);
+        for(Map.Entry<Integer, Pair<String, Rect>> e : rects.entrySet()){
+            lables.put(e.getKey(), e.getValue().first);
+        }
+
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 for(Map.Entry<Integer,TextView> e : mLabels.entrySet()){
                     Integer uid = e.getKey();
-                    Rect r = rects.get(uid);
-                    if(r == null)
+                    if(rects.get(uid) == null)
                         continue;
+                    Rect r = rects.get(uid).second;
                     TextView tv = e.getValue();
                     tv.setX(r.left);
                     tv.setY(r.top);
@@ -163,6 +164,14 @@ public class PreviewActivity extends AppCompatActivity {
                 }
             }
         });
+    }
+
+    private void clearLables(){
+        if(mLabels != null){
+            for(Map.Entry<Integer, TextView> label : mLabels.entrySet())
+                label.getValue().setVisibility(View.GONE);
+            mLabels = null;
+        }
     }
 
     @Override
@@ -180,6 +189,7 @@ public class PreviewActivity extends AppCompatActivity {
             public void onFrameset(FrameSet frameSet) {
                 mStreamingStats.onFrameset(frameSet);
                 if(statsToggle){
+                    clearLables();
                     runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
@@ -188,11 +198,10 @@ public class PreviewActivity extends AppCompatActivity {
                     });
                 }
                 else{
-                    try (FrameSet processed = frameSet.applyFilter(mColorizer)) {
-                        mGLSurfaceView.upload(processed);
-                        Map<Integer, Rect> rects = mGLSurfaceView.getRectangles();
-                        printLables(processed, rects);
-                    }
+                    mGLSurfaceView.showPointcloud(mShow3D);
+                    mGLSurfaceView.upload(frameSet);
+                    Map<Integer, Pair<String, Rect>> rects = mGLSurfaceView.getRectangles();
+                    printLables(rects);
                 }
             }
         });
@@ -215,11 +224,7 @@ public class PreviewActivity extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
 
-        for(Map.Entry<Integer,TextView> e : mLabels.entrySet()){
-            TextView tv = e.getValue();
-            tv.setVisibility(View.GONE);
-        }
-        mLabels = null;
+        clearLables();
         if(mStreamer != null)
             mStreamer.stop();
     }

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/RecordingActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/RecordingActivity.java
@@ -12,7 +12,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.WindowManager;
 
-import com.intel.realsense.librealsense.Colorizer;
 import com.intel.realsense.librealsense.Config;
 import com.intel.realsense.librealsense.FrameSet;
 import com.intel.realsense.librealsense.GLRsSurfaceView;
@@ -27,7 +26,6 @@ public class RecordingActivity extends AppCompatActivity {
 
     private Streamer mStreamer;
     private GLRsSurfaceView mGLSurfaceView;
-    private Colorizer mColorizer = new Colorizer();
 
     private boolean mPermissionsGrunted = false;
 
@@ -82,9 +80,7 @@ public class RecordingActivity extends AppCompatActivity {
 
                 @Override
                 public void onFrameset(FrameSet frameSet) {
-                    try (FrameSet processed = frameSet.applyFilter(mColorizer)) {
-                        mGLSurfaceView.upload(processed);
-                    }
+                    mGLSurfaceView.upload(frameSet);
                 }
             });
             try {
@@ -105,6 +101,9 @@ public class RecordingActivity extends AppCompatActivity {
     }
 
     private String getFilePath(){
+        File rsFolder = new File(Environment.getExternalStorageDirectory().getAbsolutePath() +
+                File.separator + getString(R.string.realsense_folder));
+        rsFolder.mkdir();
         File folder = new File(Environment.getExternalStorageDirectory().getAbsolutePath() +
                 File.separator + getString(R.string.realsense_folder) + File.separator + "video");
         folder.mkdir();

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/Streamer.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/Streamer.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 public class Streamer {
     private static final String TAG = "librs camera streamer";
+    private static final int DEFAULT_TIMEOUT = 3000;
+    private static final int L500_TIMEOUT = 15000;
 
     interface Listener{
         void config(Config config);
@@ -63,11 +65,13 @@ public class Streamer {
         RsContext ctx = new RsContext();
         try(DeviceList devices = ctx.queryDevices()) {
             if (devices.getDeviceCount() == 0) {
-                return 0;
+                return DEFAULT_TIMEOUT;
             }
             try (Device device = devices.createDevice(0)) {
+                if(device == null)
+                    return DEFAULT_TIMEOUT;
                 ProductLine pl = ProductLine.valueOf(device.getInfo(CameraInfo.PRODUCT_LINE));
-                return pl == ProductLine.L500 ? 15000 : 3000;
+                return pl == ProductLine.L500 ? L500_TIMEOUT : DEFAULT_TIMEOUT;
             }
         }
     }
@@ -82,6 +86,10 @@ public class Streamer {
                 return;
             }
             try (Device device = devices.createDevice(0)) {
+                if(device == null){
+                    Log.e(TAG, "failed to create device");
+                    return;
+                }
                 pid = device.getInfo(CameraInfo.PRODUCT_ID);
                 profilesMap = SettingsActivity.createProfilesMap(device);
 

--- a/wrappers/android/tools/camera/src/main/res/layout-land/activity_playback.xml
+++ b/wrappers/android/tools/camera/src/main/res/layout-land/activity_playback.xml
@@ -25,10 +25,11 @@
     </android.support.v7.widget.LinearLayoutCompat>
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_marginBottom="100dp">
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_alignParentRight="true"
+        android:layout_marginRight="20dp"
+        android:orientation="vertical">
 
         <Space
             android:layout_width="0dp"
@@ -49,7 +50,6 @@
             android:layout_width="0dp"
             android:layout_height="1dp"
             android:layout_weight="1" />
-
     </LinearLayout>
 
 </RelativeLayout>

--- a/wrappers/android/tools/camera/src/main/res/layout-land/activity_preview.xml
+++ b/wrappers/android/tools/camera/src/main/res/layout-land/activity_preview.xml
@@ -30,6 +30,7 @@
         android:visibility="gone"/>
 
     <LinearLayout
+        android:id="@+id/preview_controls"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentRight="true"
@@ -80,6 +81,21 @@
             android:textColor="#ffffff"
             android:backgroundTint="#000000"
             android:text="Playback"/>
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_weight="1" />
+
+        <TextView
+            android:id="@+id/preview_3d_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:textSize="14dp"
+            android:textColor="#ffffff"
+            android:backgroundTint="#000000"
+            android:text="3D"/>
 
         <Space
             android:layout_width="0dp"

--- a/wrappers/android/tools/camera/src/main/res/layout/activity_preview.xml
+++ b/wrappers/android/tools/camera/src/main/res/layout/activity_preview.xml
@@ -85,6 +85,21 @@
             android:layout_height="1dp"
             android:layout_weight="1" />
 
+        <TextView
+            android:id="@+id/preview_3d_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:textSize="14dp"
+            android:textColor="#ffffff"
+            android:backgroundTint="#000000"
+            android:text="3D"/>
+
+        <Space
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_weight="1" />
+
     </LinearLayout>
 
     <android.support.design.widget.FloatingActionButton

--- a/wrappers/android/tools/camera/src/main/res/values/strings.xml
+++ b/wrappers/android/tools/camera/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="firmware_update_file_path">firmware_update_file_path</string>
     <string name="browse_folder">browse_folder</string>
     <string name="realsense_folder">realsense</string>
+    <string name="show_3d">show_3d</string>
 </resources>


### PR DESCRIPTION
This PR reverts the bulk transfer reads on the streaming endpoints back to USB requests.
The bulk transfer (`ioctl(device, USBDEVFS_BULK, &ctrl)`) requires memory allocation of the entire frame size which failed on some devices with "Out of memory" error.
Moving back to USB requests (`ioctl(device, USBDEVFS_SUBMITURB, urb)`) seems to eliminate this issue.
Removing unnecessary synchronization and memcopies from the previous implementation of the backend with USB requests equalized the performance that we had with the bulk transfer implementation.
Fix issues: #3612, #4091, #4215