### PR TITLE
Automatically set supported profiles in viewer

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1455,7 +1455,7 @@ namespace rs2
                     }
                 }
                 else if (!def_p.get() && cond(vid_prof))
-                    def_p = p; // in case no matching profile for current stream will be found, we'll use a random profile with given resolution
+                    def_p = p; // in case no matching profile for current stream will be found, we'll use some profile that matches the condition
             }
         }
         return found;
@@ -1592,6 +1592,7 @@ namespace rs2
 
             for (auto&& p : sorted_profiles)
             {
+                // first try to find profile from the new stream to meatch the current configuration
                 if (check_profile(p, [&](video_stream_profile vid_prof)
                 { return (p.fps() == fps && vid_prof.width() == width && vid_prof.height() == height); },
                     profiles_by_format, results, p.format(), num_streams, def_p))
@@ -1605,6 +1606,7 @@ namespace rs2
                 {
                     if (auto vid_prof = p.as<video_stream_profile>())
                     {
+                        // if no stream with current configuration was found, try to find some configuration to match all enabled streams
                         if (check_profile(p, [&](video_stream_profile vsp) { return true; }, profiles_by_fps_res, results,
                             std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height()), num_streams, def_p))
                             break;
@@ -1612,6 +1614,7 @@ namespace rs2
                 }
             }
         }
+
         if (results.empty())
             results.push_back(def_p);
         update_ui(results);

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1387,29 +1387,89 @@ namespace rs2
         return results.size() >= size_t(std::count_if(stream_enabled.begin(), stream_enabled.end(), [](const std::pair<int, bool>& kpv)-> bool { return kpv.second == true; }));
     }
     
