### PR TITLE
Fix extrinsics commutativity

### DIFF
--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -1072,13 +1072,22 @@ namespace librealsense
 
     std::shared_ptr<stream_profile_interface> synthetic_sensor::clone_profile(const std::shared_ptr<stream_profile_interface>& profile)
     {
-        auto cloned = profile->clone();
+        auto cloned = std::make_shared<stream_profile_base>(platform::stream_profile{});
 
-        auto vsp = std::dynamic_pointer_cast<video_stream_profile>(cloned);
+        auto vsp = std::dynamic_pointer_cast<video_stream_profile>(profile);
         if (vsp)
         {
-            vsp->set_dims(vsp->get_width(), vsp->get_height());
+            cloned = std::make_shared<video_stream_profile>(platform::stream_profile{});
+            std::shared_ptr<video_stream_profile> cloned_vsp = std::dynamic_pointer_cast<video_stream_profile>(cloned);
+            cloned_vsp->set_dims(vsp->get_width(), vsp->get_height());
         }
+
+        auto msp = std::dynamic_pointer_cast<motion_stream_profile>(profile);
+        if (msp)
+        {
+            cloned = std::make_shared<motion_stream_profile>(platform::stream_profile{});
+        }
+
         cloned->set_unique_id(profile->get_unique_id());
         cloned->set_format(profile->get_format());
         cloned->set_stream_index(profile->get_stream_index());

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -1074,16 +1074,13 @@ namespace librealsense
     {
         auto cloned = std::make_shared<stream_profile_base>(platform::stream_profile{});
 
-        auto vsp = std::dynamic_pointer_cast<video_stream_profile>(profile);
-        if (vsp)
+        if (auto vsp = std::dynamic_pointer_cast<video_stream_profile>(profile))
         {
             cloned = std::make_shared<video_stream_profile>(platform::stream_profile{});
-            std::shared_ptr<video_stream_profile> cloned_vsp = std::dynamic_pointer_cast<video_stream_profile>(cloned);
-            cloned_vsp->set_dims(vsp->get_width(), vsp->get_height());
+            std::dynamic_pointer_cast<video_stream_profile>(cloned)->set_dims(vsp->get_width(), vsp->get_height());
         }
 
-        auto msp = std::dynamic_pointer_cast<motion_stream_profile>(profile);
-        if (msp)
+        if (auto msp = std::dynamic_pointer_cast<motion_stream_profile>(profile))
         {
             cloned = std::make_shared<motion_stream_profile>(platform::stream_profile{});
         }

--- a/src/stream.h
+++ b/src/stream.h
@@ -117,7 +117,7 @@ namespace librealsense
             std::function<rs2_intrinsics()> int_func = _calc_intrinsics;
             res->set_intrinsics([int_func]() { return int_func(); });
             res->set_framerate(get_framerate());
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*res, *this);
+            //environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*res, *this);
             return res;
         }
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -117,7 +117,7 @@ namespace librealsense
             std::function<rs2_intrinsics()> int_func = _calc_intrinsics;
             res->set_intrinsics([int_func]() { return int_func(); });
             res->set_framerate(get_framerate());
-            //environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*res, *this);
+            environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*res, *this);
             return res;
         }
 


### PR DESCRIPTION
Manually create a new stream profile for every clone needed by the sensor while initializing the stream profiles, instead of cloning via the raw profile.
Cloning the profiles caused extrinsic registration with incomplete profiles.

Addresses #5451

Tested:
Recordings, live-tests, rs-enumerate-devices, rs-viewer.

Follow-up:
Add test case to unit-tests