### PR TITLE
Update doxygen of pose_sensor

### DIFF
--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -425,6 +425,15 @@ namespace rs2
         std::shared_ptr<rs2_device_list> _list;
     };
 
+    /**
+     * The tm2 class is an interface for T2XX devices, such as T265.
+     *
+     * For T265, it provides RS2_STREAM_FISHEYE (2), RS2_STREAM_GYRO, RS2_STREAM_ACCEL, and RS2_STREAM_POSE streams,
+     * and contains the following sensors:
+     *
+     * - pose_sensor: map and relocalization functions.
+     * - wheel_odometer: input for odometry data.
+     */
     class tm2 : public device //TODO: add to wrappers
     {
     public:

--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -449,10 +449,15 @@ namespace rs2
             error::handle(e);
         }
 
-        /** Load SLAM localization map from host to device
-        * \param[in] lmap_buf   localization map blob
-        * \return true on success
-        */
+        /**
+         * Load relocalization map onto device. Only one relocalization map can be imported at a time;
+         * any previously existing map will be overwritten.
+         * The imported map exists simultaneously with the map created during the most tracking session after start(),
+         * and they are merged after the imported map is relocalized.
+         * This operation must be done before start().
+         * \param[in] lmap_buf map data as a binary blob
+         * \return true if success
+         */
         bool import_localization_map(const std::vector<uint8_t>& lmap_buf) const
         {
             rs2_error* e = nullptr;
@@ -461,9 +466,11 @@ namespace rs2
             return !!res;
         }
 
-        /** Extract SLAM localization map from device and store on host
-        * \return - localization map blob
-        */
+        /**
+         * Get relocalization map that is currently on device, created and updated during most recent tracking session.
+         * Can be called before or after stop().
+         * \return map data as a binary blob
+         */
         std::vector<uint8_t> export_localization_map() const
         {
             rs2_error* e = nullptr;
@@ -486,12 +493,16 @@ namespace rs2
             return results;
         }
 
-        /** Create a named reference frame anchored to a specific 3D pose
-        * \param[in] guid   String to designate the reference (limited to 127 chars)
-        * \param[in] pos    3D Pose position in meters
-        * \param[in] orient 3D Pose attitude (quaternion)
-        * \return true on success
-        */
+        /**
+         * Creates a named virtual landmark in the current map, known as static node.
+         * The static node's pose is provided relative to the origin of current coordinate system of device poses.
+         * This function fails if the current tracker confidence is below 3 (high confidence).
+         * \param[in] guid unique name of the static node (limited to 127 chars).
+         * If a static node with the same name already exists in the current map or the imported map, the static node is overwritten.
+         * \param[in] pos position of the static node in the 3D space.
+         * \param[in] orient_quat orientation of the static node in the 3D space, represented by a unit quaternion.
+         * \return true if success.
+         */
         bool set_static_node(const std::string& guid, const rs2_vector& pos, const rs2_quaternion& orient) const
         {
             rs2_error* e = nullptr;
@@ -501,12 +512,17 @@ namespace rs2
         }
 
 
-        /** Retrieve a named reference frame anchored to a specific 3D pose
-        * \param[in] guid       String to designate the reference (limited to 127 chars)
-        * \param[out] pos       3D Pose position in meters
-        * \param[out] orient    3D Pose attitude (quaternion)
-        * \return true on success
-        */
+        /**
+         * Gets the current pose of a static node that was created in the current map or in an imported map.
+         * Static nodes of imported maps are available after relocalizing the imported map.
+         * The static node's pose is returned relative to the current origin of coordinates of device poses.
+         * Thus, poses of static nodes of an imported map are consistent with current device poses after relocalization.
+         * This function fails if the current tracker confidence is below 3 (high confidence).
+         * \param[in] guid unique name of the static node (limited to 127 chars).
+         * \param[out] pos position of the static node in the 3D space.
+         * \param[out] orient_quat orientation of the static node in the 3D space, represented by a unit quaternion.
+         * \return true if success.
+         */
         bool get_static_node(const std::string& guid, rs2_vector& pos, rs2_quaternion& orient) const
         {
             rs2_error* e = nullptr;

--- a/src/tm2/tm-device.h
+++ b/src/tm2/tm-device.h
@@ -96,49 +96,9 @@ namespace librealsense
         void set_manual_exposure(bool manual);
 
         // Pose interfaces
-
-        /**
-         * Get relocalization map that is currently on device, created and updated during most recent tracking session.
-         * Can be called before or after stop().
-         * \param[out] lmap_buf map data as a binary blob
-         * \return true if success
-         */
         bool export_relocalization_map(std::vector<uint8_t>& lmap_buf) const override;
-
-        /**
-         * Load relocalization map onto device. Only one relocalization map can be imported at a time;
-         * any previously existing map will be overwritten.
-         * The imported map exists simultaneously with the map created during the most tracking session after start(),
-         * and they are merged after the imported map is relocalized.
-         * This operation must be done before start().
-         * \param[in] lmap_buf map data as a binary blob
-         * \return true if success
-         */
         bool import_relocalization_map(const std::vector<uint8_t>& lmap_buf) const override;
-
-        /**
-         * Creates a named virtual landmark in the current map, known as static node.
-         * The static node's pose is provided relative to the origin of current coordinate system of device poses.
-         * This function fails if the current tracker confidence is below 3 (high confidence).
-         * \param[in] guid unique name of the static node. If a static node with the same name already exists
-         * in the current map or the imported map, the static node is overwritten.
-         * \param[in] pos position of the static node in the 3D space.
-         * \param[in] orient_quat orientation of the static node in the 3D space, represented by a unit quaternion.
-         * \return true if success.
-         */
         bool set_static_node(const std::string& guid, const float3& pos, const float4& orient_quat) const override;
-
-        /**
-         * Gets the current pose of a static node that was created in the current map or in an imported map.
-         * Static nodes of imported maps are available after relocalizing the imported map.
-         * The static node's pose is returned relative to the current origin of coordinates of device poses.
-         * Thus, poses of static nodes of an imported map are consistent with current device poses after relocalization.
-         * This function fails if the current tracker confidence is below 3 (high confidence).
-         * \param[in] guid unique name of the static node.
-         * \param[out] pos position of the static node in the 3D space.
-         * \param[out] orient_quat orientation of the static node in the 3D space, represented by a unit quaternion.
-         * \return true if success.
-         */
         bool get_static_node(const std::string& guid, float3& pos, float4& orient_quat) const override;
 
         // Wheel odometer


### PR DESCRIPTION
This places the doxygen doc of `pose_sensor` in the correct place and adds links from `tm2` device to its sensors.