### PR TITLE
Fix std::string error on VS2019

### DIFF
--- a/tools/terminal/auto-complete.cpp
+++ b/tools/terminal/auto-complete.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <thread>
 #include <algorithm>
-#include <string>
 #include <cmath>
 
 using namespace std;

--- a/tools/terminal/auto-complete.h
+++ b/tools/terminal/auto-complete.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include <set>
+#include <string>
 #include <vector>
 #include <functional>
 #include <stdint.h>


### PR DESCRIPTION
Fix <code>std::string</code> error on VS2019.
It is necessary to include in header.