### PR TITLE
notification registration route to base sensor

### DIFF
--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -95,7 +95,7 @@ void librealsense::record_sensor::register_notifications_callback(notifications_
 {
     if (m_register_notification_to_base)
     {
-        m_sensor.register_notifications_callback(std::move(callback));
+        m_sensor.register_notifications_callback(std::move(callback)); //route to base sensor
         return;
     }
 

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -14,6 +14,7 @@ librealsense::record_sensor::record_sensor( device_interface& device,
     m_is_recording(false),
     m_parent_device(device),
     m_is_sensor_hooked(false),
+    m_register_notification_to_base(true),
     m_before_start_callback_token(-1)
 {
     LOG_DEBUG("Created record_sensor");
@@ -92,6 +93,12 @@ bool librealsense::record_sensor::supports_option(rs2_option id) const
 
 void librealsense::record_sensor::register_notifications_callback(notifications_callback_ptr callback)
 {
+    if (m_register_notification_to_base)
+    {
+        m_sensor.register_notifications_callback(std::move(callback));
+        return;
+    }
+
     m_user_notification_callback = std::move(callback);
     auto from_live_sensor = notifications_callback_ptr(new notification_callback([&](rs2_notification* n)
     {
@@ -262,9 +269,11 @@ void record_sensor::disable_sensor_hooks()
         return;
     unhook_sensor_callbacks();
     m_is_sensor_hooked = false;
+    m_register_notification_to_base = true;
 }
 void record_sensor::hook_sensor_callbacks()
 {
+    m_register_notification_to_base = false;
     m_user_notification_callback = m_sensor.get_notifications_callback();
     register_notifications_callback(m_user_notification_callback);
     m_original_callback = m_sensor.get_frames_callback();

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -73,6 +73,7 @@ namespace librealsense
         int m_before_start_callback_token;
         device_interface& m_parent_device;
         bool m_is_sensor_hooked;
+        bool m_register_notification_to_base;
         std::mutex m_mutex;
     };
 


### PR DESCRIPTION
Bug #5479

Cause: relocalization notification callback registration happens before record_sensor::hook_sensor_callbacks() is called which is to register stream callback. The stream callback registration overwritten m_user_notification_callback that has been registered as reloc notification callback. That caused recursive call on on_notification() and will crash App.

Fix: register notification callback to base sensor before record_sensor::hook_sensor_callbacks() is called which is to register stream callback.