### PR TITLE
fix openni2 wrapper convertDepthToColorCoordinates

### DIFF
--- a/wrappers/openni2/src/Rs2Stream.h
+++ b/wrappers/openni2/src/Rs2Stream.h
@@ -79,6 +79,8 @@ protected:
 	std::vector<Rs2StreamProfileInfo> m_profiles;
 	OniVideoMode m_videoMode;
 	rs2_intrinsics m_intrinsics;
+	rs2_extrinsics m_extrinsicsDepthToColor;
+	bool m_needUpdateExtrinsicsDepthToColor;
 	float m_depthScale;
 	float m_fovX;
 	float m_fovY;


### PR DESCRIPTION
Оnly intrinsics are used in the function `Rs2Stream::convertDepthToColorCoordinates`, which leads to a small error due to the fact that the depth and color cameras are offset relative to each other.

Added use of extrinsics as here: https://github.com/IntelRealSense/librealsense/blob/2decb32456fc68396da2bc4de25028b1ee2d735f/include/librealsense2/rsutil.h#L169-L214