### PR TITLE
fix recording crash

### DIFF
--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -1513,6 +1513,11 @@ namespace librealsense
         return _raw_sensor->register_before_streaming_changes_callback(callback);
     }
 
+    void synthetic_sensor::unregister_before_start_callback(int token)
+    {
+        _raw_sensor->unregister_before_start_callback(token);
+    }
+
     void synthetic_sensor::register_metadata(rs2_frame_metadata_value metadata, std::shared_ptr<md_attribute_parser_base> metadata_parser) const
     {
         sensor_base::register_metadata(metadata, metadata_parser);

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -155,6 +155,7 @@ namespace librealsense
         void set_frames_callback(frame_callback_ptr callback) override;
         void register_notifications_callback(notifications_callback_ptr callback) override;
         int register_before_streaming_changes_callback(std::function<void(bool)> callback) override;
+        void unregister_before_start_callback(int token) override;
         void register_metadata(rs2_frame_metadata_value metadata, std::shared_ptr<md_attribute_parser_base> metadata_parser) const override;
         bool is_streaming() const override;
         bool is_opened() const override;


### PR DESCRIPTION
Recording unsubscribe signal was not called properly,
causing sensor hooks to be called even after the record device object was destroyed.