### PR TITLE
Added API for depth auto calibration.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -996,7 +996,7 @@ namespace rs2
             auto sensor_profiles = s->get_stream_profiles();
             reverse(begin(sensor_profiles), end(sensor_profiles));
             rs2_format def_format{ RS2_FORMAT_ANY };
-            std::pair<int, int> default_resolution;
+            auto default_resolution = std::make_pair(1280, 720);
             for (auto&& profile : sensor_profiles)
             {
                 std::stringstream res;

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -252,6 +252,17 @@ namespace rs2
         draw_text(get_title().c_str(), x, y, height - 35);
     }
 
+    void rs2::notification_model::draw_dismiss(ux_window & win, int x, int y)
+    {
+        ImGui::SetCursorScreenPos({ float(x + width - 105), float(y + height - 25) });
+
+        string id = to_string() << "Dismiss" << "##" << index;
+        if (ImGui::Button(id.c_str(), { 100, 20 }))
+        {
+            dismiss(true);
+        }
+    }
+
     std::function<void()> notification_model::draw(ux_window& win, int w, int y, 
         std::shared_ptr<notification_model>& selected, std::string& error_message)
     {
@@ -382,13 +393,7 @@ namespace rs2
 
             if (enable_dismiss)
             {
-                ImGui::SetCursorScreenPos({ float(x + width - 105), float(y + height - 25) });
-
-                string id = to_string() << "Dismiss" << "##" << index;
-                if (ImGui::Button(id.c_str(), { 100, 20 }))
-                {
-                    dismiss(true);
-                }
+                draw_dismiss(win, x, y);
             }
             
             unset_color_scheme();

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -47,6 +47,7 @@ namespace rs2
         virtual int calc_height();
         virtual void draw_pre_effect(int x, int y) {}
         virtual void draw_content(ux_window& win, int x, int y, float t, std::string& error_message);
+        virtual void draw_dismiss(ux_window& win, int x, int y);
         virtual void draw_expanded(ux_window& win, std::string& error_message) {}
 
         virtual void dismiss(bool snooze) { dismissed = true; snoozed = snooze; }
@@ -139,6 +140,7 @@ namespace rs2
 
         std::shared_ptr<process_manager> update_manager = nullptr;
         int update_state = 0;
+        bool tare = false;
         float progress_speed = 5.f;
         std::chrono::system_clock::time_point last_progress_time;
         int last_progress = 0;

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -140,7 +140,6 @@ namespace rs2
 
         std::shared_ptr<process_manager> update_manager = nullptr;
         int update_state = 0;
-        bool tare = false;
         float progress_speed = 5.f;
         std::chrono::system_clock::time_point last_progress_time;
         int last_progress = 0;

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -430,7 +430,7 @@ namespace rs2
 
         auto health = get_manager().get_health();
         auto recommend_keep = health > 0.15;
-        if (!recommend_keep && update_state == RS2_CALIB_STATE_CALIB_COMPLETE && !tare)
+        if (!recommend_keep && update_state == RS2_CALIB_STATE_CALIB_COMPLETE && !get_manager().tare)
         {
             auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 
@@ -455,8 +455,6 @@ namespace rs2
         ImVec4 shadow{ 1.f, 1.f, 1.f, 0.1f };
         ImGui::GetWindowDrawList()->AddRectFilled({ float(x), float(y) },
         { float(x + width), float(y + 25) }, ImColor(shadow));
-
-        tare = update_state == RS2_CALIB_STATE_TARE_INPUT;
 
         if (update_state != RS2_CALIB_STATE_COMPLETE)
         {
@@ -666,6 +664,7 @@ namespace rs2
                 {
                     get_manager().restore_workspace([this](std::function<void()> a) { a(); });
                     get_manager().reset();
+                    get_manager().tare = false;
                     get_manager().start(shared_from_this());
                     update_state = RS2_CALIB_STATE_CALIB_IN_PROCESS;
                     enable_dismiss = false;
@@ -873,7 +872,7 @@ namespace rs2
 
                 auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 
-                if (recommend_keep || tare)
+                if (recommend_keep || get_manager().tare)
                 {
                     ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
                     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
@@ -897,7 +896,7 @@ namespace rs2
 
                     get_manager().restore_workspace([this](std::function<void()> a) { a(); });
                 }
-                if (recommend_keep || tare)
+                if (recommend_keep || get_manager().tare)
                 {
                     ImGui::PopStyleColor(2);
                 }

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -16,61 +16,6 @@
 
 namespace rs2
 {
-#pragma pack(push, 1)
-#pragma pack(1)
-    struct table_header
-    {
-        uint16_t version;        // major.minor. Big-endian
-        uint16_t table_type;     // ctCalibration
-        uint32_t table_size;     // full size including: TOC header + TOC + actual tables
-        uint32_t param;          // This field content is defined ny table type
-        uint32_t crc32;          // crc of all the actual table data excluding header/CRC
-    };
-
-    enum rs2_dsc_status : uint16_t
-    {
-        RS2_DSC_STATUS_SUCCESS = 0, /**< Self calibration succeeded*/
-        RS2_DSC_STATUS_RESULT_NOT_READY = 1, /**< Self calibration result is not ready yet*/
-        RS2_DSC_STATUS_FILL_FACTOR_TOO_LOW = 2, /**< There are too little textures in the scene*/
-        RS2_DSC_STATUS_EDGE_TOO_CLOSE = 3, /**< Self calibration range is too small*/
-        RS2_DSC_STATUS_NOT_CONVERGE = 4, /**< For tare calibration only*/
-        RS2_DSC_STATUS_BURN_SUCCESS = 5,
-        RS2_DSC_STATUS_BURN_ERROR = 6,
-        RS2_DSC_STATUS_NO_DEPTH_AVERAGE = 7,
-    };
-
-#define MAX_STEP_COUNT 256
-
-    struct DirectSearchCalibrationResult
-    {
-        uint32_t opcode;
-        uint16_t status;      // DscStatus
-        uint16_t stepCount;
-        uint16_t stepSize; // 1/1000 of a pixel
-        uint32_t pixelCountThreshold; // minimum number of pixels in
-                                      // selected bin
-        uint16_t minDepth;  // Depth range for FWHM
-        uint16_t maxDepth;
-        uint32_t rightPy;   // 1/1000000 of normalized unit
-        float healthCheck;
-        float rightRotation[9]; // Right rotation
-        //uint16_t results[0]; // 1/100 of a percent
-    };
-
-    typedef struct
-    {
-        uint16_t m_status;
-        float    m_healthCheck;
-    } DscResultParams;
-
-    typedef struct
-    {
-        uint16_t m_paramSize;
-        DscResultParams m_dscResultParams;
-        uint16_t m_tableSize;
-    } DscResultBuffer;
-#pragma pack(pop)
-
     void on_chip_calib_manager::stop_viewer(invoker invoke)
     {
         try
@@ -362,10 +307,6 @@ namespace rs2
 
     void on_chip_calib_manager::calibrate()
     {
-        rs2_dsc_status status = RS2_DSC_STATUS_BURN_SUCCESS;
-
-        DirectSearchCalibrationResult result;
-
         std::stringstream ss;
         ss << "{\n \"speed\":" << speed <<
                ",\n \"average_step_count\":" << average_step_count <<

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -162,8 +162,9 @@ namespace rs2
             {
                 for (int i = 0; i < _sub->shared_fps_values.size(); i++)
                 {
-                    if (_sub->shared_fps_values[i] == 30)
+                    //if (_sub->shared_fps_values[i] == 30)
                         _sub->ui.selected_shared_fps_id = i;
+                        if (_sub->is_selected_combination_supported()) break;
                 }
 
                 // If still not supported, try VGA30
@@ -365,165 +366,20 @@ namespace rs2
 
         DirectSearchCalibrationResult result;
 
+        std::stringstream ss;
+        ss << "{\n \"speed\":" << speed <<
+               ",\n \"average_step_count\":" << average_step_count <<
+               ",\n \"step_count\":" << step_count <<
+               ",\n \"accuracy\":" << accuracy <<"}";
+
+        std::string json = ss.str();
+        
+
+        auto calib_dev = _dev.as<auto_calibrated_device>();
         if (tare)
-        {
-            std::vector<uint8_t> cmd =
-            {
-                0x14, 0x00, 0xab, 0xcd,
-                0x80, 0x00, 0x00, 0x00,
-                0x0b, 0x00, 0x00, 0x00,
-                0xb8, 0x0b, 0x00, 0x00,
-                0x1e, 0x1e, 0x03, 0x00,
-                0x00, 0x00, 0x00, 0x00
-            };
-            uint32_t* param2 = (uint32_t*)cmd.data() + 3;
-            *param2 = ground_truth * 100;
-            cmd.data()[16] = average_step_count;
-            cmd.data()[17] = step_count;
-            cmd.data()[18] = accuracy;
-
-            safe_send_command(cmd, "START_TARE");
-
-            // While not ready...
-            int count = 0;
-            bool done = false;
-            do
-            {
-                memset(&result, 0, sizeof(DirectSearchCalibrationResult));
-
-                std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-                // Check calibration status
-                cmd =
-                {
-                    0x14, 0x00, 0xab, 0xcd,
-                    0x80, 0x00, 0x00, 0x00,
-                    0x0c, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00
-                };
-
-                try
-                {
-                    auto res = safe_send_command(cmd, "CALIB_STATUS");
-
-                    if (res.size() < sizeof(int32_t) + sizeof(DirectSearchCalibrationResult))
-                        throw std::runtime_error("Not enough data from CALIB_STATUS!");
-
-                    result = *reinterpret_cast<DirectSearchCalibrationResult*>(res.data());
-                    done = result.status != RS2_DSC_STATUS_RESULT_NOT_READY;
-                }
-                catch (const std::exception& ex)
-                {
-                    log(to_string() << "Warning: " << ex.what());
-                }
-
-                _progress = count * (2 * speed);
-            } while (count++ < 200 && !done);
-
-            // If we exit due to counter, report timeout
-            if (!done)
-            {
-                throw std::runtime_error("Operation timed-out!\n"
-                    "Calibration state did not converged in time");
-            }
-
-            status = (rs2_dsc_status)result.status;
-        }
+            _new_calib = calib_dev.run_tare_calibration(ground_truth, 5000, json, &_health, [&](const float progress) {_progress = progress;});
         else
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-            // Begin auto-calibration
-            std::vector<uint8_t> cmd =
-            {
-                0x14, 0x00, 0xab, 0xcd,
-                0x80, 0x00, 0x00, 0x00,
-                0x08, 0x00, 0x00, 0x00,
-                (uint8_t)speed, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00
-            };
-
-            safe_send_command(cmd, "START_CALIB");
-
-            memset(&result, 0, sizeof(DirectSearchCalibrationResult));
-
-            // While not ready...
-            int count = 0;
-            bool done = false;
-            do
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-                // Check calibration status
-                cmd =
-                {
-                    0x14, 0x00, 0xab, 0xcd,
-                    0x80, 0x00, 0x00, 0x00,
-                    0x03, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x00
-                };
-
-                try
-                {
-                    auto res = safe_send_command(cmd, "CALIB_STATUS");
-
-                    if (res.size() < sizeof(int32_t) + sizeof(DirectSearchCalibrationResult))
-                        throw std::runtime_error("Not enough data from CALIB_STATUS!");
-
-                    result = *reinterpret_cast<DirectSearchCalibrationResult*>(res.data());
-                    done = result.status != RS2_DSC_STATUS_RESULT_NOT_READY;
-                }
-                catch (const std::exception& ex)
-                {
-                    log(to_string() << "Warning: " << ex.what());
-                }
-
-                _progress = count * (2 * speed);
-
-            } while (count++ < 200 && !done);
-
-            // If we exit due to counter, report timeout
-            if (!done)
-            {
-                throw std::runtime_error("Operation timed-out!\n"
-                    "Calibration state did not converged in time");
-            }
-
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-            status = (rs2_dsc_status)result.status;
-        }
-
-        // Handle errors from firmware
-        if (status != RS2_DSC_STATUS_SUCCESS)
-        {
-            if (status == RS2_DSC_STATUS_EDGE_TOO_CLOSE)
-            {
-                throw std::runtime_error("Calibration didn't converge! (EDGE_TO_CLOSE)\n"
-                    "Please retry in different lighting conditions");
-            }
-            else if (status == RS2_DSC_STATUS_FILL_FACTOR_TOO_LOW)
-            {
-                throw std::runtime_error("Not enough depth pixels! (FILL_FACTOR_LOW)\n"
-                    "Please retry in different lighting conditions");
-            }
-            else if (status == RS2_DSC_STATUS_NOT_CONVERGE)
-            {
-                throw std::runtime_error("Calibration didn't converge! (NOT_CONVERGE)\n"
-                    "Please retry in different lighting conditions");
-            }
-            else if (status == RS2_DSC_STATUS_NO_DEPTH_AVERAGE)
-            {
-                throw std::runtime_error("Calibration didn't converge! (NO_AVERAGE)\n"
-                    "Please retry in different lighting conditions");
-            }
-            else throw std::runtime_error(to_string() << "Calibration didn't converge! (RESULT=" << result.status << ")");
-        }
+            _new_calib = calib_dev.run_on_chip_calibration(5000, json, &_health, [&](const float progress) {_progress = progress;});
     }
 
     void on_chip_calib_manager::process_flow(std::function<void()> cleanup, 
@@ -536,21 +392,8 @@ namespace rs2
         _in_3d_view = _viewer.is_3d_view;
         _viewer.is_3d_view = true;
 
-        // Fetch current calibration using GETINITCAL command
-        std::vector<uint8_t> fetch_calib{
-            0x14, 0, 0xAB, 0xCD, 0x15, 0, 0, 0, 0x19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        };
-        auto calib = safe_send_command(fetch_calib, "GETINITCAL");
-        if (calib.size() < sizeof(table_header) + sizeof(int32_t)) throw std::runtime_error("Missing calibration header from GETINITCAL!");
-
-        auto table = (uint8_t*)(calib.data() + sizeof(int32_t) + sizeof(table_header));
-        auto hd = (table_header*)(calib.data() + sizeof(int32_t));
-
-        if (calib.size() < sizeof(table_header) + sizeof(int32_t) + hd->table_size) 
-            throw std::runtime_error("Table truncated from GETINITCAL!");
-
-        _old_calib.resize(sizeof(table_header) + hd->table_size, 0);
-        memcpy(_old_calib.data(), hd, _old_calib.size()); // Copy to old_calib
+        auto calib_dev = _dev.as<auto_calibrated_device>();
+        _old_calib = calib_dev.get_calibration_table();
 
         _was_streaming = _sub->streaming;
         _synchronized = _viewer.synchronization_enable.load();
@@ -576,45 +419,7 @@ namespace rs2
         // Switch into special Auto-Calibration mode
         start_viewer(256, 144, 90, invoke);
 
-        if (speed == 4) // White-wall
-        {
-            if (_sub->s->supports(RS2_OPTION_VISUAL_PRESET))
-            {
-                log("Switching into High-Quality preset for White-Wall mode");
-                _sub->s->set_option(RS2_OPTION_VISUAL_PRESET, 3.f);
-                std::this_thread::sleep_for(std::chrono::milliseconds(200));
-            }
-        }
-
         calibrate();
-
-        // Get new calibration from the firmware
-        std::vector<uint8_t> cmd =
-        {
-            0x14, 0x00, 0xab, 0xcd,
-            0x80, 0x00, 0x00, 0x00,
-            13, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00
-        };
-
-        auto res = safe_send_command(cmd, "CALIB_RESULT");
-
-        if (res.size() < sizeof(int32_t) + sizeof(DscResultBuffer))
-            throw std::runtime_error("Not enough data from CALIB_STATUS!");
-
-        auto result = (DscResultBuffer*)(res.data() + sizeof(int32_t));
-
-        table_header* header = reinterpret_cast<table_header*>(res.data() + sizeof(int32_t) + sizeof(DscResultBuffer));
-
-        if (res.size() < sizeof(int32_t) + sizeof(DscResultBuffer) + sizeof(table_header) + header->table_size)
-            throw std::runtime_error("Table truncated in CALIB_STATUS!");
-
-        _new_calib.resize(sizeof(table_header) + header->table_size, 0);
-        memcpy(_new_calib.data(), header, _new_calib.size()); // Copy to new_calib
-
-        _health = abs(result->m_dscResultParams.m_healthCheck);
 
         log(to_string() << "Calibration completed, health factor = " << _health);
 
@@ -666,37 +471,35 @@ namespace rs2
     void on_chip_calib_manager::keep()
     {
         // Write new calibration using SETINITCAL command
-        uint16_t size = (uint16_t)(0x14 + _new_calib.size());
+        auto calib_dev = _dev.as<auto_calibrated_device>();
+        calib_dev.write_calibration();
 
-        std::vector<uint8_t> save_calib{
-            0x14, 0, 0xAB, 0xCD, 0x16, 0, 0, 0, 0x19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-        };
-
-        auto up = (uint16_t*)save_calib.data();
-        up[0] = size;
-
-        save_calib.insert(save_calib.end(), _new_calib.data(), _new_calib.data() + _new_calib.size());
-
-        safe_send_command(save_calib, "SETINITCAL");
     }
 
     void on_chip_calib_manager::apply_calib(bool use_new)
     {
-        table_header* hd = (table_header*)(use_new ? _new_calib.data() : _old_calib.data());
-        uint8_t* table = (uint8_t*)((use_new ? _new_calib.data() : _old_calib.data()) + sizeof(table_header));
+        auto calib_dev = _dev.as<auto_calibrated_device>();
+        calib_dev.set_calibration_table(use_new ? _new_calib : _old_calib);
+    }
 
-        uint16_t size = (uint16_t)(0x14 + hd->table_size);
+    void autocalib_notification_model::draw_dismiss(ux_window& win, int x, int y)
+    {
+        using namespace std;
+        using namespace chrono;
 
-        std::vector<uint8_t> apply_calib{
-            0x14, 0, 0xAB, 0xCD, 0x51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xfe, 0xca, 0xfe, 0xca
-        };
+        auto health = get_manager().get_health();
+        auto recommend_keep = health > 0.15;
+        if (!recommend_keep && update_state == RS2_CALIB_STATE_CALIB_COMPLETE && !tare)
+        {
+            auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 
-        auto up = (uint16_t*)apply_calib.data();
-        up[0] = size;
-
-        apply_calib.insert(apply_calib.end(), (uint8_t*)table, ((uint8_t*)table) + hd->table_size);
-
-        safe_send_command(apply_calib, "CALIBRECALC");
+            ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
+            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
+            notification_model::draw_dismiss(win, x, y);
+            ImGui::PopStyleColor(2);
+        }
+        else
+            notification_model::draw_dismiss(win, x, y);
     }
 
     void autocalib_notification_model::draw_content(ux_window& win, int x, int y, float t, std::string& error_message)
@@ -712,6 +515,8 @@ namespace rs2
         ImGui::GetWindowDrawList()->AddRectFilled({ float(x), float(y) },
         { float(x + width), float(y + 25) }, ImColor(shadow));
 
+        tare = update_state == RS2_CALIB_STATE_TARE_INPUT;
+
         if (update_state != RS2_CALIB_STATE_COMPLETE)
         {
             if (update_state == RS2_CALIB_STATE_INITIAL_PROMPT)
@@ -720,12 +525,15 @@ namespace rs2
                      update_state == RS2_CALIB_STATE_CALIB_COMPLETE ||
                      update_state == RS2_CALIB_STATE_SELF_INPUT)
                 ImGui::Text("%s", "On-Chip Calibration");
-            else if (update_state == RS2_CALIB_STATE_TARE_INPUT)
+            else if (update_state == RS2_CALIB_STATE_TARE_INPUT || update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
                 ImGui::Text("%s", "Tare Calibration");
             if (update_state == RS2_CALIB_STATE_FAILED)
                 ImGui::Text("%s", "Calibration Failed");
 
-            ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
+            if (update_state == RS2_CALIB_STATE_TARE_INPUT || update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
+                ImGui::SetCursorScreenPos({ float(x + width - 30), float(y) });
+            else
+                ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
 
             ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1. - t));
 
@@ -748,56 +556,106 @@ namespace rs2
                 enable_dismiss = false;
                 ImGui::Text("%s", "Camera is being calibrated...\nKeep the camera stationary pointing at a wall");
             }
-            else if (update_state == RS2_CALIB_STATE_TARE_INPUT)
+            else if (update_state == RS2_CALIB_STATE_TARE_INPUT || update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
             {
-                ImGui::SetCursorScreenPos({ float(x + 9), float(y + 33) });
-                ImGui::Text("%s", "Avg Step Count:");
+                ImGui::PushStyleColor(ImGuiCol_Text, update_state != RS2_CALIB_STATE_TARE_INPUT_ADVANCED ? light_grey : light_blue);
+                ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, update_state != RS2_CALIB_STATE_TARE_INPUT_ADVANCED ? light_grey : light_blue);
 
-                ImGui::SetCursorScreenPos({ float(x + 135), float(y + 30) });
+                if (ImGui::Button(u8"\uf0d7"))
+                {
+                    if (update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
+                        update_state = RS2_CALIB_STATE_TARE_INPUT;
+                    else
+                        update_state = RS2_CALIB_STATE_TARE_INPUT_ADVANCED;
+                }
 
-                std::string id = to_string() << "##avg_step_count_" << index;
-                ImGui::PushItemWidth(width - 145);
-                ImGui::SliderInt(id.c_str(), &get_manager().average_step_count, 1, 30);
-                ImGui::PopItemWidth();
+                if (ImGui::IsItemHovered())
+                {
+                    if(update_state == RS2_CALIB_STATE_TARE_INPUT)
+                        ImGui::SetTooltip("%s", "More Options...");
+                    else
+                        ImGui::SetTooltip("%s", "Less Options...");
+                }
 
-                //-------------------------
+                ImGui::PopStyleColor(2);
+                if(update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
+                {
+                    ImGui::SetCursorScreenPos({ float(x + 9), float(y + 33) });
+                    ImGui::Text("%s", "Avg Step Count:");
+                    if (ImGui::IsItemHovered())
+                    {
+                        ImGui::SetTooltip("%s", "Number of frames to average, Min = 1, Max = 30, Default = 10");
+                    }
+                    ImGui::SetCursorScreenPos({ float(x + 135), float(y + 30) });
 
-                ImGui::SetCursorScreenPos({ float(x + 9), float(y + 38 + ImGui::GetTextLineHeightWithSpacing()) });
-                ImGui::Text("%s", "Step Count:");
+                    std::string id = to_string() << "##avg_step_count_" << index;
+                    ImGui::PushItemWidth(width - 145);
+                    ImGui::SliderInt(id.c_str(), &get_manager().average_step_count, 1, 30);
+                    ImGui::PopItemWidth();
 
-                ImGui::SetCursorScreenPos({ float(x + 135), float(y + 35 + ImGui::GetTextLineHeightWithSpacing()) });
+                    //-------------------------
 
-                id = to_string() << "##step_count_" << index;
+                    ImGui::SetCursorScreenPos({ float(x + 9), float(y + 38 + ImGui::GetTextLineHeightWithSpacing()) });
+                    ImGui::Text("%s", "Step Count:");
+                    if (ImGui::IsItemHovered())
+                    {
+                        ImGui::SetTooltip("%s", "Max iteration steps, Min = 5, Max = 30, Default = 10");
+                    }
+                    ImGui::SetCursorScreenPos({ float(x + 135), float(y + 35 + ImGui::GetTextLineHeightWithSpacing()) });
 
-                ImGui::PushItemWidth(width - 145);
-                ImGui::SliderInt(id.c_str(), &get_manager().step_count, 1, 30);
-                ImGui::PopItemWidth();
+                    id = to_string() << "##step_count_" << index;
 
-                //-------------------------
+                    ImGui::PushItemWidth(width - 145);
+                    ImGui::SliderInt(id.c_str(), &get_manager().step_count, 1, 30);
+                    ImGui::PopItemWidth();
 
-                ImGui::SetCursorScreenPos({ float(x + 9), float(y + 43 + 2 * ImGui::GetTextLineHeightWithSpacing()) });
-                ImGui::Text("%s", "Accuracy:");
+                    //-------------------------
 
-                ImGui::SetCursorScreenPos({ float(x + 135), float(y + 40 + 2 * ImGui::GetTextLineHeightWithSpacing()) });
+                    ImGui::SetCursorScreenPos({ float(x + 9), float(y + 43 + 2 * ImGui::GetTextLineHeightWithSpacing()) });
+                    ImGui::Text("%s", "Accuracy:");
+                    if (ImGui::IsItemHovered())
+                    {
+                        ImGui::SetTooltip("%s", "Subpixel accuracy level, Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%)");
+                    }
 
-                id = to_string() << "##accuracy_" << index;
+                    ImGui::SetCursorScreenPos({ float(x + 135), float(y + 40 + 2 * ImGui::GetTextLineHeightWithSpacing()) });
 
-                std::vector<std::string> vals{ "Very High", "High", "Medium", "Low" };
-                std::vector<const char*> vals_cstr;
-                for (auto&& s : vals) vals_cstr.push_back(s.c_str());
+                    id = to_string() << "##accuracy_" << index;
 
-                ImGui::PushItemWidth(width - 145);
-                ImGui::Combo(id.c_str(), &get_manager().accuracy, vals_cstr.data(), vals.size());
-                ImGui::PopItemWidth();
+                    std::vector<std::string> vals{ "Very High", "High", "Medium", "Low" };
+                    std::vector<const char*> vals_cstr;
+                    for (auto&& s : vals) vals_cstr.push_back(s.c_str());
 
-                //-------------------------
+                    ImGui::PushItemWidth(width - 145);
+                    ImGui::Combo(id.c_str(), &get_manager().accuracy, vals_cstr.data(), vals.size());
+                   
+                    ImGui::SetCursorScreenPos({ float(x + 135), float(y + 35 + ImGui::GetTextLineHeightWithSpacing()) });
 
-                ImGui::SetCursorScreenPos({ float(x + 9), float(y + 48 + 3 * ImGui::GetTextLineHeightWithSpacing()) });
-                ImGui::Text("%s", "Ground Truth(mm):");
+                    ImGui::PopItemWidth();
+                }
 
-                ImGui::SetCursorScreenPos({ float(x + 135), float(y + 45 + 3 * ImGui::GetTextLineHeightWithSpacing()) });
+                if (update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
+                {
+                    ImGui::SetCursorScreenPos({ float(x + 9), float(y + 48 + 3 * ImGui::GetTextLineHeightWithSpacing()) });
+                    ImGui::Text("%s", "Ground Truth(mm):");
+                    ImGui::SetCursorScreenPos({ float(x + 135), float(y + 45 + 3 * ImGui::GetTextLineHeightWithSpacing()) });
+                }
+                else
+                {
+                    ImGui::SetCursorScreenPos({ float(x + 9), float(y + 33) });
+                    ImGui::Text("%s", "Ground Truth(mm):");
+                    ImGui::SetCursorScreenPos({ float(x + 135), float(y + 28) });
+                }
 
-                id = to_string() << "##ground_truth_for_tare" << index;
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("%s", "Tare depth in 1 / 100 of depth unit, Min = 2500, Max = 2000000");
+                }
+                
+
+                //ImGui::SetCursorScreenPos({ float(x + 135), float(y + 45 + 3 * ImGui::GetTextLineHeightWithSpacing()) });
+
+                std::string id = to_string() << "##ground_truth_for_tare" << index;
 
                 std::string gt = to_string() << get_manager().ground_truth;
                 const int MAX_SIZE = 256;
@@ -911,7 +769,7 @@ namespace rs2
             {
                 auto health = get_manager().get_health();
 
-                auto recommend_keep = get_manager().allow_calib_keep();
+                auto recommend_keep = health > 0.15;
 
                 ImGui::SetCursorScreenPos({ float(x + 15), float(y + 33) });
 
@@ -921,7 +779,7 @@ namespace rs2
                 }
                 else
                 {
-                    ImGui::Text("%s", "Calibration Error: ");
+                    ImGui::Text("%s", "Health-Check: ");
 
                     std::stringstream ss; ss << std::fixed << std::setprecision(2) << health;
                     auto health_str = ss.str();
@@ -963,41 +821,38 @@ namespace rs2
 
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Calibration error captures how far camera calibration is from the optimal one\n"
+                        ImGui::SetTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
                             "[0, 0.15) - Good\n"
                             "[0.15, 0.25) - Can be Improved\n"
                             "[0.25, ) - Requires Calibration");
                     }
                 }
 
-                if (recommend_keep)
+                auto old_fr = get_manager().get_metric(false).first;
+                auto new_fr = get_manager().get_metric(true).first;
+
+                auto old_rms = fabs(get_manager().get_metric(false).second);
+                auto new_rms = fabs(get_manager().get_metric(true).second);
+
+                auto fr_improvement = 100.f * ((new_fr - old_fr) / old_fr);
+                auto rms_improvement = 100.f * ((old_rms - new_rms) / old_rms);
+
+                std::string old_units = "mm";
+                if (old_rms > 10.f)
                 {
-                
-                    auto old_fr = get_manager().get_metric(false).first;
-                    auto new_fr = get_manager().get_metric(true).first;
+                    old_rms /= 10.f;
+                    old_units = "cm";
+                }
+                std::string new_units = "mm";
+                if (new_rms > 10.f)
+                {
+                    new_rms /= 10.f;
+                    new_units = "cm";
+                }
 
-                    auto old_rms = fabs(get_manager().get_metric(false).second);
-                    auto new_rms = fabs(get_manager().get_metric(true).second);
-
-                    auto fr_improvement = 100.f * ((new_fr - old_fr) / old_fr);
-                    auto rms_improvement = 100.f * ((old_rms - new_rms) / old_rms);
-
-                    std::string old_units = "mm";
-                    if (old_rms > 10.f)
-                    {
-                        old_rms /= 10.f;
-                        old_units = "cm";
-                    }
-                    std::string new_units = "mm";
-                    if (new_rms > 10.f)
-                    {
-                        new_rms /= 10.f;
-                        new_units = "cm";
-                    }
-
-                    // NOTE: Disabling metrics temporarily
-                    // TODO: Re-enable in future release
-                    if (/* fr_improvement > 1.f || rms_improvement > 1.f */ false)
+                // NOTE: Disabling metrics temporarily
+                // TODO: Re-enable in future release
+                if (/* fr_improvement > 1.f || rms_improvement > 1.f */ false)
                     {
                         std::string txt = to_string() << "  Fill-Rate: " << std::setprecision(1) << std::fixed << new_fr << "%%";
 
@@ -1054,58 +909,60 @@ namespace rs2
                             }
                         }
                     }
-                    else
-                    {
-                        ImGui::SetCursorScreenPos({ float(x + 12), float(y + 100) });
-                        ImGui::Text("%s", "Please compare new vs old calibration\nand decide if to keep or discard the result...");
-                    }
+                else
+                {
+                    ImGui::SetCursorScreenPos({ float(x + 12), float(y + 100) });
+                    ImGui::Text("%s", "Please compare new vs old calibration\nand decide if to keep or discard the result...");
+                }
 
-                    ImGui::SetCursorScreenPos({ float(x + 9), float(y + 60) });
+                ImGui::SetCursorScreenPos({ float(x + 9), float(y + 60) });
 
-                    if (ImGui::RadioButton("New", use_new_calib))
-                    {
-                        use_new_calib = true;
-                        get_manager().apply_calib(true);
-                    }
+                if (ImGui::RadioButton("New", use_new_calib))
+                {
+                    use_new_calib = true;
+                    get_manager().apply_calib(true);
+                }
 
-                    ImGui::SetCursorScreenPos({ float(x + 150), float(y + 60) });
-                    if (ImGui::RadioButton("Original", !use_new_calib))
-                    {
-                        use_new_calib = false;
-                        get_manager().apply_calib(false);
-                    }
+                ImGui::SetCursorScreenPos({ float(x + 150), float(y + 60) });
+                if (ImGui::RadioButton("Original", !use_new_calib))
+                {
+                    use_new_calib = false;
+                    get_manager().apply_calib(false);
+                }
 
-                    auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
+                auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 
-                
+                if (recommend_keep || tare)
+                {
                     ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
                     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
+                }
+                
+                std::string button_name = to_string() << "Apply New" << "##apply" << index;
+                if (!use_new_calib) button_name = to_string() << "Keep Original" << "##original" << index;
 
-                    std::string button_name = to_string() << "Apply New" << "##apply" << index;
-                    if (!use_new_calib) button_name = to_string() << "Keep Original" << "##original" << index;
-
-                    ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 25) });
-                    if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
+                ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 25) });
+                if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
+                {
+                    if (use_new_calib)
                     {
-                        if (use_new_calib)
-                        {
-                            get_manager().keep();
-                            update_state = RS2_CALIB_STATE_COMPLETE;
-                            pinned = false;
-                            enable_dismiss = false;
-                            last_progress_time = last_interacted = system_clock::now() + milliseconds(500);
-                        }
-                        else dismiss(false);
-
-                        get_manager().restore_workspace([this](std::function<void()> a) { a(); });
+                        get_manager().keep();
+                        update_state = RS2_CALIB_STATE_COMPLETE;
+                        pinned = false;
+                        enable_dismiss = false;
+                        last_progress_time = last_interacted = system_clock::now() + milliseconds(500);
                     }
+                    else dismiss(false);
 
+                    get_manager().restore_workspace([this](std::function<void()> a) { a(); });
+                }
+                if (recommend_keep || tare)
+                {
                     ImGui::PopStyleColor(2);
-
-                    if (ImGui::IsItemHovered())
-                    {
-                        ImGui::SetTooltip("%s", "New calibration values will be saved in device memory");
-                    }
+                }
+                if (ImGui::IsItemHovered())
+                {
+                    ImGui::SetTooltip("%s", "New calibration values will be saved in device memory");
                 }
             }
 
