### PR TITLE
Add sensor extensions

### DIFF
--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -174,6 +174,8 @@ typedef enum rs2_extension
     RS2_EXTENSION_L500_DEPTH_SENSOR,
     RS2_EXTENSION_TM2_SENSOR,
     RS2_EXTENSION_AUTO_CALIBRATED_DEVICE,
+    RS2_EXTENSION_COLOR_SENSOR,
+    RS2_EXTENSION_MOTION_SENSOR,
     RS2_EXTENSION_COUNT
 } rs2_extension;
 const char* rs2_extension_type_to_string(rs2_extension type);

--- a/include/librealsense2/h/rs_types.h
+++ b/include/librealsense2/h/rs_types.h
@@ -176,6 +176,7 @@ typedef enum rs2_extension
     RS2_EXTENSION_AUTO_CALIBRATED_DEVICE,
     RS2_EXTENSION_COLOR_SENSOR,
     RS2_EXTENSION_MOTION_SENSOR,
+    RS2_EXTENSION_FISHEYE_SENSOR,
     RS2_EXTENSION_COUNT
 } rs2_extension;
 const char* rs2_extension_type_to_string(rs2_extension type);

--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -345,6 +345,38 @@ namespace rs2
             && std::string(lhs.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)) == rhs.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
     }
 
+    class motion_sensor : public sensor
+    {
+    public:
+        motion_sensor(sensor s)
+            : sensor(s.get())
+        {
+            rs2_error* e = nullptr;
+            if (rs2_is_sensor_extendable_to(_sensor.get(), RS2_EXTENSION_MOTION_SENSOR, &e) == 0 && !e)
+            {
+                _sensor.reset();
+            }
+            error::handle(e);
+        }
+        operator bool() const { return _sensor.get() != nullptr; }
+    };
+
+    class color_sensor : public sensor
+    {
+    public:
+        color_sensor(sensor s)
+            : sensor(s.get())
+        {
+            rs2_error* e = nullptr;
+            if (rs2_is_sensor_extendable_to(_sensor.get(), RS2_EXTENSION_COLOR_SENSOR, &e) == 0 && !e)
+            {
+                _sensor.reset();
+            }
+            error::handle(e);
+        }
+        operator bool() const { return _sensor.get() != nullptr; }
+    };
+
     class roi_sensor : public sensor
     {
     public:

--- a/include/librealsense2/hpp/rs_sensor.hpp
+++ b/include/librealsense2/hpp/rs_sensor.hpp
@@ -345,6 +345,22 @@ namespace rs2
             && std::string(lhs.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)) == rhs.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
     }
 
+    class color_sensor : public sensor
+    {
+    public:
+        color_sensor(sensor s)
+            : sensor(s.get())
+        {
+            rs2_error* e = nullptr;
+            if (rs2_is_sensor_extendable_to(_sensor.get(), RS2_EXTENSION_COLOR_SENSOR, &e) == 0 && !e)
+            {
+                _sensor.reset();
+            }
+            error::handle(e);
+        }
+        operator bool() const { return _sensor.get() != nullptr; }
+    };
+
     class motion_sensor : public sensor
     {
     public:
@@ -361,14 +377,14 @@ namespace rs2
         operator bool() const { return _sensor.get() != nullptr; }
     };
 