+    void subdevice_model::update_ui_shared_fps(stream_profile p)
+    {
+        for (int i = 0; i < shared_fps_values.size(); i++)
+        {
+            if (shared_fps_values[i] == p.fps())
+            {
+                ui.selected_shared_fps_id = i;
+                break;
+            }
+        }
+    }
+
+    void subdevice_model::update_ui_format(stream_profile p)
+    {
+        auto format_vec = format_values[p.unique_id()];
+        for (int i = 0; i < format_vec.size(); i++)
+        {
+            if (format_vec[i] == p.format())
+            {
+                ui.selected_format_id[p.unique_id()] = i;
+                break;
+            }
+        }
+    }
+
+    void subdevice_model::update_ui_resolution(stream_profile p)
+    {
+        for (int i = 0; i < res_values.size(); i++)
+        {
+            if (auto vid_prof = p.as<video_stream_profile>())
+                if (res_values[i].first == vid_prof.width() && res_values[i].second == vid_prof.height())
+                {
+                    ui.selected_res_id = i;
+                    break;
+                }
+        }
+    }
+
     std::vector<stream_profile> subdevice_model::get_supported_profile()
     {
         std::vector<stream_profile> results;
-
         std::stringstream error_message;
         error_message << "The profile ";
+        int num_streams = 0;
+        for (auto& s : stream_enabled)
+        {
+            if (s.second == true)
+                num_streams++;
+        }
+
         if (ui.selected_res_id != last_valid_ui.selected_res_id)
         {
             if (res_values.size() > 0)
             {
                 auto width = res_values[ui.selected_res_id].first;
                 auto height = res_values[ui.selected_res_id].second;
+                std::vector<stream_profile> matching_profiles;
+                std::map<int, std::map<int, stream_profile>> profiles_by_fps;
                 for (auto&& p : profiles)
                 {
                     if (auto vid_prof = p.as<video_stream_profile>())
                     {
-                        if (vid_prof.width() == width &&
-                            vid_prof.height() == height)
+                        for (auto& s : stream_enabled)
                         {
+                            // find profiles that have the required resolution and also unique_id is of an enabled stream
+                            if (s.second == true && p.unique_id() == s.first && vid_prof.width() == width && vid_prof.height() == height)
+                                    matching_profiles.push_back(p);
+                        }
+                    }
+                }
+
+                // find profiles with the same fps out of all the supported ones
+                for (auto& p : matching_profiles)
+                    profiles_by_fps[p.fps()][p.unique_id()] = p;
+
+                for (auto& it : profiles_by_fps) // iterate all fps, stop when find fps that matches all streams
+                {
+                    if (it.second.size() == num_streams)
+                    {
+                        for (auto& prof_it : it.second)
+                        {
+                            auto p = prof_it.second;
                             results.push_back(p);
-                          //  for (auto& s : stream_enabled)
-                          //      s.second = false;
-                          //  stream_enabled[p.unique_id()] = true;
 
                             if (stream_enabled[p.unique_id()] != true)
                             {
@@ -1419,26 +1479,10 @@ namespace rs2
                             }
 
                             prev_stream_enabled = stream_enabled; // make sure stream_enabeld and prev_stream_enabled differ only after user input
-                            auto format_vec = format_values[p.unique_id()];
-                            for (int i = 0; i < format_vec.size(); i++)
-                            {
-                                if (format_vec[i] == p.format())
-                                {
-                                    ui.selected_format_id[p.unique_id()] = i;
-                                    break;
-                                }
-                            }
-                            for (int i = 0; i < shared_fps_values.size(); i++)
-                            {
-                                if (shared_fps_values[i] == p.fps())
-                                {
-                                    ui.selected_shared_fps_id = i;
-                                    break;
-                                }
-                            }
-                            last_valid_ui = ui;
-                            break;
+                            update_ui_format(p);
+                            update_ui_shared_fps(p);
                         }
+                        break;
                     }
                 }
             }
@@ -1446,159 +1490,183 @@ namespace rs2
         else if (ui.selected_shared_fps_id != last_valid_ui.selected_shared_fps_id)
         {
             // TODO: handle fps_values_per_stream (?)
-
-            // save curr stream
             auto fps = 0;
             if (show_single_fps_list)
                 fps = shared_fps_values[ui.selected_shared_fps_id];
+            std::vector<stream_profile> matching_profiles;
+            std::map<std::tuple<int,int>, std::map<int, stream_profile>> profiles_by_res;
             for (auto&& p : profiles)
             {
-                if (auto vid_prof = p.as<video_stream_profile>())
+                for (auto& s : stream_enabled)
                 {
-                    if (vid_prof.fps() == fps)
+                    if (s.second == true && p.unique_id() == s.first && p.fps() == fps)
+                        matching_profiles.push_back(p);
+                }
+            }
+
+            // find profiles with the same fps out of all the supported ones
+            for (auto& p : matching_profiles)
+            {
+                if (auto vid_prof = p.as<video_stream_profile>())
+                    profiles_by_res[std::make_tuple(vid_prof.width(), vid_prof.height())][p.unique_id()] = p;
+            }
+
+            for (auto& it : profiles_by_res) 
+            {
+                if (it.second.size() == num_streams)
+                {
+                    for (auto& prof_it : it.second)
                     {
-                        // also check if p's stream is equal to curr stream & compatible with fps
+                        auto p = prof_it.second;
                         results.push_back(p);
-                        for (auto& s : stream_enabled)
-                            s.second = false;
-                        stream_enabled[p.unique_id()] = true;
+
+                        if (stream_enabled[p.unique_id()] != true)
+                        {
+                            for (auto& s : stream_enabled)
+                                s.second = false;
+                            stream_enabled[p.unique_id()] = true;
+                        }
+
                         prev_stream_enabled = stream_enabled; // make sure stream_enabeld and prev_stream_enabled differ only after user input
-                        auto format_vec = format_values[p.unique_id()];
-                        for (int i = 0; i < format_vec.size(); i++)
-                        {
-                            if (format_vec[i] == p.format())
-                            {
-                                ui.selected_format_id[p.unique_id()] = i;
-                                break;
-                            }
-                        }
-                        for (int i = 0; i < res_values.size(); i++)
-                        {
-                            if (res_values[i].first == vid_prof.width() && res_values[i].second == vid_prof.height())
-                            {
-                                ui.selected_res_id = i;
-                                break;
-                            }
-                        }
-                        last_valid_ui = ui;
-                        break;
+                        update_ui_format(p);
+                        update_ui_resolution(p);
                     }
+                    break;
                 }
             }
         }
         else if (ui.selected_format_id != last_valid_ui.selected_format_id)
         {
-            // the format we look for should match the current stream (TODO: handle for multiple streams)
-            int curr_stream_id = -1;
+            std::vector<stream_profile> matching_profiles;
+            std::map<std::tuple<int,int,int>, std::map<int, stream_profile>> profiles_by_fps_res; //fps, width, height
+            rs2_format format;
+            int stream_id;
 
-            for (auto& s : stream_enabled)
-            {
-                if (s.second == true)
+            prev_stream_enabled = stream_enabled; // make sure stream_enabeld and prev_stream_enabled differ only after user input
+
+            for (auto& it : ui.selected_format_id) // iterate pairs of stream uid + format
+                if (it.second != last_valid_ui.selected_format_id[it.first])
                 {
-                    curr_stream_id = s.first;
-                    break;
+                    format = format_values[it.first][it.second];
+                    stream_id = it.first;
+                }
+
+            for (auto&& p : profiles)
+            {
+                if (auto vid_prof = p.as<video_stream_profile>()) // find all profiles matching chosen format
+                {
+                        if (p.unique_id() == stream_id && p.format() == format) // && stream_enabled[stream_id]
+                            matching_profiles.push_back(p);
                 }
             }
-            if (curr_stream_id > 0)
-                for (auto&& p : profiles)
+
+            for (auto&& p : profiles)
+            {
+                for (auto& s : stream_enabled)
                 {
                     if (auto vid_prof = p.as<video_stream_profile>())
                     {
-                        if (p.format() == format_values[curr_stream_id][ui.selected_format_id[curr_stream_id]])
+                        // take only profiles we still didn't add to matching_profiles, which belong to an active stream and have fps+resolution compatible
+                        // with some profile in matching_profiles
+                        if (s.first != stream_id && s.second == true && p.unique_id() == s.first &&
+                            std::find_if(matching_profiles.begin(), matching_profiles.end(), [&](stream_profile sp)
                         {
-                            results.push_back(p);
-
-                            for (int i = 0; i < res_values.size(); i++)
-                            {
-                                if (res_values[i].first == vid_prof.width() && res_values[i].second == vid_prof.height())
-                                {
-                                    ui.selected_res_id = i;
-                                    break;
-                                }
-                            }
-                            for (int i = 0; i < shared_fps_values.size(); i++)
-                            {
-                                if (shared_fps_values[i] == p.fps())
-                                {
-                                    ui.selected_shared_fps_id = i;
-                                    break;
-                                }
-                            }
-                            last_valid_ui = ui;
-                            break;
+                            if (auto vsp = sp.as<video_stream_profile>())
+                                return (sp.fps() == p.fps() && vsp.width() == vid_prof.width() && vsp.height() == vid_prof.height());
+                        }) != matching_profiles.end())
+                        {
+                            matching_profiles.push_back(p);
                         }
                     }
                 }
+                
+            }
+
+            // find profiles with the same fps out of all the supported ones
+            for (auto& p : matching_profiles)
+            {
+                if (auto vid_prof = p.as<video_stream_profile>())
+                    profiles_by_fps_res[std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height())][p.unique_id()] = p;
+            }
+
+            for (auto& it : profiles_by_fps_res)
+            {
+                if (it.second.size() == num_streams)
+                {
+                    for (auto& prof_it : it.second)
+                    {
+                        auto p = prof_it.second;
+                        results.push_back(p);
+
+                        if (stream_enabled[p.unique_id()] != true)
+                        {
+                            for (auto& s : stream_enabled)
+                                s.second = false;
+                            stream_enabled[p.unique_id()] = true;
+                        }
+
+                        update_ui_format(p);
+                        update_ui_resolution(p);
+                        update_ui_shared_fps(p);
+                    }
+                    break;
+                }
+            }
         }
         else if (stream_enabled != prev_stream_enabled)
         {
-            int curr_stream_id = 0, width = 0, height = 0, fps = 0, num_streams = 0;
-            for (auto& s : stream_enabled)
-            {
-                if (s.second != prev_stream_enabled[s.first])
-                    curr_stream_id = s.first;
-                if (s.second == true)
-                    num_streams++;
-            }
+            std::vector<stream_profile> matching_profiles;
+            std::map<rs2_format, std::map<int, stream_profile>> profiles_by_format;
+            int fps = 0;
+            auto width = res_values[ui.selected_res_id].first;
+            auto height = res_values[ui.selected_res_id].second;
+            if (show_single_fps_list)
+                fps = shared_fps_values[ui.selected_shared_fps_id];
 
-            prev_stream_enabled = stream_enabled;
-
-            if (num_streams == 0)
-                return results;         
-
-            if (num_streams > 1) // if another stream is enabled, try to find a format that is compatible with the existing configuration
-            {
-                width = res_values[ui.selected_res_id].first;
-                height = res_values[ui.selected_res_id].second;
-                if (show_single_fps_list)
-                    fps = shared_fps_values[ui.selected_shared_fps_id];
-            }
+            prev_stream_enabled = stream_enabled; // make sure stream_enabeld and prev_stream_enabled differ only after user input
 
             for (auto&& p : profiles)
             {
                 if (auto vid_prof = p.as<video_stream_profile>())
                 {
-                    auto curr_formats = format_values[curr_stream_id];
-                    
-                    // if there is more than one stream, we want to use the existing configuration and find a compatible format
-                    // if there is one stream, height is 0 and we only need to find a configuration that's compatible with the stream
-                    bool cond = (height) ? std::find(curr_formats.begin(), curr_formats.end(), p.format()) != curr_formats.end() &&
-                        vid_prof.width() == width && vid_prof.height() == height && p.fps() == fps  :
-                        std::find(curr_formats.begin(), curr_formats.end(), p.format()) != curr_formats.end();
-
-                    if (cond)
+                    for (auto& s : stream_enabled)
                     {
-                        results.push_back(p);
-                        auto format_vec = format_values[p.unique_id()];
-                        for (int i = 0; i < format_vec.size(); i++)
-                        {
-                            if (format_vec[i] == p.format())
-                            {
-                                ui.selected_format_id[p.unique_id()] = i;
-                                break;
-                            }
-                        }
-
-                        for (int i = 0; i < res_values.size(); i++)
-                        {
-                            if (res_values[i].first == vid_prof.width() && res_values[i].second == vid_prof.height())
-                            {
-                                ui.selected_res_id = i;
-                                break;
-                            }
-                        }
-
-                        for (int i = 0; i < shared_fps_values.size(); i++)
-                        {
-                            if (shared_fps_values[i] == p.fps())
-                            {
-                                ui.selected_shared_fps_id = i;
-                                break;
-                            }
-                        }
-                        last_valid_ui = ui;
-                        break;
+                        if (s.second == true && p.unique_id() == s.first && p.fps() == fps &&
+                            vid_prof.width() == width && vid_prof.height() == height)
+                            matching_profiles.push_back(p);
                     }
+                }
+            }
+
+            // find profiles with the same fps out of all the supported ones
+            for (auto& p : matching_profiles)
+            {
+                if (auto vid_prof = p.as<video_stream_profile>())
+                {
+                    profiles_by_format[p.format()][p.unique_id()] = p;
+                }
+            }
+
+            for (auto& it : profiles_by_format)
+            {
+                if (it.second.size() == num_streams)
+                {
+                    for (auto& prof_it : it.second)
+                    {
+                        auto p = prof_it.second;
+                        results.push_back(p);
+
+                        if (stream_enabled[p.unique_id()] != true)
+                        {
+                            for (auto& s : stream_enabled)
+                                s.second = false;
+                            stream_enabled[p.unique_id()] = true;
+                        }
+
+                        update_ui_format(p);
+                        //update_ui_resolution(p);
+                    }
+                    break;
                 }
             }
         }
@@ -1607,6 +1675,7 @@ namespace rs2
         //    error_message << " is unsupported!";
         //    throw std::runtime_error(error_message.str());
       //  }
+        last_valid_ui = ui;
         return results;
     }
     

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1425,6 +1425,70 @@ namespace rs2
         }
     }
 
