### PR TITLE
One Viewer Context

### DIFF
--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -354,11 +354,11 @@ namespace rs2
         stbi_image_free(r);
     }
 
-    ux_window::ux_window(const char* title) :
+    ux_window::ux_window(const char* title, context &ctx) :
         _win(nullptr), _width(0), _height(0), _output_height(0),
         _font_14(nullptr), _font_18(nullptr), _app_ready(false),
         _first_frame(true), _query_devices(true), _missing_device(false),
-        _hourglass_index(0), _dev_stat_message{}, _keep_alive(true), _title(title)
+        _hourglass_index(0), _dev_stat_message{}, _keep_alive(true), _title(title), _ctx(ctx)
     {
         open_window();
 
@@ -419,7 +419,7 @@ namespace rs2
         bool do_200ms = every_200ms;
         if (_query_devices && do_200ms)
         {
-            _missing_device = rs2::context().query_devices(RS2_PRODUCT_LINE_ANY).size() == 0;
+            _missing_device = _ctx.query_devices(RS2_PRODUCT_LINE_ANY).size() == 0;
             _hourglass_index = (_hourglass_index + 1) % 5;
 
             if (!_missing_device)

--- a/common/ux-window.h
+++ b/common/ux-window.h
@@ -14,6 +14,7 @@
 namespace rs2
 {
     class visualizer_2d;
+    class context;
 
     class viewer_ui_traits
     {
@@ -34,7 +35,7 @@ namespace rs2
         std::function<void(std::string)> on_file_drop = [](std::string) {};
         std::function<bool()>            on_load = []() { return false; };
 
-        ux_window(const char* title);
+        ux_window(const char* title, context &ctx);
 
         float width() const { return float(_width); }
         float height() const { return float(_height); }
@@ -121,6 +122,7 @@ namespace rs2
 
         std::string              _title;
         std::shared_ptr<visualizer_2d> _2d_vis;
+        context                  &_ctx;
 
         bool                     _is_ui_aligned = false;
     };

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -766,8 +766,9 @@ namespace rs2
         }
     }
 
-    viewer_model::viewer_model()
-            : ppf(*this), 
+    viewer_model::viewer_model(context &ctx_)
+            : ppf(*this),
+              ctx(ctx_),
               synchronization_enable(true),
               zo_sensors(0),
               frameset_alloc(this)

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -65,7 +65,7 @@ namespace rs2
 
         rs2::frame handle_ready_frames(const rect& viewer_rect, ux_window& window, int devices, std::string& error_message);
 
-        viewer_model();
+        viewer_model(context &ctx_);
 
         ~viewer_model()
         {
@@ -128,7 +128,7 @@ namespace rs2
         std::shared_ptr<syncer_model> syncer;
         post_processing_filters ppf;
 
-        context ctx;
+        context &ctx;
         notifications_model not_model;
         bool is_output_collapsed = false;
         bool is_3d_view = false;

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -12,7 +12,9 @@ namespace rs2
     namespace depth_quality
     {
         tool_model::tool_model()
-            : _update_readonly_options_timer(std::chrono::seconds(6)), _roi_percent(0.4f),
+           :  _pipe(_ctx),
+              _viewer_model(_ctx),
+              _update_readonly_options_timer(std::chrono::seconds(6)), _roi_percent(0.4f),
               _roi_located(std::chrono::seconds(4)),
               _too_close(std::chrono::seconds(4)),
               _too_far(std::chrono::seconds(4)),

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -11,9 +11,10 @@ namespace rs2
 {
     namespace depth_quality
     {
-        tool_model::tool_model()
-           :  _pipe(_ctx),
-              _viewer_model(_ctx),
+        tool_model::tool_model(rs2::context &ctx)
+            : _ctx(ctx),
+              _pipe(ctx),
+              _viewer_model(ctx),
               _update_readonly_options_timer(std::chrono::seconds(6)), _roi_percent(0.4f),
               _roi_located(std::chrono::seconds(4)),
               _too_close(std::chrono::seconds(4)),

--- a/tools/depth-quality/depth-quality-model.h
+++ b/tools/depth-quality/depth-quality-model.h
@@ -353,7 +353,7 @@ namespace rs2
         class tool_model
         {
         public:
-            tool_model();
+            tool_model(rs2::context& ctx);
 
             bool start(ux_window& win);
 
@@ -381,7 +381,7 @@ namespace rs2
 
             std::string capture_description();
 
-            rs2::context                    _ctx;
+            rs2::context&                   _ctx;
             pipeline                        _pipe;
             std::shared_ptr<device_model>   _device_model;
             viewer_model                    _viewer_model;

--- a/tools/depth-quality/depth-quality-model.h
+++ b/tools/depth-quality/depth-quality-model.h
@@ -381,6 +381,7 @@ namespace rs2
 
             std::string capture_description();
 
+            rs2::context                    _ctx;
             pipeline                        _pipe;
             std::shared_ptr<device_model>   _device_model;
             viewer_model                    _viewer_model;
@@ -408,7 +409,6 @@ namespace rs2
 
             float                           _min_dist, _max_dist, _max_angle;
             std::mutex                      _mutex;
-            rs2::context                    _ctx;
 
             bool                            _use_ground_truth = false;
             int                             _ground_truth = 0;

--- a/tools/depth-quality/rs-depth-quality.cpp
+++ b/tools/depth-quality/rs-depth-quality.cpp
@@ -7,8 +7,9 @@
 
 int main(int argc, const char * argv[]) try
 {
-    rs2::ux_window window("Depth Quality Tool");
-    rs2::depth_quality::tool_model model;
+    rs2::context ctx;
+    rs2::ux_window window("Depth Quality Tool", ctx);
+    rs2::depth_quality::tool_model model(ctx);
 
     using namespace rs2::depth_quality;
 

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -246,10 +246,10 @@ int main(int argc, const char** argv) try
 {
     rs2::log_to_console(RS2_LOG_SEVERITY_WARN);
 
-    ux_window window("Intel RealSense Viewer");
+    context ctx;
+    ux_window window("Intel RealSense Viewer", ctx);
 
     // Create RealSense Context
-    context ctx;
     device_changes devices_connection_changes(ctx);
     std::vector<std::pair<std::string, std::string>> device_names;
 

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -259,8 +259,7 @@ int main(int argc, const char** argv) try
     std::shared_ptr<device_models_list> device_models = std::make_shared<device_models_list>();
     device_model* device_to_remove = nullptr;
 
-    viewer_model viewer_model;
-    viewer_model.ctx = ctx;
+    viewer_model viewer_model(ctx);
 
     std::vector<device> connected_devs;
     std::mutex m;


### PR DESCRIPTION
Avoid creating multiple unused `rs2::context`s.