### PR TITLE
Wheel odometry unit test fix

### DIFF
--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -51,6 +51,13 @@ add_custom_command(TARGET live-test POST_BUILD
     ${Deployment_Location}
 )
 
+# copy wheel odometry calibration file to build folder
+add_custom_command(TARGET live-test POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources/calibration_odometry.json
+    ${CMAKE_CURRENT_BINARY_DIR}/calibration_odometry.json
+)
+
 #Post-Processing data set for unit-tests
 #message(STATUS "Post processing deployment directory=${Deployment_Location}")
 list(APPEND PP_Tests_List  1551257764229 # D415_DS(2)

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -5548,7 +5548,6 @@ TEST_CASE("Wheel_Odometry_API", "[live]")
         REQUIRE(profile);
         REQUIRE_NOTHROW(dev = profile.get_device());
         REQUIRE(dev);
-        disable_sensitive_options_for(dev);
         dev_type PID = get_PID(dev);
         CAPTURE(PID.first);
 
@@ -5570,7 +5569,7 @@ TEST_CASE("Wheel_Odometry_API", "[live]")
                 THEN("Load wheel odometry calibration")
                 {
                     std::ifstream calibrationFile("calibration_odometry.json");
-                    if (calibrationFile)
+                    REQUIRE(calibrationFile);
                     {
                         const std::string json_str((std::istreambuf_iterator<char>(calibrationFile)),
                             std::istreambuf_iterator<char>());


### PR DESCRIPTION
Wheel odometry unit test was broken.
* run in default configuration (disabling sensitive options might also fail other unit tests)
* check for existence of calibration file
* copy calibration file to build folder