+    template<typename T>
+    std::vector<stream_profile> subdevice_model::get_results(int num_streams, std::map<T, std::map<int, stream_profile>> profiles_map, bool update_format,
+        bool update_resolution, bool update_fps)
+    {
+        std::vector<stream_profile> results;
+        for (auto& it : profiles_map)
+        {
+            if (it.second.size() == num_streams)
+            {
+                for (auto& prof_it : it.second)
+                {
+                    auto p = prof_it.second;
+                    results.push_back(p);
+
+                    if (stream_enabled[p.unique_id()] != true)
+                    {
+                        for (auto& s : stream_enabled)
+                            s.second = false;
+                        stream_enabled[p.unique_id()] = true;
+                    }
+
+                    if (update_format)
+                    {
+                        auto format_vec = format_values[p.unique_id()];
+                        for (int i = 0; i < format_vec.size(); i++)
+                        {
+                            if (format_vec[i] == p.format())
+                            {
+                                ui.selected_format_id[p.unique_id()] = i;
+                                break;
+                            }
+                        }
+                    }
+                    if (update_resolution)
+                    {
+                        for (int i = 0; i < res_values.size(); i++)
+                        {
+                            if (auto vid_prof = p.as<video_stream_profile>())
+                                if (res_values[i].first == vid_prof.width() && res_values[i].second == vid_prof.height())
+                                {
+                                    ui.selected_res_id = i;
+                                    break;
+                                }
+                        }
+                    }
+                    if (update_fps)
+                    {
+                        for (int i = 0; i < shared_fps_values.size(); i++)
+                        {
+                            if (shared_fps_values[i] == p.fps())
+                            {
+                                ui.selected_shared_fps_id = i;
+                                break;
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+        }
+        last_valid_ui = ui;
+        return results;
+    }
+
     std::vector<stream_profile> subdevice_model::get_supported_profile()
     {
         std::vector<stream_profile> results;
@@ -1462,29 +1526,7 @@ namespace rs2
                 for (auto& p : matching_profiles)
                     profiles_by_fps[p.fps()][p.unique_id()] = p;
 
-                for (auto& it : profiles_by_fps) // iterate all fps, stop when find fps that matches all streams
-                {
-                    if (it.second.size() == num_streams)
-                    {
-                        for (auto& prof_it : it.second)
-                        {
-                            auto p = prof_it.second;
-                            results.push_back(p);
-
-                            if (stream_enabled[p.unique_id()] != true)
-                            {
-                                for (auto& s : stream_enabled)
-                                    s.second = false;
-                                stream_enabled[p.unique_id()] = true;
-                            }
-
-                            prev_stream_enabled = stream_enabled; // make sure stream_enabeld and prev_stream_enabled differ only after user input
-                            update_ui_format(p);
-                            update_ui_shared_fps(p);
-                        }
-                        break;
-                    }
-                }
+                results = get_results<int>(num_streams, profiles_by_fps, true, false, true);
             }
         }
         else if (ui.selected_shared_fps_id != last_valid_ui.selected_shared_fps_id)
@@ -1511,29 +1553,7 @@ namespace rs2
                     profiles_by_res[std::make_tuple(vid_prof.width(), vid_prof.height())][p.unique_id()] = p;
             }
 
-            for (auto& it : profiles_by_res) 
-            {
-                if (it.second.size() == num_streams)
-                {
-                    for (auto& prof_it : it.second)
-                    {
-                        auto p = prof_it.second;
-                        results.push_back(p);
-
-                        if (stream_enabled[p.unique_id()] != true)
-                        {
-                            for (auto& s : stream_enabled)
-                                s.second = false;
-                            stream_enabled[p.unique_id()] = true;
-                        }
-
-                        prev_stream_enabled = stream_enabled; // make sure stream_enabeld and prev_stream_enabled differ only after user input
-                        update_ui_format(p);
-                        update_ui_resolution(p);
-                    }
-                    break;
-                }
-            }
+            results = get_results<std::tuple<int, int>>(num_streams, profiles_by_res, true, true, false);
         }
         else if (ui.selected_format_id != last_valid_ui.selected_format_id)
         {
@@ -1545,11 +1565,16 @@ namespace rs2
             prev_stream_enabled = stream_enabled; // make sure stream_enabeld and prev_stream_enabled differ only after user input
 
             for (auto& it : ui.selected_format_id) // iterate pairs of stream uid + format
-                if (it.second != last_valid_ui.selected_format_id[it.first])
+            {
+                auto last_valid_it = last_valid_ui.selected_format_id.find(it.first);
+                // find the stream that didn't exist in previous configuration or had a different format
+                if (last_valid_it == last_valid_ui.selected_format_id.end() || 
+                    it.second != last_valid_it->second)
                 {
                     format = format_values[it.first][it.second];
                     stream_id = it.first;
                 }
+            }
 
             for (auto&& p : profiles)
             {
@@ -1581,7 +1606,6 @@ namespace rs2
                 }
                 
             }
-
             // find profiles with the same fps out of all the supported ones
             for (auto& p : matching_profiles)
             {
@@ -1589,29 +1613,8 @@ namespace rs2
                     profiles_by_fps_res[std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height())][p.unique_id()] = p;
             }
 
-            for (auto& it : profiles_by_fps_res)
-            {
-                if (it.second.size() == num_streams)
-                {
-                    for (auto& prof_it : it.second)
-                    {
-                        auto p = prof_it.second;
-                        results.push_back(p);
 
-                        if (stream_enabled[p.unique_id()] != true)
-                        {
-                            for (auto& s : stream_enabled)
-                                s.second = false;
-                            stream_enabled[p.unique_id()] = true;
-                        }
-
-                        update_ui_format(p);
-                        update_ui_resolution(p);
-                        update_ui_shared_fps(p);
-                    }
-                    break;
-                }
-            }
+            results = get_results<std::tuple<int, int, int>>(num_streams, profiles_by_fps_res, true, true, true);
         }
         else if (stream_enabled != prev_stream_enabled)
         {
@@ -1647,35 +1650,13 @@ namespace rs2
                 }
             }
 
