### PR TITLE
Enable metadata with a single click on Windows

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -21,6 +21,8 @@ set(COMMON_SRC
         "${CMAKE_CURRENT_LIST_DIR}/os.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/fw-update-helper.h"
         "${CMAKE_CURRENT_LIST_DIR}/fw-update-helper.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/metadata-helper.h"
+        "${CMAKE_CURRENT_LIST_DIR}/metadata-helper.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/on-chip-calib.h"
         "${CMAKE_CURRENT_LIST_DIR}/on-chip-calib.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/decompress-huffman.h"

--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -1,0 +1,324 @@
+#include "metadata-helper.h"
+
+#ifdef WIN32
+
+#include <Windows.h>
+#include <memory>
+#include <vector>
+#include <algorithm>
+#include <iterator>
+
+#include <regex>
+#include <iostream>
+#include <sstream>
+#include <functional>
+#include <map>
+#include <memory>
+
+#include <librealsense2/rs.hpp>
+
+#define MAX_KEY_LENGTH 255
+#define MAX_VALUE_NAME 16383
+
+#endif
+
+namespace rs2
+{
+#ifdef WIN32
+    struct device_id
+    {
+        std::string pid, mi, guid, sn;
+    };
+
+    inline std::string to_lower(std::string x)
+    {
+        transform(x.begin(), x.end(), x.begin(), tolower);
+        return x;
+    }
+
+    bool operator==(const device_id& a, const device_id& b)
+    {
+        return (to_lower(a.pid) == to_lower(b.pid) &&
+            to_lower(a.mi) == to_lower(b.mi) &&
+            to_lower(a.guid) == to_lower(b.guid) &&
+            to_lower(a.sn) == to_lower(b.sn));
+    }
+
+    class windows_metadata_helper : public metadata_helper
+    {
+    public:
+        static bool parse_device_id(std::string id, device_id* res)
+        {
+            static const std::regex regex("[\\s\\S]*pid_([0-9a-fA-F]+)&mi_([0-9]+)#[0-9]&([0-9a-fA-F]+)&[\\s\\S]*\\{([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\\}[\\s\\S]*");
+
+            id = to_lower(id); // ignore case
+
+            std::match_results<std::string::const_iterator> match;
+
+            if (std::regex_match(id, match, regex) && match.size() > 4)
+            {
+                res->pid = match[1];
+                res->mi = match[2];
+                res->sn = match[3];
+                res->guid = match[4];
+                return true;
+            }
+            return false;
+        }
+
+        static void do_foreach_device(std::vector<device_id> devices, 
+            std::function<void(device_id&, std::wstring)> action)
+        {
+            std::map<std::string, std::vector<device_id>> guid_to_devices;
+            for (auto&& d : devices)
+            {
+                guid_to_devices[d.guid].push_back(d);
+            }
+
+            for (auto&& kvp : guid_to_devices)
+            {
+                auto guid = kvp.first;
+
+                std::stringstream ss;
+                ss << "SYSTEM\\CurrentControlSet\\Control\\DeviceClasses\\{" << guid << "}";
+                auto s = ss.str();
+                std::wstring ws(s.begin(), s.end());
+
+                HKEY hKey;
+                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, ws.c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &hKey) == ERROR_SUCCESS)
+                {
+                    // Don't forget to release in the end:
+                    std::shared_ptr<void> raii(hKey, RegCloseKey);
+
+                    TCHAR    achClass[MAX_PATH] = TEXT("");  // buffer for class name 
+                    DWORD    cchClassName = MAX_PATH;  // size of class string 
+                    DWORD    cSubKeys = 0;               // number of subkeys 
+                    DWORD    cbMaxSubKey;              // longest subkey size 
+                    DWORD    cchMaxClass;              // longest class string 
+                    DWORD    cValues;              // number of values for key 
+                    DWORD    cchMaxValue;          // longest value name 
+                    DWORD    cbMaxValueData;       // longest value data 
+                    DWORD    cbSecurityDescriptor; // size of security descriptor 
+                    FILETIME ftLastWriteTime;      // last write time 
+
+                    DWORD retCode = RegQueryInfoKey(
+                        hKey,                    // key handle 
+                        achClass,                // buffer for class name 
+                        &cchClassName,           // size of class string 
+                        NULL,                    // reserved 
+                        &cSubKeys,               // number of subkeys 
+                        &cbMaxSubKey,            // longest subkey size 
+                        &cchMaxClass,            // longest class string 
+                        &cValues,                // number of values for this key 
+                        &cchMaxValue,            // longest value name 
+                        &cbMaxValueData,         // longest value data 
+                        &cbSecurityDescriptor,   // security descriptor 
+                        &ftLastWriteTime);       // last write time 
+
+                    for (int i = 0; i<cSubKeys; i++)
+                    {
+                        TCHAR achKey[MAX_KEY_LENGTH];
+                        DWORD cbName = MAX_KEY_LENGTH;
+                        retCode = RegEnumKeyEx(hKey, i,
+                            achKey,
+                            &cbName,
+                            NULL,
+                            NULL,
+                            NULL,
+                            &ftLastWriteTime);
+                        if (retCode == ERROR_SUCCESS)
+                        {
+                            std::wstring ke = achKey;
+                            device_id rdid;
+                            if (parse_device_id(std::string(ke.begin(), ke.end()), &rdid))
+                            {
+                                for (auto&& did : kvp.second)
+                                {
+                                    if (rdid == did)
+                                    {
+                                        std::wstringstream ss;
+                                        ss << ws << "\\" << ke << "\\#GLOBAL\\Device Parameters";
+                                        auto s = ss.str();
+                                        std::wstring ws(s.begin(), s.end());
+
+                                        action(rdid, ws);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Heuristic that determines how many media-pins UVC device is expected to have
+        static int number_of_mediapins(std::string pid, std::string mi)
+        {
+            if (mi == "00")
+            {
+                // L500 has 3 media-pins
+                if (to_lower(pid) == "0b0d" || to_lower(pid) == "0b3d") return 3;
+                else return 2; // D400 has two
+            }
+            return 1; // RGB has one
+        }
+
+        bool is_running_as_admin()
+        {
+            BOOL result = FALSE;
+            PSID admin_group = NULL;
+
+            SID_IDENTIFIER_AUTHORITY ntauthority = SECURITY_NT_AUTHORITY;
+            if (!AllocateAndInitializeSid(
+                &ntauthority,
+                2,
+                SECURITY_BUILTIN_DOMAIN_RID,
+                DOMAIN_ALIAS_RID_ADMINS,
+                0, 0, 0, 0, 0, 0,
+                &admin_group))
+            {
+                return false;
+            }
+
+            if (!CheckTokenMembership(NULL, admin_group, &result))
+            {
+                FreeSid(admin_group);
+                return false;
+            }
+
+            return result;
+        }
+
+        bool elevate_to_admin()
+        {
+            if (!is_running_as_admin())
+            {
+                wchar_t szPath[MAX_PATH];
+                if (GetModuleFileName(NULL, szPath, ARRAYSIZE(szPath)))
+                {
+                    SHELLEXECUTEINFO sei = { sizeof(sei) };
+
+                    sei.lpVerb = L"runas";
+                    sei.lpFile = szPath;
+                    sei.hwnd = NULL;
+                    sei.nShow = SW_NORMAL;
+                    auto cmd_line = get_command_line_param();
+                    std::wstring wcmd(cmd_line.begin(), cmd_line.end());
+                    sei.lpParameters = wcmd.c_str();
+
+                    ShellExecuteEx(&sei); // not checking return code - what you are going to do? retry? why?
+                }
+
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        bool is_enabled(std::string id) const override
+        {
+            bool res = false;
+
+            device_id did;
+            if (parse_device_id(id, &did))
+                do_foreach_device({ did }, [&res, did](device_id&, std::wstring path) {
+
+                HKEY key;
+                if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, path.c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &key) == ERROR_SUCCESS)
+                {
+                    // Don't forget to release in the end:
+                    std::shared_ptr<void> raii(key, RegCloseKey);
+
+                    bool found = true;
+                    DWORD len = sizeof(DWORD);//size of data
+
+                    for (int i = 0; i < number_of_mediapins(did.pid, did.mi); i++)
+                    {
+                        std::wstringstream ss; ss << L"MetadataBufferSizeInKB" << i;
+                        std::wstring metadatakey = ss.str();
+
+                        DWORD MetadataBufferSizeInKB = 0;
+                        RegQueryValueEx(
+                            key,
+                            metadatakey.c_str(),
+                            NULL,
+                            NULL,
+                            (LPBYTE)(&MetadataBufferSizeInKB),
+                            &len);
+
+                        found = found && MetadataBufferSizeInKB;
+                    }
+
+                    if (found) res = true;
+                }
+            });
+
+            return res;
+        }
+
+        void enable_metadata() override
+        {
+            if (elevate_to_admin()) // Elevation to admin was succesful?
+            {
+                std::vector<device_id> dids;
+
+                rs2::context ctx;
+                auto list = ctx.query_devices();
+                for (int i = 0; i < list.size(); i++)
+                {
+                    try
+                    {
+                        rs2::device dev = list[i];
+                        if (dev.supports(RS2_CAMERA_INFO_PRODUCT_LINE) && dev.supports(RS2_CAMERA_INFO_PHYSICAL_PORT))
+                        {
+                            std::string product = dev.get_info(RS2_CAMERA_INFO_PRODUCT_LINE);
+                            if (product == "D400" || product == "SR300" || product == "L500")
+                            {
+                                std::string port = dev.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT);
+                                device_id did;
+                                if (parse_device_id(port, &did)) dids.push_back(did);
+                            }
+                        }
+                    }
+                    catch (...) {}
+                }
+
+                do_foreach_device(dids, [](device_id& did, std::wstring path) {
+                    HKEY key;
+                    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, path.c_str(), 0, KEY_WRITE | KEY_WOW64_64KEY, &key) == ERROR_SUCCESS)
+                    {
+                        // Don't forget to release in the end:
+                        std::shared_ptr<void> raii(key, RegCloseKey);
+
+                        bool found = true;
+                        DWORD len = sizeof(DWORD);//size of data
+
+                        for (int i = 0; i < number_of_mediapins(did.pid, did.mi); i++)
+                        {
+                            std::wstringstream ss; ss << L"MetadataBufferSizeInKB" << i;
+                            std::wstring metadatakey = ss.str();
+
+                            DWORD MetadataBufferSizeInKB = 5;
+                            RegSetValueEx(key, metadatakey.c_str(), 0, REG_DWORD,
+                                (const BYTE*)&MetadataBufferSizeInKB, sizeof(DWORD));
+                            // What to do if failed???
+                        }
+                    }
+                });
+            }
+        }
+    };
+#endif
+
+    metadata_helper& metadata_helper::instance() 
+    {
+#ifdef WIN32
+        static windows_metadata_helper instance;
+#else
+        static metadata_helper instance;
+#endif
+        return instance;
+    }
+}

--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -69,7 +69,7 @@ namespace rs2
         }
 
         static void foreach_device_path(const std::vector<device_id>& devices,
-            std::function<void(device_id&,  /* matched device */
+            std::function<void(const device_id&,  /* matched device */
                                std::wstring /* registry key of Device Parameters for that device */)> action)
         {
             std::map<std::string, std::vector<device_id>> guid_to_devices;
@@ -243,7 +243,7 @@ namespace rs2
 
             device_id did;
             if (parse_device_id(id, &did))
-                foreach_device_path({ did }, [&res, did](device_id&, std::wstring path) {
+                foreach_device_path({ did }, [&res, did](const device_id&, std::wstring path) {
 
                 HKEY key;
                 if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, path.c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &key) == ERROR_SUCCESS)
@@ -307,7 +307,7 @@ namespace rs2
                 }
 
                 bool failure = false;
-                foreach_device_path(dids, [&failure](device_id& did, std::wstring path) {
+                foreach_device_path(dids, [&failure](const device_id& did, std::wstring path) {
                     HKEY key;
                     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, path.c_str(), 0, KEY_WRITE | KEY_WOW64_64KEY, &key) == ERROR_SUCCESS)
                     {

--- a/common/metadata-helper.h
+++ b/common/metadata-helper.h
@@ -13,9 +13,11 @@ namespace rs2
 
         // Check if metadata is enabled using Physical Port ID
         // (can be retrieved with device::get_info(RS2_CAMERA_INFO_PHYSICAL_PORT))
+        // throws runtime_error in case of errors
         virtual bool is_enabled(std::string id) const { return true; }
 
         // Enable metadata for all connected devices
+        // throws runtime_error in case of errors
         virtual void enable_metadata() { }
 
         static bool can_support_metadata(const std::string& product)

--- a/common/metadata-helper.h
+++ b/common/metadata-helper.h
@@ -12,11 +12,18 @@ namespace rs2
         static metadata_helper& instance();
 
         // Check if metadata is enabled using Physical Port ID
+        // (can be retrieved with device::get_info(RS2_CAMERA_INFO_PHYSICAL_PORT))
         virtual bool is_enabled(std::string id) const { return true; }
 
         // Enable metadata for all connected devices
         virtual void enable_metadata() { }
 
+        static bool can_support_metadata(const std::string& product)
+        {
+            return product == "D400" || product == "SR300" || product == "L500";
+        }
+
+        // This is the command-line parameter that gets passed to another process (running as admin) in order to enable metadata -- see WinMain
         static std::string get_command_line_param() { return "--enable_metadata"; }
     };
 }

--- a/common/metadata-helper.h
+++ b/common/metadata-helper.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+namespace rs2
+{
+    // Helper class that is responsible for enabling per-frame metadata on different platforms
+    // Currently implemented for Windows
+    class metadata_helper
+    {
+    public:
+        static metadata_helper& instance();
+
+        // Check if metadata is enabled using Physical Port ID
+        virtual bool is_enabled(std::string id) const { return true; }
+
+        // Enable metadata for all connected devices
+        virtual void enable_metadata() { }
+
+        static std::string get_command_line_param() { return "--enable_metadata"; }
+    };
+}

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -998,8 +998,8 @@ namespace rs2
         {
             std::string product = dev.get_info(RS2_CAMERA_INFO_PRODUCT_LINE);
             std::string id = dev.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT);
-            bool has_metadata = rs2::metadata_helper::instance().is_enabled(id) ||
-                !(product == "D400" || product == "SR300" || product == "L500");
+            bool has_metadata = !rs2::metadata_helper::instance().can_support_metadata(product)
+                || rs2::metadata_helper::instance().is_enabled(id);
             static bool showed_metadata_prompt = false;
 
             if (!has_metadata && !showed_metadata_prompt)

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -1033,7 +1033,7 @@ namespace rs2
 
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("%s", "You will be prompted to enabled metadata on the device");
+            ImGui::SetTooltip("%s", "Enables metadata on connected devices (you may be prompted for administrator privileges)");
         }
     }
 }

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -23,6 +23,8 @@
 
 #include "viewer.h"
 
+#include "metadata-helper.h"
+
 using namespace std;
 using namespace chrono;
 
@@ -979,5 +981,65 @@ namespace rs2
         this->category = RS2_NOTIFICATION_CATEGORY_FIRMWARE_UPDATE_RECOMMENDED;
 
         pinned = true;
+    }
+
+    metadata_warning_model::metadata_warning_model()
+        : process_notification_model(nullptr)
+    {
+        enable_expand = false;
+        enable_dismiss = true;
+        update_state = 0;
+        pinned = true;
+        message = "Frame Metadata is device feature allowing\n"
+                  "software synchronization between different\n"
+                  "camera streams.\n"
+                  "It must be explicitly enabled on Windows OS\n";
+        last_progress_time = system_clock::now();
+    }
+
+    void metadata_warning_model::set_color_scheme(float t) const
+    {
+        notification_model::set_color_scheme(t);
+        ImGui::PopStyleColor(1);
+        auto c = alpha(sensor_bg, 1 - t);
+        ImGui::PushStyleColor(ImGuiCol_WindowBg, c);
+    }
+
+    void metadata_warning_model::draw_content(ux_window& win, int x, int y, float t, std::string& error_message)
+    {
+        ImGui::SetCursorScreenPos({ float(x + 9), float(y + 4) });
+
+        ImVec4 shadow{ 1.f, 1.f, 1.f, 0.1f };
+        ImGui::GetWindowDrawList()->AddRectFilled({ float(x), float(y) },
+        { float(x + width), float(y + 25) }, ImColor(shadow));
+
+        ImGui::Text("Frame Metadata Disabled");
+
+        ImGui::SetCursorScreenPos({ float(x + 5), float(y + 27) });
+
+        ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
+        draw_text(get_title().c_str(), x, y, height - 50);
+        ImGui::PopStyleColor();
+
+        ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 25) });
+
+        auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
+        ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
+        std::string button_name = to_string() << "Enable" << "##enable_metadata" << index;
+
+        const auto bar_width = width - 115;
+        if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
+        {
+            metadata_helper::instance().enable_metadata();
+            dismiss(false);
+            last_progress_time = system_clock::now();
+        }
+        ImGui::PopStyleColor(2);
+
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("%s", "You will be prompted to enabled metadata on the device");
+        }
     }
 }

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -56,7 +56,6 @@ namespace rs2
         return _timestamp;
     }
 
