### PR TITLE
Fix for conversion from RGB to BGR in the OpenCV wrapper helpers file

### DIFF
--- a/wrappers/opencv/cv-helpers.hpp
+++ b/wrappers/opencv/cv-helpers.hpp
@@ -23,9 +23,10 @@ cv::Mat frame_to_mat(const rs2::frame& f)
     }
     else if (f.get_profile().format() == RS2_FORMAT_RGB8)
     {
-        auto r = Mat(Size(w, h), CV_8UC3, (void*)f.get_data(), Mat::AUTO_STEP);
-        cvtColor(r, r, COLOR_RGB2BGR);
-        return r;
+        auto r_rgb = Mat(Size(w, h), CV_8UC3, (void*)f.get_data(), Mat::AUTO_STEP);
+        Mat r_bgr;
+        cvtColor(r_rgb, r_bgr, COLOR_RGB2BGR);
+        return r_bgr;
     }
     else if (f.get_profile().format() == RS2_FORMAT_Z16)
     {


### PR DESCRIPTION
This PR is related to the following issue #5701 that I reported. Without converting to a seperate `cv::Mat` object, the conversion would not happen on my machine. This seems to be the case for other users, see [this example.](https://answers.opencv.org/question/199603/problem-with-intel-realsense-sdk-20-and-cvcvtcolor/)