### PR TITLE
Fix memory leak in hid sensor

### DIFF
--- a/src/mf/mf-hid.cpp
+++ b/src/mf/mf-hid.cpp
@@ -207,6 +207,7 @@ namespace librealsense
 
                 pSensor->GetFriendlyName(&fName);
                 d.sensor.name = CW2A(fName);
+                SysFreeString(fName); // free string after it was copied to sensor data
 
                 d.fo.pixels = &data;
                 d.fo.metadata = &meta_data;

--- a/src/mf/mf-hid.h
+++ b/src/mf/mf-hid.h
@@ -27,6 +27,7 @@ namespace librealsense
                 }
 
                 _name = CW2A(fName);
+                SysFreeString(fName);
             };
 
             const std::string& get_sensor_name() const { return _name; }


### PR DESCRIPTION
Free string `fName` in `mf-hid.cpp` after it was used, to avoid memory leaks in accel and gyro streams on windows.

Fixes: #4332