### PR TITLE
Some updates to auto calibration

### DIFF
--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -318,9 +318,9 @@ namespace rs2
 
         auto calib_dev = _dev.as<auto_calibrated_device>();
         if (tare)
-            _new_calib = calib_dev.run_tare_calibration(ground_truth, 5000, json, &_health, [&](const float progress) {_progress = progress;});
+            _new_calib = calib_dev.run_tare_calibration(ground_truth, json, [&](const float progress) {_progress = progress;}, 5000);
         else
-            _new_calib = calib_dev.run_on_chip_calibration(5000, json, &_health, [&](const float progress) {_progress = progress;});
+            _new_calib = calib_dev.run_on_chip_calibration(json, &_health, [&](const float progress) {_progress = progress;}, 5000);
     }
 
     void on_chip_calib_manager::process_flow(std::function<void()> cleanup, 
@@ -429,7 +429,7 @@ namespace rs2
         using namespace chrono;
 
         auto health = get_manager().get_health();
-        auto recommend_keep = health > 0.15;
+        auto recommend_keep = health > 0.25;
         if (!recommend_keep && update_state == RS2_CALIB_STATE_CALIB_COMPLETE && !get_manager().tare)
         {
             auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
@@ -709,7 +709,7 @@ namespace rs2
             {
                 auto health = get_manager().get_health();
 
-                auto recommend_keep = health > 0.15;
+                auto recommend_keep = health > 0.25;
 
                 ImGui::SetCursorScreenPos({ float(x + 15), float(y + 33) });
 
@@ -747,7 +747,7 @@ namespace rs2
                         ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
                         ImGui::Text("%s", "(Good)");
                     }
-                    else if (health < 0.25f)
+                    else if (health < 0.75f)
                     {
                         ImGui::PushStyleColor(ImGuiCol_Text, yellowish);
                         ImGui::Text("%s", "(Can be Improved)");

--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -246,11 +246,11 @@ void rs2_enter_update_state(const rs2_device* device, rs2_error** error);
 * \param[in] json_content       Json string to configure speed on chip calibration parameters:
                                     {
                                       "speed": 3,
-                                      "scan_direction": 0,
+                                      "scan_parameter": 0,
                                       "data_sampling": 0
                                     }
                                     speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
-                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                     data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                     if json is nullptr it will be ignored and calibration will use the default parameters
 * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
@@ -268,11 +268,11 @@ const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, c
 * \param[in] json_content       Json string to configure speed on chip calibration parameters:
                                     {
                                       "speed": 3,
-                                      "scan_direction": 0,
+                                      "scan_parameter": 0,
                                       "data_sampling": 0
                                     }
                                     speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
-                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                     data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                     if json is nullptr it will be ignored and calibration will use the default parameters
 * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
@@ -294,13 +294,13 @@ const rs2_raw_data_buffer* rs2_run_on_chip_calibration(rs2_device* device, const
                                       "average_step_count": 20,
                                       "step_count": 20,
                                       "accuracy": 2,
-                                      "scan_direction": 0,
+                                      "scan_parameter": 0,
                                       "data_sampling": 0
                                     }
                                     average step count - number of frames to average, must be between 1 - 30, default = 20
                                     step count - max iteration steps, must be between 5 - 30, default = 10
                                     accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
-                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                     data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                     if json is nullptr it will be ignored and calibration will use the default parameters
 * \param[in]  content_size        Json string size if its 0 the json will be ignored and calibration will use the default parameters
@@ -318,13 +318,13 @@ const rs2_raw_data_buffer* rs2_run_tare_calibration_cpp(rs2_device* dev, float g
                                       "average_step_count": 20,
                                       "step_count": 20,
                                       "accuracy": 2,
-                                      "scan_direction": 0,
+                                      "scan_parameter": 0,
                                       "data_sampling": 0
                                     }
                                     average step count - number of frames to average, must be between 1 - 30, default = 20
                                     step count - max iteration steps, must be between 5 - 30, default = 10
                                     accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
-                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                     data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                     if json is nullptr it will be ignored and calibration will use the default parameters
 * \param[in]  content_size       Json string size if its 0 the json will be ignored and calibration will use the default parameters

--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -243,42 +243,97 @@ void rs2_enter_update_state(const rs2_device* device, rs2_error** error);
 
 /**
 * This will improve the depth noise.
-* \param[in] timeout_ms         Timeout in ms
-* \param[in] json_content       Json file to configure speed on chip calibration parameters:
+* \param[in] json_content       Json string to configure speed on chip calibration parameters:
                                     {
-                                      "speed": 3
+                                      "speed": 3,
+                                      "scan_direction": 0,
+                                      "data_sampling": 0
                                     }
-                                speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
-                                if json is nullptr it will be ignored and calibration will use the defualt parameters
+                                    speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
+                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
+                                    if json is nullptr it will be ignored and calibration will use the default parameters
 * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
-                                [0, 0.15) - Good
-                                [0.15, 0.25) - Can be Improved
-                                [0.25, ) - Requires Calibration
-* \param[in] callback           Callback to get progress notifications
+                                [0, 0.25) - Good
+                                [0.25, 0.75) - Can be Improved
+                                [0.75, ) - Requires Calibration
+* \param[in] callback           Optional callback to get progress notifications
+* \param[in] timeout_ms         Timeout in ms (use 5000 msec unless instructed otherwise)
 * \return                       New calibration table
 */
-const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error);
+const rs2_raw_data_buffer* rs2_run_on_chip_calibration_cpp(rs2_device* device, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, int timeout_ms, rs2_error** error);
+
+/**
+* This will improve the depth noise.
+* \param[in] json_content       Json string to configure speed on chip calibration parameters:
+                                    {
+                                      "speed": 3,
+                                      "scan_direction": 0,
+                                      "data_sampling": 0
+                                    }
+                                    speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
+                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
+                                    if json is nullptr it will be ignored and calibration will use the default parameters
+* \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
+                                [0, 0.25) - Good
+                                [0.25, 0.75) - Can be Improved
+                                [0.75, ) - Requires Calibration
+* \param[in]  callback          Optional callback for update progress notifications, the progress value is normailzed to 1
+* \param[in]  client_data       Optional client data for the callback
+* \param[in] timeout_ms         Timeout in ms (use 5000 msec unless instructed otherwise)
+* \return                       New calibration table
+*/
+const rs2_raw_data_buffer* rs2_run_on_chip_calibration(rs2_device* device, const void* json_content, int content_size, float* health, rs2_update_progress_callback_ptr callback, void* client_data, int timeout_ms, rs2_error** error);
 
 /**
 * This will adjust camera absolute distance to flat target. User needs to enter the known ground truth.
 * \param[in] ground_truth_mm     Ground truth in mm must be between 2500 - 2000000
-* \param[in] timeout_ms          Timeout in ms
-* \param[in] json_content        Json file to configure tare calibration parametars:
+* \param[in] json_content        Json string to configure tare calibration parameters:
                                     {
                                       "average_step_count": 20,
                                       "step_count": 20,
-                                      "accuracy": 2
+                                      "accuracy": 2,
+                                      "scan_direction": 0,
+                                      "data_sampling": 0
                                     }
                                     average step count - number of frames to average, must be between 1 - 30, default = 20
                                     step count - max iteration steps, must be between 5 - 30, default = 10
                                     accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
-                                 if json is nullptr it will be ignored and calibration will use the defualt parameters
-* \param[in] content_size        Json file size if its 0 the json will be ignored and calibration will use the defualt parameters
-* \param[out] health             Calibration Health-Check captures how far camera calibration is from the optimal one
-* \param[in] callback            Callback to get progress notifications
+                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
+                                    if json is nullptr it will be ignored and calibration will use the default parameters
+* \param[in]  content_size        Json string size if its 0 the json will be ignored and calibration will use the default parameters
+* \param[in]  callback            Optional callback to get progress notifications
+* \param[in] timeout_ms          Timeout in ms (use 5000 msec unless instructed otherwise)
+* \return                         New calibration table
+*/
+const rs2_raw_data_buffer* rs2_run_tare_calibration_cpp(rs2_device* dev, float ground_truth_mm, const void* json_content, int content_size, rs2_update_progress_callback* progress_callback, int timeout_ms, rs2_error** error);
+
+/**
+* This will adjust camera absolute distance to flat target. User needs to enter the known ground truth.
+* \param[in] ground_truth_mm     Ground truth in mm must be between 2500 - 2000000
+* \param[in] json_content        Json string to configure tare calibration parameters:
+                                    {
+                                      "average_step_count": 20,
+                                      "step_count": 20,
+                                      "accuracy": 2,
+                                      "scan_direction": 0,
+                                      "data_sampling": 0
+                                    }
+                                    average step count - number of frames to average, must be between 1 - 30, default = 20
+                                    step count - max iteration steps, must be between 5 - 30, default = 10
+                                    accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
+                                    scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                    data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
+                                    if json is nullptr it will be ignored and calibration will use the default parameters
+* \param[in]  content_size       Json string size if its 0 the json will be ignored and calibration will use the default parameters
+* \param[in]  callback           Optional callback for update progress notifications, the progress value is normailzed to 1
+* \param[in]  client_data        Optional client data for the callback
+* \param[in] timeout_ms          Timeout in ms (use 5000 msec unless instructed otherwise)
 * \return                        New calibration table
 */
-const rs2_raw_data_buffer* rs2_run_tare_calibration_cpp(rs2_device* dev, float ground_truth_mm, int timeout_ms, const void* json_content, int content_size, float* health, rs2_update_progress_callback* progress_callback, rs2_error** error);
+const rs2_raw_data_buffer* rs2_run_tare_calibration(rs2_device* dev, float ground_truth_mm, const void* json_content, int content_size, rs2_update_progress_callback_ptr callback, void* client_data, int timeout_ms, rs2_error** error);
 
 /**
 *  Read current calibration table from flash.

--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -331,11 +331,11 @@ return results;
         * \param[in] json_content       Json string to configure speed on chip calibration parameters:
                                             {
                                               "speed": 3,
-                                              "scan_direction": 0,
+                                              "scan_parameter": 0,
                                               "data_sampling": 0
                                             }
                                             speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
-                                            scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                            scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                             data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                             if json is nullptr it will be ignored and calibration will use the default parameters
         * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
@@ -372,11 +372,11 @@ return results;
          * \param[in] json_content       Json string to configure speed on chip calibration parameters:
                                             {
                                               "speed": 3,
-                                              "scan_direction": 0,
+                                              "scan_parameter": 0,
                                               "data_sampling": 0
                                             }
                                             speed - value can be one of: Very fast = 0, Fast = 1, Medium = 2, Slow = 3, White wall = 4, default is  Slow
-                                            scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                            scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                             data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                             if json is nullptr it will be ignored and calibration will use the default parameters
          * \param[out] health            Calibration Health-Check captures how far camera calibration is from the optimal one
@@ -413,13 +413,13 @@ return results;
                                               "average_step_count": 20,
                                               "step_count": 20,
                                               "accuracy": 2,
-                                              "scan_direction": 0,
+                                              "scan_parameter": 0,
                                               "data_sampling": 0
                                             }
                                             average step count - number of frames to average, must be between 1 - 30, default = 20
                                             step count - max iteration steps, must be between 5 - 30, default = 10
                                             accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
-                                            scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                            scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                             data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                             if json is nullptr it will be ignored and calibration will use the default parameters
         * \param[in]  content_size        Json string size if its 0 the json will be ignored and calibration will use the default parameters
@@ -456,13 +456,13 @@ return results;
                                                "average_step_count": 20,
                                                "step_count": 20,
                                                "accuracy": 2,
-                                               "scan_direction": 0,
+                                               "scan_parameter": 0,
                                                "data_sampling": 0
                                              }
                                              average step count - number of frames to average, must be between 1 - 30, default = 20
                                              step count - max iteration steps, must be between 5 - 30, default = 10
                                              accuracy - Subpixel accuracy level, value can be one of: Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%), default is very high (0.025%)
-                                             scan_direction - value can be one of: Py scan (default) = 0, Rx scan = 1
+                                             scan_parameter - value can be one of: Py scan (default) = 0, Rx scan = 1
                                              data_sampling - value can be one of:polling data sampling = 0, interrupt data sampling = 1
                                              if json is nullptr it will be ignored and calibration will use the default parameters
          * \param[in]  content_size        Json string size if its 0 the json will be ignored and calibration will use the default parameters

--- a/src/auto-calibrated-device.h
+++ b/src/auto-calibrated-device.h
@@ -13,7 +13,7 @@ namespace librealsense
     public:
         virtual void write_calibration() const = 0;
         virtual std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json, float* health, update_progress_callback_ptr progress_callback) = 0;
-        virtual std::vector<uint8_t> run_tare_calibration( int timeout_ms, float ground_truth_mm, std::string json, float* health, update_progress_callback_ptr progress_callback) = 0;
+        virtual std::vector<uint8_t> run_tare_calibration( int timeout_ms, float ground_truth_mm, std::string json, update_progress_callback_ptr progress_callback) = 0;
         virtual std::vector<uint8_t> get_calibration_table() const = 0;
         virtual void set_calibration_table(const std::vector<uint8_t>& calibration) = 0;
         virtual void reset_to_factory_calibration() const = 0;

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -397,7 +397,7 @@ namespace librealsense
         memcpy(calib.data(), header, calib.size()); // Copy to new_calib
 
         if(health)
-            *health = abs(reslt->m_dscResultParams.m_healthCheck);
+            *health = reslt->m_dscResultParams.m_healthCheck;
 
         return calib;
     }

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -41,7 +41,7 @@ namespace librealsense
         interrupt = 1
     };
 
-    enum scan_direction
+    enum scan_parameter
     {
         py_scan = 0,
         rx_scan = 1
@@ -57,7 +57,7 @@ namespace librealsense
 
     struct params4
     {
-        int scan_direction : 1;
+        int scan_parameter : 1;
         int reserved : 2;
         int data_sampling : 1;
     };
@@ -78,7 +78,7 @@ namespace librealsense
     const int DEFAULT_STEP_COUNT = 20;
     const int DEFAULT_ACCURACY = subpixel_accuracy::medium;
     const int DEFAULT_SPEED = auto_calib_speed::speed_slow;
-    const int DEFAULT_SCAN = scan_direction::py_scan;
+    const int DEFAULT_SCAN = scan_parameter::py_scan;
     const int DEFAULT_SAMPLING = data_sampling::polling;
 
     auto_calibrated::auto_calibrated(std::shared_ptr<hw_monitor>& hwm)
@@ -103,7 +103,7 @@ namespace librealsense
     std::vector<uint8_t> auto_calibrated::run_on_chip_calibration(int timeout_ms, std::string json, float* health, update_progress_callback_ptr progress_callback)
     {
         int speed = DEFAULT_SPEED;
-        int scan_direction = DEFAULT_SCAN;
+        int scan_parameter = DEFAULT_SCAN;
         int data_sampling = DEFAULT_SAMPLING;
 
         if (json.size() > 0)
@@ -115,7 +115,7 @@ namespace librealsense
             }
             if (jsn.find("scan direction") != jsn.end())
             {
-                scan_direction = jsn["scan direction"];
+                scan_parameter = jsn["scan direction"];
             }
             if (jsn.find("data sampling") != jsn.end())
             {
@@ -123,9 +123,9 @@ namespace librealsense
             }
         }
 
-        check_params(speed, scan_direction, data_sampling);
+        check_params(speed, scan_parameter, data_sampling);
 
-        param4 param{ (byte)scan_direction, 0, (byte)data_sampling };
+        param4 param{ (byte)scan_parameter, 0, (byte)data_sampling };
 
         std::shared_ptr<ds5_advanced_mode_base> preset_recover;
         if (speed == speed_white_wall)
@@ -199,7 +199,7 @@ namespace librealsense
         int step_count = DEFAULT_STEP_COUNT;
         int accuracy = DEFAULT_ACCURACY;
         int speed = DEFAULT_SPEED;
-        int scan_direction = DEFAULT_SCAN;
+        int scan_parameter = DEFAULT_SCAN;
         int data_sampling = DEFAULT_SAMPLING;
 
         if (json.size() > 0)
@@ -221,9 +221,9 @@ namespace librealsense
             {
                 accuracy = jsn["accuracy"];
             }
-            if (jsn.find("scan_direction") != jsn.end())
+            if (jsn.find("scan_parameter") != jsn.end())
             {
-                scan_direction = jsn["scan direction"];
+                scan_parameter = jsn["scan direction"];
             }
             if (jsn.find("data_sampling") != jsn.end())
             {
@@ -231,7 +231,7 @@ namespace librealsense
             }
         }
 
-        check_tare_params(speed, scan_direction, data_sampling, average_step_count, step_count, accuracy);
+        check_tare_params(speed, scan_parameter, data_sampling, average_step_count, step_count, accuracy);
 
         auto preset_recover = change_preset();
 
@@ -239,7 +239,7 @@ namespace librealsense
 
         tare_calibration_params param3{ (byte)average_step_count, (byte)step_count, (byte)accuracy, 0};
 
-        param4 param{ (byte)scan_direction, 0, (byte)data_sampling };
+        param4 param{ (byte)scan_parameter, 0, (byte)data_sampling };
 
         _hw_monitor->send(command{ ds::AUTO_CALIB, tare_calib_begin, param2, param3.param3, param.param_4});
 
@@ -327,20 +327,20 @@ namespace librealsense
         return recover_preset;
     }
 
-    void auto_calibrated::check_params(int speed, int scan_direction, int data_sampling) const
+    void auto_calibrated::check_params(int speed, int scan_parameter, int data_sampling) const
     {
         if (speed < speed_very_fast || speed >  speed_white_wall)
             throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'speed' " << speed << " is out of range (0 - 4).");
-       if (scan_direction != py_scan && scan_direction != rx_scan)
-            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'scan direction' " << scan_direction << " is out of range (0 - 1).");
+       if (scan_parameter != py_scan && scan_parameter != rx_scan)
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'scan direction' " << scan_parameter << " is out of range (0 - 1).");
         if (data_sampling != polling && data_sampling != interrupt)
             throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'data sampling' " << data_sampling << " is out of range (0 - 1).");
 
     }
 
-    void auto_calibrated::check_tare_params(int speed, int scan_direction, int data_sampling, int average_step_count, int step_count, int accuracy)
+    void auto_calibrated::check_tare_params(int speed, int scan_parameter, int data_sampling, int average_step_count, int step_count, int accuracy)
     {
-        check_params(speed, scan_direction, data_sampling);
+        check_params(speed, scan_parameter, data_sampling);
 
         if (average_step_count < 1 || average_step_count > 30)
             throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'number of frames to average' " << average_step_count << " is out of range (1 - 30).");

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -113,9 +113,9 @@ namespace librealsense
             {
                 speed = jsn["speed"];
             }
-            if (jsn.find("scan direction") != jsn.end())
+            if (jsn.find("scan parameter") != jsn.end())
             {
-                scan_parameter = jsn["scan direction"];
+                scan_parameter = jsn["scan parameter"];
             }
             if (jsn.find("data sampling") != jsn.end())
             {
@@ -165,7 +165,7 @@ namespace librealsense
                 LOG_WARNING(ex.what());
             }
             if (progress_callback)
-                progress_callback->on_update_progress(count++ * (2 * speed));
+                progress_callback->on_update_progress(count++ * (2 * speed)); //curently this number does not reflect the actual progress
 
             now = std::chrono::high_resolution_clock::now();
 
@@ -223,7 +223,7 @@ namespace librealsense
             }
             if (jsn.find("scan_parameter") != jsn.end())
             {
-                scan_parameter = jsn["scan direction"];
+                scan_parameter = jsn["scan parameter"];
             }
             if (jsn.find("data_sampling") != jsn.end())
             {
@@ -275,7 +275,7 @@ namespace librealsense
             }
 
             if (progress_callback)
-                progress_callback->on_update_progress(count * (2 * speed));
+                progress_callback->on_update_progress(count * (2 * speed)); //curently this number does not reflect the actual progress
 
             now = std::chrono::high_resolution_clock::now();
 
@@ -332,7 +332,7 @@ namespace librealsense
         if (speed < speed_very_fast || speed >  speed_white_wall)
             throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'speed' " << speed << " is out of range (0 - 4).");
        if (scan_parameter != py_scan && scan_parameter != rx_scan)
-            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'scan direction' " << scan_parameter << " is out of range (0 - 1).");
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'scan parameter' " << scan_parameter << " is out of range (0 - 1).");
         if (data_sampling != polling && data_sampling != interrupt)
             throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'data sampling' " << data_sampling << " is out of range (0 - 1).");
 

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -18,6 +18,69 @@ namespace librealsense
         set_coefficients = 0x19
     };
 
+    enum auto_calib_speed
+    {
+        speed_very_fast = 0,
+        speed_fast = 1,
+        speed_medium = 2,
+        speed_slow = 3,
+        speed_white_wall = 4
+    };
+
+    enum subpixel_accuracy
+    {
+        very_high = 0, //(0.025%)
+        high = 1, //(0.05%)
+        medium = 2, //(0.1%)
+        low = 3 //(0.2%)
+    };
+
+    enum data_sampling
+    {
+        polling = 0,
+        interrupt = 1
+    };
+
+    enum scan_direction
+    {
+        py_scan = 0,
+        rx_scan = 1
+    };
+
+    struct tare_params3
+    {
+        byte average_step_count;
+        byte step_count;
+        byte accuracy;
+        byte reserved;
+    };
+
+    struct params4
+    {
+        int scan_direction : 1;
+        int reserved : 2;
+        int data_sampling : 1;
+    };
+
+    union tare_calibration_params
+    {
+        tare_params3 param3_struct;
+        int param3;
+    };
+
+    union param4
+    {
+        params4 param4_struct;
+        int param_4;
+    };
+
+    const int DEFAULT_AVERAGE_STEP_COUNT = 20;
+    const int DEFAULT_STEP_COUNT = 20;
+    const int DEFAULT_ACCURACY = subpixel_accuracy::medium;
+    const int DEFAULT_SPEED = auto_calib_speed::speed_slow;
+    const int DEFAULT_SCAN = scan_direction::py_scan;
+    const int DEFAULT_SAMPLING = data_sampling::polling;
+
     auto_calibrated::auto_calibrated(std::shared_ptr<hw_monitor>& hwm)
         :_hw_monitor(hwm){}
 
@@ -39,25 +102,39 @@ namespace librealsense
 
     std::vector<uint8_t> auto_calibrated::run_on_chip_calibration(int timeout_ms, std::string json, float* health, update_progress_callback_ptr progress_callback)
     {
+        int speed = DEFAULT_SPEED;
+        int scan_direction = DEFAULT_SCAN;
+        int data_sampling = DEFAULT_SAMPLING;
+
         if (json.size() > 0)
         {
             auto jsn = parse_json(json);
             if (jsn.find("speed") != jsn.end())
             {
-                _speed = jsn["speed"];
+                speed = jsn["speed"];
+            }
+            if (jsn.find("scan direction") != jsn.end())
+            {
+                scan_direction = jsn["scan direction"];
+            }
+            if (jsn.find("data sampling") != jsn.end())
+            {
+                data_sampling = jsn["data sampling"];
             }
         }
 
-        check_params();
+        check_params(speed, scan_direction, data_sampling);
+
+        param4 param{ (byte)scan_direction, 0, (byte)data_sampling };
 
         std::shared_ptr<ds5_advanced_mode_base> preset_recover;
-        if (_speed == speed_white_wall)
+        if (speed == speed_white_wall)
             preset_recover = change_preset();
 
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
         // Begin auto-calibration
-        _hw_monitor->send(command{ ds::AUTO_CALIB, auto_calib_begin, _speed });
+        _hw_monitor->send(command{ ds::AUTO_CALIB, auto_calib_begin, speed, 0, 0, param.param_4});
 
         DirectSearchCalibrationResult result{};
 
@@ -88,7 +165,7 @@ namespace librealsense
                 LOG_WARNING(ex.what());
             }
             if (progress_callback)
-                progress_callback->on_update_progress(count++ * (2 * _speed));
+                progress_callback->on_update_progress(count++ * (2 * speed));
 
             now = std::chrono::high_resolution_clock::now();
 
@@ -116,38 +193,55 @@ namespace librealsense
         return res;
     }
 
-    std::vector<uint8_t> auto_calibrated::run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, float* health, update_progress_callback_ptr progress_callback)
+    std::vector<uint8_t> auto_calibrated::run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, update_progress_callback_ptr progress_callback)
     {
+        int average_step_count = DEFAULT_AVERAGE_STEP_COUNT;
+        int step_count = DEFAULT_STEP_COUNT;
+        int accuracy = DEFAULT_ACCURACY;
+        int speed = DEFAULT_SPEED;
+        int scan_direction = DEFAULT_SCAN;
+        int data_sampling = DEFAULT_SAMPLING;
+
         if (json.size() > 0)
         {
             auto jsn = parse_json(json);
             if (jsn.find("speed") != jsn.end())
             {
-                _speed = jsn["speed"];
+                speed = jsn["speed"];
             }
             if (jsn.find("average_step_count") != jsn.end())
             {
-                _average_step_count = jsn["average_step_count"];
+                average_step_count = jsn["average_step_count"];
             }
             if (jsn.find("step_count") != jsn.end())
             {
-                _step_count = jsn["step_count"];
+                step_count = jsn["step_count"];
             }
             if (jsn.find("accuracy") != jsn.end())
             {
-                _accuracy = jsn["accuracy"];
+                accuracy = jsn["accuracy"];
+            }
+            if (jsn.find("scan_direction") != jsn.end())
+            {
+                scan_direction = jsn["scan direction"];
+            }
+            if (jsn.find("data_sampling") != jsn.end())
+            {
+                data_sampling = jsn["data sampling"];
             }
         }
 
-        check_params();
+        check_tare_params(speed, scan_direction, data_sampling, average_step_count, step_count, accuracy);
 
         auto preset_recover = change_preset();
 
         auto param2 = (int)ground_truth_mm * 100;
-       
-        tare_calibration_params param3{ (byte)_average_step_count, (byte)_step_count, (byte)_accuracy, 0};
 
-        _hw_monitor->send(command{ ds::AUTO_CALIB, tare_calib_begin, param2, param3.param3});
+        tare_calibration_params param3{ (byte)average_step_count, (byte)step_count, (byte)accuracy, 0};
+
+        param4 param{ (byte)scan_direction, 0, (byte)data_sampling };
+
+        _hw_monitor->send(command{ ds::AUTO_CALIB, tare_calib_begin, param2, param3.param3, param.param_4});
 
         DirectSearchCalibrationResult result;
 
@@ -181,7 +275,7 @@ namespace librealsense
             }
 
             if (progress_callback)
-                progress_callback->on_update_progress(count * (2 * _speed));
+                progress_callback->on_update_progress(count * (2 * speed));
 
             now = std::chrono::high_resolution_clock::now();
 
@@ -202,7 +296,7 @@ namespace librealsense
             handle_calibration_error(status);
         }
 
-        return get_calibration_results(health);
+        return get_calibration_results();
     }
 
     std::shared_ptr<ds5_advanced_mode_base> auto_calibrated::change_preset()
@@ -233,16 +327,27 @@ namespace librealsense
         return recover_preset;
     }
 
-    void auto_calibrated::check_params() const
+    void auto_calibrated::check_params(int speed, int scan_direction, int data_sampling) const
     {
-        if (_speed < speed_very_fast || _speed >  speed_white_wall)
-            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'speed' " << _speed << " is out of range (0 - 4).");
-        if(_average_step_count < 1 || _average_step_count > 30)
-            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'number of frames to average' " << _average_step_count << " is out of range (1 - 30).");
-        if (_step_count < 5 || _step_count > 30)
-            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'max iteration steps' " << _step_count << " is out of range (5 - 30).");
-        if(_accuracy < very_high || _accuracy > low)
-            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'subpixel accuracy' " << _accuracy << " is out of range (0 - 3).");
+        if (speed < speed_very_fast || speed >  speed_white_wall)
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'speed' " << speed << " is out of range (0 - 4).");
+       if (scan_direction != py_scan && scan_direction != rx_scan)
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'scan direction' " << scan_direction << " is out of range (0 - 1).");
+        if (data_sampling != polling && data_sampling != interrupt)
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'data sampling' " << data_sampling << " is out of range (0 - 1).");
+
+    }
+
+    void auto_calibrated::check_tare_params(int speed, int scan_direction, int data_sampling, int average_step_count, int step_count, int accuracy)
+    {
+        check_params(speed, scan_direction, data_sampling);
+
+        if (average_step_count < 1 || average_step_count > 30)
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'number of frames to average' " << average_step_count << " is out of range (1 - 30).");
+        if (step_count < 5 || step_count > 30)
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'max iteration steps' " << step_count << " is out of range (5 - 30).");
+        if (accuracy < very_high || accuracy > low)
+            throw invalid_value_exception(to_string() << "Auto calibration failed! Given value of 'subpixel accuracy' " << accuracy << " is out of range (0 - 3).");
     }
 
     void auto_calibrated::handle_calibration_error(rs2_dsc_status status) const
@@ -291,7 +396,8 @@ namespace librealsense
         calib.resize(sizeof(table_header) + header->table_size, 0);
         memcpy(calib.data(), header, calib.size()); // Copy to new_calib
 
-        *health = abs(reslt->m_dscResultParams.m_healthCheck);
+        if(health)
+            *health = abs(reslt->m_dscResultParams.m_healthCheck);
 
         return calib;
     }

--- a/src/ds5/ds5-auto-calibration.h
+++ b/src/ds5/ds5-auto-calibration.h
@@ -51,67 +51,27 @@ namespace librealsense
             RS2_DSC_STATUS_NO_DEPTH_AVERAGE = 7
         };
 
-        enum auto_calib_speed
-        {
-            speed_very_fast = 0,
-            speed_fast = 1,
-            speed_medium = 2,
-            speed_slow = 3,
-            speed_white_wall = 4
-        };
-
-        enum subpixel_accuracy
-        {
-            very_high = 0, //(0.025%)
-            high = 1, //(0.05%)
-            medium = 2, //(0.1%)
-            low = 3 //(0.2%)
-        };
-
-        struct tare_params3
-        {
-            byte average_step_count;
-            byte step_count;
-            byte accuracy;
-            byte reserved;
-        };
-
-        union tare_calibration_params
-        {
-            tare_params3 param3_struct;
-            int param3;
-        };
-
 #pragma pack(pop)
-
-        const int DEFAULT_AVERAGE_STEP_COUNT = 20;
-        const int DEFAULT_STEP_COUNT = 20;
-        const int DEFAULT_ACCURACY = subpixel_accuracy::medium;
-        const int DEFAULT_SPEED = auto_calib_speed::speed_slow;
 
     public:
         auto_calibrated(std::shared_ptr<hw_monitor>& hwm);
         void write_calibration() const override;
         std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json, float* health, update_progress_callback_ptr progress_callback) override;
-        std::vector<uint8_t> run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, float* health, update_progress_callback_ptr progress_callback) override;
+        std::vector<uint8_t> run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, update_progress_callback_ptr progress_callback) override;
         std::vector<uint8_t> get_calibration_table() const override;
         void set_calibration_table(const std::vector<uint8_t>& calibration) override;
         void reset_to_factory_calibration() const override;
 
     private:
-        std::vector<uint8_t> get_calibration_results(float* health) const;
+        std::vector<uint8_t> get_calibration_results(float* health = nullptr) const;
         void handle_calibration_error(rs2_dsc_status status) const;
         std::map<std::string, int> parse_json(std::string json);
         std::shared_ptr< ds5_advanced_mode_base> change_preset();
-        void check_params() const;
+        void check_params(int speed, int scan_direction, int data_sampling) const;
+        void check_tare_params(int speed, int scan_direction, int data_sampling, int average_step_count, int step_count, int accuracy);
 
         std::vector<uint8_t> _curr_calibration;
         std::shared_ptr<hw_monitor>& _hw_monitor;
-
-        int _average_step_count = DEFAULT_AVERAGE_STEP_COUNT;
-        int _step_count = DEFAULT_STEP_COUNT;
-        int _accuracy = DEFAULT_ACCURACY;
-        int _speed = DEFAULT_SPEED;
     };
 
 }

--- a/src/ds5/ds5-auto-calibration.h
+++ b/src/ds5/ds5-auto-calibration.h
@@ -67,8 +67,8 @@ namespace librealsense
         void handle_calibration_error(rs2_dsc_status status) const;
         std::map<std::string, int> parse_json(std::string json);
         std::shared_ptr< ds5_advanced_mode_base> change_preset();
-        void check_params(int speed, int scan_direction, int data_sampling) const;
-        void check_tare_params(int speed, int scan_direction, int data_sampling, int average_step_count, int step_count, int accuracy);
+        void check_params(int speed, int scan_parameter, int data_sampling) const;
+        void check_tare_params(int speed, int scan_parameter, int data_sampling, int average_step_count, int step_count, int accuracy);
 
         std::vector<uint8_t> _curr_calibration;
         std::shared_ptr<hw_monitor>& _hw_monitor;

--- a/src/l500/l500-fw-update-device.cpp
+++ b/src/l500/l500-fw-update-device.cpp
@@ -25,7 +25,7 @@ namespace librealsense
             throw std::runtime_error("DFU - failed to parse serial number!");
 
         auto rev = buffer;
-        std::reverse(std::begin(rev), std::end(rev));// TODO: FW bug?
+
         std::stringstream rv;
         for (auto i = 0; i < ivcam2::module_serial_size; i++)
             rv << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(rev[i]);

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -65,26 +65,24 @@ void init_device(py::module &m) {
     py::class_<rs2::auto_calibrated_device, rs2::device> auto_calibrated_device(m, "auto_calibrated_device");
     auto_calibrated_device.def(py::init<rs2::device>(), "device"_a)
         .def("write_calibration", &rs2::auto_calibrated_device::write_calibration, "Write calibration that was set by set_calibration_table to device's EEPROM.")
-        .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, int timeout_ms, std::string json_content)
+        .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, std::string json_content, int timeout_ms)
         { 
             float health;
-            return py::make_tuple(self.run_on_chip_calibration(timeout_ms, json_content, &health), health);
-        },"This will improve the depth noise (plane fit RMS). This call is executed on the caller's thread and it supports progress notifications via the callback.", "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
-        .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, int timeout_ms, std::string json_content, std::function<void(float)> f)
+            return py::make_tuple(self.run_on_chip_calibration(json_content, &health, timeout_ms), health);
+        },"This will improve the depth noise (plane fit RMS). This call is executed on the caller's thread.","json_content"_a, "timeout_ms"_a, py::call_guard<py::gil_scoped_release>())
+        .def("run_on_chip_calibration", [](rs2::auto_calibrated_device& self, std::string json_content, std::function<void(float)> f, int timeout_ms)
         {
             float health;
-            return py::make_tuple(self.run_on_chip_calibration(timeout_ms, json_content, &health, f), health);
-        },"This will improve the depth noise (plane fit RMS). This call is executed on the caller's thread.", "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
-        .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, int timeout_ms, std::string json_content)
+            return py::make_tuple(self.run_on_chip_calibration(json_content, &health, f, timeout_ms), health);
+        },"This will improve the depth noise (plane fit RMS). This call is executed on the caller's thread and it supports progress notifications via the callback.", "json_content"_a, "callback"_a, "timeout_ms"_a, py::call_guard<py::gil_scoped_release>())
+        .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, std::string json_content, int timeout_ms)
         {
-            float health;
-            return py::make_tuple(self.run_tare_calibration(ground_truth_mm, timeout_ms, json_content, &health), health);
-        }, "This will adjust camera absolute distance to flat target. This call is executed on the caller's thread and it supports progress notifications via the callback.", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, py::call_guard<py::gil_scoped_release>())
-        .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, int timeout_ms, std::string json_content, std::function<void(float)> callback) 
+            return self.run_tare_calibration(ground_truth_mm, json_content, timeout_ms);
+        }, "This will adjust camera absolute distance to flat target. This call is executed on the caller's thread and it supports progress notifications via the callback.", "ground_truth_mm"_a, "json_content"_a, "timeout_ms"_a, py::call_guard<py::gil_scoped_release>())
+        .def("run_tare_calibration", [](const rs2::auto_calibrated_device& self, float ground_truth_mm, std::string json_content, std::function<void(float)> callback, int timeout_ms)
         {
-            float health;
-            return py::make_tuple(self.run_tare_calibration(ground_truth_mm, timeout_ms, json_content, &health, callback), health);
-        }, "This will adjust camera absolute distance to flat target. This call is executed on the caller's thread.", "ground_truth_mm"_a, "timeout_ms"_a, "json_content"_a, "callback"_a, py::call_guard<py::gil_scoped_release>())
+            return self.run_tare_calibration(ground_truth_mm, json_content, callback, timeout_ms);
+        }, "This will adjust camera absolute distance to flat target. This call is executed on the caller's thread.", "ground_truth_mm"_a, "json_content"_a, "callback"_a, "timeout_ms"_a, py::call_guard<py::gil_scoped_release>())
         .def("get_calibration_table", &rs2::auto_calibrated_device::get_calibration_table, "Read current calibration table from flash.")
         .def("set_calibration_table", &rs2::auto_calibrated_device::set_calibration_table, "Set current table to dynamic area.")
         .def("reset_to_factory_calibration", &rs2::auto_calibrated_device::reset_to_factory_calibration, "Reset device to factory calibration.");


### PR DESCRIPTION
Added rs2_run_on_chip_calibration and rs2_run_tare_calibration for c API,
added 'scan direction' and 'data sampling' parameters to auto calibration,
declare all the parameters as locals instead of members,
remove 'health' parameter from tare calibration,
fix health limits on viewer, 
and set default value to timeout on auto calibration.