### PR TITLE
Fix format-security warnings (again)

### DIFF
--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -3,7 +3,7 @@ message(STATUS "Setting Unix configurations")
 macro(os_set_flags)
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_BSD_SOURCE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pedantic -g -Wno-missing-field-initializers")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar -Wsequence-point -Wformat-security")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar -Wsequence-point -Wformat -Wformat-security")
 
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_VARIABLE MACHINE)
     if(${MACHINE} MATCHES "arm-linux-gnueabihf")

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2408,7 +2408,7 @@ namespace rs2
                             ImColor(alpha(sensor_bg, 0.1f)));
 
                         ImGui::PushStyleColor(ImGuiCol_Text, redish);
-                        ImGui::Text(text);
+                        ImGui::Text("%s", text);
                         ImGui::PopStyleColor();
 
                         line_y += ImGui::GetTextLineHeight() + 3;
@@ -2425,13 +2425,13 @@ namespace rs2
                             ImColor(alpha(sensor_bg, 0.1f)));
 
                         ImGui::PushStyleColor(ImGuiCol_Text, white);
-                        ImGui::Text(text.c_str()); ImGui::SameLine();
+                        ImGui::Text("%s", text.c_str()); ImGui::SameLine();
 
                         if (at.description != "")
                         {
                             if (ImGui::IsItemHovered())
                             {
-                                ImGui::SetTooltip(at.description.c_str());
+                                ImGui::SetTooltip("%s", at.description.c_str());
                             }
                         }
 

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -734,7 +734,7 @@ namespace rs2
         std::string txt = to_string() << "librealsense " << RS2_API_VERSION_STR << "!";
 
         ImGui::PushStyleColor(ImGuiCol_Text, alpha(white, 1.f - t));
-        ImGui::Text(txt.c_str());
+        ImGui::Text("%s", txt.c_str());
         ImGui::PopStyleColor();
         ImGui::PopFont();
 

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -732,7 +732,7 @@ namespace rs2
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + 47) });
 
                 ImGui::PushStyleColor(ImGuiCol_Text, white);
-                ImGui::Text(message.c_str());
+                ImGui::Text("%s", message.c_str());
                 ImGui::PopStyleColor();
 
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + 65) });
@@ -835,7 +835,7 @@ namespace rs2
             }
             else if (update_state == RS2_CALIB_STATE_FAILED)
             {
-                ImGui::Text(_error_message.c_str());
+                ImGui::Text("%s", _error_message.c_str());
 
                 auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 
@@ -906,11 +906,11 @@ namespace rs2
 
                     ImGui::SetCursorScreenPos({ float(x + 12), float(y + 90) });
                     ImGui::PushFont(win.get_large_font());
-                    ImGui::Text(textual_icons::check);
+                    ImGui::Text("%s", static_cast<const char *>(textual_icons::check));
                     ImGui::PopFont();
 
                     ImGui::SetCursorScreenPos({ float(x + 35), float(y + 92) });
-                    ImGui::Text(txt.c_str());
+                    ImGui::Text("%s", txt.c_str());
 
                     if (use_new_calib)
                     {
@@ -918,7 +918,7 @@ namespace rs2
 
                         ImGui::PushStyleColor(ImGuiCol_Text, white);
                         txt = to_string() << " ( +" << std::fixed << std::setprecision(0) << fr_improvement << "%% )";
-                        ImGui::Text(txt.c_str());
+                        ImGui::Text("%s", txt.c_str());
                         ImGui::PopStyleColor();
                     }
 
@@ -935,11 +935,11 @@ namespace rs2
 
                         ImGui::SetCursorScreenPos({ float(x + 12), float(y + 90 + ImGui::GetTextLineHeight() + 6) });
                         ImGui::PushFont(win.get_large_font());
-                        ImGui::Text(textual_icons::check);
+                        ImGui::Text("%s", static_cast<const char *>(textual_icons::check));
                         ImGui::PopFont();
 
                         ImGui::SetCursorScreenPos({ float(x + 35), float(y + 92 + ImGui::GetTextLineHeight() + 6) });
-                        ImGui::Text(txt.c_str());
+                        ImGui::Text("%s", txt.c_str());
 
                         if (use_new_calib)
                         {
@@ -947,7 +947,7 @@ namespace rs2
 
                             ImGui::PushStyleColor(ImGuiCol_Text, white);
                             txt = to_string() << " ( -" << std::setprecision(0) << std::fixed << rms_improvement << "%% )";
-                            ImGui::Text(txt.c_str());
+                            ImGui::Text("%s", txt.c_str());
                             ImGui::PopStyleColor();
                         }
                     }


### PR DESCRIPTION
Use string literals in all format strings and cast to `char *` if necessary. Also include `-Wformat`, which is necessary if you want to use `-Wformat-security`.

See also #915 that did something similar.