@@ -1289,7 +1146,8 @@ namespace rs2
             else return 80;
         }
         else if (update_state == RS2_CALIB_STATE_SELF_INPUT) return 85;
-        else if (update_state == RS2_CALIB_STATE_TARE_INPUT) return 160;
+        else if (update_state == RS2_CALIB_STATE_TARE_INPUT) return 85;
+        else if (update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED) return 160;
         else return 100;
     }
 

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -28,7 +28,7 @@ namespace rs2
         {
         }
 
-        bool allow_calib_keep() const { return get_health() > 0.15 || tare; }
+        bool allow_calib_keep() const { return true; }
 
         // Get health number from the calibration summary
         float get_health() const { return _health; }
@@ -66,7 +66,7 @@ namespace rs2
 
         void process_flow(std::function<void()> cleanup, invoker invoke) override;
 
-        float _health = 0.f;
+        float _health = -1.0f;
         device _dev;
 
         bool _was_streaming = false;
@@ -100,6 +100,7 @@ namespace rs2
             RS2_CALIB_STATE_CALIB_IN_PROCESS,// Calibration in process... Shows progressbar
             RS2_CALIB_STATE_CALIB_COMPLETE,  // Calibration complete, show before/after toggle and metrics
             RS2_CALIB_STATE_TARE_INPUT,      // Collect input parameters for Tare calib
