### PR TITLE
rs-rosbag-inspector crash fix

### DIFF
--- a/tools/rosbag-inspector/rs-rosbag-inspector.cpp
+++ b/tools/rosbag-inspector/rs-rosbag-inspector.cpp
@@ -82,6 +82,7 @@ private:
     void init_window()
     {
         glfwMakeContextCurrent(_window);
+        gladLoadGLLoader((GLADloadproc)glfwGetProcAddress);
         glfwSetWindowUserPointer(_window, &files);
 
         glfwSetDropCallback(_window, [](GLFWwindow* w, int count, const char** paths)


### PR DESCRIPTION
Added a call to `gladLoadGLLoader()` in `init_window` to avoid segmentation fault when calling openGL functions.

fixes: #4704, #4932