-    class color_sensor : public sensor
+    class fisheye_sensor : public sensor
     {
     public:
-        color_sensor(sensor s)
+        fisheye_sensor(sensor s)
             : sensor(s.get())
         {
             rs2_error* e = nullptr;
-            if (rs2_is_sensor_extendable_to(_sensor.get(), RS2_EXTENSION_COLOR_SENSOR, &e) == 0 && !e)
+            if (rs2_is_sensor_extendable_to(_sensor.get(), RS2_EXTENSION_FISHEYE_SENSOR, &e) == 0 && !e)
             {
                 _sensor.reset();
             }

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -277,6 +277,15 @@ namespace librealsense
 
     class depth_stereo_sensor;
 
+    class color_sensor
+    {
+    public:
+        virtual ~color_sensor() = default;
+    };
+
+    MAP_EXTENSION(RS2_EXTENSION_COLOR_SENSOR, librealsense::color_sensor);
+
+
     class depth_sensor : public recordable<depth_sensor>
     {
     public:

--- a/src/ds5/ds5-color.h
+++ b/src/ds5/ds5-color.h
@@ -36,7 +36,8 @@ namespace librealsense
 
     class ds5_color_sensor : public synthetic_sensor,
                              public video_sensor_interface,
-                             public roi_sensor_base
+                             public roi_sensor_base,
+                             public color_sensor
     {
     public:
         explicit ds5_color_sensor(ds5_color* owner,

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -105,7 +105,7 @@ namespace librealsense
         const ds5_motion* _owner;
     };
 
-    class ds5_fisheye_sensor : public synthetic_sensor, public video_sensor_interface, public roi_sensor_base
+    class ds5_fisheye_sensor : public synthetic_sensor, public video_sensor_interface, public roi_sensor_base, public fisheye_sensor
     {
     public:
         explicit ds5_fisheye_sensor(std::shared_ptr<sensor_base> sensor,

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -58,7 +58,8 @@ namespace librealsense
         region_of_interest _roi{};
     };
 
-    class ds5_hid_sensor : public synthetic_sensor
+    class ds5_hid_sensor : public synthetic_sensor,
+                           public motion_sensor
     {
     public:
         explicit ds5_hid_sensor(std::string name,

--- a/src/ivcam/sr300.h
+++ b/src/ivcam/sr300.h
@@ -236,7 +236,7 @@ namespace librealsense
             sr300_camera& _owner;
         };
 
-        class sr300_color_sensor : public synthetic_sensor, public video_sensor_interface, public roi_sensor_base
+        class sr300_color_sensor : public synthetic_sensor, public video_sensor_interface, public roi_sensor_base, public color_sensor
         {
         public:
             explicit sr300_color_sensor(sr300_camera* owner,

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -40,7 +40,7 @@ namespace librealsense
         std::vector<uint8_t> get_raw_extrinsics_table() const;
     };
 
-    class l500_color_sensor : public synthetic_sensor, public video_sensor_interface
+    class l500_color_sensor : public synthetic_sensor, public video_sensor_interface, public color_sensor
         {
         public:
             explicit l500_color_sensor(l500_color* owner,

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -51,7 +51,7 @@ namespace librealsense
                         {400,  4}}} };
 #endif
 
-    class l500_hid_sensor : public synthetic_sensor
+    class l500_hid_sensor : public synthetic_sensor, public motion_sensor
     {
     public:
         explicit l500_hid_sensor(std::string name,

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -257,7 +257,7 @@ namespace librealsense
                     throw std::runtime_error(to_string() << "Device disconnected. Failed to recconect: " << e.what() << timeout_ms);
                 }
             }
-            throw std::runtime_error(to_string() << "Frame didn't arrived within " << timeout_ms);
+            throw std::runtime_error(to_string() << "Frame didn't arrive within " << timeout_ms);
         }
 
         bool pipeline::poll_for_frames(frame_holder* frame)

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1133,7 +1133,8 @@ int rs2_is_sensor_extendable_to(const rs2_sensor* sensor, rs2_extension extensio
     case RS2_EXTENSION_WHEEL_ODOMETER      : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::wheel_odometry_interface)!= nullptr;
     case RS2_EXTENSION_TM2_SENSOR          : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::tm2_sensor_interface)   != nullptr;
     case RS2_EXTENSION_COLOR_SENSOR        : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::color_sensor)           != nullptr;
-    case RS2_EXTENSION_MOTION_SENSOR       : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::motion_sensor)             != nullptr;
+    case RS2_EXTENSION_MOTION_SENSOR       : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::motion_sensor)          != nullptr;
+    case RS2_EXTENSION_FISHEYE_SENSOR      : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::fisheye_sensor)         != nullptr;
 
     default:
         return false;

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1131,7 +1131,9 @@ int rs2_is_sensor_extendable_to(const rs2_sensor* sensor, rs2_extension extensio
     case RS2_EXTENSION_SOFTWARE_SENSOR     : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::software_sensor)        != nullptr;
     case RS2_EXTENSION_POSE_SENSOR         : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::pose_sensor_interface)  != nullptr;
     case RS2_EXTENSION_WHEEL_ODOMETER      : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::wheel_odometry_interface)!= nullptr;
