### PR TITLE
Fix depth measurement with mouse pointer - Z16H

### DIFF
--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -24,8 +24,8 @@ extern "C" {
 
 #define RS2_API_MAJOR_VERSION    2
 #define RS2_API_MINOR_VERSION    32
-#define RS2_API_PATCH_VERSION    0
-#define RS2_API_BUILD_VERSION    7
+#define RS2_API_PATCH_VERSION    1
+#define RS2_API_BUILD_VERSION    0
 
 #ifndef STRINGIFY
 #define STRINGIFY(arg) #arg

--- a/src/usb/usb-request.h
+++ b/src/usb/usb-request.h
@@ -53,7 +53,7 @@ namespace librealsense
             {
                 _buffer = buffer;
                 set_native_buffer(_buffer.data());
-                set_native_buffer_length(_buffer.size());
+                set_native_buffer_length(int(_buffer.size()));
             }
 
         protected:


### PR DESCRIPTION
Ensure that the depth frame used in depth measurements is the standard Z16 format.
Promote to v2.32.1.0