### PR TITLE
CMake: unix_config, set CMAKE_POSITION_INDEPENDENT_CODE

### DIFF
--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -1,8 +1,9 @@
 message(STATUS "Setting Unix configurations")
 
 macro(os_set_flags)
-    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fPIC -pedantic -g -D_DEFAULT_SOURCE")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pedantic -g -Wno-missing-field-initializers")
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+    set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -pedantic -g -D_DEFAULT_SOURCE")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -g -Wno-missing-field-initializers")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-switch -Wno-multichar -Wsequence-point -Wformat -Wformat-security")
 
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_VARIABLE MACHINE)


### PR DESCRIPTION
And remove manually set `fPIC`. `CMAKE_POSITION_INDEPENDENT_CODE` properly
sets `fPIC` for libraries and `fPIE` for executables.