-
     rs2_log_severity notification_data::get_severity() const
     {
         return _severity;
@@ -665,8 +664,6 @@ namespace rs2
 
             ImGui::PopStyleVar(2);
             ImGui::PopStyleColor(3);
-            //selected.unset_color_scheme();
-            //ImGui::End();
 
             ImGui::PopStyleColor();
         }
@@ -984,17 +981,15 @@ namespace rs2
     }
 
     metadata_warning_model::metadata_warning_model()
-        : process_notification_model(nullptr)
+        : notification_model()
     {
         enable_expand = false;
         enable_dismiss = true;
-        update_state = 0;
         pinned = true;
-        message = "Frame Metadata is device feature allowing\n"
+        message = "Frame Metadata is a device feature allowing\n"
                   "software synchronization between different\n"
                   "camera streams.\n"
                   "It must be explicitly enabled on Windows OS\n";
-        last_progress_time = system_clock::now();
     }
 
     void metadata_warning_model::set_color_scheme(float t) const
@@ -1033,7 +1028,6 @@ namespace rs2
         {
             metadata_helper::instance().enable_metadata();
             dismiss(false);
-            last_progress_time = system_clock::now();
         }
         ImGui::PopStyleColor(2);
 

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -160,7 +160,7 @@ namespace rs2
         bool _first = true;
     };
 