-    case RS2_EXTENSION_TM2_SENSOR          : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::tm2_sensor_interface) != nullptr;
+    case RS2_EXTENSION_TM2_SENSOR          : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::tm2_sensor_interface)   != nullptr;
+    case RS2_EXTENSION_COLOR_SENSOR        : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::color_sensor)           != nullptr;
+    case RS2_EXTENSION_MOTION_SENSOR       : return VALIDATE_INTERFACE_NO_THROW(sensor->sensor, librealsense::motion_sensor)             != nullptr;
 
     default:
         return false;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -130,6 +130,14 @@ namespace librealsense
 
     MAP_EXTENSION(RS2_EXTENSION_MOTION_SENSOR, librealsense::motion_sensor);
 
+    class fisheye_sensor
+    {
+    public:
+        virtual ~fisheye_sensor() = default;
+    };
+
+    MAP_EXTENSION(RS2_EXTENSION_FISHEYE_SENSOR, librealsense::fisheye_sensor);
+
     class synthetic_sensor :
         public sensor_base
     {

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -122,6 +122,14 @@ namespace librealsense
 
     class processing_block;
 
+    class motion_sensor
+    {
+    public:
+        virtual ~motion_sensor() = default;
+    };
+
+    MAP_EXTENSION(RS2_EXTENSION_MOTION_SENSOR, librealsense::motion_sensor);
+
     class synthetic_sensor :
         public sensor_base
     {

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -3838,6 +3838,7 @@ TEST_CASE("color sensor API", "[live][options]")
         REQUIRE(dev);
         auto sensor = profile.get_device().first<rs2::color_sensor>();
         std::string module_name = sensor.get_info(RS2_CAMERA_INFO_NAME);
+        REQUIRE(sensor.is<rs2::color_sensor>());
         WARN("module_name=" << module_name);
         REQUIRE(module_name.size() > 0);
     }

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -3863,6 +3863,26 @@ TEST_CASE("motion sensor API", "[live][options]")
     }
 }
 
+TEST_CASE("fisheye sensor API", "[live][options]")
+{
+    rs2::context ctx;
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.17.1"))
+    {
+        rs2::device dev;
+        rs2::pipeline pipe(ctx);
+        rs2::config cfg;
+        rs2::pipeline_profile profile;
+        REQUIRE_NOTHROW(profile = cfg.resolve(pipe));
+        REQUIRE(profile);
+        REQUIRE_NOTHROW(dev = profile.get_device());
+        REQUIRE(dev);
+        auto sensor = profile.get_device().first<rs2::fisheye_sensor>();
+        std::string module_name = sensor.get_info(RS2_CAMERA_INFO_NAME);
+        WARN("module_name=" << module_name);
+        REQUIRE(module_name.size() > 0);
+    }
+}
+
 // FW Sub-presets API
 TEST_CASE("Alternating Emitter", "[live][options]")
 {

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -3823,6 +3823,46 @@ TEST_CASE("Per-frame metadata sanity check", "[live][!mayfail]") {
     }
 }
 