+            RS2_CALIB_STATE_TARE_INPUT_ADVANCED,      // Collect input parameters for Tare calib
             RS2_CALIB_STATE_SELF_INPUT,      // Collect input parameters for Self calib
         };
 
@@ -112,6 +113,7 @@ namespace rs2
 
         void set_color_scheme(float t) const override;
         void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
+        void draw_dismiss(ux_window& win, int x, int y) override;
         void draw_expanded(ux_window& win, std::string& error_message) override;
         int calc_height() override;
         void dismiss(bool snooze) override;

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -49,7 +49,7 @@ namespace rs2
 
         uint32_t ground_truth = 2500;
         int average_step_count = 20;
-        int step_count = 10;
+        int step_count = 20;
         int accuracy = 2;
         int speed = 3;
         bool tare = false;

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -49,7 +49,7 @@ namespace rs2
 
         uint32_t ground_truth = 2500;
         int average_step_count = 20;
-        int step_count = 20;
+        int step_count = 10;
         int accuracy = 2;
         int speed = 3;
         bool tare = false;

--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -241,6 +241,44 @@ void rs2_update_firmware_unsigned(const rs2_device* device, const void* fw_image
 */
 void rs2_enter_update_state(const rs2_device* device, rs2_error** error);
 
+/**
+* This will improve the depth noise.
+* \param[in] timeout_ms         timeout in ms
+* \param[in] json_content       json file to configure speed parameter
+* \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
+                                [0, 0.15) - Good
+                                [0.15, 0.25) - Can be Improved
+                                [0.25, ) - Requires Calibration
+* \param[in] callback           callback to get progress notifications
+* \return                       new calibration table
+*/
+const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error);
+
+/**
+* This will adjust camera absolute distance to flat target. User needs to enter the known ground truth.
+* \param[in] ground_truth_mm     ground truth in mm
+* \param[in] timeout_ms          timeout in ms
+* \param[in] json_content        json file to configure: average step count - number of frames to average,
+                                                         step Count - max iteration steps
+                                                         Accuracy - Subpixel accuracy level, Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%)
+* \param[out] health             Calibration Health-Check captures how far camera calibration is from the optimal one
+* \param[in] callback            callback to get progress notifications
+* \return                        new calibration table
+*/
+const rs2_raw_data_buffer* rs2_run_tare_calibration_cpp(rs2_device* dev, float ground_truth_mm, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error);
+
+/**
+*  Read current calibration table from flash.
+* \return    calibration table
+*/
+const rs2_raw_data_buffer* rs2_get_calibration_table(const rs2_device* dev, rs2_error** error);
+
+/**
+*  Set current table to dynamic area.
+* \param[in]     calibration table
+*/
+void rs2_set_calibration_table(const rs2_device* device, const void* calibration, int calibration_size, rs2_error** error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -255,7 +255,7 @@ void rs2_enter_update_state(const rs2_device* device, rs2_error** error);
                                 [0.15, 0.25) - Can be Improved
                                 [0.25, ) - Requires Calibration
 * \param[in] callback           Callback to get progress notifications
-* \return                       Nnew calibration table
+* \return                       New calibration table
 */
 const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error);
 

