### PR TITLE
Added to align sse support on distortion parameters and fixed bug on playback  

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -5088,7 +5088,8 @@ namespace rs2
         const ImVec2 name_pos = { pos.x + 9, pos.y + 17 };
         ImGui::SetCursorPos(name_pos);
         std::stringstream ss;
-        ss << dev.get_info(RS2_CAMERA_INFO_NAME);
+        if(dev.supports(RS2_CAMERA_INFO_NAME))
+            ss << dev.get_info(RS2_CAMERA_INFO_NAME);
         ImGui::Text(" %s", ss.str().c_str());
         if (dev.supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
         {

--- a/src/proc/sse/sse-align.cpp
+++ b/src/proc/sse/sse-align.cpp
@@ -288,6 +288,7 @@ void image_transform::align_other_to_depth(const uint16_t* z_pixels, const byte*
     switch (to.model)
     {
     case RS2_DISTORTION_MODIFIED_BROWN_CONRADY:
+    case RS2_DISTORTION_INVERSE_BROWN_CONRADY:
         align_other_to_depth_sse<RS2_DISTORTION_MODIFIED_BROWN_CONRADY>(z_pixels, source, dest, bpp, to, from_to_other);
         break;
     default:


### PR DESCRIPTION
1. Align-sse will support RS2_DISTORTION_INVERSE_BROWN_CONRADY 
2. Fixed bug on record-playback , if the user stopped recording before recording camera info, viewer will not crashed but will not present camera info.
Tracked-on: RS5-3373
