### PR TITLE
Upgrade T265 firmware to 0.2.0.857

### DIFF
--- a/third-party/libtm/fw/CMakeLists.txt
+++ b/third-party/libtm/fw/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 cmake_minimum_required(VERSION 3.1.3)
 
-set( FW_VERSION "0.1.0.279")
-set( FW_SHA1 3b30f13e04a932a261d7d5f59a9b7ca0fd342758)
+set( FW_VERSION "0.2.0.857")
+set( FW_SHA1 7b2d8ad77d4f0c64b3d20f4dd45447124bd00637)
 set(APP_VERSION "2.0.19.271")
 set(APP_SHA1 cab0011e9e18edc8bcca20afb2f944399ac8b81c)
 set( BL_VERSION "1.0.1.112")

--- a/third-party/libtm/libtm/include/TrackingCommon.h
+++ b/third-party/libtm/libtm/include/TrackingCommon.h
@@ -65,6 +65,7 @@ namespace perc {
         Stereo = 9,
         Pose = 10,
         ControllerProperty = 11,
+        Mask = 12,
         Max
     };
 

--- a/third-party/libtm/libtm/src/Device.cpp
+++ b/third-party/libtm/libtm/src/Device.cpp
@@ -202,6 +202,11 @@ namespace perc {
                     break;
                 }
 
+                case SensorType::Mask:
+                {
+                    break;
+                }
+
                 default:
                     DEVICELOGE("Unknown SensorType support (0x%X)", GET_SENSOR_TYPE(streams[i].bSensorID));
                     break;


### PR DESCRIPTION
  - Mask API (to convey image locations to avoid when detecting features)
  - Cross-device localization maps
  - Numerical stability improvements
  - 2.5x lower latency for relocalizations