+TEST_CASE("color sensor API", "[live][options]")
+{
+    rs2::context ctx;
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.17.1"))
+    {
+        rs2::device dev;
+        rs2::pipeline pipe(ctx);
+        rs2::config cfg;
+        rs2::pipeline_profile profile;
+        REQUIRE_NOTHROW(profile = cfg.resolve(pipe));
+        REQUIRE(profile);
+        REQUIRE_NOTHROW(dev = profile.get_device());
+        REQUIRE(dev);
+        auto sensor = profile.get_device().first<rs2::color_sensor>();
+        std::string module_name = sensor.get_info(RS2_CAMERA_INFO_NAME);
+        WARN("module_name=" << module_name);
+        REQUIRE(module_name.size() > 0);
+    }
+}
+
+TEST_CASE("motion sensor API", "[live][options]")
+{
+    rs2::context ctx;
+    if (make_context(SECTION_FROM_TEST_NAME, &ctx, "2.17.1"))
+    {
+        rs2::device dev;
+        rs2::pipeline pipe(ctx);
+        rs2::config cfg;
+        rs2::pipeline_profile profile;
+        REQUIRE_NOTHROW(profile = cfg.resolve(pipe));
+        REQUIRE(profile);
+        REQUIRE_NOTHROW(dev = profile.get_device());
+        REQUIRE(dev);
+        auto sensor = profile.get_device().first<rs2::motion_sensor>();
+        std::string module_name = sensor.get_info(RS2_CAMERA_INFO_NAME);
+        WARN("module_name=" << module_name);
+        REQUIRE(module_name.size() > 0);
+    }
+}
+
 // FW Sub-presets API
 TEST_CASE("Alternating Emitter", "[live][options]")
 {

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -3836,10 +3836,26 @@ TEST_CASE("color sensor API", "[live][options]")
         REQUIRE(profile);
         REQUIRE_NOTHROW(dev = profile.get_device());
         REQUIRE(dev);
+        dev_type PID = get_PID(dev);
+        if (!librealsense::val_in_range(PID.first, { std::string("0AA5"),
+                                                     std::string("0B48"),
+                                                     std::string("0AD3"),
+                                                     std::string("0AD4"),
+                                                     std::string("0AD5"),
+                                                     std::string("0B01"),
+                                                     std::string("0B07"),
+                                                     std::string("0B3A"),
+                                                     std::string("0B3D") }))
+        {
+            WARN("Skipping test - no motion sensor is device type: " << PID.first << (PID.second ? " USB3" : " USB2"));
+            return;
+        }
         auto sensor = profile.get_device().first<rs2::color_sensor>();
         std::string module_name = sensor.get_info(RS2_CAMERA_INFO_NAME);
         REQUIRE(sensor.is<rs2::color_sensor>());
-        WARN("module_name=" << module_name);
+        REQUIRE(!sensor.is<rs2::motion_sensor>());
+        REQUIRE(!sensor.is<rs2::depth_sensor>());
+        REQUIRE(!sensor.is<rs2::fisheye_sensor>());
         REQUIRE(module_name.size() > 0);
     }
 }
@@ -3857,9 +3873,22 @@ TEST_CASE("motion sensor API", "[live][options]")
         REQUIRE(profile);
         REQUIRE_NOTHROW(dev = profile.get_device());
         REQUIRE(dev);
+        dev_type PID = get_PID(dev);
+        if (!librealsense::val_in_range(PID.first, { std::string("0AD5"),
+                                                     std::string("0AFE"),
+                                                     std::string("0AFF"),
+                                                     std::string("0B00"),
+                                                     std::string("0B01"),
+                                                     std::string("0B3A"),
+                                                     std::string("0B3D")}))
+        {
+            WARN("Skipping test - no motion sensor is device type: " << PID.first << (PID.second ? " USB3" : " USB2"));
+            return;
+        }
         auto sensor = profile.get_device().first<rs2::motion_sensor>();
         std::string module_name = sensor.get_info(RS2_CAMERA_INFO_NAME);
-        WARN("module_name=" << module_name);
+        REQUIRE(!sensor.is<rs2::color_sensor>());
+        REQUIRE(!sensor.is<rs2::depth_sensor>());
         REQUIRE(module_name.size() > 0);
     }
 }
@@ -3877,9 +3906,21 @@ TEST_CASE("fisheye sensor API", "[live][options]")
         REQUIRE(profile);
         REQUIRE_NOTHROW(dev = profile.get_device());
         REQUIRE(dev);
+
+        dev_type PID = get_PID(dev);
+        if (!librealsense::val_in_range(PID.first, { std::string("0AD5"),
+                                                     std::string("0AFE"),
+                                                     std::string("0AFF"),
+                                                     std::string("0B00"),
+                                                     std::string("0B01") }))
+        {
+            WARN("Skipping test - no fisheye sensor is device type: " << PID.first << (PID.second ? " USB3" : " USB2"));
+            return;
+        }
         auto sensor = profile.get_device().first<rs2::fisheye_sensor>();
         std::string module_name = sensor.get_info(RS2_CAMERA_INFO_NAME);
