### PR TITLE
Version compatibility enhancement

### DIFF
--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -23,8 +23,8 @@ extern "C" {
 #include "h/rs_sensor.h"
 
 #define RS2_API_MAJOR_VERSION    2
-#define RS2_API_MINOR_VERSION    30
-#define RS2_API_PATCH_VERSION    1
+#define RS2_API_MINOR_VERSION    31
+#define RS2_API_PATCH_VERSION    0
 #define RS2_API_BUILD_VERSION    0
 
 #ifndef STRINGIFY

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
 <package format="2">
   <name>librealsense2</name>
   <!-- The version tag needs to be updated with each new release of librealsense -->
-  <version>2.30.1</version>
+  <version>2.31.0</version>
   <description>
   Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.
   </description>

--- a/src/api.h
+++ b/src/api.h
@@ -482,8 +482,9 @@ inline void verify_version_compatibility(int api_version)
     else
     {
         // starting with 1.10.0, versions with same patch are compatible
+        // Incompatible versions differ on major, or with the executable's minor bigger than the library's one.
         if ((lrs_major(api_version) != lrs_major(runtime_api_version))
-            || (lrs_minor(api_version) != lrs_minor(runtime_api_version)))
+            || (lrs_minor(api_version) > lrs_minor(runtime_api_version)))
             report_version_mismatch(runtime_api_version, api_version);
     }
 }

--- a/unit-tests/internal/CMakeLists.txt
+++ b/unit-tests/internal/CMakeLists.txt
@@ -11,6 +11,7 @@ set (INTERNAL_TESTS_SOURCES
     internal-tests-extrinsic.cpp
     internal-tests-types.cpp
     internal-tests-uv-map.cpp
+    internal-tests-class-logic.cpp
 )
 
 add_executable(${PROJECT_NAME} ${INTERNAL_TESTS_SOURCES})

--- a/unit-tests/internal/internal-tests-class-logic.cpp
+++ b/unit-tests/internal/internal-tests-class-logic.cpp
@@ -1,0 +1,45 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+
+#include "catch/catch.hpp"
+#include <cmath>
+#include <iostream>
+#include "./../src/api.h"
+
+TEST_CASE("verify_version_compatibility", "[code]")
+{
+    rs2_error* e = 0;
+    rs2_context* ctx=nullptr;
+
+    auto runtime_api_version = rs2_get_api_version(&e);
+    CAPTURE(runtime_api_version);
+    REQUIRE(!e);
+
+    int api_ver = RS2_API_VERSION;
+    int major = (api_ver / 10000);
+    int minor = (api_ver / 100) % 100;
+    int patch = api_ver  % 100;
+
+    REQUIRE_NOTHROW(verify_version_compatibility(api_ver));
+    //// Differences in major shall always result in error
+    REQUIRE_THROWS(verify_version_compatibility(api_ver + 10000));
+    REQUIRE_THROWS(verify_version_compatibility(api_ver - 10000));
+
+    // Differences in minor are compatible as long as exe_ver <= lib_ver
+    if (minor > 0)
+    {
+        REQUIRE_NOTHROW(verify_version_compatibility(api_ver - 100));
+    }
+    if (minor < 99)
+    {
+        REQUIRE_THROWS(verify_version_compatibility(api_ver + 100));
+    }
+
+    // differences in patch version do not affect compatibility
+    int base = api_ver - patch;
+    for (int i = 0; i < 100; i++)
+    {
+        CAPTURE(base + i);
+        REQUIRE_NOTHROW(verify_version_compatibility(base+i));
+    }
+}

--- a/unit-tests/internal/internal-tests-usb.cpp
+++ b/unit-tests/internal/internal-tests-usb.cpp
@@ -143,11 +143,12 @@ TEST_CASE("query_controls", "[live][usb]")
         auto dev = usb_enumerator::create_usb_device(info);
         if (!dev)
             continue;
-        std::vector<rs_usb_interface> interfaces = dev->get_interfaces();
-        REQUIRE(interfaces.size() > 0);
-        if (0 !=info.mi)        // Lookup for controls interface only
+        if (0 != info.mi)        // Lookup for controls interface only
             continue;
         auto m = dev->open(info.mi);
+
+        std::vector<rs_usb_interface> interfaces = dev->get_interfaces();
+        REQUIRE(interfaces.size() > 0);
 
         //uvc units, rs uvc api is not implemented yet so we use hard coded mapping for reading the PUs
         std::map<int,int> processing_units =

--- a/unit-tests/internal/internal-tests-usb.cpp
+++ b/unit-tests/internal/internal-tests-usb.cpp
@@ -143,9 +143,11 @@ TEST_CASE("query_controls", "[live][usb]")
         auto dev = usb_enumerator::create_usb_device(info);
         if (!dev)
             continue;
-        auto m = dev->open();
-
         std::vector<rs_usb_interface> interfaces = dev->get_interfaces();
+        REQUIRE(interfaces.size() > 0);
+        if (0 !=info.mi)        // Lookup for controls interface only
+            continue;
+        auto m = dev->open(info.mi);
 
         //uvc units, rs uvc api is not implemented yet so we use hard coded mapping for reading the PUs
         std::map<int,int> processing_units =

--- a/wrappers/matlab/Factory.h
+++ b/wrappers/matlab/Factory.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <map>
+#include <string>
 #include <mex.h>
 #include <matrix.h>
 


### PR DESCRIPTION
Relax version compatibility constrain from strict identity to the standardized convention:
 -The versions are compatible when the majors align and the version minors hold (lib_ver >= exe_ver).
  -Patch number version does not affect compatibility.
Cover compatibility constrain with unit-test.

Minor fixes 