### PR TITLE
Remove "not supported for rendering" error

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -1265,14 +1265,11 @@ namespace rs2
                 //    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width / 2, height / 2, 0, GL_RGB, GL_UNSIGNED_BYTE, rgb.data());
                 //}
                 //break;
-                //case RS2_FORMAT_RAW10:
-                //{
-                //  memset((void*)data, 0, height*width);
-                //  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
-                //  break;
-                //}
-               // default:
-               //     throw std::runtime_error("The requested format is not supported for rendering");
+                default:
+                {
+                    memset((void*)data, 0, height*width);
+                    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
+                }
                 }
 
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -1265,8 +1265,14 @@ namespace rs2
                 //    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width / 2, height / 2, 0, GL_RGB, GL_UNSIGNED_BYTE, rgb.data());
                 //}
                 //break;
-                default:
-                    throw std::runtime_error("The requested format is not supported for rendering");
+                //case RS2_FORMAT_RAW10:
+                //{
+                //  memset((void*)data, 0, height*width);
+                //  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
+                //  break;
+                //}
+               // default:
+               //     throw std::runtime_error("The requested format is not supported for rendering");
                 }
 
                 glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -827,16 +827,30 @@ namespace rs2
         ImGui::PopFont();
     }
 
-    void viewer_model::show_rendering_not_supported(ImFont* font_18, int min_x, int min_y, int max_x, int max_y)
+    void viewer_model::show_rendering_not_supported(ImFont* font_18, int min_x, int min_y, int max_x, int max_y, rs2_format format)
     {
-        ImGui::PushFont(font_18);
-
+        static periodic_timer update_string(std::chrono::milliseconds(200));
+        static int counter = 0;
+        static std::string to_print;
         auto pos = ImGui::GetCursorScreenPos();
-        ImGui::SetCursorScreenPos({ min_x + max_x / 2.f - 200, min_y + max_y / 2.f - 20 });
-
-        ImGui::PushStyleColor(ImGuiCol_Text, sensor_header_light_blue);
-        std::string text = to_string() << textual_icons::exclamation_triangle << " The requested format is not supported for rendering ";
+        
+        ImGui::PushFont(font_18);
+        ImGui::SetCursorScreenPos({ min_x + max_x / 2.f - 210, min_y + max_y / 2.f - 20 });
+        ImGui::PushStyleColor(ImGuiCol_Text, yellowish);
+        std::string text = to_string() << textual_icons::exclamation_triangle;
         ImGui::Text("%s", text.c_str());
+        ImGui::SetCursorScreenPos({ min_x + max_x / 2.f - 180, min_y + max_y / 2.f - 20 });
+        text = to_string() <<  " The requested format " << format << " is not supported for rendering  ";
+
+        if (update_string)
+        {
+            to_print.clear();
+            for (int i = 0; i < text.size(); i++)
+                to_print += text[(i + counter) % text.size()];
+            counter++;
+        }
+
+        ImGui::Text("%s", to_print.c_str());
         ImGui::PopStyleColor();
 
         ImGui::SetCursorScreenPos(pos);
@@ -1298,10 +1312,11 @@ namespace rs2
 
             stream_mv.show_stream_header(font1, stream_rect, *this);
             stream_mv.show_stream_footer(font1, stream_rect, mouse, *this);
-            
-            if (stream_mv.profile.format() == RS2_FORMAT_RAW10 || stream_mv.profile.format() == RS2_FORMAT_RAW16)
+
+            if (val_in_range(stream_mv.profile.format(), { RS2_FORMAT_RAW10 , RS2_FORMAT_RAW16, RS2_FORMAT_MJPEG }))
             {
-                show_rendering_not_supported(font2, static_cast<int>(stream_rect.x), static_cast<int>(stream_rect.y), static_cast<int>(stream_rect.w), static_cast<int>(stream_rect.h));
+                show_rendering_not_supported(font2, static_cast<int>(stream_rect.x), static_cast<int>(stream_rect.y), static_cast<int>(stream_rect.w),
+                    static_cast<int>(stream_rect.h), stream_mv.profile.format());
             }
 
             if (stream_mv.dev->_is_being_recorded)

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -827,6 +827,23 @@ namespace rs2
         ImGui::PopFont();
     }
 
+    void viewer_model::show_rendering_not_supported(ImFont* font_18, int min_x, int min_y, int max_x, int max_y)
+    {
+        ImGui::PushFont(font_18);
+
+        auto pos = ImGui::GetCursorScreenPos();
+        ImGui::SetCursorScreenPos({ min_x + max_x / 2.f - 200, min_y + max_y / 2.f - 20 });
+
+        ImGui::PushStyleColor(ImGuiCol_Text, sensor_header_light_blue);
+        std::string text = to_string() << textual_icons::exclamation_triangle << " The requested format is not supported for rendering ";
+        ImGui::Text("%s", text.c_str());
+        ImGui::PopStyleColor();
+
+        ImGui::SetCursorScreenPos(pos);
+
+        ImGui::PopFont();
+    }
+
     void viewer_model::show_no_device_overlay(ImFont* font_18, int x, int y)
     {
         auto pos = ImGui::GetCursorScreenPos();
@@ -1281,6 +1298,11 @@ namespace rs2
 
             stream_mv.show_stream_header(font1, stream_rect, *this);
             stream_mv.show_stream_footer(font1, stream_rect, mouse, *this);
+            
+            if (stream_mv.profile.format() == RS2_FORMAT_RAW10 || stream_mv.profile.format() == RS2_FORMAT_RAW16)
+            {
+                show_rendering_not_supported(font2, static_cast<int>(stream_rect.x), static_cast<int>(stream_rect.y), static_cast<int>(stream_rect.w), static_cast<int>(stream_rect.h));
+            }
 
             if (stream_mv.dev->_is_being_recorded)
             {
@@ -1293,8 +1315,8 @@ namespace rs2
             auto stream_type = stream_mv.profile.stream_type();
 
             if (streams[stream].is_stream_visible())
-            {
                 switch (stream_type)
+            {
                 {
                     case RS2_STREAM_GYRO: /* Fall Through */
                     case RS2_STREAM_ACCEL:

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -60,7 +60,7 @@ namespace rs2
 
         void show_no_stream_overlay(ImFont* font, int min_x, int min_y, int max_x, int max_y);
         void show_no_device_overlay(ImFont* font, int min_x, int min_y);
-        void show_rendering_not_supported(ImFont* font_18, int min_x, int min_y, int max_x, int max_y);
+        void show_rendering_not_supported(ImFont* font_18, int min_x, int min_y, int max_x, int max_y, rs2_format format);
 
         void show_paused_icon(ImFont* font, int x, int y, int id);
         void show_recording_icon(ImFont* font_18, int x, int y, int id, float alpha_delta);

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -60,6 +60,7 @@ namespace rs2
 
         void show_no_stream_overlay(ImFont* font, int min_x, int min_y, int max_x, int max_y);
         void show_no_device_overlay(ImFont* font, int min_x, int min_y);
+        void show_rendering_not_supported(ImFont* font_18, int min_x, int min_y, int max_x, int max_y);
 
         void show_paused_icon(ImFont* font, int x, int y, int id);
         void show_recording_icon(ImFont* font_18, int x, int y, int id, float alpha_delta);


### PR DESCRIPTION
When streaming a format that is not supported for rendering, instead of throwing error notifications, show message that rendering is not supported in the stream view.