--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -243,39 +243,52 @@ void rs2_enter_update_state(const rs2_device* device, rs2_error** error);
 
 /**
 * This will improve the depth noise.
-* \param[in] timeout_ms         timeout in ms
-* \param[in] json_content       json file to configure speed parameter
+* \param[in] timeout_ms         Timeout in ms
+* \param[in] json_content       Json file to configure speed on chip calibration parameters:
+                                    {
+                                      "speed": 3
+                                    }
+                                speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
+                                if json is nullptr it will be ignored and calibration will use the defualt parameters
 * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
                                 [0, 0.15) - Good
                                 [0.15, 0.25) - Can be Improved
                                 [0.25, ) - Requires Calibration
-* \param[in] callback           callback to get progress notifications
-* \return                       new calibration table
+* \param[in] callback           Callback to get progress notifications
+* \return                       Nnew calibration table
 */
 const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error);
 
 /**
 * This will adjust camera absolute distance to flat target. User needs to enter the known ground truth.
-* \param[in] ground_truth_mm     ground truth in mm
-* \param[in] timeout_ms          timeout in ms
-* \param[in] json_content        json file to configure: average step count - number of frames to average,
-                                                         step Count - max iteration steps
-                                                         Accuracy - Subpixel accuracy level, Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%)
+* \param[in] ground_truth_mm     Ground truth in mm must be between 2500 - 2000000
+* \param[in] timeout_ms          Timeout in ms
+* \param[in] json_content        Json file to configure tare calibration parametars:
+                                    {
+                                      "average_step_count": 20,
+                                      "step_count": 20,
+                                      "accuracy": 2
+                                    }
+                                    average step count - number of frames to average, must be between 1 - 30, default = 20
+                                    step count - max iteration steps, must be between 5 - 30, default = 10
+                                    accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
+                                 if json is nullptr it will be ignored and calibration will use the defualt parameters
+* \param[in] content_size        Json file size if its 0 the json will be ignored and calibration will use the defualt parameters
 * \param[out] health             Calibration Health-Check captures how far camera calibration is from the optimal one
-* \param[in] callback            callback to get progress notifications
-* \return                        new calibration table
+* \param[in] callback            Callback to get progress notifications
+* \return                        New calibration table
 */
 const rs2_raw_data_buffer* rs2_run_tare_calibration_cpp(rs2_device* dev, float ground_truth_mm, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error);
 
 /**
 *  Read current calibration table from flash.
-* \return    calibration table
+* \return    Calibration table
 */
 const rs2_raw_data_buffer* rs2_get_calibration_table(const rs2_device* dev, rs2_error** error);
 
 /**
 *  Set current table to dynamic area.
-* \param[in]     calibration table
+* \param[in]     Calibration table
 */
 void rs2_set_calibration_table(const rs2_device* device, const void* calibration, int calibration_size, rs2_error** error);
 

--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -173,7 +173,7 @@ typedef enum rs2_extension
     RS2_EXTENSION_UPDATE_DEVICE,
     RS2_EXTENSION_L500_DEPTH_SENSOR,
     RS2_EXTENSION_TM2_SENSOR,
-    RS2_EXTENSION_AUTO_CALIBRARED_DEVICE,
+    RS2_EXTENSION_AUTO_CALIBRATED_DEVICE,
     RS2_EXTENSION_COUNT
 } rs2_extension;
 const char* rs2_extension_type_to_string(rs2_extension type);

--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -173,6 +173,7 @@ typedef enum rs2_extension
     RS2_EXTENSION_UPDATE_DEVICE,
     RS2_EXTENSION_L500_DEPTH_SENSOR,
     RS2_EXTENSION_TM2_SENSOR,
+    RS2_EXTENSION_AUTO_CALIBRARED_DEVICE,
     RS2_EXTENSION_COUNT
 } rs2_extension;
 const char* rs2_extension_type_to_string(rs2_extension type);

--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -289,7 +289,7 @@ return results;
             : device(d.get())
         {
             rs2_error* e = nullptr;
-            if (rs2_is_device_extendable_to(_dev.get(), RS2_EXTENSION_AUTO_CALIBRARED_DEVICE, &e) == 0 && !e)
+            if (rs2_is_device_extendable_to(_dev.get(), RS2_EXTENSION_AUTO_CALIBRATED_DEVICE, &e) == 0 && !e)
             {
                 _dev.reset();
             }
@@ -298,14 +298,19 @@ return results;
 
         /**
         * This will improve the depth noise.
-        * \param[in] timeout_ms         timeout in ms
-        * \param[in] json_content       json file to configure speed parameter
+        * \param[in] timeout_ms         Timeout in ms
+        * \param[in] json_content       Json file to configure speed on chip calibration parameters:
+                                            {
+                                              "speed": 3
+                                            }
+                                        speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is Slow
+                                        if json is nullptr it will be ignored and calibration will use the defualt parameters
         * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
                                         [0, 0.15) - Good
                                         [0.15, 0.25) - Can be Improved
                                         [0.25, ) - Requires Calibration
-        * \param[in] callback           callback to get progress notifications
-        * \return                       new calibration table
+        * \param[in] callback           Callback to get progress notifications
+        * \return                       Nnew calibration table
         */
         template<class T>
         std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json_content, float* health, T callback) const
@@ -329,14 +334,19 @@ return results;
         }
 
         /**
-        * This will improve the depth noise (plane fit RMS).
-        * \param[in] timeout_ms      timeout in ms
-        * \param[in] json_content    json file to configure speed parameter
-        * \param[out] health         Calibration Health-Check captures how far camera calibration is from the optimal one
-                                     [0, 0.15) - Good
-                                     [0.15, 0.25) - Can be Improved
-                                     [0.25, ) - Requires Calibration
-        * \return                    new calibration table
+        * This will improve the depth noise.
+        * \param[in] timeout_ms         Timeout in ms
+        * \param[in] json_content       Json file to configure speed on chip calibration parameters:
+                                            {
+                                              "speed": 3
+                                            }
+                                        speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
+                                        if json is nullptr it will be ignored and calibration will use the defualt parameters
+        * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
+                                        [0, 0.15) - Good
+                                        [0.15, 0.25) - Can be Improved
+                                        [0.25, ) - Requires Calibration
+        * \return                       Nnew calibration table
         */
         std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json_content, float* health) const
         {
@@ -359,14 +369,22 @@ return results;
 
         /**
         * This will adjust camera absolute distance to flat target. User needs to enter the known ground truth.
-        * \param[in] ground_truth_mm     ground truth in mm
-        * \param[in] timeout_ms          timeout in ms
-        * \param[in] json_content        json file to configure: average step count - number of frames to average,
-                                                                 step Count - max iteration steps
-                                                                 Accuracy - Subpixel accuracy level, Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%)
+        * \param[in] ground_truth_mm     Ground truth in mm must be between 2500 - 2000000
+        * \param[in] timeout_ms          Timeout in ms
+        * \param[in] json_content        Json file to configure tare calibration parametars:
+                                            {
+                                              "average_step_count": 20,
+                                              "step_count": 20,
+                                              "accuracy": 2
+                                            }
+                                            average step count - number of frames to average, must be between 1 - 30, default = 20
+                                            step count - max iteration steps, must be between 5 - 30, default = 10
+                                            accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
+                                         if json is nullptr it will be ignored and calibration will use the defualt parameters
+        * \param[in] content_size        Json file size if its 0 the json will be ignored and calibration will use the defualt parameters
         * \param[out] health             Calibration Health-Check captures how far camera calibration is from the optimal one
-        * \param[in] callback            callback to get progress notifications
-        * \return                        new calibration table
+        * \param[in] callback            Callback to get progress notifications
+        * \return                        New calibration table
         */
         template<class T>
         std::vector<uint8_t> run_tare_calibration(float ground_truth_mm, int timeout_ms, std::string json_content, float* health, T callback) const
@@ -391,13 +409,21 @@ return results;
 
         /**
         * This will adjust camera absolute distance to flat target. User needs to enter the known ground truth.
-        * \param[in] ground_truth_mm     ground truth in mm
-        * \param[in] timeout_ms          timeout in ms
-        * \param[in] json_content        json file to configure: average step count - number of frames to average,
-                                                                step Count - max iteration steps
-                                                                Accuracy - Subpixel accuracy level, Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%)
+        * \param[in] ground_truth_mm     Ground truth in mm must be between 2500 - 2000000
+        * \param[in] timeout_ms          Timeout in ms
+        * \param[in] json_content        Json file to configure tare calibration parametars:
+                                            {
+                                              "average_step_count": 20,
+                                              "step_count": 20,
+                                              "accuracy": 2
+                                            }
+                                            average step count - number of frames to average, must be between 1 - 30, default = 20
+                                            step count - max iteration steps, must be between 5 - 30, default = 10
+                                            accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
+                                         if json is nullptr it will be ignored and calibration will use the defualt parameters
+        * \param[in] content_size        Json file size if its 0 the json will be ignored and calibration will use the defualt parameters
         * \param[out] health             Calibration Health-Check captures how far camera calibration is from the optimal one
-        * \return                        new calibration table
+        * \return                        New calibration table
         */
         std::vector<uint8_t> run_tare_calibration(float ground_truth_mm, int timeout_ms, std::string json_content, float* health) const
         {
@@ -421,7 +447,7 @@ return results;
 
         /**
         *  Read current calibration table from flash.
-        * \return    calibration table
+        * \return    Calibration table
         */
         std::vector<uint8_t> get_calibration_table()
         {
@@ -445,7 +471,7 @@ return results;
 
         /**
         *  Set current table to dynamic area.
-        * \param[in]     calibration table
+        * \param[in]     Calibration table
         */
         void set_calibration_table(const std::vector<uint8_t>& calibration)
         {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,4 +120,5 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/types.h"
         "${CMAKE_CURRENT_LIST_DIR}/command_transfer.h"
         "${CMAKE_CURRENT_LIST_DIR}/frame-validator.h"
+        "${CMAKE_CURRENT_LIST_DIR}/auto-calibrated-device.h"
 )

--- a/src/auto-calibrated-device.h
+++ b/src/auto-calibrated-device.h
@@ -1,0 +1,22 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "types.h"
+#include "core/streaming.h"
+
+namespace librealsense
+{
+    class auto_calibrated_interface
+    {
+    public:
+        virtual void write_calibration() const = 0;
+        virtual std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json, float* health, update_progress_callback_ptr progress_callback) = 0;
+        virtual std::vector<uint8_t> run_tare_calibration( int timeout_ms, float ground_truth_mm, std::string json, float* health, update_progress_callback_ptr progress_callback) = 0;
+        virtual std::vector<uint8_t> get_calibration_table() const = 0;
+        virtual void set_calibration_table(const std::vector<uint8_t>& calibration) = 0;
+        virtual void reset_to_factory_calibration() const = 0;
+    };
+    MAP_EXTENSION(RS2_EXTENSION_AUTO_CALIBRARED_DEVICE, auto_calibrated_interface);
+}

--- a/src/auto-calibrated-device.h
+++ b/src/auto-calibrated-device.h
@@ -18,5 +18,5 @@ namespace librealsense
         virtual void set_calibration_table(const std::vector<uint8_t>& calibration) = 0;
         virtual void reset_to_factory_calibration() const = 0;
     };
-    MAP_EXTENSION(RS2_EXTENSION_AUTO_CALIBRARED_DEVICE, auto_calibrated_interface);
+    MAP_EXTENSION(RS2_EXTENSION_AUTO_CALIBRATED_DEVICE, auto_calibrated_interface);
 }

