### PR TITLE
Update t265_rpy.py

### DIFF
--- a/wrappers/python/examples/t265_rpy.py
+++ b/wrappers/python/examples/t265_rpy.py
@@ -37,9 +37,9 @@ try:
             # and https://github.com/IntelRealSense/librealsense/issues/5178#issuecomment-550217609
 
             w = data.rotation.w
-            x = data.rotation.z
+            x = -data.rotation.z
             y = data.rotation.x
-            z = data.rotation.y
+            z = -data.rotation.y
 
             pitch =  -m.asin(2.0 * (x*z - w*y)) * 180.0 / m.pi;
             roll  =  m.atan2(2.0 * (w*x + y*z), w*w - x*x - y*y + z*z) * 180.0 / m.pi;


### PR DESCRIPTION
Reverting regression regarding negative signs introduced with last commit to this PR. The negation of z and y is required in order to obtain similarity to the previous sample code (used in the ArduPilot project)