### PR TITLE
Fix for memory overrun when parsing metadata

### DIFF
--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -25,7 +25,7 @@ extern "C" {
 #define RS2_API_MAJOR_VERSION    2
 #define RS2_API_MINOR_VERSION    32
 #define RS2_API_PATCH_VERSION    0
-#define RS2_API_BUILD_VERSION    0
+#define RS2_API_BUILD_VERSION    7
 
 #ifndef STRINGIFY
 #define STRINGIFY(arg) #arg

--- a/src/archive.h
+++ b/src/archive.h
@@ -41,7 +41,7 @@ namespace librealsense
                                                  // if true, this will force any queue receiving this frame not to drop it
         uint32_t            raw_size = 0;   // The frame transmitted size (payload only)
 
-        frame_additional_data() {};
+        frame_additional_data() {}
 
         frame_additional_data(double in_timestamp,
             unsigned long long in_frame_number,

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -927,7 +927,7 @@ namespace librealsense
 
                                     if (val > 1)
                                         LOG_INFO("Frame buf ready, md size: " << std::dec << (int)buf_mgr.metadata_size() << " seq. id: " << buf.sequence);
-                                    frame_object fo{ std::min(buf.bytesused, buffer->get_length_frame_only())  - buf_mgr.metadata_size(), buf_mgr.metadata_size(),
+                                    frame_object fo{ std::min(buf.bytesused - buf_mgr.metadata_size(), buffer->get_length_frame_only()), buf_mgr.metadata_size(),
                                         buffer->get_frame_start(), buf_mgr.metadata_start(), timestamp };
 
                                      buffer->attach_buffer(buf);

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -313,7 +313,7 @@ namespace librealsense
             };
         }
 
-        void buffers_mgr::set_md_from_video_node()
+        void buffers_mgr::set_md_from_video_node(bool compressed)
         {
             void* md_start = nullptr;
             auto md_size = 0;
@@ -321,37 +321,36 @@ namespace librealsense
             if (buffers.at(e_video_buf)._file_desc >=0)
             {
                 auto buffer = buffers.at(e_video_buf)._data_buf;
-                auto dq  = buffers.at(e_video_buf)._dq_buf;
+                auto fr_payload_size = buffer->get_length_frame_only();
 
-                // For compressed data assume D4XX metadata struct
-                static const int d4xx_md_size = 248;
-                auto md_payload_size = 0L;
-                if (dq.bytesused < buffer->get_length_frame_only())
-                    md_payload_size = d4xx_md_size; // The stream appendix is a fixed size
-                else
-                    md_payload_size = dq.bytesused - buffer->get_length_frame_only();
-
-                if (md_payload_size < 0)
-                {
-                    md_payload_size = 0;
-                    std::stringstream msg;
-                    msg <<  "Unexpected metadata size: kernel bytesused: " << std::dec << dq.bytesused
-                        << " buffer size: " << dq.length << " , payload length: "
-                        << buffer->get_length_frame_only() << " frame size: " << buffer->get_full_length();
-                    LOG_WARNING(msg.str().c_str());
-                }
-
-                md_start = buffer->get_frame_start() + dq.bytesused - md_payload_size;
+                md_start = buffer->get_frame_start() + fr_payload_size;
                 md_size = (*(static_cast<uint8_t*>(md_start)));
-                int md_flags = (*(static_cast<uint8_t*>(md_start)+1));
 
-                // Heuristics to evaluate whether the buffer has metadata
-                if ((md_size !=d4xx_md_size) || (!val_in_range(md_flags, {0x8e, 0x8f}) ))
+                // For compressed data assume D4XX metadata struct. TODO - make provisions for L500
+                if (compressed)
                 {
-                    md_size = 0;
-                    md_start=nullptr;
+                    static const int d4xx_md_size = 248;
+                    auto md_payload_size = 0L;
+                    auto dq  = buffers.at(e_video_buf)._dq_buf;
+
+                    if (dq.bytesused < fr_payload_size)
+                        md_payload_size = d4xx_md_size; // The stream appendix is a fixed size
+                    else
+                        md_payload_size = dq.bytesused - fr_payload_size;
+
+                    md_start = buffer->get_frame_start() + dq.bytesused - md_payload_size;
+                    md_size = (*(static_cast<uint8_t*>(md_start)));
+
+                    // Use heuristics to validate metadata buffer. Strict to D4XX
+                    int md_flags = (*(static_cast<uint8_t*>(md_start)+1));
+                    if ((md_size !=d4xx_md_size) || (!val_in_range(md_flags, {0x8e, 0x8f}) ))
+                    {
+                        md_size = 0;
+                        md_start=nullptr;
+                    }
                 }
             }
+
             set_md_attributes(static_cast<uint8_t>(md_size),md_start);
         }
 
@@ -905,9 +904,9 @@ namespace librealsense
                                     return;
                                 }
 
