### PR TITLE
Rename foreach to foreachRS

### DIFF
--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -943,7 +943,7 @@ namespace rs2
         frame first_or_default(rs2_stream s, rs2_format f = RS2_FORMAT_ANY) const
         {
             frame result;
-            foreach([&result, s, f](frame frm) {
+            foreachRS([&result, s, f](frame frm) {
                 if (!result && frm.get_profile().stream_type() == s && (f == RS2_FORMAT_ANY || f == frm.get_profile().format()))
                 {
                     result = std::move(frm);
@@ -1003,7 +1003,7 @@ namespace rs2
             }
             else
             {
-                foreach([&f, index](const frame& frm) {
+                foreachRS([&f, index](const frame& frm) {
                     if (frm.get_profile().stream_type() == RS2_STREAM_INFRARED &&
                         frm.get_profile().stream_index() == index) f = frm;
                 });
@@ -1025,7 +1025,7 @@ namespace rs2
             }
             else
             {
-                foreach([&f, index](const frame& frm) {
+                foreachRS([&f, index](const frame& frm) {
                     if (frm.get_profile().stream_type() == RS2_STREAM_FISHEYE &&
                         frm.get_profile().stream_index() == index) f = frm;
                 });
@@ -1047,7 +1047,7 @@ namespace rs2
             }
             else
             {
-                foreach([&f, index](const frame& frm) {
+                foreachRS([&f, index](const frame& frm) {
                     if (frm.get_profile().stream_type() == RS2_STREAM_POSE &&
                         frm.get_profile().stream_index() == index) f = frm;
                 });
@@ -1069,7 +1069,7 @@ namespace rs2
         * \param[in] action - instance with () operator implemented will be invoke after frame extraction.
         */
         template<class T>
-        void foreach(T action) const
+        void foreachRS(T action) const
         {
             rs2_error* e = nullptr;
             auto count = size();

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -943,7 +943,7 @@ namespace rs2
         frame first_or_default(rs2_stream s, rs2_format f = RS2_FORMAT_ANY) const
         {
             frame result;
-            foreachRS([&result, s, f](frame frm) {
+            foreach_rs([&result, s, f](frame frm) {
                 if (!result && frm.get_profile().stream_type() == s && (f == RS2_FORMAT_ANY || f == frm.get_profile().format()))
                 {
                     result = std::move(frm);
@@ -1003,7 +1003,7 @@ namespace rs2
             }
             else
             {
-                foreachRS([&f, index](const frame& frm) {
+                foreach_rs([&f, index](const frame& frm) {
                     if (frm.get_profile().stream_type() == RS2_STREAM_INFRARED &&
                         frm.get_profile().stream_index() == index) f = frm;
                 });
@@ -1025,7 +1025,7 @@ namespace rs2
             }
             else
             {
-                foreachRS([&f, index](const frame& frm) {
+                foreach_rs([&f, index](const frame& frm) {
                     if (frm.get_profile().stream_type() == RS2_STREAM_FISHEYE &&
                         frm.get_profile().stream_index() == index) f = frm;
                 });
@@ -1047,7 +1047,7 @@ namespace rs2
             }
             else
             {
-                foreachRS([&f, index](const frame& frm) {
+                foreach_rs([&f, index](const frame& frm) {
                     if (frm.get_profile().stream_type() == RS2_STREAM_POSE &&
                         frm.get_profile().stream_index() == index) f = frm;
                 });
@@ -1069,7 +1069,7 @@ namespace rs2
         * \param[in] action - instance with () operator implemented will be invoke after frame extraction.
         */
         template<class T>
-        void foreachRS(T action) const
+        void foreach_rs(T action) const
         {
             rs2_error* e = nullptr;
             auto count = size();

--- a/src/proc/align.cpp
+++ b/src/proc/align.cpp
@@ -192,8 +192,8 @@ namespace librealsense
 
         //process composite frame only if it contains both a depth frame and the requested texture frame
         bool has_tex = false, has_depth = false;
-        set.foreach([this, &has_tex](const rs2::frame& frame) { if (frame.get_profile().stream_type() == _to_stream_type) has_tex = true; });
-        set.foreach([&has_depth](const rs2::frame& frame)
+        set.foreachRS([this, &has_tex](const rs2::frame& frame) { if (frame.get_profile().stream_type() == _to_stream_type) has_tex = true; });
+        set.foreachRS([&has_depth](const rs2::frame& frame)
             { if (frame.get_profile().stream_type() == RS2_STREAM_DEPTH && frame.get_profile().format() == RS2_FORMAT_Z16) has_depth = true; });
         if (!has_tex || !has_depth)
             return false;
@@ -259,9 +259,9 @@ namespace librealsense
         _depth_scale = ((librealsense::depth_frame*)depth.get())->get_units();
 
         if (_to_stream_type == RS2_STREAM_DEPTH)
-            frames.foreach([&other_frames](const rs2::frame& f) {if ((f.get_profile().stream_type() != RS2_STREAM_DEPTH) && f.is<rs2::video_frame>()) other_frames.push_back(f); });
+            frames.foreachRS([&other_frames](const rs2::frame& f) {if ((f.get_profile().stream_type() != RS2_STREAM_DEPTH) && f.is<rs2::video_frame>()) other_frames.push_back(f); });
         else
-            frames.foreach([this, &other_frames](const rs2::frame& f) {if (f.get_profile().stream_type() == _to_stream_type) other_frames.push_back(f); });
+            frames.foreachRS([this, &other_frames](const rs2::frame& f) {if (f.get_profile().stream_type() == _to_stream_type) other_frames.push_back(f); });
 
         if (_to_stream_type == RS2_STREAM_DEPTH)
         {

--- a/src/proc/align.cpp
+++ b/src/proc/align.cpp
@@ -192,8 +192,8 @@ namespace librealsense
 
         //process composite frame only if it contains both a depth frame and the requested texture frame
         bool has_tex = false, has_depth = false;
-        set.foreachRS([this, &has_tex](const rs2::frame& frame) { if (frame.get_profile().stream_type() == _to_stream_type) has_tex = true; });
-        set.foreachRS([&has_depth](const rs2::frame& frame)
+        set.foreach_rs([this, &has_tex](const rs2::frame& frame) { if (frame.get_profile().stream_type() == _to_stream_type) has_tex = true; });
+        set.foreach_rs([&has_depth](const rs2::frame& frame)
             { if (frame.get_profile().stream_type() == RS2_STREAM_DEPTH && frame.get_profile().format() == RS2_FORMAT_Z16) has_depth = true; });
         if (!has_tex || !has_depth)
             return false;
@@ -259,9 +259,9 @@ namespace librealsense
         _depth_scale = ((librealsense::depth_frame*)depth.get())->get_units();
 
         if (_to_stream_type == RS2_STREAM_DEPTH)
-            frames.foreachRS([&other_frames](const rs2::frame& f) {if ((f.get_profile().stream_type() != RS2_STREAM_DEPTH) && f.is<rs2::video_frame>()) other_frames.push_back(f); });
+            frames.foreach_rs([&other_frames](const rs2::frame& f) {if ((f.get_profile().stream_type() != RS2_STREAM_DEPTH) && f.is<rs2::video_frame>()) other_frames.push_back(f); });
         else
-            frames.foreachRS([this, &other_frames](const rs2::frame& f) {if (f.get_profile().stream_type() == _to_stream_type) other_frames.push_back(f); });
+            frames.foreach_rs([this, &other_frames](const rs2::frame& f) {if (f.get_profile().stream_type() == _to_stream_type) other_frames.push_back(f); });
 
         if (_to_stream_type == RS2_STREAM_DEPTH)
         {

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -120,7 +120,7 @@ namespace librealsense
 
         std::vector<rs2::frame> original_set;
         if (auto composite = input.as<rs2::frameset>())
-            composite.foreach([&](const rs2::frame& frame)
+            composite.foreachRS([&](const rs2::frame& frame)
             {
                 auto format = frame.get_profile().format();
                 if (depth_result_frame && (format == RS2_FORMAT_DISPARITY32 || format == RS2_FORMAT_DISPARITY16))

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -120,7 +120,7 @@ namespace librealsense
 
         std::vector<rs2::frame> original_set;
         if (auto composite = input.as<rs2::frameset>())
-            composite.foreachRS([&](const rs2::frame& frame)
+            composite.foreach_rs([&](const rs2::frame& frame)
             {
                 auto format = frame.get_profile().format();
                 if (depth_result_frame && (format == RS2_FORMAT_DISPARITY32 || format == RS2_FORMAT_DISPARITY16))

--- a/src/proc/zero-order.cpp
+++ b/src/proc/zero-order.cpp
@@ -488,7 +488,7 @@ namespace librealsense
     {
         if (auto composite = input.as<rs2::frameset>())
         {
-            composite.foreachRS([&](rs2::frame f)
+            composite.foreach_rs([&](rs2::frame f)
             {
                 if (f.get_profile().stream_type() != RS2_STREAM_DEPTH && f.get_profile().stream_type() != RS2_STREAM_INFRARED && f.get_profile().stream_type() != RS2_STREAM_CONFIDENCE && 
                     results.size() > 0)

--- a/src/proc/zero-order.cpp
+++ b/src/proc/zero-order.cpp
@@ -488,7 +488,7 @@ namespace librealsense
     {
         if (auto composite = input.as<rs2::frameset>())
         {
-            composite.foreach([&](rs2::frame f) 
+            composite.foreachRS([&](rs2::frame f)
             {
                 if (f.get_profile().stream_type() != RS2_STREAM_DEPTH && f.get_profile().stream_type() != RS2_STREAM_INFRARED && f.get_profile().stream_type() != RS2_STREAM_CONFIDENCE && 
                     results.size() > 0)

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -368,7 +368,7 @@ bool is_equal(rs2::frameset org, rs2::frameset processed)
     {
         auto curr_profile = o.get_profile();
         bool found = false;
-        processed.foreach([&curr_profile, &found](const rs2::frame& f)
+        processed.foreachRS([&curr_profile, &found](const rs2::frame& f)
         {
             auto processed_profile = f.get_profile();
             if (curr_profile.unique_id() == processed_profile.unique_id())
@@ -552,7 +552,7 @@ TEST_CASE("Post-Processing processing pipe", "[post-processing-filters]")
         full_pipe = full_pipe.apply_filter(pc);
 
         //printf("test frame:\n");
-        full_pipe.foreach([&](const rs2::frame& f) {
+        full_pipe.foreachRS([&](const rs2::frame& f) {
             uids.insert(f.get_profile().unique_id());
             //printf("stream: %s, format: %d, uid: %d\n", f.get_profile().stream_name().c_str(), f.get_profile().format(), f.get_profile().unique_id());
         });

--- a/unit-tests/unit-tests-post-processing.cpp
+++ b/unit-tests/unit-tests-post-processing.cpp
@@ -368,7 +368,7 @@ bool is_equal(rs2::frameset org, rs2::frameset processed)
     {
         auto curr_profile = o.get_profile();
         bool found = false;
-        processed.foreachRS([&curr_profile, &found](const rs2::frame& f)
+        processed.foreach_rs([&curr_profile, &found](const rs2::frame& f)
         {
             auto processed_profile = f.get_profile();
             if (curr_profile.unique_id() == processed_profile.unique_id())
@@ -552,7 +552,7 @@ TEST_CASE("Post-Processing processing pipe", "[post-processing-filters]")
         full_pipe = full_pipe.apply_filter(pc);
 
         //printf("test frame:\n");
-        full_pipe.foreachRS([&](const rs2::frame& f) {
+        full_pipe.foreach_rs([&](const rs2::frame& f) {
             uids.insert(f.get_profile().unique_id());
             //printf("stream: %s, format: %d, uid: %d\n", f.get_profile().stream_name().c_str(), f.get_profile().format(), f.get_profile().unique_id());
         });

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -256,7 +256,7 @@ void init_frame(py::module &m) {
         .def("size", &rs2::frameset::size, "Return the size of the frameset")
         .def("__len__", &rs2::frameset::size, "Return the size of the frameset")
         .def("foreach", [](const rs2::frameset& self, std::function<void(rs2::frame)> callable) {
-            self.foreachRS(callable);
+            self.foreach_rs(callable);
         }, "Extract internal frame handles from the frameset and invoke the action function", "callable"_a)
         .def("__getitem__", &rs2::frameset::operator[])
         .def("get_depth_frame", &rs2::frameset::get_depth_frame, "Retrieve the first depth frame, if no frame is found, return an empty frame instance.")

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -256,7 +256,7 @@ void init_frame(py::module &m) {
         .def("size", &rs2::frameset::size, "Return the size of the frameset")
         .def("__len__", &rs2::frameset::size, "Return the size of the frameset")
         .def("foreach", [](const rs2::frameset& self, std::function<void(rs2::frame)> callable) {
-            self.foreach(callable);
+            self.foreachRS(callable);
         }, "Extract internal frame handles from the frameset and invoke the action function", "callable"_a)
         .def("__getitem__", &rs2::frameset::operator[])
         .def("get_depth_frame", &rs2::frameset::get_depth_frame, "Retrieve the first depth frame, if no frame is found, return an empty frame instance.")


### PR DESCRIPTION
Fix @cgpadwick's pull request #2470 (renaming `frameset::foreach` to `frameset::foreachRS` to avoid conflict with QT foreach macro).
Fixes issue #4461