### PR TITLE
Hint that metadata support requires OS level settings/changes

### DIFF
--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -120,7 +120,7 @@ namespace librealsense
             auto s = reinterpret_cast<const S*>(((const uint8_t*)frm.additional_data.metadata_blob.data()) + _offset);
 
             if (!is_attribute_valid(s))
-                throw invalid_value_exception("metadata not available");
+                throw invalid_value_exception("metadata not available (to enable metadata support in your OS, see the documentation)");
 
             auto attrib = static_cast<rs2_metadata_type>((*s).*_md_attribute);
             if (_modifyer) attrib = _modifyer(attrib);


### PR DESCRIPTION
Warn users that try and fail to access frame metadata that they may be able to enable support for frame metadata by making OS level changes.  It took me quite a long time to figure this out, and other users [continue](https://github.com/IntelRealSense/librealsense/issues/5596) to run into this problem.