### PR TITLE
Disable GLOBAL_TIME option

### DIFF
--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -20,6 +20,7 @@ namespace librealsense
             ctx);
 
         color_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+        color_ep->get_option(RS2_OPTION_GLOBAL_TIME_ENABLED).set(0);
         color_ep->register_pixel_format(pf_yuy2);
         color_ep->register_pixel_format(pf_yuyv);
 

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -113,6 +113,7 @@ namespace librealsense
             std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(timestamp_reader_metadata), _tf_keeper, enable_global_time_option)));
 
         depth_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+        depth_ep->get_option(RS2_OPTION_GLOBAL_TIME_ENABLED).set(0);
         depth_ep->register_xu(depth_xu);
         depth_ep->register_pixel_format(pf_z16_l500);
         depth_ep->register_pixel_format(pf_confidence_l500);

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -116,6 +116,7 @@ namespace librealsense
             l500_sensor_name_and_hid_profiles);
 
         hid_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
+        hid_ep->get_option(RS2_OPTION_GLOBAL_TIME_ENABLED).set(0);
         hid_ep->register_pixel_format(pf_accel_axes);
         hid_ep->register_pixel_format(pf_gyro_axes);
 


### PR DESCRIPTION
Disable global timestamp by default for specific SKU