--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -156,6 +156,7 @@ namespace librealsense
         static const uint16_t HW_MONITOR_BUFFER_SIZE = 1024;
 
     private:
+        friend class auto_calibrated;
         void set_exposure(synthetic_sensor& sensor, const exposure_control& val);
         void set_auto_exposure(synthetic_sensor& sensor, const auto_exposure_control& val);
         void get_exposure(synthetic_sensor& sensor, exposure_control* ptr) const;

--- a/src/ds5/CMakeLists.txt
+++ b/src/ds5/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/rs_advanced_mode.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/presets.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/advanced_mode.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/ds5-auto-calibration.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/ds5-factory.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds5-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds5-options.h"
@@ -26,5 +27,5 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/ds5-color.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds5-fw-update-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/json_loader.hpp"
-        "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/presets.h"
+        "${CMAKE_CURRENT_LIST_DIR}/ds5-auto-calibration.h"
 )

--- a/src/ds5/CMakeLists.txt
+++ b/src/ds5/CMakeLists.txt
@@ -27,5 +27,6 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/ds5-color.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds5-fw-update-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/json_loader.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/presets.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds5-auto-calibration.h"
 )

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -233,7 +233,7 @@ namespace librealsense
         return recover_preset;
     }
 
-    void auto_calibrated::check_params()
+    void auto_calibrated::check_params() const
     {
         if (_speed < speed_very_fast || _speed >  speed_white_wall)
             throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'speed' " << _speed << " is out of range (0 - 4).");

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -322,6 +322,11 @@ namespace librealsense
 
     void auto_calibrated::write_calibration() const
     {
+        using namespace ds;
+
+        if(_curr_calibration.size() < sizeof(table_header))
+            throw std::runtime_error("Write calibration can be called only after set calibration table was called");
+
         command write_calib( ds::SETINTCAL, set_coefficients );
         write_calib.data = _curr_calibration;
         _hw_monitor->send(write_calib);

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -1,0 +1,324 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2016 Intel Corporation. All Rights Reserved.
+
+#include "ds5-auto-calibration.h"
+#include "../third-party/json.hpp"
+#include "ds5-device.h"
+
+namespace librealsense
+{
+    enum auto_calib_sub_cmd : uint8_t
+    {
+        auto_calib_begin = 0x08,
+        auto_calib_check_status = 0x03,
+        tare_calib_begin = 0x0b,
+        tare_calib_check_status = 0x0c,
+        get_calibration_result = 0x0d,
+        set_coefficients = 0x19
+    };
+
+    auto_calibrated::auto_calibrated(std::shared_ptr<hw_monitor>& hwm)
+        :_hw_monitor(hwm){}
+
+    std::map<std::string, int> auto_calibrated::parse_json(std::string json_content)
+    {
+        using json = nlohmann::json;
+
+         auto j = json::parse(json_content);
+
+        std::map<std::string, int> values;
+
+        for (json::iterator it = j.begin(); it != j.end(); ++it)
+        {
+            values[it.key()] = it.value();
+        }
+        return values;
+    }
+
+    std::vector<uint8_t> auto_calibrated::run_on_chip_calibration(int timeout_ms, std::string json, float* health, update_progress_callback_ptr progress_callback)
+    {
+        if (json.size() > 0)
+        {
+            auto jsn = parse_json(json);
+            if (jsn.find("speed") != jsn.end())
+            {
+                _speed = jsn["speed"];
+            }
+        }
+
+        std::shared_ptr<ds5_advanced_mode_base> preset_recover;
+        if (_speed == 4)
+            preset_recover = change_preset();
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+        // Begin auto-calibration
+        _hw_monitor->send(command{ ds::AUTO_CALIB, auto_calib_begin, _speed });
+
+        DirectSearchCalibrationResult result;
+        memset(&result, 0, sizeof(DirectSearchCalibrationResult));
+
+        int count = 0;
+        bool done = false;
+
+        auto start = std::chrono::high_resolution_clock::now();
+        auto now = start;
+
+        // While not ready...
+        do
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+            // Check calibration status
+            try
+            {
+                auto res = _hw_monitor->send(command{ ds::AUTO_CALIB, auto_calib_check_status });
+
+                if (res.size() < sizeof(DirectSearchCalibrationResult))
+                    throw std::runtime_error("Not enough data from CALIB_STATUS!");
+
+                result = *reinterpret_cast<DirectSearchCalibrationResult*>(res.data());
+                done = result.status != RS2_DSC_STATUS_RESULT_NOT_READY;
+            }
+            catch (const std::exception& ex)
+            {
+                LOG_WARNING(ex.what());
+            }
+            if (progress_callback)
+                progress_callback->on_update_progress(count++ * (2 * _speed));
+
+            now = std::chrono::high_resolution_clock::now();
+
+        } while (now - start < std::chrono::milliseconds(timeout_ms) && !done);
+
+
+        // If we exit due to timeout, report timeout
+        if (!done)
+        {
+            throw std::runtime_error("Operation timed-out!\n"
+                "Calibration state did not converged in time");
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        auto status = (rs2_dsc_status)result.status;
+
+        // Handle errors from firmware
+        if (status != RS2_DSC_STATUS_SUCCESS)
+        {
+            handle_calibration_error(status);
+        }
+
+        auto res = get_calibration_results(health);
+        return res;
+    }
+
+    std::vector<uint8_t> auto_calibrated::run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, float* health, update_progress_callback_ptr progress_callback)
+    {
+        if (json.size() > 0)
+        {
+            auto jsn = parse_json(json);
+            if (jsn.find("speed") != jsn.end())
+            {
+                _speed = jsn["speed"];
+            }
+            if (jsn.find("average_step_count") != jsn.end())
+            {
+                _average_step_count = jsn["average_step_count"];
+            }
+            if (jsn.find("step_count") != jsn.end())
+            {
+                _step_count = jsn["step_count"];
+            }
+            if (jsn.find("accuracy") != jsn.end())
+            {
+                _accuracy = jsn["accuracy"];
+            }
+        }
+
+        auto preset_recover = change_preset();
+
+        auto param2 = (int)ground_truth_mm * 100;
+        auto param3 = (_average_step_count ) + (_step_count << 8) + (_accuracy << 16);
+
+        _hw_monitor->send(command{ ds::AUTO_CALIB, tare_calib_begin, param2, param3 });
+
+        DirectSearchCalibrationResult result;
+
+        // While not ready...
+        int count = 0;
+        bool done = false;
+
+        auto start = std::chrono::high_resolution_clock::now();
+        auto now = start;
+
+        do
+        {
+            memset(&result, 0, sizeof(DirectSearchCalibrationResult));
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+            // Check calibration status
+            try
+            {
+                auto res = _hw_monitor->send(command{ ds::AUTO_CALIB, tare_calib_check_status });
+                if (res.size() < sizeof(DirectSearchCalibrationResult))
+                    throw std::runtime_error("Not enough data from CALIB_STATUS!");
+
+                auto result = *reinterpret_cast<DirectSearchCalibrationResult*>(res.data());
+                done = result.status != RS2_DSC_STATUS_RESULT_NOT_READY;
+            }
+
+            catch (const std::exception& ex)
+            {
+                LOG_WARNING(ex.what());
+            }
+
+            if (progress_callback)
+                progress_callback->on_update_progress(count * (2 * _speed));
+
+            now = std::chrono::high_resolution_clock::now();
+
+        } while (now - start < std::chrono::milliseconds(timeout_ms) && !done);
+
+        // If we exit due to timeout, report timeout
+        if (!done)
+        {
+            throw std::runtime_error("Operation timed-out!\n"
+                "Calibration state did not converged in time");
+        }
+
+        auto status = (rs2_dsc_status)result.status;
+
+        // Handle errors from firmware
+        if (status != RS2_DSC_STATUS_SUCCESS)
+        {
+            handle_calibration_error(status);
+        }
+
+        return get_calibration_results(health);
+    }
+
+    std::shared_ptr<ds5_advanced_mode_base> auto_calibrated::change_preset()
+    {
+        preset old_preset_values;
+        rs2_rs400_visual_preset old_preset;
+
+        auto advanced_mode = dynamic_cast<ds5_advanced_mode_base*>(this);
+        if (advanced_mode)
+        {
+            old_preset = (rs2_rs400_visual_preset)(int)advanced_mode->_preset_opt->query();
+            if (old_preset == RS2_RS400_VISUAL_PRESET_CUSTOM)
+                old_preset_values = advanced_mode->get_all();
+            advanced_mode->_preset_opt->set(RS2_RS400_VISUAL_PRESET_HIGH_ACCURACY);
+        }
+
+        std::shared_ptr<ds5_advanced_mode_base> recover_preset(advanced_mode, [old_preset, advanced_mode, old_preset_values](ds5_advanced_mode_base* adv)
+        {
+            if (old_preset == RS2_RS400_VISUAL_PRESET_CUSTOM)
+            {
+                advanced_mode->_preset_opt->set(RS2_RS400_VISUAL_PRESET_CUSTOM);
+                adv->set_all(old_preset_values);
+            }
+            else
+                advanced_mode->_preset_opt->set(old_preset);
+        });
+
+        return recover_preset;
+    }
+
+    void auto_calibrated::handle_calibration_error(rs2_dsc_status status) const
+    {
+        if (status == RS2_DSC_STATUS_EDGE_TOO_CLOSE)
+        {
+            throw std::runtime_error("Calibration didn't converge! (EDGE_TO_CLOSE)\n"
+                "Please retry in different lighting conditions");
+        }
+        else if (status == RS2_DSC_STATUS_FILL_FACTOR_TOO_LOW)
+        {
+            throw std::runtime_error("Not enough depth pixels! (FILL_FACTOR_LOW)\n"
+                "Please retry in different lighting conditions");
+        }
+        else if (status == RS2_DSC_STATUS_NOT_CONVERGE)
+        {
+            throw std::runtime_error("Calibration didn't converge! (NOT_CONVERGE)\n"
+                "Please retry in different lighting conditions");
+        }
+        else if (status == RS2_DSC_STATUS_NO_DEPTH_AVERAGE)
+        {
+            throw std::runtime_error("Calibration didn't converge! (NO_AVERAGE)\n"
+                "Please retry in different lighting conditions");
+        }
+        else throw std::runtime_error(to_string() << "Calibration didn't converge! (RESULT=" << status << ")");
+    }
+
+    std::vector<uint8_t> auto_calibrated::get_calibration_results(float* health) const
+    {
+        // Get new calibration from the firmware
+        auto res = _hw_monitor->send(command{ ds::AUTO_CALIB, get_calibration_result});
+        if (res.size() < sizeof(DscResultBuffer))
+            throw std::runtime_error("Not enough data from CALIB_STATUS!");
+
+        auto reslt = (DscResultBuffer*)(res.data());
+
+        table_header* header = reinterpret_cast<table_header*>(res.data() + sizeof(DscResultBuffer));
+
+        if (res.size() < sizeof(DscResultBuffer) + sizeof(table_header) + header->table_size)
+            throw std::runtime_error("Table truncated in CALIB_STATUS!");
+
+        std::vector<uint8_t> calib;
+
+        calib.resize(sizeof(table_header) + header->table_size, 0);
+        memcpy(calib.data(), header, calib.size()); // Copy to new_calib
+
+        *health = abs(reslt->m_dscResultParams.m_healthCheck);
+
+        return calib;
+    }
+
+    std::vector<uint8_t> auto_calibrated::get_calibration_table() const
+    {
+        std::vector<uint8_t> res;
+
+        // Fetch current calibration using GETINITCAL command
+        command cmd(ds::GETINTCAL, ds::coefficients_table_id);
+        auto calib = _hw_monitor->send(cmd);
+
+        if (calib.size() < sizeof(table_header)) throw std::runtime_error("Missing calibration header from GETINITCAL!");
+
+        auto table = (uint8_t*)(calib.data() + sizeof(table_header));
+        auto hd = (table_header*)(calib.data());
+
+        if (calib.size() < sizeof(table_header) + hd->table_size)
+            throw std::runtime_error("Table truncated from GETINITCAL!");
+
+        res.resize(sizeof(table_header) + hd->table_size, 0);
+        memcpy(res.data(), hd, res.size()); // Copy to old_calib
+
+        return res;
+    }
+
+    void auto_calibrated::write_calibration() const
+    {
+        command write_calib( ds::SETINTCAL, set_coefficients );
+        write_calib.data = _curr_calibration;
+        _hw_monitor->send(write_calib);
+    }
+
+    void auto_calibrated::set_calibration_table(const std::vector<uint8_t>& calibration)
+    {
+        table_header* hd = (table_header*)(calibration.data());
+        uint8_t* table = (uint8_t*)(calibration.data() + sizeof(table_header));
+        command write_calib(ds::CALIBRECALC, 0, 0, 0, 0xcafecafe);
+        write_calib.data.insert(write_calib.data.end(), (uint8_t*)table, ((uint8_t*)table) + hd->table_size);
+        _hw_monitor->send(write_calib);
+
+        _curr_calibration = calibration;
+    }
+
+    void auto_calibrated::reset_to_factory_calibration() const
+    {
+        command cmd(ds::fw_cmd::CAL_RESTORE_DFLT);
+        _hw_monitor->send(cmd);
+    }
+}

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -249,7 +249,7 @@ namespace librealsense
             throw std::runtime_error("Calibration didn't converge! (NO_AVERAGE)\n"
                 "Please retry in different lighting conditions");
         }