-            for (auto& it : profiles_by_format)
-            {
-                if (it.second.size() == num_streams)
-                {
-                    for (auto& prof_it : it.second)
-                    {
-                        auto p = prof_it.second;
-                        results.push_back(p);
-
-                        if (stream_enabled[p.unique_id()] != true)
-                        {
-                            for (auto& s : stream_enabled)
-                                s.second = false;
-                            stream_enabled[p.unique_id()] = true;
-                        }
-
-                        update_ui_format(p);
-                        //update_ui_resolution(p);
-                    }
-                    break;
-                }
-            }
+            results = get_results<rs2_format>(num_streams, profiles_by_format, true, false, false);
         }
       //  if (results.size() == 0)
       //  {
         //    error_message << " is unsupported!";
         //    throw std::runtime_error(error_message.str());
       //  }
-        last_valid_ui = ui;
         return results;
     }
     

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1290,7 +1290,6 @@ namespace rs2
                         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, { 1,1,1,1 });
                         ImGui::Combo(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
                             static_cast<int>(formats_chars.size()));
-                      //  last_valid_ui.
                         ImGui::PopStyleColor();
                         ImGui::PopItemWidth();
                     }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1290,6 +1290,7 @@ namespace rs2
                         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, { 1,1,1,1 });
                         ImGui::Combo(label.c_str(), &ui.selected_format_id[f.first], formats_chars.data(),
                             static_cast<int>(formats_chars.size()));
