### PR TITLE
remove rosdep 'linux-headers-generic'

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,6 @@
   <build_depend>pkg-config</build_depend>
 
   <depend>libusb-1.0-dev</depend>
-  <depend>linux-headers-generic</depend>
   <depend>libssl-dev</depend>
   <depend>dkms</depend>
   <depend>udev</depend>


### PR DESCRIPTION
The `linux-headers-generic` rosdep key does not guarantee that the headers of the running kernel will be installed. E.g. on a Ubuntu 18.04 LTS, the rosdep and package `linux-headers-generic` will depend on `linux-headers-4.15.0-72-generic`, while point releases (.2, .3, ...) will likely have packages `linux-headers-generic-hwe-18.04` installed, which will depend on `linux-headers-5.0.0-37-generic`.
The build system has to determine the running kernel version in any case and this rosdep key just installs "old" unused header packages.