### PR TITLE
Include stddef in usbhost.h

### DIFF
--- a/src/usbhost/usbhost.h
+++ b/src/usbhost/usbhost.h
@@ -21,6 +21,7 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include <linux/version.h>

--- a/tools/fw-update/readme.md
+++ b/tools/fw-update/readme.md
@@ -3,7 +3,7 @@
 ## Goal
 `rs-fw-update` tool is a console application for updating the depth cameras firmware.
 
-#Prerequisites
+## Prerequisites
 In order to update a depth camera firmware, a signed image file is required.
 The latest firmware for D400 cameras is available [here.](https://downloadcenter.intel.com/download/28870/Latest-Firmware-for-Intel-RealSense-D400-Product-Family?product=128255)
 The firmware is packed into zip file and contains a file with "bin" extension with the following naming convension: "Signed_Image_UVC_<firmware_version>.bin"
@@ -75,5 +75,7 @@ recovery done
 |`-l`|List all available devices and exits|
 |`-v`|Displays version information and exits|
 |`-h`|Displays usage information and exits|
-
 | None| List supported streaming modes|
+
+## Limitation
+* Do not run additional applications that use the RealSense camera, such as Viewer, together with the rs-fw-update tool

--- a/wrappers/opencv/latency-tool/readme.md
+++ b/wrappers/opencv/latency-tool/readme.md
@@ -34,6 +34,7 @@ Once it detects bits and decodes the clock value embedded in the image, the samp
 
 To make sure expensive detection logic is not preventing us from getting the frames in time, detection is being done on a seperate thread. Frames are being passed to this thread, alongside their respective clock measurements, using a concurrent queue. 
 We ensure that the queue will not spill, by emptying it after each successful or unsuccessful detection attempt. 
+Please refer to [Frame Buffer Management](https://github.com/IntelRealSense/librealsense/wiki/Frame-Buffering-Management-in-RealSense-SDK-2.0) for further information.
 
 ## Controlling the Demo
 


### PR DESCRIPTION
usbhost.h uses size_t, which is defined in stddef.h. This change includes stddef.h header.