+                      //  last_valid_ui.
                         ImGui::PopStyleColor();
                         ImGui::PopItemWidth();
                     }
@@ -1546,15 +1547,17 @@ namespace rs2
             std::map<std::tuple<int,int,int>, std::map<int, stream_profile>> profiles_by_fps_res; //fps, width, height
             rs2_format format;
             int stream_id;
-
-            for (auto& it : ui.selected_format_id) // iterate pairs of stream uid + format
+            // find the stream to which the user made changes
+            for (auto& it : ui.selected_format_id)
             {
-                auto last_valid_it = last_valid_ui.selected_format_id.find(it.first);
-                // find the stream to which the user made changes
-                if (last_valid_it == last_valid_ui.selected_format_id.end() || it.second != last_valid_it->second)
+                if (stream_enabled[it.first])
                 {
-                    format = format_values[it.first][it.second];
-                    stream_id = it.first;
+                    auto last_valid_it = last_valid_ui.selected_format_id.find(it.first);
+                    if ((last_valid_it == last_valid_ui.selected_format_id.end() || it.second != last_valid_it->second))
+                    {
+                        format = format_values[it.first][it.second];
+                        stream_id = it.first;
+                    }
                 }
             }
             for (auto&& p : sorted_profiles)

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1380,7 +1380,144 @@ namespace rs2
         // TODO - review whether the comparison can be made strict (==)
         return results.size() >= size_t(std::count_if(stream_enabled.begin(), stream_enabled.end(), [](const std::pair<int, bool>& kpv)-> bool { return kpv.second == true; }));
     }
