### PR TITLE
Fixing basic threading issues within on-chip calibration UI

### DIFF
--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -168,7 +168,9 @@ namespace rs2
         return false;
     }
 
-    void firmware_update_manager::process_flow(std::function<void()> cleanup)
+    void firmware_update_manager::process_flow(
+        std::function<void()> cleanup,
+        invoker invoke)
     {
         std::string serial = "";
         if (_dev.supports(RS2_CAMERA_INFO_ASIC_SERIAL_NUMBER))

--- a/common/fw-update-helper.h
+++ b/common/fw-update-helper.h
@@ -22,7 +22,8 @@ namespace rs2
               _fw(fw), _is_signed(is_signed), _dev(dev), _ctx(ctx) {}
 
     private:
-        void process_flow(std::function<void()> cleanup) override;
+        void process_flow(std::function<void()> cleanup, 
+            invoker invoke) override;
         bool check_for(
             std::function<bool()> action, std::function<void()> cleanup,
             std::chrono::system_clock::duration delta);

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "notifications.h"
+#include "../src/concurrency.h"
 
 #include <random>
 
@@ -38,7 +39,7 @@ namespace rs2
         void keep();
 
         // Restore Viewer UI to how it was before auto-calib
-        void restore_workspace();
+        void restore_workspace(invoker invoke);
         
         // Ask the firmware to use one of the before/after calibration tables
         void apply_calib(bool old);
@@ -60,11 +61,11 @@ namespace rs2
 
         std::vector<uint8_t> safe_send_command(const std::vector<uint8_t>& cmd, const std::string& name);
 
-        rs2::depth_frame fetch_depth_frame();
+        rs2::depth_frame fetch_depth_frame(invoker invoke);
 
-        std::pair<float, float> get_depth_metrics();
+        std::pair<float, float> get_depth_metrics(invoker invoke);
 
-        void process_flow(std::function<void()> cleanup) override;
+        void process_flow(std::function<void()> cleanup, invoker invoke) override;
 
         float _health = 0.f;
         int _speed = 4;
@@ -84,8 +85,8 @@ namespace rs2
 
         bool _restored = true;
 
-        void stop_viewer();
-        void start_viewer(int w, int h, int fps);
+        void stop_viewer(invoker invoke);
+        void start_viewer(int w, int h, int fps, invoker invoke);
     };
 
     // Auto-calib notification model is managing the UI state-machine


### PR DESCRIPTION
Current implementation can sometimes crash due to a race between UI thread and the calibration process thread. This should be solved by this patch, introducing simple invoker mechanism - this way the calibration thread can execute code on the UI thread at next render frame and wait until its done. 