### PR TITLE
fix global timestamp domain query crash

### DIFF
--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/TimestampDomain.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/TimestampDomain.java
@@ -2,7 +2,8 @@ package com.intel.realsense.librealsense;
 
 public enum TimestampDomain {
     HARDWARE_CLOCK(0),
-    SYSTEM_TIME(1);
+    SYSTEM_TIME(1),
+    GLOBAL_TIME(2);
 
     private final int mValue;
 


### PR DESCRIPTION
DSO-13980

- Add missing global timestamp case to timestamp domain enum.