+    
+    std::vector<stream_profile> subdevice_model::get_supported_profile()
+    {
+        std::vector<stream_profile> results;
 
+        std::stringstream error_message;
+        error_message << "The profile ";
+
+        if (ui.selected_res_id != last_valid_ui.selected_res_id)
+        {
+            if (res_values.size() > 0)
+            {
+                auto width = res_values[ui.selected_res_id].first;
+                auto height = res_values[ui.selected_res_id].second;
+                for (auto&& p : profiles)
+                {
+                    if (auto vid_prof = p.as<video_stream_profile>())
+                    {
+                        if (vid_prof.width() == width &&
+                            vid_prof.height() == height)
+                        {
+                            results.push_back(p);
+                            for (auto& s : stream_enabled)
+                                s.second = false;
+                            stream_enabled[p.unique_id()] = true;
+                            auto format_vec = format_values[p.unique_id()];
+                            for (int i = 0; i < format_vec.size(); i++)
+                            {
+                                if (format_vec[i] == p.format())
+                                {
+                                    ui.selected_format_id[p.unique_id()] = i;
+                                    break;
+                                }
+                            }
+                            for (int i = 0; i < shared_fps_values.size(); i++)
+                            {
+                                if (shared_fps_values[i] == p.fps())
+                                {
+                                    ui.selected_shared_fps_id = i;
+                                    break;
+                                }
+                            }
+                            last_valid_ui = ui;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        else if (ui.selected_shared_fps_id != last_valid_ui.selected_shared_fps_id)
+        {
+            // TODO: handle fps_values_per_stream (?)
+            auto fps = 0;
+            if (show_single_fps_list)
+                fps = shared_fps_values[ui.selected_shared_fps_id];
+            for (auto&& p : profiles)
+            {
+                if (auto vid_prof = p.as<video_stream_profile>())
+                {
+                    if (vid_prof.fps() == fps)
+                    {
+                        results.push_back(p);
+                        for (auto& s : stream_enabled)
+                            s.second = false;
+                        stream_enabled[p.unique_id()] = true;
+                        auto format_vec = format_values[p.unique_id()];
+                        for (int i = 0; i < format_vec.size(); i++)
+                        {
+                            if (format_vec[i] == p.format())
+                            {
+                                ui.selected_format_id[p.unique_id()] = i;
+                                break;
+                            }
+                        }
+                        for (int i = 0; i < res_values.size(); i++)
+                        {
+                            if (res_values[i].first == vid_prof.width() && res_values[i].second == vid_prof.height())
+                            {
+                                ui.selected_res_id = i;
+                                break;
+                            }
+                        }
+                        last_valid_ui = ui;
+                        break;
+                    }
+                }
+            }
+        }
+        else if (ui.selected_format_id != last_valid_ui.selected_format_id)
+        {
+            // the format we look for should match the current stream (TODO: handle for multiple streams)
+            int curr_stream_id;
+            for (auto& s : stream_enabled)
+            {
+                if (s.second == true)
+                {
+                    curr_stream_id = s.first;
+                    break;
+                }
+            }
+            for (auto&& p : profiles)
+            {
+                if (auto vid_prof = p.as<video_stream_profile>())
+                {
+                    if (p.format() == format_values[curr_stream_id][ui.selected_format_id[curr_stream_id]])
+                    {
+                        results.push_back(p);
+
+                        for (int i = 0; i < res_values.size(); i++)
+                        {
+                            if (res_values[i].first == vid_prof.width() && res_values[i].second == vid_prof.height())
+                            {
+                                ui.selected_res_id = i;
+                                break;
+                            }
+                        }
+                        for (int i = 0; i < shared_fps_values.size(); i++)
+                        {
+                            if (shared_fps_values[i] == p.fps())
+                            {
+                                ui.selected_shared_fps_id = i;
+                                break;
+                            }
+                        }
+                        last_valid_ui = ui;
+                        break;
+                    }
+                }
+            }
+        }
+        if (results.size() == 0)
+        {
+            error_message << " is unsupported!";
+            throw std::runtime_error(error_message.str());
+        }
+        return results;
+    }
+    
     std::vector<stream_profile> subdevice_model::get_selected_profiles()
     {
         std::vector<stream_profile> results;
@@ -5283,14 +5420,46 @@ namespace rs2
                         ImGui_ScopePushStyleColor(ImGuiCol_Text, redish);
                         ImGui_ScopePushStyleColor(ImGuiCol_TextSelectedBg, redish + 0.1f);
 
-                        if (sub->is_selected_combination_supported())
+                        std::vector<stream_profile> profiles;
+                        auto is_comb_supported = sub->is_selected_combination_supported();
+                        bool can_stream;
+                        if (is_comb_supported)
+                            can_stream = true;
+                        else
+                        {
+                            profiles = sub->get_supported_profile();
+                            if (!profiles.empty())
+                                can_stream = true;
+                            else
+                            {
+                                std::string text = to_string() << "  " << textual_icons::toggle_off << "\noff   ";
+                                ImGui::TextDisabled("%s", text.c_str());
+                                if (std::any_of(sub->stream_enabled.begin(), sub->stream_enabled.end(), [](std::pair<int, bool> const& s) { return s.second; }))
+                                {
+                                    if (ImGui::IsItemHovered())
+                                    {
+                                        // ImGui::SetTooltip("Selected configuration (FPS, Resolution) is not supported");
+                                        ImGui::SetTooltip("Selected value is not supported");
+                                    }
+                                }
+                                else
+                                {
+                                    if (ImGui::IsItemHovered())
+                                    {
+                                        ImGui::SetTooltip("No stream selected");
+                                    }
+                                }
+                            }
+                        }
+                        if (can_stream)
                         {
                             if (ImGui::Button(label.c_str(), { 30,30 }))
                             {
-                                auto profiles = sub->get_selected_profiles();
+                                if(profiles.empty()) // profiles might be already filled (if unsopported configuration was chosen and a random one was taken instead)
+                                    profiles = sub->get_selected_profiles();
                                 try
                                 {
-                                    if(!dev_syncer)
+                                    if (!dev_syncer)
                                         dev_syncer = viewer.syncer->create_syncer();
 
                                     std::string friendly_name = sub->s->get_info(RS2_CAMERA_INFO_NAME);
@@ -5321,26 +5490,6 @@ namespace rs2
                                 window.link_hovered();
                                 ImGui::SetTooltip("Start streaming data from this sensor");
                             }
-                        }
-                        else
-                        {
-                            std::string text = to_string() << "  " << textual_icons::toggle_off << "\noff   ";
-                            ImGui::TextDisabled("%s", text.c_str());
-                            if (std::any_of(sub->stream_enabled.begin(), sub->stream_enabled.end(), [](std::pair<int, bool> const& s) { return s.second; }))
-                            {
-                                if (ImGui::IsItemHovered())
-                                {
-                                    ImGui::SetTooltip("Selected configuration (FPS, Resolution) is not supported");
-                                }
-                            }
-                            else
-                            {
-                                if (ImGui::IsItemHovered())
-                                {
-                                    ImGui::SetTooltip("No stream selected");
-                                }
-                            }
-
                         }
                     }
                     else

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1436,31 +1436,13 @@ namespace rs2
         last_valid_ui = ui;
     }
 
-    template<typename T>
-    std::vector<stream_profile> subdevice_model::get_results(int num_streams, std::map<T, std::map<int, stream_profile>> profiles_map)
-    {
-        std::vector<stream_profile> results;
-        for (auto& it : profiles_map)
-        {
-            if (it.second.size() == num_streams)
-            {
-                for (auto& prof_it : it.second)
-                {
-                    auto p = prof_it.second;
-                    results.push_back(p);
-                }
-                break;
-            }
-        }
-        return results;
-    }
-
     std::vector<stream_profile> subdevice_model::get_supported_profile()
     {
         std::vector<stream_profile> results;
         std::stringstream error_message;
         error_message << "The profile ";
         int num_streams = 0;
+        bool found = false;
         stream_profile def_p;
         for (auto& s : stream_enabled)
         {
@@ -1488,19 +1470,18 @@ namespace rs2
                             { 
                                 profiles_by_fps[p.fps()][p.unique_id()] = p;
                                 if (profiles_by_fps[p.fps()].size() == num_streams)
-                                    match = profiles_by_fps[p.fps()];
-
+                                {
+                                    for (auto& p : profiles_by_fps[p.fps()])
+                                        results.push_back(p.second);
+                                    found = true;
+                                }
                             }
                             else if (!def_p.get() && vid_prof.width() == width && vid_prof.height() == height)
                                 def_p = p; // in case no matching profile for current stream will be found, we'll use a random profile with given resolution
                         }
                     }
-                    if (match.size() > 0)
-                    {
-                        for (auto& p : match)
-                            results.push_back(p.second);
+                    if (found)
                         break;
-                    }
                 }
 
                 if (results.empty())
@@ -1530,18 +1511,18 @@ namespace rs2
                             auto key = std::make_tuple(vid_prof.width(), vid_prof.height());
                             profiles_by_res[key][p.unique_id()] = p;
                             if (profiles_by_res[key].size() == num_streams)
-                                match = profiles_by_res[key];
+                            {
+                                for (auto& p : profiles_by_res[key])
+                                    results.push_back(p.second);
+                                found = true;
+                            }
                         }
                         else if (!def_p.get() && p.fps() == fps)
                             def_p = p;
                     }
                 }
-                if (match.size() > 0)
-                {
-                    for (auto& p : match)
-                        results.push_back(p.second);
+                if (found)
                     break;
-                }
             }
 
             if (results.empty())
