### PR TITLE
Fix default path bug in viewer

### DIFF
--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -23,6 +23,13 @@ namespace rs2
             return res;
         }
 
+		// When converting config_value to string, we can't use >> operator since it reads until first whitespace rather than the whole string;
+		// Therefore we use a different overload for strings
+		operator std::string()
+		{
+			return _val;
+		}
+		
         config_value(std::string val) : _val(std::move(val)) {}
 
     private:


### PR DESCRIPTION
`config_value` which is used by `config_file` had a bug in conversion to string, causing issues with paths that contain whitespaces. As a result, default path for recording was corrupt for usernames containing whitespace. Fixed by adding a separate conversion from `config_value` to `std::string`.

Solves: #3779