### PR TITLE
Prevent UVC frame overflow with v4l

### DIFF
--- a/src/proc/processing-blocks-factory.h
+++ b/src/proc/processing-blocks-factory.h
@@ -17,7 +17,7 @@ namespace librealsense
     class processing_block_factory
     {
     public:
-        processing_block_factory() {};
+        processing_block_factory() {}
 
         processing_block_factory(const std::vector<stream_profile>& from,
             const std::vector<stream_profile>& to,

--- a/src/types.h
+++ b/src/types.h
@@ -636,7 +636,7 @@ namespace librealsense
             uint32_t framerate = 0,
             resolution_func res_func = [](resolution res) { return res; }) :
             format(fmt), stream(strm), index(idx), height(h), width(w), stream_resolution(res_func), fps(framerate)
-        {};
+        {}
 
         rs2_format format;
         rs2_stream stream;


### PR DESCRIPTION
Add heuristic to drop UVC overflow frames with v4l kernel prior to v4.16
Handle GCC pedantic

Tracked on: DSO-14370