-        else throw std::runtime_error(to_string() << "Calibration didn't converge! (RESULT=" << status << ")");
+        else throw std::runtime_error(to_string() << "Calibration didn't converge! (RESULT=" << int(status) << ")");
     }
 
     std::vector<uint8_t> auto_calibrated::get_calibration_results(float* health) const

--- a/src/ds5/ds5-auto-calibration.h
+++ b/src/ds5/ds5-auto-calibration.h
@@ -6,21 +6,18 @@
 #include "auto-calibrated-device.h"
 #include "../core/advanced_mode.h"
 
+const int DEFUALT_AVERAGE_STEP_COUNT = 20;
+const int DEFUALT_STEP_COUNT = 10;
+const int DEFUALT_ACCURACY = 2;
+const int DEFUALT_SPEED = 3;
+
+
 namespace librealsense
 {
     class auto_calibrated : public auto_calibrated_interface
     {
 #pragma pack(push, 1)
 #pragma pack(1)
-        struct table_header
-        {
-            uint16_t version;        // major.minor. Big-endian
-            uint16_t table_type;     // ctCalibration
-            uint32_t table_size;     // full size including: TOC header + TOC + actual tables
-            uint32_t param;          // This field content is defined ny table type
-            uint32_t crc32;          // crc of all the actual table data excluding header/CRC
-        };
-
         struct DirectSearchCalibrationResult
         {
             uint16_t status;      // DscStatus
@@ -33,7 +30,6 @@ namespace librealsense
             uint32_t rightPy;   // 1/1000000 of normalized unit
             float healthCheck;
             float rightRotation[9]; // Right rotation
-            //uint16_t results[0]; // 1/100 of a percent
         };
 
         struct DscResultParams
@@ -58,8 +54,40 @@ namespace librealsense
             RS2_DSC_STATUS_NOT_CONVERGE = 4, /**< For tare calibration only*/
             RS2_DSC_STATUS_BURN_SUCCESS = 5,
             RS2_DSC_STATUS_BURN_ERROR = 6,
-            RS2_DSC_STATUS_NO_DEPTH_AVERAGE = 7,
+            RS2_DSC_STATUS_NO_DEPTH_AVERAGE = 7
         };
+
+        enum speed
+        {
+            speed_very_fast = 0,
+            speed_fast = 1,
+            speed_medium = 2,
+            speed_slow = 3,
+            speed_white_wall = 4
+        };
+
+        enum subpixel_accuracy
+        {
+            very_high = 0, //(0.025%)
+            high = 1, //(0.05%)
+            medium = 2, //(0.1%)
+            low = 3 //(0.2%)
+        };
+
+        struct tare_params3
+        {
+            byte average_step_count;
+            byte step_count;
+            byte accuracy;
+            byte reserved;
+        };
+
+        union tare_calibration_params
+        {
+            tare_params3 param3_struct;
+            int param3;
+        };
+
 #pragma pack(pop)
 
     public:
@@ -76,13 +104,15 @@ namespace librealsense
         void handle_calibration_error(rs2_dsc_status status) const;
         std::map<std::string, int> parse_json(std::string json);
         std::shared_ptr< ds5_advanced_mode_base> change_preset();
+        void check_params();
+
         std::vector<uint8_t> _curr_calibration;
         std::shared_ptr<hw_monitor>& _hw_monitor;
 
-        int _average_step_count = 20;
-        int _step_count = 20;
-        int _accuracy = 2;
-        int _speed = 3;
+        int _average_step_count = DEFUALT_AVERAGE_STEP_COUNT;
+        int _step_count = DEFUALT_STEP_COUNT;
+        int _accuracy = DEFUALT_ACCURACY;
+        int _speed = DEFUALT_SPEED;
     };
 
 }

--- a/src/ds5/ds5-auto-calibration.h
+++ b/src/ds5/ds5-auto-calibration.h
@@ -1,0 +1,88 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "auto-calibrated-device.h"
+#include "../core/advanced_mode.h"
+
+namespace librealsense
+{
+    class auto_calibrated : public auto_calibrated_interface
+    {
+#pragma pack(push, 1)
+#pragma pack(1)
+        struct table_header
+        {
+            uint16_t version;        // major.minor. Big-endian
+            uint16_t table_type;     // ctCalibration
+            uint32_t table_size;     // full size including: TOC header + TOC + actual tables
+            uint32_t param;          // This field content is defined ny table type
+            uint32_t crc32;          // crc of all the actual table data excluding header/CRC
+        };
+
+        struct DirectSearchCalibrationResult
+        {
+            uint16_t status;      // DscStatus
+            uint16_t stepCount;
+            uint16_t stepSize; // 1/1000 of a pixel
+            uint32_t pixelCountThreshold; // minimum number of pixels in
+                                          // selected bin
+            uint16_t minDepth;  // Depth range for FWHM
+            uint16_t maxDepth;
+            uint32_t rightPy;   // 1/1000000 of normalized unit
+            float healthCheck;
+            float rightRotation[9]; // Right rotation
+            //uint16_t results[0]; // 1/100 of a percent
+        };
+
+        struct DscResultParams
+        {
+            uint16_t m_status;
+            float    m_healthCheck;
+        };
+
+        struct DscResultBuffer
+        {
+            uint16_t m_paramSize;
+            DscResultParams m_dscResultParams;
+            uint16_t m_tableSize;
+        };
+
+        enum rs2_dsc_status : uint16_t
+        {
+            RS2_DSC_STATUS_SUCCESS = 0, /**< Self calibration succeeded*/
+            RS2_DSC_STATUS_RESULT_NOT_READY = 1, /**< Self calibration result is not ready yet*/
+            RS2_DSC_STATUS_FILL_FACTOR_TOO_LOW = 2, /**< There are too little textures in the scene*/
+            RS2_DSC_STATUS_EDGE_TOO_CLOSE = 3, /**< Self calibration range is too small*/
+            RS2_DSC_STATUS_NOT_CONVERGE = 4, /**< For tare calibration only*/
+            RS2_DSC_STATUS_BURN_SUCCESS = 5,
+            RS2_DSC_STATUS_BURN_ERROR = 6,
+            RS2_DSC_STATUS_NO_DEPTH_AVERAGE = 7,
+        };
+#pragma pack(pop)
+
+    public:
+        auto_calibrated(std::shared_ptr<hw_monitor>& hwm);
+        void write_calibration() const override;
+        std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json, float* health, update_progress_callback_ptr progress_callback) override;
+        std::vector<uint8_t> run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, float* health, update_progress_callback_ptr progress_callback) override;
+        std::vector<uint8_t> get_calibration_table() const override;
+        void set_calibration_table(const std::vector<uint8_t>& calibration) override;
+        void reset_to_factory_calibration() const override;
+
+    private:
+        std::vector<uint8_t> get_calibration_results(float* health) const;
+        void handle_calibration_error(rs2_dsc_status status) const;
+        std::map<std::string, int> parse_json(std::string json);
+        std::shared_ptr< ds5_advanced_mode_base> change_preset();
+        std::vector<uint8_t> _curr_calibration;
+        std::shared_ptr<hw_monitor>& _hw_monitor;
+
+        int _average_step_count = 20;
+        int _step_count = 20;
+        int _accuracy = 2;
+        int _speed = 3;
+    };
+
+}

--- a/src/ds5/ds5-auto-calibration.h
+++ b/src/ds5/ds5-auto-calibration.h
@@ -6,12 +6,6 @@
 #include "auto-calibrated-device.h"
 #include "../core/advanced_mode.h"
 
-const int DEFUALT_AVERAGE_STEP_COUNT = 20;
-const int DEFUALT_STEP_COUNT = 10;
-const int DEFUALT_ACCURACY = 2;
-const int DEFUALT_SPEED = 3;
-
-
 namespace librealsense
 {
     class auto_calibrated : public auto_calibrated_interface
@@ -57,7 +51,7 @@ namespace librealsense
             RS2_DSC_STATUS_NO_DEPTH_AVERAGE = 7
         };
 