+                                bool compressed_format = val_in_range(_profile.format, { 0x4d4a5047U , 0x5a313648U});
                                 // Relax the required frame size for compressed formats, i.e. MJPG, Z16H
-                                if (!val_in_range(_profile.format, { 0x4d4a5047U , 0x5a313648U}) &&
-                                        (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE))
+                                if (!compressed_format && (buf.bytesused < buffer->get_full_length() - MAX_META_DATA_SIZE))
                                 {
                                     auto percentage = (100 * buf.bytesused) / buffer->get_full_length();
                                     std::stringstream s;
@@ -923,7 +922,7 @@ namespace librealsense
                                     timestamp = monotonic_to_realtime(timestamp);
 
                                     // read metadata from the frame appendix
-                                    acquire_metadata(buf_mgr,fds);
+                                    acquire_metadata(buf_mgr,fds,compressed_format);
 
                                     if (val > 1)
                                         LOG_INFO("Frame buf ready, md size: " << std::dec << (int)buf_mgr.metadata_size() << " seq. id: " << buf.sequence);
@@ -961,10 +960,10 @@ namespace librealsense
             }
         }
 
-        void v4l_uvc_device::acquire_metadata(buffers_mgr & buf_mgr,fd_set &)
+        void v4l_uvc_device::acquire_metadata(buffers_mgr & buf_mgr,fd_set &, bool compressed_format)
         {
             if (has_metadata())
-                buf_mgr.set_md_from_video_node();
+                buf_mgr.set_md_from_video_node(compressed_format);
             else
                 buf_mgr.set_md_attributes(0, nullptr);
         }
@@ -1550,7 +1549,7 @@ namespace librealsense
         }
 
         // retrieve metadata from a dedicated UVC node
-        void v4l_uvc_meta_device::acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds)
+        void v4l_uvc_meta_device::acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds, bool)
         {
             // Metadata is calculated once per frame
             if (buf_mgr.metadata_size())

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -176,7 +176,7 @@ namespace librealsense
 
             void    set_md_attributes(uint8_t md_size, void* md_start)
                     { _md_start = md_start; _md_size = md_size; }
-            void    set_md_from_video_node();
+            void    set_md_from_video_node(bool compressed);
 
         private:
             void*                               _md_start;  // marks the address of metadata blob
@@ -222,7 +222,7 @@ namespace librealsense
             virtual void set_format(stream_profile profile) = 0;
             virtual void prepare_capture_buffers() = 0;
             virtual void stop_data_capture() = 0;
-            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds) = 0;
+            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds, bool compressed_format) = 0;
         };
 
         class v4l_uvc_device : public uvc_device, public v4l_uvc_interface
@@ -291,7 +291,7 @@ namespace librealsense
             virtual void set_format(stream_profile profile) override;
             virtual void prepare_capture_buffers() override;
             virtual void stop_data_capture() override;
-            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds) override;
+            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds, bool compressed_format = false) override;
 
             power_state _state = D3;
             std::string _name = "";
@@ -335,7 +335,7 @@ namespace librealsense
             void unmap_device_descriptor();
             void set_format(stream_profile profile);
             void prepare_capture_buffers();
-            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds);
+            virtual void acquire_metadata(buffers_mgr & buf_mgr,fd_set &fds, bool compressed_format=false);
 
             int _md_fd = -1;
             std::string _md_name = "";

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -13,6 +13,7 @@
 #include "proc/temporal-filter.h"
 #include "proc/hole-filling-filter.h"
 #include "proc/zero-order.h"
+#include "proc/depth-decompress.h"
 #include "std_msgs/Float32MultiArray.h"
 
 namespace librealsense
@@ -1396,6 +1397,8 @@ namespace librealsense
             return std::make_shared<ExtensionToType<RS2_EXTENSION_HOLE_FILLING_FILTER>::type>();
         case RS2_EXTENSION_ZERO_ORDER_FILTER:
             return std::make_shared<ExtensionToType<RS2_EXTENSION_ZERO_ORDER_FILTER>::type>();
