### PR TITLE
polling_device_watcher: fix race between construction and start

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -1482,6 +1482,9 @@ namespace librealsense
             polling(cancellable_timer);
         }), _devices_data()
         {
+            _devices_data = {   _backend->query_uvc_devices(),
+                                _backend->query_usb_devices(),
+                                _backend->query_hid_devices() };
         }
 
         ~polling_device_watcher()
@@ -1512,10 +1515,6 @@ namespace librealsense
         {
             stop();
             _callback = std::move(callback);
-            _devices_data = {   _backend->query_uvc_devices(),
-                                _backend->query_usb_devices(),
-                                _backend->query_hid_devices() };
-
             _active_object.start();
         }
 


### PR DESCRIPTION
Device watchers do not notify for devices that already exist when they
are constructed (e.g. win_event_device_watcher), but
polling_device_watcher was also not notifying if devices were added
between construction and start. This aligns polling_device_watcher
with win_event_device_watcher