### PR TITLE
Fixing typo in align-depth2color.py

### DIFF
--- a/wrappers/python/examples/align-depth2color.py
+++ b/wrappers/python/examples/align-depth2color.py
@@ -18,7 +18,7 @@ pipeline = rs.pipeline()
 #Create a config and configure the pipeline to stream
 #  different resolutions of color and depth streams
 config = rs.config()
-config.enable_stream(rs.stream.depth, 640, 360, rs.format.z16, 30)
+config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
 config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)
 
 # Start streaming
@@ -46,26 +46,26 @@ try:
         # Get frameset of color and depth
         frames = pipeline.wait_for_frames()
         # frames.get_depth_frame() is a 640x360 depth image
-        
+
         # Align the depth frame to color frame
         aligned_frames = align.process(frames)
-        
+
         # Get aligned frames
         aligned_depth_frame = aligned_frames.get_depth_frame() # aligned_depth_frame is a 640x480 depth image
         color_frame = aligned_frames.get_color_frame()
-        
+
         # Validate that both frames are valid
         if not aligned_depth_frame or not color_frame:
             continue
-        
+
         depth_image = np.asanyarray(aligned_depth_frame.get_data())
         color_image = np.asanyarray(color_frame.get_data())
-        
+
         # Remove background - Set pixels further than clipping_distance to grey
         grey_color = 153
         depth_image_3d = np.dstack((depth_image,depth_image,depth_image)) #depth image is 1 channel, color is 3 channels
         bg_removed = np.where((depth_image_3d > clipping_distance) | (depth_image_3d <= 0), grey_color, color_image)
-        
+
         # Render images
         depth_colormap = cv2.applyColorMap(cv2.convertScaleAbs(depth_image, alpha=0.03), cv2.COLORMAP_JET)
         images = np.hstack((bg_removed, depth_colormap))
@@ -78,4 +78,3 @@ try:
             break
 finally:
     pipeline.stop()
-


### PR DESCRIPTION
When I copied the **_align-depth2color.py_** example script and ran it, there was a nasty output:

_Traceback (most recent call last):
  File "RS_align_depth2color.py", line 25, in <module>
    profile = pipeline.start(config)
RuntimeError: Couldn't resolve requests_

It seems that the resolutions weren't matching on code lines 21 & 22.  The depth cam was set to (640, 360) and the color cam was set to (640, 480).

Simply changing resolutions to match fixed it.