+        case RS2_EXTENSION_DEPTH_HUFFMAN_DECODER:
+            return std::make_shared<ExtensionToType<RS2_EXTENSION_DEPTH_HUFFMAN_DECODER>::type>();
         default:
             return nullptr;
         }

--- a/src/media/ros/ros_writer.cpp
+++ b/src/media/ros/ros_writer.cpp
@@ -8,6 +8,7 @@
 #include "proc/temporal-filter.h"
 #include "proc/hole-filling-filter.h"
 #include "proc/zero-order.h"
+#include "proc/depth-decompress.h"
 #include "ros_writer.h"
 #include "l500/l500-motion.h"
 #include "l500/l500-depth.h"
@@ -543,6 +544,7 @@ namespace librealsense
         RETURN_IF_EXTENSION(block, RS2_EXTENSION_TEMPORAL_FILTER);
         RETURN_IF_EXTENSION(block, RS2_EXTENSION_HOLE_FILLING_FILTER);
         RETURN_IF_EXTENSION(block, RS2_EXTENSION_ZERO_ORDER_FILTER);
+        RETURN_IF_EXTENSION(block, RS2_EXTENSION_DEPTH_HUFFMAN_DECODER);
 
 #undef RETURN_IF_EXTENSION
 

--- a/src/proc/depth-decompress.cpp
+++ b/src/proc/depth-decompress.cpp
@@ -13,22 +13,14 @@ namespace librealsense
     {
         get_option(RS2_OPTION_STREAM_FILTER).set(RS2_STREAM_DEPTH);
         get_option(RS2_OPTION_STREAM_FORMAT_FILTER).set(RS2_FORMAT_Z16H);
-    };
+    }
 
     void depth_decompression_huffman::process_function(byte* const dest[], const byte* source, int width, int height, int actual_size, int input_size)
     {
         if (!unhuffimage4(reinterpret_cast<uint32_t*>(const_cast<byte*>(source)), uint32_t(input_size >> 2), width << 1, height, const_cast<byte*>(*dest)))
         {
-            std::stringstream ss;
-            ss << "Depth_huffman_decode_error_input_ts_" << static_cast<uint64_t>(environment::get_instance().get_time_service()->get_time()) << "_"
-                <<  input_size << "_output_" << actual_size << ".raw";
-            std::string filename = ss.str().c_str();
-
-            LOG_ERROR("Depth decompression error, binary dump: " << filename);
-            std::ofstream file(filename, std::ios::binary | std::ios::trunc);
-            if (!file.good())
-                throw std::runtime_error(to_string() << "Invalid binary file specified " << filename << " verify the target path and location permissions");
-            file.write((const char*)source, input_size);
+            LOG_WARNING("Depth decompression failed, ts: " << static_cast<uint64_t>(environment::get_instance().get_time_service()->get_time())
+                        << " , compressed size: " << input_size);
         }
     }
 }

--- a/src/proc/depth-decompress.cpp
+++ b/src/proc/depth-decompress.cpp
@@ -19,7 +19,7 @@ namespace librealsense
     {
         if (!unhuffimage4(reinterpret_cast<uint32_t*>(const_cast<byte*>(source)), uint32_t(input_size >> 2), width << 1, height, const_cast<byte*>(*dest)))
         {
-            LOG_WARNING("Depth decompression failed, ts: " << static_cast<uint64_t>(environment::get_instance().get_time_service()->get_time())
+            LOG_INFO("Depth decompression failed, ts: " << static_cast<uint64_t>(environment::get_instance().get_time_service()->get_time())
                         << " , compressed size: " << input_size);
         }
     }

--- a/tools/benchmark/rs-benchmark.cpp
+++ b/tools/benchmark/rs-benchmark.cpp
@@ -106,7 +106,7 @@ public:
     frame process(frame f) override
     {
         return _block.process(f);
-    };
+    }
     virtual const std::string& name() const override
     {
         return _name;
@@ -135,7 +135,7 @@ public:
         auto res = pb_test<T>::process(f);
         flush();
         return res;
-    };
+    }
     frame prepare(frame f) override
     {
         auto res = _upload.process(f);


### PR DESCRIPTION
Trim frame size when the metadata is present but invalid
Add heuristics to validate metadata existence. (assume d4xx format)
Fix Z16H record&playback

Tracked on : DSO-14292