@@ -1552,7 +1533,6 @@ namespace rs2
         {
             std::vector<stream_profile> matching_profiles;
             std::map<std::tuple<int,int,int>, std::map<int, stream_profile>> profiles_by_fps_res; //fps, width, height
-            std::map<int, stream_profile> match;
             rs2_format format;
             int stream_id;
 
@@ -1576,7 +1556,6 @@ namespace rs2
                     if (p.unique_id() == stream_id && p.format() == format) // && stream_enabled[stream_id]
                     {
                         profiles_by_fps_res[std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height())][p.unique_id()] = p;
-                      //  matching_profiles.push_back(p);
                         if (!def_p.get())
                             def_p = p;
                     }
@@ -1600,16 +1579,16 @@ namespace rs2
                             auto key = std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height());
                             profiles_by_fps_res[key][p.unique_id()] = p;
                             if (profiles_by_fps_res[key].size() == num_streams)
-                                match = profiles_by_fps_res[key];
+                            {
+                                for (auto& p : profiles_by_fps_res[key])
+                                    results.push_back(p.second);
+                                found = true;
+                            }
                         }
                     }
                 }
-                if (match.size() > 0)
-                {
-                    for (auto& p : match)
-                        results.push_back(p.second);
+                if (found)
                     break;
-                }
             }
 
             if (results.empty())
@@ -1636,21 +1615,20 @@ namespace rs2
                     {
                         if (s.second == true && p.unique_id() == s.first && p.fps() == fps &&
                             vid_prof.width() == width && vid_prof.height() == height)
-                            matching_profiles.push_back(p);
+                        {
+                            profiles_by_format[p.format()][p.unique_id()] = p;
+                            if (profiles_by_format[p.format()].size() == num_streams)
+                            {
+                                for (auto& p : profiles_by_format[p.format()])
+                                    results.push_back(p.second);
+                                found = true;
+                            }
+                        }
                     }
                 }
+                if (found)
+                    break;
             }
-
-            // find profiles with the same fps out of all the supported ones
-            for (auto& p : matching_profiles)
-            {
-                if (auto vid_prof = p.as<video_stream_profile>())
-                {
-                    profiles_by_format[p.format()][p.unique_id()] = p;
-                }
-            }
-
-            results = get_results<rs2_format>(num_streams, profiles_by_format);
 
             if (results.empty()) // find a profile that 
             {
@@ -1665,18 +1643,19 @@ namespace rs2
                             // find profiles that have the required resolution and also unique_id is of an enabled stream
                             if (p.unique_id() == s.first && s.second == true)
                             {
-                                profiles_by_fps_res[std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height())][p.unique_id()] = p;
-                                if (profiles_by_fps_res[std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height())].size() == num_streams)
-                                    match = profiles_by_fps_res[std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height())];
+                                auto key = std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height());
+                                profiles_by_fps_res[key][p.unique_id()] = p;
+                                if (profiles_by_fps_res[key].size() == num_streams)
+                                {
+                                    for (auto& p : profiles_by_fps_res[key])
+                                        results.push_back(p.second);
+                                    found = true;
+                                }
                             }
                         }
                     }
