### PR TITLE
Disable default decimation for RGB sensors

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -967,9 +967,15 @@ namespace rs2
                     model->enabled = false;
             }
 
-
             if (shared_filter->is<hole_filling_filter>())
                 model->enabled = false;
+
+            if (shared_filter->is<decimation_filter>())
+            {
+                std::string sn_name(s->get_info(RS2_CAMERA_INFO_NAME));
+                if (sn_name == "RGB Camera")
+                    model->enabled = false;
+            }
 
             post_processing.push_back(model);
         }

--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -261,7 +261,7 @@ namespace rs2
             for (auto i = 0; i < size; i++)
             {
                 auto f = std::shared_ptr<rs2_processing_block>(
-                    rs2_get_processing_block(list.get(), i, &e), 
+                    rs2_get_processing_block(list.get(), i, &e),
                     rs2_delete_processing_block);
                 error::handle(e);
                 results.push_back(f);


### PR DESCRIPTION
Remove a trailing space
Tracked on: DSO-13570