-        enum speed
+        enum auto_calib_speed
         {
             speed_very_fast = 0,
             speed_fast = 1,
@@ -90,6 +84,11 @@ namespace librealsense
 
 #pragma pack(pop)
 
+        const int DEFAULT_AVERAGE_STEP_COUNT = 20;
+        const int DEFAULT_STEP_COUNT = 10;
+        const int DEFAULT_ACCURACY = subpixel_accuracy::medium;
+        const int DEFAULT_SPEED = auto_calib_speed::speed_slow;
+
     public:
         auto_calibrated(std::shared_ptr<hw_monitor>& hwm);
         void write_calibration() const override;
@@ -104,15 +103,15 @@ namespace librealsense
         void handle_calibration_error(rs2_dsc_status status) const;
         std::map<std::string, int> parse_json(std::string json);
         std::shared_ptr< ds5_advanced_mode_base> change_preset();
-        void check_params();
+        void check_params() const;
 
         std::vector<uint8_t> _curr_calibration;
         std::shared_ptr<hw_monitor>& _hw_monitor;
 
-        int _average_step_count = DEFUALT_AVERAGE_STEP_COUNT;
-        int _step_count = DEFUALT_STEP_COUNT;
-        int _accuracy = DEFUALT_ACCURACY;
-        int _speed = DEFUALT_SPEED;
+        int _average_step_count = DEFAULT_AVERAGE_STEP_COUNT;
+        int _step_count = DEFAULT_STEP_COUNT;
+        int _accuracy = DEFAULT_ACCURACY;
+        int _speed = DEFAULT_SPEED;
     };
 
 }

--- a/src/ds5/ds5-auto-calibration.h
+++ b/src/ds5/ds5-auto-calibration.h
@@ -85,7 +85,7 @@ namespace librealsense
 #pragma pack(pop)
 
         const int DEFAULT_AVERAGE_STEP_COUNT = 20;
-        const int DEFAULT_STEP_COUNT = 10;
+        const int DEFAULT_STEP_COUNT = 20;
         const int DEFAULT_ACCURACY = subpixel_accuracy::medium;
         const int DEFAULT_SPEED = auto_calib_speed::speed_slow;
 

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -36,6 +36,7 @@
 #include "proc/depth-formats-converter.h"
 #include "../common/fw/firmware-version.h"
 #include "fw-update/fw-update-unsigned.h"
+#include "../third-party/json.hpp"
 
 namespace librealsense
 {
@@ -562,6 +563,7 @@ namespace librealsense
     ds5_device::ds5_device(std::shared_ptr<context> ctx,
         const platform::backend_device_group& group)
         : device(ctx, group), global_time_interface(),
+        auto_calibrated(_hw_monitor),
         _depth_stream(new stream(RS2_STREAM_DEPTH)),
         _left_ir_stream(new stream(RS2_STREAM_INFRARED, 1)),
         _right_ir_stream(new stream(RS2_STREAM_INFRARED, 2)),

--- a/src/ds5/ds5-device.h
+++ b/src/ds5/ds5-device.h
@@ -12,6 +12,7 @@
 #include "device.h"
 #include "global_timestamp_reader.h"
 #include "fw-update/fw-update-device-interface.h"
+#include "ds5-auto-calibration.h"
 
 namespace librealsense
 {
@@ -28,7 +29,7 @@ namespace librealsense
         const hw_monitor& _hw_monitor;
     };
 
-    class ds5_device : public virtual device, public debug_interface, public global_time_interface, public updatable
+    class ds5_device : public virtual device, public debug_interface, public global_time_interface, public updatable, public auto_calibrated
     {
     public:
         std::shared_ptr<synthetic_sensor> create_depth_device(std::shared_ptr<context> ctx,
@@ -51,6 +52,10 @@ namespace librealsense
         std::vector<uint8_t> send_receive_raw_data(const std::vector<uint8_t>& input) override;
 
         void hardware_reset() override;
+
+
+       
+
         void create_snapshot(std::shared_ptr<debug_interface>& snapshot) const override;
         void enable_recording(std::function<void(const debug_interface&)> record_action) override;
         platform::usb_spec get_usb_spec() const;

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -296,9 +296,9 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
@@ -337,9 +337,9 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
@@ -371,9 +371,9 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
@@ -404,9 +404,9 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
@@ -445,9 +445,9 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, 2, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, 2, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
 
             }
             else
@@ -531,8 +531,8 @@ namespace librealsense
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
                 tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
@@ -572,13 +572,15 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             bool usb3mode = (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined);
 
-            uint32_t width  = usb3mode ?  1280 : 640;
-            uint32_t height = usb3mode ?   720 : 480;
-            uint32_t fps    = usb3mode ?    30 :  15;
+            uint32_t depth_width  = usb3mode ?      848 : 640;
+            uint32_t depth_height = usb3mode ?      480 : 480;
+            uint32_t color_width = usb3mode ?       1280 : 640;
+            uint32_t color_height = usb3mode ?      720 : 480;
+            uint32_t fps    = usb3mode ?            30 :  15;
 
-            tags.push_back({ RS2_STREAM_COLOR, -1, width, height, RS2_FORMAT_RGB8, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_DEPTH, -1, width, height, RS2_FORMAT_Z16, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_INFRARED, -1, width, height, RS2_FORMAT_Y8, fps, profile_tag::PROFILE_TAG_SUPERSET });
+            tags.push_back({ RS2_STREAM_COLOR, -1, color_width, color_height, RS2_FORMAT_RGB8, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_DEPTH, -1, depth_width, depth_height, RS2_FORMAT_Z16, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_INFRARED, -1, depth_width, depth_height, RS2_FORMAT_Y8, fps, profile_tag::PROFILE_TAG_SUPERSET });
             tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 

--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -492,8 +492,8 @@ namespace librealsense
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
                 tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+                tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_INFRARED, -1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -309,6 +309,7 @@ namespace librealsense
 
         const std::string DEPTH_STEREO = "Stereo Module";
 
+#pragma pack(push, 1)
         struct table_header
         {
             big_endian<uint16_t>    version;        // major.minor. Big-endian
@@ -317,6 +318,7 @@ namespace librealsense
             uint32_t                param;          // This field content is defined ny table type
             uint32_t                crc32;          // crc of all the actual table data excluding header/CRC
         };
+#pragma pack(pop)
 
         enum ds5_rect_resolutions : unsigned short
         {

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -167,6 +167,7 @@ namespace librealsense
             GLD             = 0x0f,     // FW logs
             GVD             = 0x10,     // camera details
             GETINTCAL       = 0x15,     // Read calibration table
+            SETINTCAL       = 0x16,     // Set Internal sub calibration table
             LOADINTCAL      = 0x1D,     // Get Internal sub calibration table
             DFU             = 0x1E,     // Enter to FW update mode
             HWRST           = 0x20,     // hardware reset
@@ -179,6 +180,7 @@ namespace librealsense
             SETAEROI        = 0x44,     // set auto-exposure region of interest
             GETAEROI        = 0x45,     // get auto-exposure region of interest
             MMER            = 0x4F,     // MM EEPROM read ( from DS5 cache )
+            CALIBRECALC     = 0x51,     // Calibration recalc and update on the fly
             GET_EXTRINSICS  = 0x53,     // get extrinsics
             CAL_RESTORE_DFLT= 0x61,     // Reset Depth/RGB calibration to factory settings
             SETINTCALNEW    = 0x62,     // Set Internal sub calibration table
@@ -192,6 +194,7 @@ namespace librealsense
             GETSUBPRESET    = 0x7C,     // Upload the current sub-preset
             GETSUBPRESETNAME= 0x7D,     // Retrieve sub-preset's name
             RECPARAMSGET    = 0x7E,     // Retrieve depth calibration table in new format (fw >= 5.11.12.100)
+            AUTO_CALIB      = 0x80      // auto calibration commands
         };
 
         #define TOSTRING(arg) #arg

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -325,3 +325,8 @@ EXPORTS
     rs2_update_firmware_unsigned
     rs2_update_firmware_unsigned_cpp
     rs2_enter_update_state
+    rs2_run_on_chip_calibration_cpp
+    rs2_run_tare_calibration_cpp
+    rs2_get_calibration_table
+    rs2_set_calibration_table
+

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -39,7 +39,7 @@
 #include "software-device.h"
 #include "fw-update/fw-update-device-interface.h"
 #include "global_timestamp_reader.h"
-
+#include "auto-calibrated-device.h"
 ////////////////////////
 // API implementation //
 ////////////////////////
@@ -1159,6 +1159,8 @@ int rs2_is_device_extendable_to(const rs2_device* dev, rs2_extension extension, 
         case RS2_EXTENSION_UPDATABLE             : return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::updatable)                   != nullptr;
         case RS2_EXTENSION_UPDATE_DEVICE         : return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::update_device_interface)     != nullptr;
         case RS2_EXTENSION_GLOBAL_TIMER          : return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::global_time_interface)       != nullptr;
+        case RS2_EXTENSION_AUTO_CALIBRARED_DEVICE: return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::auto_calibrated_interface) != nullptr;
+
         default:
             return false;
     }
@@ -2283,16 +2285,32 @@ HANDLE_EXCEPTIONS_AND_RETURN(, sensor, profile, intrinsics)
 void rs2_reset_to_factory_calibration(const rs2_device* device, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(device);
-    auto tm2 = VALIDATE_INTERFACE(&device->device->get_sensor(0), librealsense::tm2_sensor_interface);
-    tm2->reset_to_factory_calibration();
+    auto tm2 = dynamic_cast<tm2_sensor_interface*>(&device->device->get_sensor(0));
+    if (tm2)
+        tm2->reset_to_factory_calibration();
+    else
+    {
+        auto auto_calib = std::dynamic_pointer_cast<auto_calibrated_interface>(device->device);
+        if (!auto_calib)
+            throw std::runtime_error("this device does not supports reset to factory calibration");
+        auto_calib->reset_to_factory_calibration();
+    }
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, device)
 
 void rs2_write_calibration(const rs2_device* device, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(device);
-    auto tm2 = VALIDATE_INTERFACE(&device->device->get_sensor(0), librealsense::tm2_sensor_interface);
-    tm2->write_calibration();
+    auto tm2 = dynamic_cast<tm2_sensor_interface*>(&device->device->get_sensor(0));
+    if (tm2)
+        tm2->write_calibration();
+    else
+    {
+        auto auto_calib = std::dynamic_pointer_cast<auto_calibrated_interface>(device->device);
+        if (!auto_calib)
+            throw std::runtime_error("this device does not supports auto calibration");
+        auto_calib->write_calibration();
+    }
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, device)
 
@@ -2575,3 +2593,60 @@ void rs2_enter_update_state(const rs2_device* device, rs2_error** error) BEGIN_A
     fwud->enter_update_state();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, device)
