### PR TITLE
Fix possible bug in device-hid detection

### DIFF
--- a/src/ds5/ds5-factory.cpp
+++ b/src/ds5/ds5-factory.cpp
@@ -920,7 +920,7 @@ namespace librealsense
             // Assuming that hids amount of 2 and above guarantee that gyro and accelerometer are present
             if (is_device_hid_sensor)
             {
-                all_sensors_present &= (hids.capacity() >= 2);
+                all_sensors_present &= (hids.size() >= 2);
             }
 #endif
 


### PR DESCRIPTION
Comparison to capacity(), which can be greater than size(), can lead to wrong logic