### PR TITLE
Drop dkms, udev deps from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,10 +29,7 @@
   <build_depend>pkg-config</build_depend>
 
   <depend>libusb-1.0-dev</depend>
-  <depend>linux-headers-generic</depend>
   <depend>libssl-dev</depend>
-  <depend>dkms</depend>
-  <depend>udev</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
In my opinion, the removed lines do not belong here— the scenario where the `package.xml` file is used is when `librealsense2` is being built in a catkin workspace with ROS, but typically then the udev rule installation and kernel patching will either be handled by a) installing the standalone, Intel-supplied `librealsense2-dkms` and `librealsense2-udev-rules` packages, or b) by manually running the various programs in the `scripts` directory.

In our build setup, eliminating these unwanted dependencies means either having to patch them out of the source, or use null rosdep mappings to silence them at that level.