### PR TITLE
libuvc: fix QW_TO_QUAD losing data due to 32-bit type

### DIFF
--- a/src/libuvc/libuvc_internal.h
+++ b/src/libuvc/libuvc_internal.h
@@ -27,8 +27,8 @@
 /** Converts an unaligned two-byte little-endian integer into an int16 */
 #define SW_TO_SHORT(p) ((p)[0] | ((p)[1] << 8))
 /** Converts an unaligned eight-byte little-endian integer into an int64 */
-#define QW_TO_QUAD(p) ((p)[0] | ((p)[1] << 8) | ((p)[2] << 16) | ((p)[3] << 24) |  \
-                       ((p)[4] << 32) |((p)[5] << 40) |((p)[6] << 48) |((p)[7] << 56))
+#define QW_TO_QUAD(p) ((uint64_t)(p)[0] | ((uint64_t)(p)[1] << 8) | ((uint64_t)(p)[2] << 16) | ((uint64_t)(p)[3] << 24) |  \
+    ((uint64_t)(p)[4] << 32) | ((uint64_t)(p)[5] << 40) | ((uint64_t)(p)[6] << 48) | ((uint64_t)(p)[7] << 56))
 
 /** Converts an int16 into an unaligned two-byte little-endian integer */
 #define SHORT_TO_SW(s, p) \


### PR DESCRIPTION
libuvc performs a 64-bit leftshifts on 32-bit types, losing data in the process. Compiling librealsense with `-DFORCE_LIBUVC=ON` shows a warning about this:

```
In file included from /home/gekko/librealsense/src/libuvc/stream.cpp:40:
/home/gekko/librealsense/src/libuvc/stream.cpp: In function ‘uvc_error_t uvc_query_stream_ctrl(uvc_device_handle_t*, uvc_stream_ctrl_t*, uint8_t, uvc_req_code)’:
/home/gekko/librealsense/src/libuvc/libuvc_internal.h:31:35: warning: left shift count >= width of type [-Wshift-count-overflow]
                        ((p)[4] << 32) |((p)[5] << 40) |((p)[6] << 48) |((p)[7] << 56))
                                   ^~
/home/gekko/librealsense/src/libuvc/stream.cpp:274:35: note: in expansion of macro ‘QW_TO_QUAD’
         ctrl->bmLayoutPerStream = QW_TO_QUAD(buf + 40);
                                   ^~~~~~~~~~
/home/gekko/librealsense/src/libuvc/libuvc_internal.h:31:51: warning: left shift count >= width of type [-Wshift-count-overflow]
                        ((p)[4] << 32) |((p)[5] << 40) |((p)[6] << 48) |((p)[7] << 56))
                                                   ^~
/home/gekko/librealsense/src/libuvc/stream.cpp:274:35: note: in expansion of macro ‘QW_TO_QUAD’
         ctrl->bmLayoutPerStream = QW_TO_QUAD(buf + 40);
                                   ^~~~~~~~~~
/home/gekko/librealsense/src/libuvc/libuvc_internal.h:31:67: warning: left shift count >= width of type [-Wshift-count-overflow]
                        ((p)[4] << 32) |((p)[5] << 40) |((p)[6] << 48) |((p)[7] << 56))
                                                                   ^~
/home/gekko/librealsense/src/libuvc/stream.cpp:274:35: note: in expansion of macro ‘QW_TO_QUAD’
         ctrl->bmLayoutPerStream = QW_TO_QUAD(buf + 40);
                                   ^~~~~~~~~~
/home/gekko/librealsense/src/libuvc/libuvc_internal.h:31:83: warning: left shift count >= width of type [-Wshift-count-overflow]
                        ((p)[4] << 32) |((p)[5] << 40) |((p)[6] << 48) |((p)[7] << 56))
                                                                                   ^~
/home/gekko/librealsense/src/libuvc/stream.cpp:274:35: note: in expansion of macro ‘QW_TO_QUAD’
         ctrl->bmLayoutPerStream = QW_TO_QUAD(buf + 40);
                                   ^~~~~~~~~~
```

This PR changes the shifts to use 64-bit types.