-                    if (match.size() > 0)
-                    {
-                        for (auto& p : match)
-                            results.push_back(p.second);
+                    if (found)
                         break;
-                    }
                 }
             }
             update_ui(results, true, true, true);

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -609,6 +609,10 @@ namespace rs2
         bool can_enable_zero_order();
         void verify_zero_order_conditions();
 
+        void update_ui_shared_fps(stream_profile p);
+        void update_ui_format(stream_profile p);
+        void update_ui_resolution(stream_profile p);
+
         void restore_ui_selection() { ui = last_valid_ui; }
         void store_ui_selection() { last_valid_ui = ui; }
 

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -645,6 +645,7 @@ namespace rs2
         std::vector<std::string> shared_fpses;
         std::map<int, std::vector<std::string>> formats;
         std::map<int, bool> stream_enabled;
+        std::map<int, bool> prev_stream_enabled;
         std::map<int, std::string> stream_display_names;
 
         subdevice_ui_selection ui;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -609,8 +609,6 @@ namespace rs2
         bool can_enable_zero_order();
         void verify_zero_order_conditions();
 
-        template<typename T>
-        std::vector<stream_profile> get_results(int num_streams, std::map<T, std::map<int, stream_profile>> profiles_map);
         void update_ui(std::vector<stream_profile> profiles_vec, bool update_format, bool update_resolution, bool update_fps);
 
         void restore_ui_selection() { ui = last_valid_ui; }

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -587,7 +587,7 @@ namespace rs2
         bool draw_stream_selection();
         bool is_selected_combination_supported();
         std::vector<stream_profile> get_selected_profiles();
-        std::vector<stream_profile> get_supported_profile();
+        std::vector<stream_profile> get_supported_profiles();
         void stop(viewer_model& viewer);
         void play(const std::vector<stream_profile>& profiles, viewer_model& viewer, std::shared_ptr<rs2::asynchronous_syncer>);
         bool is_synchronized_frame(viewer_model& viewer, const frame& f);
@@ -610,6 +610,7 @@ namespace rs2
         void verify_zero_order_conditions();
 
         void update_ui(std::vector<stream_profile> profiles_vec);
+        void get_sorted_profiles(std::vector<stream_profile>& profiles);
 
         template<typename T, typename V>
         bool check_profile(stream_profile p, T cond, std::map<V, std::map<int, stream_profile>>& profiles_map,

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -609,13 +609,9 @@ namespace rs2
         bool can_enable_zero_order();
         void verify_zero_order_conditions();
 
-        void update_ui_shared_fps(stream_profile p);
-        void update_ui_format(stream_profile p);
-        void update_ui_resolution(stream_profile p);
-
         template<typename T>
-        std::vector<stream_profile> get_results(int num_streams, std::map<T, std::map<int, stream_profile>> profiles_map, bool update_format,
-            bool update_resolution, bool update_fps);
+        std::vector<stream_profile> get_results(int num_streams, std::map<T, std::map<int, stream_profile>> profiles_map);
+        void update_ui(std::vector<stream_profile> profiles_vec, bool update_format, bool update_resolution, bool update_fps);
 
         void restore_ui_selection() { ui = last_valid_ui; }
         void store_ui_selection() { last_valid_ui = ui; }

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -587,6 +587,7 @@ namespace rs2
         bool draw_stream_selection();
         bool is_selected_combination_supported();
         std::vector<stream_profile> get_selected_profiles();
+        std::vector<stream_profile> get_supported_profile();
         void stop(viewer_model& viewer);
         void play(const std::vector<stream_profile>& profiles, viewer_model& viewer, std::shared_ptr<rs2::asynchronous_syncer>);
         bool is_synchronized_frame(viewer_model& viewer, const frame& f);

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -613,6 +613,10 @@ namespace rs2
         void update_ui_format(stream_profile p);
         void update_ui_resolution(stream_profile p);
 
+        template<typename T>
+        std::vector<stream_profile> get_results(int num_streams, std::map<T, std::map<int, stream_profile>> profiles_map, bool update_format,
+            bool update_resolution, bool update_fps);
+
         void restore_ui_selection() { ui = last_valid_ui; }
         void store_ui_selection() { last_valid_ui = ui; }
 

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -609,7 +609,11 @@ namespace rs2
         bool can_enable_zero_order();
         void verify_zero_order_conditions();
 
-        void update_ui(std::vector<stream_profile> profiles_vec, bool update_format, bool update_resolution, bool update_fps);
+        void update_ui(std::vector<stream_profile> profiles_vec);
+
+        template<typename T, typename V>
+        bool check_profile(stream_profile p, T cond, std::map<V, std::map<int, stream_profile>>& profiles_map,
+            std::vector<stream_profile>& results, V key, int num_streams, stream_profile& def_p);
 
         void restore_ui_selection() { ui = last_valid_ui; }
         void store_ui_selection() { last_valid_ui = ui; }


### PR DESCRIPTION
Added functionality to the realsense viewer: when the user picks a value (resolution / fps / format / stream) that isn't compatible with the current configuration, a new configuration that supports the chosen value is set.