### PR TITLE
add build depends to package.xml for ros source builds and CI tests to defend ROS source build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ matrix:
       env:
         - ROS_DISTRO=kinetic
         - ROS_REPO=ros
+        - TEST_BLACKLIST="librealsense2"
       script:
         - cd $TRAVIS_BUILD_DIR
         - git clone --depth 1 -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
@@ -126,6 +127,7 @@ matrix:
       env:
         - ROS_DISTRO=melodic
         - ROS_REPO=ros
+        - TEST_BLACKLIST="librealsense2"
       script:
         - cd $TRAVIS_BUILD_DIR
         - git clone --depth 1 -q https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,40 @@ matrix:
         - cmake --build . --config $LRS_BUILD_CONFIG -- -j4
         - ls
 
+    - name: "ROS - Kinetic"
+      os: linux
+      language: cpp
+      sudo: required
+      dist: xenial
+      services:
+        - docker
+      compiler: gcc
+      cache: ccache
+      env:
+        - ROS_DISTRO=kinetic
+        - ROS_REPO=ros
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - git clone --depth 1 -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+        - .moveit_ci/travis.sh
+
+    - name: "ROS - Melodic"
+      os: linux
+      language: cpp
+      sudo: required
+      dist: bionic
+      services:
+        - docker
+      compiler: gcc
+      cache: ccache
+      env:
+        - ROS_DISTRO=melodic
+        - ROS_REPO=ros
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - git clone --depth 1 -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
+        - .moveit_ci/travis.sh
+
 before_install:
   - cd scripts && ./api_check.sh && cd ..
   - if [[ "$LRS_BUILD_NODEJS" == "true" ]]; then

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,12 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>pkg-config</build_depend>
+  <build_depend>libx11-dev</build_depend>
+  <build_depend>libxrandr</build_depend>
+  <build_depend>libxinerama-dev</build_depend>
+  <build_depend>libxcursor-dev</build_depend>
+  <build_depend>libxi-dev</build_depend>
+  <build_depend>opengl</build_depend>
 
   <depend>libusb-1.0-dev</depend>
   <depend>linux-headers-generic</depend>


### PR DESCRIPTION
This fixes source builds in `ROS Melodic`.  I reported this issue here: https://github.com/IntelRealSense/librealsense/issues/5512

This also extends the unit tests to guarantee this continues to build for both ROS kinetic and melodic.  That way, as future dependencies are added the package.xml file will have to be updated to reflect that so ROS users of this library can continue to build.