-    struct metadata_warning_model : public process_notification_model
+    struct metadata_warning_model : public notification_model
     {
         metadata_warning_model();
 

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -160,6 +160,17 @@ namespace rs2
         bool _first = true;
     };
 
+    struct metadata_warning_model : public process_notification_model
+    {
+        metadata_warning_model();
+
+        void set_color_scheme(float t) const override;
+        void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
+        int calc_height() override { return 130; }
+        const int get_max_lifetime_ms() const override { return 40000; }
+    };
+
+
     struct notifications_model
     {
         std::shared_ptr<notification_model> add_notification(const notification_data& n);

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -35,8 +35,13 @@ int CALLBACK WinMain(
 
         if (s == rs2::metadata_helper::get_command_line_param())
         {
-            rs2::metadata_helper::instance().enable_metadata();
-            exit(0);
+            try
+            {
+                DebugBreak();
+                rs2::metadata_helper::instance().enable_metadata();
+                exit(0);
+            }
+            catch (...) { exit(-1); }
         }
 
         args.push_back(s);

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <iterator>
 
+#include "metadata-helper.h"
+
 int main(int argv, const char** argc);
 
 int CALLBACK WinMain(
@@ -30,6 +32,13 @@ int CALLBACK WinMain(
     {
         std::wstring ws = szArgList.get()[i];
         std::string s(ws.begin(), ws.end());
+
+        if (s == rs2::metadata_helper::get_command_line_param())
+        {
+            rs2::metadata_helper::instance().enable_metadata();
+            exit(0);
+        }
+
         args.push_back(s);
     }
 

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -37,7 +37,6 @@ int CALLBACK WinMain(
         {
             try
             {
-                DebugBreak();
                 rs2::metadata_helper::instance().enable_metadata();
                 exit(0);
             }

--- a/src/ds5/ds5-color.cpp
+++ b/src/ds5/ds5-color.cpp
@@ -84,12 +84,12 @@ namespace librealsense
         color_ep->register_pu(RS2_OPTION_GAIN);
         color_ep->register_pu(RS2_OPTION_GAMMA);
         color_ep->register_pu(RS2_OPTION_SHARPNESS);
+        color_ep->register_pu(RS2_OPTION_BACKLIGHT_COMPENSATION);
 
         // Currently disabled for certain sensors
         if (!val_in_range(color_devices_info.front().pid, { ds::RS465_PID }))
         {
             color_ep->register_pu(RS2_OPTION_HUE);
-            color_ep->register_pu(RS2_OPTION_BACKLIGHT_COMPENSATION);
             color_ep->register_pu(RS2_OPTION_AUTO_EXPOSURE_PRIORITY);
         }
         // From 5.11.15 auto-exposure priority is supported on the D465


### PR DESCRIPTION
UVC frame metadata on Windows is causing a lot of questions and confusion, adding a single click solution that would be applicable from within the Viewer. 
Alternative solution is to download and install [Intel-RealSense-D400-Series-Universal-Windows-Platform-UWP-Driver-for-Windows](https://downloadcenter.intel.com/download/28723/Intel-RealSense-D400-Series-Universal-Windows-Platform-UWP-Driver-for-Windows-10?elq_cid=4227251&erpm_id=7211449) but from our experience a lot of users don't do this. 
Related to #5669