### PR TITLE
Upgrade T265 firmware to 0.2.0.896

### DIFF
--- a/third-party/libtm/fw/CMakeLists.txt
+++ b/third-party/libtm/fw/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 cmake_minimum_required(VERSION 3.1.3)
 
-set( FW_VERSION "0.2.0.879")
-set( FW_SHA1 b7b722b785fcf5f8c31877173c8ba02fed120e03)
+set( FW_VERSION "0.2.0.896")
+set( FW_SHA1 1b1bc1f33bcc67dfb0eda9eed61f9e285de5d6dc)
 set(APP_VERSION "2.0.19.271")
 set(APP_SHA1 cab0011e9e18edc8bcca20afb2f944399ac8b81c)
 set( BL_VERSION "1.0.1.112")


### PR DESCRIPTION
  - Avoid pruning the map near static nodes
  - Avoid starting upside down in rare cases (fixes fly-aways during initialization)
  - Fix/allow map preservatiom when there is was no previous map to preserve (#5401)