+
+const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(device);
+
+    auto auto_calib = VALIDATE_INTERFACE(device->device, librealsense::auto_calibrated_interface);
+
+    std::vector<uint8_t> buffer;
+
+    std::string json((char*)json_content, (char*)json_content + content_size);
+    if (progress_callback == nullptr)
+        buffer = auto_calib->run_on_chip_calibration(timeout_ms, json, health, nullptr);
+    else
+        buffer = auto_calib->run_on_chip_calibration(timeout_ms, json, health, { progress_callback, [](rs2_update_progress_callback* p) { p->release(); } });
+
+    return new rs2_raw_data_buffer { buffer };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, device)
+
+const rs2_raw_data_buffer* rs2_run_tare_calibration_cpp(rs2_device* device, float ground_truth_mm, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(device);
+
+    auto auto_calib = VALIDATE_INTERFACE(device->device, librealsense::auto_calibrated_interface);
+
+    std::vector<uint8_t> buffer;
+    std::string json((char*)json_content, (char*)json_content + content_size);
+    if (progress_callback == nullptr)
+        buffer = auto_calib->run_tare_calibration(timeout_ms, ground_truth_mm, json, health, nullptr);
+    else
+        buffer = auto_calib->run_tare_calibration(timeout_ms, ground_truth_mm, json, health, { progress_callback, [](rs2_update_progress_callback* p) { p->release(); } });
+
+    return new rs2_raw_data_buffer{ buffer };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, device)
+
+const rs2_raw_data_buffer* rs2_get_calibration_table(const rs2_device* device, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(device);
+   
+    auto auto_calib = VALIDATE_INTERFACE(device->device, librealsense::auto_calibrated_interface);
+    auto buffer = auto_calib->get_calibration_table();
+    return new rs2_raw_data_buffer{ buffer };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, device)
+
+void rs2_set_calibration_table(const rs2_device* device, const void* calibration, int calibration_size, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(device);
+    VALIDATE_NOT_NULL(calibration);
+
+    auto auto_calib = VALIDATE_INTERFACE(device->device, librealsense::auto_calibrated_interface);
+
+    std::vector<uint8_t> buffer((uint8_t*)calibration, (uint8_t*)calibration + calibration_size);
+    auto_calib->set_calibration_table(buffer);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(,calibration, device)

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1159,7 +1159,7 @@ int rs2_is_device_extendable_to(const rs2_device* dev, rs2_extension extension, 
         case RS2_EXTENSION_UPDATABLE             : return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::updatable)                   != nullptr;
         case RS2_EXTENSION_UPDATE_DEVICE         : return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::update_device_interface)     != nullptr;
         case RS2_EXTENSION_GLOBAL_TIMER          : return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::global_time_interface)       != nullptr;
-        case RS2_EXTENSION_AUTO_CALIBRARED_DEVICE: return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::auto_calibrated_interface) != nullptr;
+        case RS2_EXTENSION_AUTO_CALIBRATED_DEVICE: return VALIDATE_INTERFACE_NO_THROW(dev->device, librealsense::auto_calibrated_interface) != nullptr;
 
         default:
             return false;
@@ -2597,6 +2597,10 @@ HANDLE_EXCEPTIONS_AND_RETURN(, device)
 const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(device);
+    VALIDATE_NOT_NULL(health);
+
+    if (content_size > 0)
+        VALIDATE_NOT_NULL(json_content);
 
     auto auto_calib = VALIDATE_INTERFACE(device->device, librealsense::auto_calibrated_interface);
 
@@ -2615,6 +2619,10 @@ HANDLE_EXCEPTIONS_AND_RETURN(nullptr, device)
 const rs2_raw_data_buffer* rs2_run_tare_calibration_cpp(rs2_device* device, float ground_truth_mm, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(device);
+    VALIDATE_NOT_NULL(health);
+
+    if(content_size > 0)
+        VALIDATE_NOT_NULL(json_content);
 
     auto auto_calib = VALIDATE_INTERFACE(device->device, librealsense::auto_calibrated_interface);
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -186,6 +186,7 @@ namespace librealsense
             CASE(GLOBAL_TIMER)
             CASE(L500_DEPTH_SENSOR)
             CASE(TM2_SENSOR)
+            CASE(AUTO_CALIBRARED_DEVICE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -186,7 +186,7 @@ namespace librealsense
             CASE(GLOBAL_TIMER)
             CASE(L500_DEPTH_SENSOR)
             CASE(TM2_SENSOR)
-            CASE(AUTO_CALIBRARED_DEVICE)
+            CASE(AUTO_CALIBRATED_DEVICE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/wrappers/python/examples/auto_calibration_config.json
+++ b/wrappers/python/examples/auto_calibration_config.json
@@ -1,0 +1,6 @@
+{
+  "speed": 3,
+  "average_step_count": 20,
+  "step_count": 20,
+  "accuracy": 2
+}

--- a/wrappers/python/examples/depth_auto_calibration_example.py
+++ b/wrappers/python/examples/depth_auto_calibration_example.py
@@ -1,0 +1,80 @@
+## License: Apache 2.0. See LICENSE file in root directory.
+## Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+
+#####################################################
+##                   auto calibration              ##
+#####################################################
+
+# First import the library
+import pyrealsense2 as rs
+import  sys, getopt
+def read_parameters(argv):
+    opts, args = getopt.getopt(argv, "i:", ["ifile="])
+    jcnt = ''
+    size = 0
+
+    if len(opts) > 0:
+        json_file = opts[0][1]
+        file_object = open(json_file)
+        jcnt = file_object.read()
+        size = len(jcnt)
+
+    return size, jcnt
+
+def main(argv):
+
+    size, file_cnt = read_parameters(argv)
+
+    pipeline = rs.pipeline()
+    config = rs.config()
+
+    config.enable_stream(rs.stream.depth, 256, 144, rs.format.z16, 90)
+    conf = pipeline.start(config)
+    calib_dev = rs.auto_calibrated_device(conf.get_device())
+
+    def on_chip_calib_cb(progress):
+        print(". ")
+
+    while True:
+        try:
+            input = raw_input("Please select what the operation you want to do\nc - on chip calibration\nt - tare calibration\ng - get the active calibration\nw - write new calibration\ne - exit\n")
+
+            if input == 'c':
+                print("Starting on chip calibration")
+                new_calib, health = calib_dev.run_on_chip_calibration(5000, file_cnt, on_chip_calib_cb)
+                print("Calibration completed")
+                print("health factor = ", health)
+
+            if input == 't':
+                print("Starting tare calibration")
+                ground_truth = float(raw_input("Please enter ground truth in mm\n"))
+                new_calib, health = calib_dev.run_tare_calibration(ground_truth, 5000, file_cnt, on_chip_calib_cb)
+                print("Calibration completed")
+                print("health factor = ", health)
+
+            if input == 'g':
+                calib = calib_dev.get_calibration_table()
+                print("Calibration", calib)
+
+            if input == 'w':
+                print("Writing the new calibration")
+                calib_dev.set_calibration_table(new_calib)
+                calib_dev.write_calibration()
+
+            if input == 'e':
+                pipeline.stop()
+                return
+
+            print("Done\n")
+        except Exception as e:
+            pipeline.stop()
+            print(e)
+        except:
+            pipeline.stop()
+            print("A different Error")
+
+
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -64,30 +64,30 @@ void init_device(py::module &m) {
 
     py::class_<rs2::auto_calibrated_device, rs2::device> auto_calibrated_device(m, "auto_calibrated_device");
     auto_calibrated_device.def(py::init<rs2::device>(), "device"_a)
-        .def("write_calibration", &rs2::auto_calibrated_device::write_calibration, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.")
+        .def("write_calibration", &rs2::auto_calibrated_device::write_calibration, "Write calibration that was set by set_calibration_table to device's EEPROM.")
         .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, int timeout_ms, std::string json_content)
         { 
             float health;
             return py::make_tuple(self.run_on_chip_calibration(timeout_ms, json_content, &health), health);
-        },"Update an updatable device to the provided unsigned firmware. This call is executed on the caller's thread.", "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
+        },"This will improve the depth noise (plane fit RMS). This call is executed on the caller's thread and it supports progress notifications via the callback.", "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
         .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, int timeout_ms, std::string json_content, std::function<void(float)> f)
         {
             float health;
             return py::make_tuple(self.run_on_chip_calibration(timeout_ms, json_content, &health, f), health);
-        },"Update an updatable device to the provided unsigned firmware. This call is executed on the caller's thread and it supports progress notifications via the callback.", "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
+        },"This will improve the depth noise (plane fit RMS). This call is executed on the caller's thread.", "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
         .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, int timeout_ms, std::string json_content)
         {
             float health;
             return py::make_tuple(self.run_tare_calibration(ground_truth_mm, timeout_ms, json_content, &health), health);
-        }, "Run tare calibration", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
+        }, "This will adjust camera absolute distance to flat target. This call is executed on the caller's thread and it supports progress notifications via the callback.", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
         .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, int timeout_ms, std::string json_content, std::function<void(float)> callback) 
         {
             float health;
             return py::make_tuple(self.run_tare_calibration(ground_truth_mm, timeout_ms, json_content, &health, callback), health);
-        }, "Run tare calibration", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
-        .def("get_calibration_table", &rs2::auto_calibrated_device::get_calibration_table, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.")
-        .def("set_calibration_table", &rs2::auto_calibrated_device::set_calibration_table, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.")
-        .def("reset_to_factory_calibration", &rs2::auto_calibrated_device::reset_to_factory_calibration, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.");
+        }, "This will adjust camera absolute distance to flat target. This call is executed on the caller's thread.", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
+        .def("get_calibration_table", &rs2::auto_calibrated_device::get_calibration_table, "Read current calibration table from flash.")
+        .def("set_calibration_table", &rs2::auto_calibrated_device::set_calibration_table, "Set current table to dynamic area.")
+        .def("reset_to_factory_calibration", &rs2::auto_calibrated_device::reset_to_factory_calibration, "Reset device to factory calibration.");
 
 
     py::class_<rs2::debug_protocol> debug_protocol(m, "debug_protocol"); // No docstring in C++

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -27,6 +27,7 @@ void init_device(py::module &m) {
         .def(BIND_DOWNCAST(device, tm2))
         .def(BIND_DOWNCAST(device, updatable))
         .def(BIND_DOWNCAST(device, update_device))
+        .def(BIND_DOWNCAST(device, auto_calibrated_device))
         .def("__repr__", [](const rs2::device &self) {
             std::stringstream ss;
             ss << "<" SNAME ".device: " << self.get_info(RS2_CAMERA_INFO_NAME)
@@ -60,6 +61,34 @@ void init_device(py::module &m) {
         .def("update", [](rs2::update_device& self, const std::vector<uint8_t>& fw_image, std::function<void(float)> f) { return self.update(fw_image, f); },
              "Update an updatable device to the provided firmware. This call is executed on the caller's thread and it supports progress notifications via the callback.",
              "fw_image"_a, "callback"_a);
+
+    py::class_<rs2::auto_calibrated_device, rs2::device> auto_calibrated_device(m, "auto_calibrated_device");
+    auto_calibrated_device.def(py::init<rs2::device>(), "device"_a)
+        .def("write_calibration", &rs2::auto_calibrated_device::write_calibration, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.")
+        .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, int timeout_ms, std::string json_content)
+        { 
+            float health;
+            return py::make_tuple(self.run_on_chip_calibration(timeout_ms, json_content, &health), health);
+        },"Update an updatable device to the provided unsigned firmware. This call is executed on the caller's thread.", "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
+        .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, int timeout_ms, std::string json_content, std::function<void(float)> f)
+        {
+            float health;
+            return py::make_tuple(self.run_on_chip_calibration(timeout_ms, json_content, &health, f), health);
+        },"Update an updatable device to the provided unsigned firmware. This call is executed on the caller's thread and it supports progress notifications via the callback.", "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
+        .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, int timeout_ms, std::string json_content)
+        {
+            float health;
+            return py::make_tuple(self.run_tare_calibration(ground_truth_mm, timeout_ms, json_content, &health), health);
+        }, "Run tare calibration", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
+        .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, int timeout_ms, std::string json_content, std::function<void(float)> callback) 
+        {
+            float health;
+            return py::make_tuple(self.run_tare_calibration(ground_truth_mm, timeout_ms, json_content, &health, callback), health);
+        }, "Run tare calibration", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
+        .def("get_calibration_table", &rs2::auto_calibrated_device::get_calibration_table, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.")
+        .def("set_calibration_table", &rs2::auto_calibrated_device::set_calibration_table, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.")
+        .def("reset_to_factory_calibration", &rs2::auto_calibrated_device::reset_to_factory_calibration, "Move the device to update state, this will cause the updatable device to disconnect and reconnect as an update device.");
+
 
     py::class_<rs2::debug_protocol> debug_protocol(m, "debug_protocol"); // No docstring in C++
     debug_protocol.def(py::init<rs2::device>())


### PR DESCRIPTION
Added auto_calibrated_device extension for on-chip (plane fit RMS) and tare calibration (absolute distance).
Use this API in viewer and added example on python for auto calibration.
Fixed viewer to put the default resolution on top and fixed default resolution in RS435. 