### PR TITLE
suppress -Wpadantic in glad.c

### DIFF
--- a/third-party/glad/glad.c
+++ b/third-party/glad/glad.c
@@ -23,6 +23,9 @@
         https://glad.dav1d.de/#profile=compatibility&language=c&specification=gl&api=gl%3D3.2&extensions=GL_APPLE_vertex_array_object&extensions=GL_ARB_multisample&extensions=GL_ARB_robustness&extensions=GL_ARB_vertex_array_object&extensions=GL_KHR_debug
 */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1718,3 +1721,4 @@ int gladLoadGLLoader(GLADloadproc load) {
 	return GLVersion.major != 0 || GLVersion.minor != 0;
 }
 
+#pragma GCC diagnostic pop

--- a/tools/fw-update/readme.md
+++ b/tools/fw-update/readme.md
@@ -3,7 +3,7 @@
 ## Goal
 `rs-fw-update` tool is a console application for updating the depth cameras firmware.
 
-#Prerequisites
+## Prerequisites
 In order to update a depth camera firmware, a signed image file is required.
 The latest firmware for D400 cameras is available [here.](https://downloadcenter.intel.com/download/28870/Latest-Firmware-for-Intel-RealSense-D400-Product-Family?product=128255)
 The firmware is packed into zip file and contains a file with "bin" extension with the following naming convension: "Signed_Image_UVC_<firmware_version>.bin"
@@ -75,5 +75,7 @@ recovery done
 |`-l`|List all available devices and exits|
 |`-v`|Displays version information and exits|
 |`-h`|Displays usage information and exits|
-
 | None| List supported streaming modes|
+
+## Limitation
+* Do not run additional applications that use the RealSense camera, such as Viewer, together with the rs-fw-update tool


### PR DESCRIPTION
This suppresses the flood of `-Wpadantic` warnings from this file in my CI logs.  `glfw` also has a bunch of these, but not as many, and spread across several source files.

Issue: https://github.com/IntelRealSense/librealsense/issues/5525