### PR TITLE
 Revert a WA to handle extrinsic data externally

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -48,6 +48,7 @@ namespace librealsense
     void extrinsics_graph::register_extrinsics(const stream_interface & from, const stream_interface & to, rs2_extrinsics extr)
     {
         auto lazy_extr = std::make_shared<lazy<rs2_extrinsics>>([=]() {return extr; });
+        _external_extrinsics.push_back(lazy_extr);
         register_extrinsics(from, to, lazy_extr);
     }
 

--- a/src/environment.h
+++ b/src/environment.h
@@ -46,6 +46,8 @@ namespace librealsense
     private:
         std::mutex _mutex;
         std::shared_ptr<lazy<rs2_extrinsics>> _id;
+        // Required by current implementation to hold the reference instead of the device for certain types. TODO
+        std::vector<std::shared_ptr<lazy<rs2_extrinsics>>> _external_extrinsics;
 
     PRIVATE_TESTABLE:
         std::shared_ptr<lazy<rs2_extrinsics>> fetch_edge(int from, int to);


### PR DESCRIPTION
Required by T265 and Software devices