### PR TITLE
Fix save_to_ply symbols in python

### DIFF
--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -26,13 +26,13 @@ PYBIND11_MODULE(NAME, m) {
     init_export(m);
     init_advanced_mode(m);
     init_util(m);
-    py::class_<rs2::save_to_ply, rs2::filter> save_to_ply(m, "save_to_ply"); // No docstring in C++
-    save_to_ply.def(py::init<std::string, rs2::pointcloud>(), "filename"_a = "RealSense Pointcloud ", "pc"_a = rs2::pointcloud())
-        .def_readonly_static("option_ignore_color", &rs2::save_to_ply::OPTION_IGNORE_COLOR)
-        .def_readonly_static("option_ply_mesh", &rs2::save_to_ply::OPTION_PLY_MESH)
-        .def_readonly_static("option_ply_binary", &rs2::save_to_ply::OPTION_PLY_BINARY)
-        .def_readonly_static("option_ply_normals", &rs2::save_to_ply::OPTION_PLY_NORMALS)
-        .def_readonly_static("option_ply_threshold", &rs2::save_to_ply::OPTION_PLY_THRESHOLD);
+    py::class_<rs2::save_to_ply, rs2::filter>(m, "save_to_ply")
+        .def(py::init<std::string, rs2::pointcloud>(), "filename"_a = "RealSense Pointcloud ", "pc"_a = rs2::pointcloud())
+        .def_property_readonly_static("option_ignore_color", []() { return rs2::save_to_ply::OPTION_IGNORE_COLOR; })
+        .def_property_readonly_static("option_ply_mesh", []() { return rs2::save_to_ply::OPTION_PLY_MESH; })
+        .def_property_readonly_static("option_ply_binary", []() { return rs2::save_to_ply::OPTION_PLY_BINARY; })
+        .def_property_readonly_static("option_ply_normals", []() { return rs2::save_to_ply::OPTION_PLY_NORMALS; })
+        .def_property_readonly_static("option_ply_threshold", []() { return rs2::save_to_ply::OPTION_PLY_THRESHOLD; });
 
     /** rs.hpp **/
     m.def("log_to_console", &rs2::log_to_console, "min_severity"_a);


### PR DESCRIPTION
The core issue is that `static const` members are not instantiated anywhere python can access, so taking a reference to them doesn't work. Fix that by creating lambdas that return the value.