-        WARN("module_name=" << module_name);
+        REQUIRE(!sensor.is<rs2::color_sensor>());
+        REQUIRE(!sensor.is<rs2::depth_sensor>());
         REQUIRE(module_name.size() > 0);
     }
 }

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -15,6 +15,9 @@ void init_device(py::module &m) {
         .def("first_depth_sensor", [](rs2::device& self) { return self.first<rs2::depth_sensor>(); }) // No docstring in C++
         .def("first_roi_sensor", [](rs2::device& self) { return self.first<rs2::roi_sensor>(); }) // No docstring in C++
         .def("first_pose_sensor", [](rs2::device& self) { return self.first<rs2::pose_sensor>(); }) // No docstring in C++
+        .def("first_color_sensor", [](rs2::device& self) { return self.first<rs2::color_sensor>(); }) // No docstring in C++
+        .def("first_motion_sensor", [](rs2::device& self) { return self.first<rs2::motion_sensor>(); }) // No docstring in C++
+        .def("first_fisheye_sensor", [](rs2::device& self) { return self.first<rs2::fisheye_sensor>(); }) // No docstring in C++
         .def("supports", &rs2::device::supports, "Check if specific camera info is supported.", "info"_a)
         .def("get_info", &rs2::device::get_info, "Retrieve camera specific information, "
              "like versions of various internal components", "info"_a)

--- a/wrappers/python/pyrs_sensor.cpp
+++ b/wrappers/python/pyrs_sensor.cpp
@@ -67,6 +67,9 @@ void init_sensor(py::module &m) {
         .def("__nonzero__", &rs2::sensor::operator bool) // No docstring in C++
         .def(BIND_DOWNCAST(sensor, roi_sensor))
         .def(BIND_DOWNCAST(sensor, depth_sensor))
+        .def(BIND_DOWNCAST(sensor, color_sensor))
+        .def(BIND_DOWNCAST(sensor, motion_sensor))
+        .def(BIND_DOWNCAST(sensor, fisheye_sensor))
         .def(BIND_DOWNCAST(sensor, pose_sensor))
         .def(BIND_DOWNCAST(sensor, wheel_odometer));
 
@@ -85,6 +88,18 @@ void init_sensor(py::module &m) {
              "Retrieves mapping between the units of the depth image and meters.")
         .def("__nonzero__", &rs2::depth_sensor::operator bool); // No docstring in C++
 
+    py::class_<rs2::color_sensor, rs2::sensor> color_sensor(m, "color_sensor"); // No docstring in C++
+    color_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
+        .def("__nonzero__", &rs2::color_sensor::operator bool); // No docstring in C++
+
+    py::class_<rs2::motion_sensor, rs2::sensor> motion_sensor(m, "motion_sensor"); // No docstring in C++
+    motion_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
+        .def("__nonzero__", &rs2::motion_sensor::operator bool); // No docstring in C++
+
+    py::class_<rs2::fisheye_sensor, rs2::sensor> fisheye_sensor(m, "fisheye_sensor"); // No docstring in C++
+    fisheye_sensor.def(py::init<rs2::sensor>(), "sensor"_a)
+        .def("__nonzero__", &rs2::fisheye_sensor::operator bool); // No docstring in C++
+
     // rs2::depth_stereo_sensor
     py::class_<rs2::depth_stereo_sensor, rs2::depth_sensor> depth_stereo_sensor(m, "depth_stereo_sensor"); // No docstring in C++
     depth_stereo_sensor.def(py::init<rs2::sensor>())
@@ -96,7 +111,7 @@ void init_sensor(py::module &m) {
              "Load relocalization map onto device. Only one relocalization map can be imported at a time; "
              "any previously existing map will be overwritten.\n"
              "The imported map exists simultaneously with the map created during the most recent tracking "
-             "session after \start(),"
+             "session after start(),"
              "and they are merged after the imported map is relocalized.\n"
              "This operation must be done before start().", "lmap_buf"_a)
         .def("export_localization_map", &rs2::pose_sensor::export_localization_map,


### PR DESCRIPTION
Add color_sensor, motion_sensor and fisheye_sensor extensions.
Enable the option to dev.first<rs2::color_sensor>() or sensor.is<rs2::color_sensor>() etc.