### PR TITLE
rs-enumerate-devices and libusb handling fixes

### DIFF
--- a/src/command_transfer.h
+++ b/src/command_transfer.h
@@ -42,21 +42,24 @@ namespace librealsense
                     throw std::runtime_error("can't find VENDOR_SPECIFIC interface of device: " + _device->get_info().id);
 
                 auto hwm = *it;
-                const auto& m = _device->open(hwm->get_number());
 
-                uint32_t transfered_count = 0;
-                auto sts = m->bulk_transfer(hwm->first_endpoint(RS2_USB_ENDPOINT_DIRECTION_WRITE), const_cast<uint8_t*>(data.data()), static_cast<uint32_t>(data.size()), transfered_count, timeout_ms);
+                std::vector<uint8_t> output;
+                if (const auto& m = _device->open(hwm->get_number()))
+                {
+                    uint32_t transfered_count = 0;
+                    auto sts = m->bulk_transfer(hwm->first_endpoint(RS2_USB_ENDPOINT_DIRECTION_WRITE), const_cast<uint8_t*>(data.data()), static_cast<uint32_t>(data.size()), transfered_count, timeout_ms);
 
-                if (sts != RS2_USB_STATUS_SUCCESS)
-                    throw std::runtime_error("command transfer failed to execute bulk transfer, error: " + usb_status_to_string.at(sts));
+                    if (sts != RS2_USB_STATUS_SUCCESS)
+                        throw std::runtime_error("command transfer failed to execute bulk transfer, error: " + usb_status_to_string.at(sts));
 
-                std::vector<uint8_t> output(DEFAULT_BUFFER_SIZE);
-                sts = m->bulk_transfer(hwm->first_endpoint(RS2_USB_ENDPOINT_DIRECTION_READ), output.data(), static_cast<uint32_t>(output.size()), transfered_count, timeout_ms);
+                    output.resize(DEFAULT_BUFFER_SIZE);
+                    sts = m->bulk_transfer(hwm->first_endpoint(RS2_USB_ENDPOINT_DIRECTION_READ), output.data(), static_cast<uint32_t>(output.size()), transfered_count, timeout_ms);
 
-                if (sts != RS2_USB_STATUS_SUCCESS)
-                    throw std::runtime_error("command transfer failed to execute bulk transfer, error: " + usb_status_to_string.at(sts));
+                    if (sts != RS2_USB_STATUS_SUCCESS)
+                        throw std::runtime_error("command transfer failed to execute bulk transfer, error: " + usb_status_to_string.at(sts));
 
-                output.resize(transfered_count);
+                    output.resize(transfered_count);
+                }
                 return output;
             }
 

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -458,9 +458,9 @@ namespace librealsense
                 calib_id = *reinterpret_cast<uint16_t*>(raw.data());
                 valid = true;
             }
-            catch(const std::exception& exc)
+            catch(const std::exception&)
             {
-                LOG_INFO("IMU EEPROM Read error: " << exc.what());
+                LOG_WARNING("IMU Calibration is not available, see the previous message");
             }
 
             std::shared_ptr<mm_calib_parser> prs = nullptr;

--- a/src/tm2/tm-boot.h
+++ b/src/tm2/tm-boot.h
@@ -22,21 +22,22 @@ namespace librealsense {
                     LOG_INFO("Found a T265 to boot");
                     found = true;
                     auto dev = usb_enumerator::create_usb_device(device_info);
-                    const auto& m = dev->open(0);
+                     if (const auto& m = dev->open(0))
+                     {
+                        // transfer the firmware data
+                        int size{};
+                        auto target_hex = fw_get_target(size);
 
-                    // transfer the firmware data
-                    int size;
-                    auto target_hex = fw_get_target(size);
+                        if(!target_hex)
+                            LOG_ERROR("librealsense failed to get T265 FW resource");
 
-                    if(!target_hex)
-                        LOG_ERROR("librealsense failed to get T265 FW resource");
-
-                    auto iface = dev->get_interface(0);
-                    auto endpoint = iface->first_endpoint(RS2_USB_ENDPOINT_DIRECTION_WRITE);
-                    uint32_t transfered = 0;
-                    auto status = m->bulk_transfer(endpoint, const_cast<uint8_t*>(target_hex), static_cast<uint32_t>(size), transfered, 1000);
-                    if(status != RS2_USB_STATUS_SUCCESS)
-                        LOG_ERROR("Error booting T265");
+                        auto iface = dev->get_interface(0);
+                        auto endpoint = iface->first_endpoint(RS2_USB_ENDPOINT_DIRECTION_WRITE);
+                        uint32_t transfered = 0;
+                        auto status = m->bulk_transfer(endpoint, const_cast<uint8_t*>(target_hex), static_cast<uint32_t>(size), transfered, 1000);
+                        if(status != RS2_USB_STATUS_SUCCESS)
+                            LOG_ERROR("Error booting T265");
+                     }
                 }
             }
             return found;

--- a/tools/enumerate-devices/readme.md
+++ b/tools/enumerate-devices/readme.md
@@ -1,7 +1,7 @@
 # rs-enumerate-devices Tool
 
 ## Goal
-`rs-enumerate-devices` tool is a console application providing information about connected devices.
+`rs-enumerate-devices` tool is a console application providing information about the connected devices.
 
 ## Usage
 After installing `librealsense` run ` rs-enumerate-devices` to launch the tool.
@@ -21,7 +21,16 @@ Product Id                    :     0AD3
 
 |Flag   |Description   |
 |---|---|
-|`-s`|Provide short summary, one line per device|
-|`-o`|List supported device controls and options|
-|`-c`|Provide calibration (Intrinsic/Extrinsic) information|
-| None| List supported streaming modes|
+|`-s`|Provide a one-line summary, one line per device|
+|`-S`|Extends `-s` by providing a short summary for each device|
+|`-o`|List supported device controls, options and streaming modes|
+|`-c`|Provide calibration (Intrinsic/Extrinsic) and steraming modes information|
+|`-p`|Enumerate streams contained in ROSBag record file. Usage `-p <rosbag_full_path>`|
+| None| The default mode. Equivalent to `-S` plus the list of all the supported streaming profiles|
+
+The options `-o`, `-c` `-p` are additive and can concatenated:
+`rs-enumerate-devices -o -c -p rosbag.rec` - will print the camera info, streaming modes,
+supported option and the calibration info both for the live cameras and the prerecorded `rosbag.rec` file.
+
+The options `-S`, `-s` are restrictive and therefore incompatible with `-o` and `-c`,
+but still can be used with `-p <file_name>`.

--- a/tools/enumerate-devices/readme.md
+++ b/tools/enumerate-devices/readme.md
@@ -1,36 +1,45 @@
 # rs-enumerate-devices Tool
 
 ## Goal
-`rs-enumerate-devices` tool is a console application providing information about the connected devices.
+`rs-enumerate-devices` tool is a console application providing information about Realsense devices.
 
 ## Usage
 After installing `librealsense` run ` rs-enumerate-devices` to launch the tool.
-An example for output for a D415 camera is:
+An example output for a D415 camera (using `-S` option) is:
 
 ```
-Name                          :     Intel RealSense 415    
-Serial Number                 :     725112060346     
-Firmware Version              :     05.08.14.00
-Physical Port                 :     /sys/devices/pci0000:00/0000:00:14.0/usb2/2-2/2-2:1.0/video4linux/video1
-Debug Op Code                 :     15
-Advanced Mode                 :     YES
-Product Id                    :     0AD3
+Device Name                   Serial Number       Firmware Version
+Intel RealSense D415          725112060411        05.12.02.100
+Device info:
+    Name                          :     Intel RealSense D415
+    Serial Number                 :     725112060411
+    Firmware Version              :     05.12.02.100
+    Recommended Firmware Version  :     05.12.02.100
+    Physical Port                 :     \\?\usb#vid_8086&pid_0ad3&mi_00#6&2a371216&0&0000#{e5323777-f976-4f5b-9b55-b94699c46e44}\global
+    Debug Op Code                 :     15
+    Advanced Mode                 :     YES
+    Product Id                    :     0AD3
+    Camera Locked                 :     NO
+    Usb Type Descriptor           :     3.2
+    Product Line                  :     D400
+    Asic Serial Number            :     012345678901
+    Firmware Update Id            :     012345678901
+
 ```
 
 ## Command Line Parameters
 
 |Flag   |Description   |
 |---|---|
-|`-s`|Provide a one-line summary, one line per device|
-|`-S`|Extends `-s` by providing a short summary for each device|
+|`-s`|Generate a one-line info for each connected device|
+|`-S`|Extends `-s` by providing a short summary per device|
 |`-o`|List supported device controls, options and streaming modes|
-|`-c`|Provide calibration (Intrinsic/Extrinsic) and steraming modes information|
-|`-p`|Enumerate streams contained in ROSBag record file. Usage `-p <rosbag_full_path>`|
+|`-c`|Provide calibration (Intrinsic/Extrinsic) and streaming modes information|
+|`-p`|Enumerate streams contained in ROSBag record file. Usage `-p <rosbag_full_path_name>`.|
 | None| The default mode. Equivalent to `-S` plus the list of all the supported streaming profiles|
 
-The options `-o`, `-c` `-p` are additive and can concatenated:
-`rs-enumerate-devices -o -c -p rosbag.rec` - will print the camera info, streaming modes,
-supported option and the calibration info both for the live cameras and the prerecorded `rosbag.rec` file.
+The options `-o`, `-c` and `-p` are additive and can be combined, e.g. call 
+`rs-enumerate-devices -o -c -p rosbag.rec` to print the camera info, streaming modes,  supported options and the calibration data both for the live cameras and the prerecorded `rosbag.rec` file.
 
 The options `-S`, `-s` are restrictive and therefore incompatible with `-o` and `-c`,
 but still can be used with `-p <file_name>`.

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -207,6 +207,17 @@ int main(int argc, char** argv) try
     bool show_modes = !(compact_view || short_view);
     auto playback_dev_file = show_playback_device_arg.getValue();
 
+    if ((short_view || compact_view) && (show_options || show_calibration_data))
+    {
+        std::stringstream s;
+        s << "rs-enumerate-devices ";
+        for (int i = 1; i < argc; ++i)
+            s << argv[i] << ' ';
+        std::cout << "Warning: The command line \"" << s.str().c_str()
+            <<"\" has conflicting requests.\n The flags \"-s\" / \"-S\" are compatible with \"-p\" only,"
+            << " other options will be ignored.\nRefer to the tool's documentation for details\n" << std::endl;
+    }
+
     // Obtain a list of devices currently present on the system
     context ctx;
     rs2::device d;
@@ -224,7 +235,7 @@ int main(int argc, char** argv) try
     // Retrieve the viable devices
     std::vector<rs2::device> devices;
 
-    for ( size_t i = 0u; i < device_count; i++)
+    for ( auto i = 0u; i < device_count; i++)
     {
         try
         {
@@ -257,10 +268,6 @@ int main(int argc, char** argv) try
                 << setw(20) << dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION)
                 << endl;
         }
-
-        if (show_options || show_calibration_data || show_modes)
-            cout << "\n\nNote:  \"-s\"\\\"-S\" option is not compatible with the other flags specified,"
-            << " the additional options are skipped" << endl;
 
         show_options = show_calibration_data = show_modes = false;
     }

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -17,7 +17,7 @@ using namespace std;
 using namespace TCLAP;
 using namespace rs2;
 
-std::vector<std::string> tokenize_floats(string input, char separator){
+std::vector<std::string> tokenize_floats(string input, char separator) {
     std::vector<std::string> tokens;
     stringstream ss(input);
     string token;
@@ -35,22 +35,22 @@ void print(const rs2_extrinsics& extrinsics)
     ss << " Rotation Matrix:\n";
 
     // Align displayed data along decimal point
-    for (auto i = 0 ; i < 3 ; ++i)
+    for (auto i = 0; i < 3; ++i)
     {
-        for (auto j = 0 ; j < 3 ; ++j)
+        for (auto j = 0; j < 3; ++j)
         {
             std::ostringstream oss;
-            oss << extrinsics.rotation[j*3 +i];
-            auto tokens = tokenize_floats(oss.str().c_str(),'.');
+            oss << extrinsics.rotation[j * 3 + i];
+            auto tokens = tokenize_floats(oss.str().c_str(), '.');
             ss << right << setw(4) << tokens[0];
-            if (tokens.size()>1)
-                ss << "." << left <<setw(12) << tokens[1];
+            if (tokens.size() > 1)
+                ss << "." << left << setw(12) << tokens[1];
         }
         ss << endl;
     }
 
     ss << "\n Translation Vector: ";
-    for (auto i = 0u ; i < sizeof(extrinsics.translation)/sizeof(extrinsics.translation[0]) ; ++i)
+    for (auto i = 0u; i < sizeof(extrinsics.translation) / sizeof(extrinsics.translation[0]); ++i)
         ss << setprecision(15) << extrinsics.translation[i] << "  ";
 
     cout << ss.str() << endl << endl;
@@ -61,17 +61,17 @@ void print(const rs2_motion_device_intrinsic& intrinsics)
     stringstream ss;
     ss << "Bias Variances: \t";
 
-    for (auto i = 0u ; i < sizeof(intrinsics.bias_variances)/sizeof(intrinsics.bias_variances[0]) ; ++i)
+    for (auto i = 0u; i < sizeof(intrinsics.bias_variances) / sizeof(intrinsics.bias_variances[0]); ++i)
         ss << setprecision(15) << std::fixed << intrinsics.bias_variances[i] << "  ";
 
     ss << "\nNoise Variances: \t";
-    for (auto i = 0u ; i < sizeof(intrinsics.noise_variances)/sizeof(intrinsics.noise_variances[0]) ; ++i)
+    for (auto i = 0u; i < sizeof(intrinsics.noise_variances) / sizeof(intrinsics.noise_variances[0]); ++i)
         ss << setprecision(15) << std::fixed << intrinsics.noise_variances[i] << "  ";
 
     ss << "\nSensitivity : " << std::endl;
-    for (auto i = 0u ; i < sizeof(intrinsics.data)/sizeof(intrinsics.data[0]) ; ++i)
+    for (auto i = 0u; i < sizeof(intrinsics.data) / sizeof(intrinsics.data[0]); ++i)
     {
-        for (auto j = 0u ; j < sizeof(intrinsics.data[0])/sizeof(intrinsics.data[0][0]) ; ++j)
+        for (auto j = 0u; j < sizeof(intrinsics.data[0]) / sizeof(intrinsics.data[0][0]); ++j)
             ss << std::right << std::setw(13) << setprecision(6) << intrinsics.data[i][j] << "  ";
         ss << "\n";
     }
@@ -82,16 +82,16 @@ void print(const rs2_motion_device_intrinsic& intrinsics)
 void print(const rs2_intrinsics& intrinsics)
 {
     stringstream ss;
-    ss << left << setw(14) << "  Width: "      << "\t" << intrinsics.width  << endl <<
-          left << setw(14) << "  Height: "     << "\t" << intrinsics.height << endl <<
-          left << setw(14) << "  PPX: "        << "\t" << setprecision(15)  << intrinsics.ppx << endl <<
-          left << setw(14) << "  PPY: "        << "\t" << setprecision(15)  << intrinsics.ppy << endl <<
-          left << setw(14) << "  Fx: "         << "\t" << setprecision(15)  << intrinsics.fx  << endl <<
-          left << setw(14) << "  Fy: "         << "\t" << setprecision(15)  << intrinsics.fy  << endl <<
-          left << setw(14) << "  Distortion: " << "\t" << rs2_distortion_to_string(intrinsics.model) << endl <<
-          left << setw(14) << "  Coeffs: ";
+    ss << left << setw(14) << "  Width: " << "\t" << intrinsics.width << endl <<
+        left << setw(14) << "  Height: " << "\t" << intrinsics.height << endl <<
+        left << setw(14) << "  PPX: " << "\t" << setprecision(15) << intrinsics.ppx << endl <<
+        left << setw(14) << "  PPY: " << "\t" << setprecision(15) << intrinsics.ppy << endl <<
+        left << setw(14) << "  Fx: " << "\t" << setprecision(15) << intrinsics.fx << endl <<
+        left << setw(14) << "  Fy: " << "\t" << setprecision(15) << intrinsics.fy << endl <<
+        left << setw(14) << "  Distortion: " << "\t" << rs2_distortion_to_string(intrinsics.model) << endl <<
+        left << setw(14) << "  Coeffs: ";
 
-    for (auto i = 0u ; i < sizeof(intrinsics.coeffs)/sizeof(intrinsics.coeffs[0]) ; ++i)
+    for (auto i = 0u; i < sizeof(intrinsics.coeffs) / sizeof(intrinsics.coeffs[0]); ++i)
         ss << "\t" << setprecision(15) << intrinsics.coeffs[i] << "  ";
 
     cout << ss.str() << endl << endl;
@@ -105,8 +105,9 @@ bool safe_get_intrinsics(const video_stream_profile& profile, rs2_intrinsics& in
         intrinsics = profile.get_intrinsics();
         ret = true;
     }
-    catch(...)
-    {}
+    catch (...)
+    {
+    }
 
     return ret;
 }
@@ -119,12 +120,13 @@ bool safe_get_motion_intrinsics(const motion_stream_profile& profile, rs2_motion
         intrinsics = profile.get_motion_intrinsics();
         ret = true;
     }
-    catch(...)
-    {}
+    catch (...)
+    {
+    }
     return ret;
 }
 
-struct stream_and_resolution{
+struct stream_and_resolution {
     rs2_stream stream;
     int stream_index;
     int width;
@@ -137,7 +139,7 @@ struct stream_and_resolution{
     }
 };
 
-struct stream_and_index{
+struct stream_and_index {
     rs2_stream stream;
     int stream_index;
 
@@ -148,20 +150,20 @@ struct stream_and_index{
 };
 
 bool operator ==(const rs2_intrinsics& lhs,
-                 const rs2_intrinsics& rhs)
+    const rs2_intrinsics& rhs)
 {
     return  lhs.width == rhs.width &&
-            lhs.height == rhs.height &&
-            (fabs(lhs.ppx - rhs.ppx) < std::numeric_limits<float>::min()) &&
-            (fabs(lhs.ppy - rhs.ppy) < std::numeric_limits<float>::min()) &&
-            (fabs(lhs.fx - rhs.fx) < std::numeric_limits<float>::min()) &&
-            (fabs(lhs.fy - rhs.fy) < std::numeric_limits<float>::min()) &&
-            lhs.model == rhs.model &&
-            !std::memcmp(lhs.coeffs, rhs.coeffs, sizeof(rhs.coeffs));
+        lhs.height == rhs.height &&
+        (fabs(lhs.ppx - rhs.ppx) < std::numeric_limits<float>::min()) &&
+        (fabs(lhs.ppy - rhs.ppy) < std::numeric_limits<float>::min()) &&
+        (fabs(lhs.fx - rhs.fx) < std::numeric_limits<float>::min()) &&
+        (fabs(lhs.fy - rhs.fy) < std::numeric_limits<float>::min()) &&
+        lhs.model == rhs.model &&
+        !std::memcmp(lhs.coeffs, rhs.coeffs, sizeof(rhs.coeffs));
 }
 
 bool operator ==(const rs2_motion_device_intrinsic& lhs,
-                 const rs2_motion_device_intrinsic& rhs)
+    const rs2_motion_device_intrinsic& rhs)
 {
     return !std::memcmp(&lhs, &rhs, sizeof(rs2_motion_device_intrinsic));
 }
@@ -171,7 +173,7 @@ string get_str_formats(const set<rs2_format>& formats)
     stringstream ss;
     for (auto format = formats.begin(); format != formats.end(); ++format)
     {
-        ss << *format << ((format != formats.end()) && (next(format) == formats.end())?"":"/");
+        ss << *format << ((format != formats.end()) && (next(format) == formats.end()) ? "" : "/");
     }
     return ss.str();
 }
@@ -180,12 +182,14 @@ int main(int argc, char** argv) try
 {
     CmdLine cmd("librealsense rs-enumerate-devices tool", ' ', RS2_API_VERSION_STR);
 
-    SwitchArg compact_view_arg("s", "short", "Provide short summary of the devices");
-    SwitchArg show_options_arg("o", "option", "Show all supported options per subdevice");
+    SwitchArg short_view_arg("s", "short", "Provide a one-line summary of the devices");
+    SwitchArg compact_view_arg("S", "compact", "Provide a short summary of the devices");
+    SwitchArg show_options_arg("o", "option", "Show all the supported options per subdevice");
     SwitchArg show_calibration_data_arg("c", "calib_data", "Show extrinsic and intrinsic of all subdevices");
-    SwitchArg show_defaults("d", "defaults", "Show default streams configuration");
+    SwitchArg show_defaults("d", "defaults", "Show the default streams configuration");
     ValueArg<string> show_playback_device_arg("p", "playback_device", "Inspect and enumerate playback device (from file)",
-                                              false, "", "Playback device - ROSBag record full path");
+        false, "", "Playback device - ROSBag record full path");
+    cmd.add(short_view_arg);
     cmd.add(compact_view_arg);
     cmd.add(show_options_arg);
     cmd.add(show_calibration_data_arg);
@@ -196,11 +200,12 @@ int main(int argc, char** argv) try
 
     log_to_console(RS2_LOG_SEVERITY_ERROR);
 
-    bool compact_view           = compact_view_arg.getValue();
-    bool show_options           = show_options_arg.getValue();
-    bool show_calibration_data  = show_calibration_data_arg.getValue();
-    bool show_modes             = !compact_view;
-    auto playback_dev_file      = show_playback_device_arg.getValue();
+    bool short_view = short_view_arg.getValue();
+    bool compact_view = compact_view_arg.getValue();
+    bool show_options = show_options_arg.getValue();
+    bool show_calibration_data = show_calibration_data_arg.getValue();
+    bool show_modes = !(compact_view || short_view);
+    auto playback_dev_file = show_playback_device_arg.getValue();
 
     // Obtain a list of devices currently present on the system
     context ctx;
@@ -208,170 +213,220 @@ int main(int argc, char** argv) try
     if (!playback_dev_file.empty())
         d = ctx.load_device(playback_dev_file.data());
 
-    auto devices = ctx.query_devices();
-    size_t device_count = devices.size();
+    auto devices_list = ctx.query_devices();
+    size_t device_count = devices_list.size();
     if (!device_count)
     {
-        cout <<"No device detected. Is it plugged in?\n";
+        cout << "No device detected. Is it plugged in?\n";
         return EXIT_SUCCESS;
     }
 
-    if (compact_view)
+    // Retrieve the viable devices
+    std::vector<rs2::device> devices;
+
+    for ( size_t i = 0u; i < device_count; i++)
+    {
+        try
+        {
+            auto dev = devices_list[i];
+            devices.emplace_back(dev);
+        }
+        catch (const std::exception & e)
+        {
+            std::cout << "Could not create device - " << e.what() <<" . Check SDK logs for details" << std::endl;
+        }
+        catch(...)
+        {
+            std::cout << "Failed to created device. Check SDK logs for details" << std::endl;
+        }
+    }
+
+    if (short_view || compact_view)
     {
         cout << left << setw(30) << "Device Name"
-             << setw(20) << "Serial Number"
-             << setw(20) << "Firmware Version"
-             << endl;
+            << setw(20) << "Serial Number"
+            << setw(20) << "Firmware Version"
+            << endl;
 
-        for (auto i = 0u; i < device_count; ++i)
+        for (auto i = 0u; i < devices.size(); ++i)
         {
             auto dev = devices[i];
 
             cout << left << setw(30) << dev.get_info(RS2_CAMERA_INFO_NAME)
-                 << setw(20) << dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)
-                 << setw(20) << dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION)
-                 << endl;
+                << setw(20) << dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)
+                << setw(20) << dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION)
+                << endl;
         }
 
-        if (show_options || show_calibration_data)
-            cout << "\n\nNote:  \"-s\" option is not compatible with the other flags specified,"
-                 << " all the additional options are skipped" << endl;
+        if (show_options || show_calibration_data || show_modes)
+            cout << "\n\nNote:  \"-s\"\\\"-S\" option is not compatible with the other flags specified,"
+            << " the additional options are skipped" << endl;
 
-        show_options = show_calibration_data = false;
+        show_options = show_calibration_data = show_modes = false;
     }
 
-    for (auto i = 0u; i < device_count; ++i)
+    for (auto i = 0u; i < devices.size(); ++i)
     {
-        try
-        {
-            auto dev = devices[i];
 
+        auto dev = devices[i];
+
+        if (!short_view)
+        {
             // Show which options are supported by this device
             cout << "Device info: \n";
             if (auto pb_dev = dev.as<playback>())
-                cout << "Playback Device (" << pb_dev.file_name() <<  ")" << std::endl;
+                cout << "Playback Device (" << pb_dev.file_name() << ")" << std::endl;
 
             for (auto j = 0; j < RS2_CAMERA_INFO_COUNT; ++j)
             {
                 auto param = static_cast<rs2_camera_info>(j);
                 if (dev.supports(param))
                     cout << "    " << left << setw(30) << rs2_camera_info_to_string(rs2_camera_info(param))
-                         << ": \t" << dev.get_info(param) << endl;
+                    << ": \t" << dev.get_info(param) << endl;
             }
 
             cout << endl;
+        }
 
-            if (show_defaults.getValue())
+        if (show_defaults.getValue())
+        {
+            if (dev.supports(RS2_CAMERA_INFO_SERIAL_NUMBER))
             {
-                if (dev.supports(RS2_CAMERA_INFO_SERIAL_NUMBER))
+                cout << "Default streams:" << endl;
+                config cfg;
+                cfg.enable_device(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+                pipeline p;
+                auto profile = cfg.resolve(p);
+                for (auto&& sp : profile.get_streams())
                 {
-                    cout << "Default streams:" << endl;
-                    config cfg;
-                    cfg.enable_device(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
-                    pipeline p;
-                    auto profile = cfg.resolve(p);
-                    for (auto&& sp : profile.get_streams())
+                    cout << "    " << sp.stream_name() << " as " << sp.format() << " at " << sp.fps() << " Hz";
+                    if (auto vp = sp.as<video_stream_profile>())
                     {
-                        cout << "    " << sp.stream_name() << " as " << sp.format() << " at " << sp.fps() << " Hz";
-                        if (auto vp = sp.as<video_stream_profile>())
-                        {
-                            cout << "; Resolution: " << vp.width() << "x" << vp.height();
-                        }
-                        cout << endl;
+                        cout << "; Resolution: " << vp.width() << "x" << vp.height();
                     }
+                    cout << endl;
                 }
-                else
+            }
+            else
+            {
+                cout << "Cannot list default streams since the device does not provide a serial number!" << endl;
+            }
+            cout << endl;
+        }
+
+        if (show_options)
+        {
+            for (auto&& sensor : dev.query_sensors())
+            {
+                cout << "Options for " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
+
+                cout << setw(35) << " Supported options:" << setw(10) << "min" << setw(10)
+                    << " max" << setw(6) << " step" << setw(10) << " default" << endl;
+                for (auto j = 0; j < RS2_OPTION_COUNT; ++j)
                 {
-                    cout << "Cannot list default streams since the device does not provide a serial number!" << endl;
+                    auto opt = static_cast<rs2_option>(j);
+                    if (sensor.supports(opt))
+                    {
+                        try
+                        {
+                            auto range = sensor.get_option_range(opt);
+                            cout << "    " << left << setw(30) << opt << " : "
+                                << setw(5) << range.min << "... " << setw(12) << range.max
+                                << setw(6) << range.step << setw(10) << range.def << "\n";
+                        }
+                        catch (const error & e)
+                        {
+                            cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << endl;
+                        }
+                    }
                 }
                 cout << endl;
             }
+        }
 
-            if (show_options)
+        if (show_modes)
+        {
+            for (auto&& sensor : dev.query_sensors())
             {
-                for (auto&& sensor : dev.query_sensors())
-                {
-                    cout << "Options for " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
+                cout << "Stream Profiles supported by " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
 
-                    cout << setw(35) << " Supported options:" << setw(10) << "min" << setw(10)
-                         << " max" << setw(6) << " step" << setw(10) << " default" << endl;
-                    for (auto j = 0; j < RS2_OPTION_COUNT; ++j)
+                cout << " Supported modes:\n" << setw(16) << "    stream" << setw(16)
+                    << " resolution" << setw(10) << " fps" << setw(10) << " format" << endl;
+                // Show which streams are supported by this device
+                for (auto&& profile : sensor.get_stream_profiles())
+                {
+                    if (auto video = profile.as<video_stream_profile>())
                     {
-                        auto opt = static_cast<rs2_option>(j);
-                        if (sensor.supports(opt))
-                        {
-                            try
-                            {
-                                auto range = sensor.get_option_range(opt);
-                                cout << "    " << left << setw(30) << opt << " : "
-                                     << setw(5) << range.min << "... " << setw(12) << range.max
-                                     << setw(6) << range.step << setw(10) << range.def << "\n";
-                            }
-                            catch (const error & e)
-                            {
-                                cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << endl;
-                            }
-                        }
+                        cout << "    " << profile.stream_name() << "\t  " << video.width() << "x"
+                            << video.height() << "\t@ " << profile.fps() << setw(6) << "Hz\t" << profile.format() << endl;
                     }
-                    cout << endl;
-                }
-            }
-
-            if (show_modes)
-            {
-                for (auto&& sensor : dev.query_sensors())
-                {
-                    cout << "Stream Profiles supported by " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
-
-                    cout << " Supported modes:\n" << setw(16) << "    stream" << setw(16)
-                         << " resolution" << setw(10) << " fps" << setw(10) << " format" << endl;
-                    // Show which streams are supported by this device
-                    for (auto&& profile : sensor.get_stream_profiles())
+                    else
                     {
-                        if (auto video = profile.as<video_stream_profile>())
-                        {
-                            cout << "    " << profile.stream_name() << "\t  " << video.width() << "x"
-                                 << video.height() << "\t@ " << profile.fps() << setw(6) << "Hz\t" << profile.format() << endl;
-                        }
-                        else
-                        {
-                            cout << "    " << profile.stream_name() << "\t N/A\t\t@ " << profile.fps()
-                                 << setw(6) << "Hz\t" << profile.format() << endl;
-                        }
+                        cout << "    " << profile.stream_name() << "\t N/A\t\t@ " << profile.fps()
+                            << setw(6) << "Hz\t" << profile.format() << endl;
                     }
-
-                    cout << endl;
                 }
+
+                cout << endl;
             }
+        }
 
-            // Print Intrinsics
-            if (show_calibration_data)
+        // Print Intrinsics
+        if (show_calibration_data)
+        {
+            std::map<stream_and_index, stream_profile> streams;
+            std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_intrinsics>>> intrinsics_map;
+            std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>>> motion_intrinsics_map;
+            for (auto&& sensor : dev.query_sensors())
             {
-                std::map<stream_and_index, stream_profile> streams;
-                std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_intrinsics>>> intrinsics_map;
-                std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>>> motion_intrinsics_map;
-                for (auto&& sensor : dev.query_sensors())
+                // Intrinsics
+                for (auto&& profile : sensor.get_stream_profiles())
                 {
-                    // Intrinsics
-                    for (auto&& profile : sensor.get_stream_profiles())
+                    if (auto video = profile.as<video_stream_profile>())
                     {
-                        if (auto video = profile.as<video_stream_profile>())
+                        if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
                         {
-                            if (streams.find(stream_and_index{profile.stream_type(), profile.stream_index()}) == streams.end())
-                            {
-                                streams[stream_and_index{profile.stream_type(), profile.stream_index()}] = profile;
-                            }
+                            streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
+                        }
 
-                            rs2_intrinsics intrinsics{};
-                            stream_and_resolution stream_res{profile.stream_type(), profile.stream_index(), video.width(), video.height(), profile.stream_name()};
-                            if (safe_get_intrinsics(video, intrinsics))
-                            {
-                                auto it = std::find_if((intrinsics_map[stream_res]).begin(), (intrinsics_map[stream_res]).end(), [&](const std::pair<std::set<rs2_format>, rs2_intrinsics>& kvp) {
-                                    return intrinsics == kvp.second;
+                        rs2_intrinsics intrinsics{};
+                        stream_and_resolution stream_res{ profile.stream_type(), profile.stream_index(), video.width(), video.height(), profile.stream_name() };
+                        if (safe_get_intrinsics(video, intrinsics))
+                        {
+                            auto it = std::find_if((intrinsics_map[stream_res]).begin(), (intrinsics_map[stream_res]).end(), [&](const std::pair<std::set<rs2_format>, rs2_intrinsics>& kvp) {
+                                return intrinsics == kvp.second;
                                 });
-                                if (it == (intrinsics_map[stream_res]).end())
+                            if (it == (intrinsics_map[stream_res]).end())
+                            {
+                                (intrinsics_map[stream_res]).push_back({ {profile.format()}, intrinsics });
+                            }
+                            else
+                            {
+                                it->first.insert(profile.format()); // If the intrinsics are equals, add the profile format to format set
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (motion_stream_profile motion = profile.as<motion_stream_profile>())
+                        {
+                            if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
+                            {
+                                streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
+                            }
+
+                            rs2_motion_device_intrinsic motion_intrinsics{};
+                            stream_and_resolution stream_res{ profile.stream_type(), profile.stream_index(), motion.stream_type(), motion.stream_index(), profile.stream_name() };
+                            if (safe_get_motion_intrinsics(motion, motion_intrinsics))
+                            {
+                                auto it = std::find_if((motion_intrinsics_map[stream_res]).begin(), (motion_intrinsics_map[stream_res]).end(),
+                                    [&](const std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>& kvp)
+                                    {
+                                        return motion_intrinsics == kvp.second;
+                                    });
+                                if (it == (motion_intrinsics_map[stream_res]).end())
                                 {
-                                    (intrinsics_map[stream_res]).push_back({ {profile.format()}, intrinsics });
+                                    (motion_intrinsics_map[stream_res]).push_back({ {profile.format()}, motion_intrinsics });
                                 }
                                 else
                                 {
@@ -381,123 +436,90 @@ int main(int argc, char** argv) try
                         }
                         else
                         {
-                            if (motion_stream_profile motion = profile.as<motion_stream_profile>())
+                            if (pose_stream_profile pose = profile.as<pose_stream_profile>())
                             {
                                 if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
                                 {
                                     streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
                                 }
-
-                                rs2_motion_device_intrinsic motion_intrinsics{};
-                                stream_and_resolution stream_res{ profile.stream_type(), profile.stream_index(), motion.stream_type(), motion.stream_index(), profile.stream_name() };
-                                if (safe_get_motion_intrinsics(motion, motion_intrinsics))
-                                {
-                                    auto it = std::find_if((motion_intrinsics_map[stream_res]).begin(), (motion_intrinsics_map[stream_res]).end(),
-                                                           [&](const std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>& kvp)
-                                    {
-                                        return motion_intrinsics == kvp.second;
-                                    });
-                                    if (it == (motion_intrinsics_map[stream_res]).end())
-                                    {
-                                        (motion_intrinsics_map[stream_res]).push_back({ {profile.format()}, motion_intrinsics });
-                                    }
-                                    else
-                                    {
-                                        it->first.insert(profile.format()); // If the intrinsics are equals, add the profile format to format set
-                                    }
-                                }
                             }
                             else
                             {
-                                if (pose_stream_profile pose = profile.as<pose_stream_profile>())
-                                {
-                                    if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
-                                    {
-                                        streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
-                                    }
-                                }
-                                else
-                                {
-                                    cout << " Unhandled profile encountered: " << profile.stream_name() << "/" << profile.format() << std::endl;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                if (intrinsics_map.size())
-                {
-                    cout << "Intrinsic Parameters:\n" << endl;
-                    for (auto& kvp : intrinsics_map)
-                    {
-                        auto stream_res = kvp.first;
-                        for (auto& intrinsics : kvp.second)
-                        {
-                            auto formats = "{" + get_str_formats(intrinsics.first) + "}";
-                            cout << " Intrinsic of \"" << stream_res.stream_name << "\" / " << stream_res.width << "x"
-                                 << stream_res.height << " / " << formats << endl;
-                            if (intrinsics.second == rs2_intrinsics{})
-                            {
-                                cout << "Intrinsic NOT available!\n\n";
-                            }
-                            else
-                            {
-                                print(intrinsics.second);
-                            }
-                        }
-                    }
-                }
-
-                if (motion_intrinsics_map.size())
-                {
-                    cout << "Motion Intrinsic Parameters:\n" << endl;
-                    for (auto& kvp : motion_intrinsics_map)
-                    {
-                        auto stream_res = kvp.first;
-                        for (auto& intrinsics : kvp.second)
-                        {
-                            auto formats = get_str_formats(intrinsics.first);
-                            cout << "Motion Intrinsic of \"" << stream_res.stream_name << "\"\t  " << formats << endl;
-                            if (intrinsics.second == rs2_motion_device_intrinsic{})
-                            {
-                                cout << "Intrinsic NOT available!\n\n";
-                            }
-                            else
-                            {
-                                print(intrinsics.second);
-                            }
-                        }
-                    }
-                }
-
-                if (streams.size())
-                {
-                    // Print Extrinsics
-                    cout << "\nExtrinsic Parameters:" << endl;
-                    rs2_extrinsics extrinsics{};
-                    for (auto kvp1 = streams.begin(); kvp1 != streams.end(); ++kvp1)
-                    {
-                        for (auto kvp2 = streams.begin(); kvp2 != streams.end(); ++kvp2)
-                        {
-                            cout << "Extrinsic from \"" << kvp1->second.stream_name() << "\"\t  " <<
-                                    "To" << "\t  \"" << kvp2->second.stream_name() << "\" :\n";
-                            try
-                            {
-                                extrinsics = kvp1->second.get_extrinsics_to(kvp2->second);
-                                print(extrinsics);
-                            }
-                            catch (...)
-                            {
-                                cout << "N/A\n";
+                                cout << " Unhandled profile encountered: " << profile.stream_name() << "/" << profile.format() << std::endl;
                             }
                         }
                     }
                 }
             }
-        }
-        catch(const std::exception& e)
-        {
-            std::cout << e.what();
+
+            if (intrinsics_map.size())
+            {
+                cout << "Intrinsic Parameters:\n" << endl;
+                for (auto& kvp : intrinsics_map)
+                {
+                    auto stream_res = kvp.first;
+                    for (auto& intrinsics : kvp.second)
+                    {
+                        auto formats = "{" + get_str_formats(intrinsics.first) + "}";
+                        cout << " Intrinsic of \"" << stream_res.stream_name << "\" / " << stream_res.width << "x"
+                            << stream_res.height << " / " << formats << endl;
+                        if (intrinsics.second == rs2_intrinsics{})
+                        {
+                            cout << "Intrinsic NOT available!\n\n";
+                        }
+                        else
+                        {
+                            print(intrinsics.second);
+                        }
+                    }
+                }
+            }
+
+            if (motion_intrinsics_map.size())
+            {
+                cout << "Motion Intrinsic Parameters:\n" << endl;
+                for (auto& kvp : motion_intrinsics_map)
+                {
+                    auto stream_res = kvp.first;
+                    for (auto& intrinsics : kvp.second)
+                    {
+                        auto formats = get_str_formats(intrinsics.first);
+                        cout << "Motion Intrinsic of \"" << stream_res.stream_name << "\"\t  " << formats << endl;
+                        if (intrinsics.second == rs2_motion_device_intrinsic{})
+                        {
+                            cout << "Intrinsic NOT available!\n\n";
+                        }
+                        else
+                        {
+                            print(intrinsics.second);
+                        }
+                    }
+                }
+            }
+
+            if (streams.size())
+            {
+                // Print Extrinsics
+                cout << "\nExtrinsic Parameters:" << endl;
+                rs2_extrinsics extrinsics{};
+                for (auto kvp1 = streams.begin(); kvp1 != streams.end(); ++kvp1)
+                {
+                    for (auto kvp2 = streams.begin(); kvp2 != streams.end(); ++kvp2)
+                    {
+                        cout << "Extrinsic from \"" << kvp1->second.stream_name() << "\"\t  " <<
+                            "To" << "\t  \"" << kvp2->second.stream_name() << "\" :\n";
+                        try
+                        {
+                            extrinsics = kvp1->second.get_extrinsics_to(kvp2->second);
+                            print(extrinsics);
+                        }
+                        catch (...)
+                        {
+                            cout << "N/A\n";
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -32,7 +32,7 @@ std::vector<std::string> tokenize_floats(string input, char separator){
 void print(const rs2_extrinsics& extrinsics)
 {
     stringstream ss;
-     ss << " Rotation Matrix:\n";
+    ss << " Rotation Matrix:\n";
 
     // Align displayed data along decimal point
     for (auto i = 0 ; i < 3 ; ++i)
@@ -59,7 +59,7 @@ void print(const rs2_extrinsics& extrinsics)
 void print(const rs2_motion_device_intrinsic& intrinsics)
 {
     stringstream ss;
-     ss << "Bias Variances: \t";
+    ss << "Bias Variances: \t";
 
     for (auto i = 0u ; i < sizeof(intrinsics.bias_variances)/sizeof(intrinsics.bias_variances[0]) ; ++i)
         ss << setprecision(15) << std::fixed << intrinsics.bias_variances[i] << "  ";
@@ -82,14 +82,14 @@ void print(const rs2_motion_device_intrinsic& intrinsics)
 void print(const rs2_intrinsics& intrinsics)
 {
     stringstream ss;
-     ss << left << setw(14) << "  Width: "      << "\t" << intrinsics.width  << endl <<
-           left << setw(14) << "  Height: "     << "\t" << intrinsics.height << endl <<
-           left << setw(14) << "  PPX: "        << "\t" << setprecision(15)  << intrinsics.ppx << endl <<
-           left << setw(14) << "  PPY: "        << "\t" << setprecision(15)  << intrinsics.ppy << endl <<
-           left << setw(14) << "  Fx: "         << "\t" << setprecision(15)  << intrinsics.fx  << endl <<
-           left << setw(14) << "  Fy: "         << "\t" << setprecision(15)  << intrinsics.fy  << endl <<
-           left << setw(14) << "  Distortion: " << "\t" << rs2_distortion_to_string(intrinsics.model) << endl <<
-           left << setw(14) << "  Coeffs: ";
+    ss << left << setw(14) << "  Width: "      << "\t" << intrinsics.width  << endl <<
+          left << setw(14) << "  Height: "     << "\t" << intrinsics.height << endl <<
+          left << setw(14) << "  PPX: "        << "\t" << setprecision(15)  << intrinsics.ppx << endl <<
+          left << setw(14) << "  PPY: "        << "\t" << setprecision(15)  << intrinsics.ppy << endl <<
+          left << setw(14) << "  Fx: "         << "\t" << setprecision(15)  << intrinsics.fx  << endl <<
+          left << setw(14) << "  Fy: "         << "\t" << setprecision(15)  << intrinsics.fy  << endl <<
+          left << setw(14) << "  Distortion: " << "\t" << rs2_distortion_to_string(intrinsics.model) << endl <<
+          left << setw(14) << "  Coeffs: ";
 
     for (auto i = 0u ; i < sizeof(intrinsics.coeffs)/sizeof(intrinsics.coeffs[0]) ; ++i)
         ss << "\t" << setprecision(15) << intrinsics.coeffs[i] << "  ";
@@ -219,18 +219,18 @@ int main(int argc, char** argv) try
     if (compact_view)
     {
         cout << left << setw(30) << "Device Name"
-            << setw(20) << "Serial Number"
-            << setw(20) << "Firmware Version"
-            << endl;
+             << setw(20) << "Serial Number"
+             << setw(20) << "Firmware Version"
+             << endl;
 
         for (auto i = 0u; i < device_count; ++i)
         {
             auto dev = devices[i];
 
             cout << left << setw(30) << dev.get_info(RS2_CAMERA_INFO_NAME)
-                << setw(20) << dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)
-                << setw(20) << dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION)
-                << endl;
+                 << setw(20) << dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER)
+                 << setw(20) << dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION)
+                 << endl;
         }
 
         if (show_options || show_calibration_data)
@@ -240,166 +240,138 @@ int main(int argc, char** argv) try
         show_options = show_calibration_data = false;
     }
 
-    log_to_console(RS2_LOG_SEVERITY_FATAL);
-
     for (auto i = 0u; i < device_count; ++i)
     {
-        auto dev = devices[i];
-
-        // Show which options are supported by this device
-        cout << "Device info: \n";
-        if (auto pb_dev = dev.as<playback>())
-            cout << "Playback Device (" << pb_dev.file_name() <<  ")" << std::endl;
-
-        for (auto j = 0; j < RS2_CAMERA_INFO_COUNT; ++j)
+        try
         {
-            auto param = static_cast<rs2_camera_info>(j);
-            if (dev.supports(param))
-                cout << "    " << left << setw(30) << rs2_camera_info_to_string(rs2_camera_info(param))
-                << ": \t" << dev.get_info(param) << endl;
-        }
+            auto dev = devices[i];
 
-        cout << endl;
+            // Show which options are supported by this device
+            cout << "Device info: \n";
+            if (auto pb_dev = dev.as<playback>())
+                cout << "Playback Device (" << pb_dev.file_name() <<  ")" << std::endl;
 
-        if (show_defaults.getValue())
-        {
-            if (dev.supports(RS2_CAMERA_INFO_SERIAL_NUMBER))
+            for (auto j = 0; j < RS2_CAMERA_INFO_COUNT; ++j)
             {
-                cout << "Default streams:" << endl;
-                config cfg;
-                cfg.enable_device(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
-                pipeline p;
-                auto profile = cfg.resolve(p);
-                for (auto&& sp : profile.get_streams())
+                auto param = static_cast<rs2_camera_info>(j);
+                if (dev.supports(param))
+                    cout << "    " << left << setw(30) << rs2_camera_info_to_string(rs2_camera_info(param))
+                         << ": \t" << dev.get_info(param) << endl;
+            }
+
+            cout << endl;
+
+            if (show_defaults.getValue())
+            {
+                if (dev.supports(RS2_CAMERA_INFO_SERIAL_NUMBER))
                 {
-                    cout << "    " << sp.stream_name() << " as " << sp.format() << " at " << sp.fps() << " Hz";
-                    if (auto vp = sp.as<video_stream_profile>())
+                    cout << "Default streams:" << endl;
+                    config cfg;
+                    cfg.enable_device(dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER));
+                    pipeline p;
+                    auto profile = cfg.resolve(p);
+                    for (auto&& sp : profile.get_streams())
                     {
-                        cout << "; Resolution: " << vp.width() << "x" << vp.height();
+                        cout << "    " << sp.stream_name() << " as " << sp.format() << " at " << sp.fps() << " Hz";
+                        if (auto vp = sp.as<video_stream_profile>())
+                        {
+                            cout << "; Resolution: " << vp.width() << "x" << vp.height();
+                        }
+                        cout << endl;
+                    }
+                }
+                else
+                {
+                    cout << "Cannot list default streams since the device does not provide a serial number!" << endl;
+                }
+                cout << endl;
+            }
+
+            if (show_options)
+            {
+                for (auto&& sensor : dev.query_sensors())
+                {
+                    cout << "Options for " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
+
+                    cout << setw(35) << " Supported options:" << setw(10) << "min" << setw(10)
+                         << " max" << setw(6) << " step" << setw(10) << " default" << endl;
+                    for (auto j = 0; j < RS2_OPTION_COUNT; ++j)
+                    {
+                        auto opt = static_cast<rs2_option>(j);
+                        if (sensor.supports(opt))
+                        {
+                            try
+                            {
+                                auto range = sensor.get_option_range(opt);
+                                cout << "    " << left << setw(30) << opt << " : "
+                                     << setw(5) << range.min << "... " << setw(12) << range.max
+                                     << setw(6) << range.step << setw(10) << range.def << "\n";
+                            }
+                            catch (const error & e)
+                            {
+                                cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << endl;
+                            }
+                        }
                     }
                     cout << endl;
                 }
             }
-            else
-            {
-                cout << "Cannot list default streams since the device does not provide a serial number!" << endl;
-            }
-            cout << endl;
-        }
 
-        if (show_options)
-        {
-            for (auto&& sensor : dev.query_sensors())
+            if (show_modes)
             {
-                cout << "Options for " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
-
-                cout << setw(35) << " Supported options:" << setw(10) << "min" << setw(10)
-                     << " max" << setw(6) << " step" << setw(10) << " default" << endl;
-                for (auto j = 0; j < RS2_OPTION_COUNT; ++j)
+                for (auto&& sensor : dev.query_sensors())
                 {
-                    auto opt = static_cast<rs2_option>(j);
-                    if (sensor.supports(opt))
+                    cout << "Stream Profiles supported by " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
+
+                    cout << " Supported modes:\n" << setw(16) << "    stream" << setw(16)
+                         << " resolution" << setw(10) << " fps" << setw(10) << " format" << endl;
+                    // Show which streams are supported by this device
+                    for (auto&& profile : sensor.get_stream_profiles())
                     {
-                        try
+                        if (auto video = profile.as<video_stream_profile>())
                         {
-                            auto range = sensor.get_option_range(opt);
-                            cout << "    " << left << setw(30) << opt << " : "
-                                << setw(5) << range.min << "... " << setw(12) << range.max
-                                << setw(6) << range.step << setw(10) << range.def << "\n";
+                            cout << "    " << profile.stream_name() << "\t  " << video.width() << "x"
+                                 << video.height() << "\t@ " << profile.fps() << setw(6) << "Hz\t" << profile.format() << endl;
                         }
-                        catch (const error & e)
+                        else
                         {
-                            cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << endl;
+                            cout << "    " << profile.stream_name() << "\t N/A\t\t@ " << profile.fps()
+                                 << setw(6) << "Hz\t" << profile.format() << endl;
                         }
                     }
+
+                    cout << endl;
                 }
-                cout << endl;
             }
-        }
 
-        if (show_modes)
-        {
-            for (auto&& sensor : dev.query_sensors())
+            // Print Intrinsics
+            if (show_calibration_data)
             {
-                cout << "Stream Profiles supported by " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
-
-                cout << " Supported modes:\n" << setw(16) << "    stream" << setw(16)
-                     << " resolution" << setw(10) << " fps" << setw(10) << " format" << endl;
-                // Show which streams are supported by this device
-                for (auto&& profile : sensor.get_stream_profiles())
+                std::map<stream_and_index, stream_profile> streams;
+                std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_intrinsics>>> intrinsics_map;
+                std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>>> motion_intrinsics_map;
+                for (auto&& sensor : dev.query_sensors())
                 {
-                    if (auto video = profile.as<video_stream_profile>())
+                    // Intrinsics
+                    for (auto&& profile : sensor.get_stream_profiles())
                     {
-                        cout << "    " << profile.stream_name() << "\t  " << video.width() << "x"
-                            << video.height() << "\t@ " << profile.fps() << setw(6) << "Hz\t" << profile.format() << endl;
-                    }
-                    else
-                    {
-                        cout << "    " << profile.stream_name() << "\t N/A\t\t@ " << profile.fps()
-                            << setw(6) << "Hz\t" << profile.format() << endl;
-                    }
-                }
-
-                cout << endl;
-            }
-        }
-
-        // Print Intrinsics
-        if (show_calibration_data)
-        {
-            std::map<stream_and_index, stream_profile> streams;
-            std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_intrinsics>>> intrinsics_map;
-            std::map<stream_and_resolution, std::vector<std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>>> motion_intrinsics_map;
-            for (auto&& sensor : dev.query_sensors())
-            {
-                // Intrinsics
-                for (auto&& profile : sensor.get_stream_profiles())
-                {
-                    if (auto video = profile.as<video_stream_profile>())
-                    {
-                        if (streams.find(stream_and_index{profile.stream_type(), profile.stream_index()}) == streams.end())
+                        if (auto video = profile.as<video_stream_profile>())
                         {
-                            streams[stream_and_index{profile.stream_type(), profile.stream_index()}] = profile;
-                        }
-
-                        rs2_intrinsics intrinsics{};
-                        stream_and_resolution stream_res{profile.stream_type(), profile.stream_index(), video.width(), video.height(), profile.stream_name()};
-                        if (safe_get_intrinsics(video, intrinsics))
-                        {
-                            auto it = std::find_if((intrinsics_map[stream_res]).begin(), (intrinsics_map[stream_res]).end(), [&](const std::pair<std::set<rs2_format>, rs2_intrinsics>& kvp) {
-                                return intrinsics == kvp.second;
-                            });
-                            if (it == (intrinsics_map[stream_res]).end())
+                            if (streams.find(stream_and_index{profile.stream_type(), profile.stream_index()}) == streams.end())
                             {
-                                (intrinsics_map[stream_res]).push_back({ {profile.format()}, intrinsics });
-                            }
-                            else
-                            {
-                                it->first.insert(profile.format()); // If the intrinsics are equals, add the profile format to format set
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (motion_stream_profile motion = profile.as<motion_stream_profile>())
-                        {
-                            if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
-                            {
-                                streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
+                                streams[stream_and_index{profile.stream_type(), profile.stream_index()}] = profile;
                             }
 
-                            rs2_motion_device_intrinsic motion_intrinsics{};
-                            stream_and_resolution stream_res{ profile.stream_type(), profile.stream_index(), motion.stream_type(), motion.stream_index(), profile.stream_name() };
-                            if (safe_get_motion_intrinsics(motion, motion_intrinsics))
+                            rs2_intrinsics intrinsics{};
+                            stream_and_resolution stream_res{profile.stream_type(), profile.stream_index(), video.width(), video.height(), profile.stream_name()};
+                            if (safe_get_intrinsics(video, intrinsics))
                             {
-                                auto it = std::find_if((motion_intrinsics_map[stream_res]).begin(), (motion_intrinsics_map[stream_res]).end(),
-                                    [&](const std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>& kvp)
-                                {
-                                    return motion_intrinsics == kvp.second;
+                                auto it = std::find_if((intrinsics_map[stream_res]).begin(), (intrinsics_map[stream_res]).end(), [&](const std::pair<std::set<rs2_format>, rs2_intrinsics>& kvp) {
+                                    return intrinsics == kvp.second;
                                 });
-                                if (it == (motion_intrinsics_map[stream_res]).end())
+                                if (it == (intrinsics_map[stream_res]).end())
                                 {
-                                    (motion_intrinsics_map[stream_res]).push_back({ {profile.format()}, motion_intrinsics });
+                                    (intrinsics_map[stream_res]).push_back({ {profile.format()}, intrinsics });
                                 }
                                 else
                                 {
@@ -409,90 +381,123 @@ int main(int argc, char** argv) try
                         }
                         else
                         {
-                            if (pose_stream_profile pose = profile.as<pose_stream_profile>())
+                            if (motion_stream_profile motion = profile.as<motion_stream_profile>())
                             {
                                 if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
                                 {
                                     streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
                                 }
+
+                                rs2_motion_device_intrinsic motion_intrinsics{};
+                                stream_and_resolution stream_res{ profile.stream_type(), profile.stream_index(), motion.stream_type(), motion.stream_index(), profile.stream_name() };
+                                if (safe_get_motion_intrinsics(motion, motion_intrinsics))
+                                {
+                                    auto it = std::find_if((motion_intrinsics_map[stream_res]).begin(), (motion_intrinsics_map[stream_res]).end(),
+                                                           [&](const std::pair<std::set<rs2_format>, rs2_motion_device_intrinsic>& kvp)
+                                    {
+                                        return motion_intrinsics == kvp.second;
+                                    });
+                                    if (it == (motion_intrinsics_map[stream_res]).end())
+                                    {
+                                        (motion_intrinsics_map[stream_res]).push_back({ {profile.format()}, motion_intrinsics });
+                                    }
+                                    else
+                                    {
+                                        it->first.insert(profile.format()); // If the intrinsics are equals, add the profile format to format set
+                                    }
+                                }
                             }
                             else
                             {
-                                cout << " Unhandled profile encountered: " << profile.stream_name() << "/" << profile.format() << std::endl;
+                                if (pose_stream_profile pose = profile.as<pose_stream_profile>())
+                                {
+                                    if (streams.find(stream_and_index{ profile.stream_type(), profile.stream_index() }) == streams.end())
+                                    {
+                                        streams[stream_and_index{ profile.stream_type(), profile.stream_index() }] = profile;
+                                    }
+                                }
+                                else
+                                {
+                                    cout << " Unhandled profile encountered: " << profile.stream_name() << "/" << profile.format() << std::endl;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (intrinsics_map.size())
+                {
+                    cout << "Intrinsic Parameters:\n" << endl;
+                    for (auto& kvp : intrinsics_map)
+                    {
+                        auto stream_res = kvp.first;
+                        for (auto& intrinsics : kvp.second)
+                        {
+                            auto formats = "{" + get_str_formats(intrinsics.first) + "}";
+                            cout << " Intrinsic of \"" << stream_res.stream_name << "\" / " << stream_res.width << "x"
+                                 << stream_res.height << " / " << formats << endl;
+                            if (intrinsics.second == rs2_intrinsics{})
+                            {
+                                cout << "Intrinsic NOT available!\n\n";
+                            }
+                            else
+                            {
+                                print(intrinsics.second);
+                            }
+                        }
+                    }
+                }
+
+                if (motion_intrinsics_map.size())
+                {
+                    cout << "Motion Intrinsic Parameters:\n" << endl;
+                    for (auto& kvp : motion_intrinsics_map)
+                    {
+                        auto stream_res = kvp.first;
+                        for (auto& intrinsics : kvp.second)
+                        {
+                            auto formats = get_str_formats(intrinsics.first);
+                            cout << "Motion Intrinsic of \"" << stream_res.stream_name << "\"\t  " << formats << endl;
+                            if (intrinsics.second == rs2_motion_device_intrinsic{})
+                            {
+                                cout << "Intrinsic NOT available!\n\n";
+                            }
+                            else
+                            {
+                                print(intrinsics.second);
+                            }
+                        }
+                    }
+                }
+
+                if (streams.size())
+                {
+                    // Print Extrinsics
+                    cout << "\nExtrinsic Parameters:" << endl;
+                    rs2_extrinsics extrinsics{};
+                    for (auto kvp1 = streams.begin(); kvp1 != streams.end(); ++kvp1)
+                    {
+                        for (auto kvp2 = streams.begin(); kvp2 != streams.end(); ++kvp2)
+                        {
+                            cout << "Extrinsic from \"" << kvp1->second.stream_name() << "\"\t  " <<
+                                    "To" << "\t  \"" << kvp2->second.stream_name() << "\" :\n";
+                            try
+                            {
+                                extrinsics = kvp1->second.get_extrinsics_to(kvp2->second);
+                                print(extrinsics);
+                            }
+                            catch (...)
+                            {
+                                cout << "N/A\n";
                             }
                         }
                     }
                 }
             }
-
-            if (intrinsics_map.size())
-            {
-                cout << "Intrinsic Parameters:\n" << endl;
-                for (auto& kvp : intrinsics_map)
-                {
-                    auto stream_res = kvp.first;
-                    for (auto& intrinsics : kvp.second)
-                    {
-                        auto formats = "{" + get_str_formats(intrinsics.first) + "}";
-                        cout << " Intrinsic of \"" << stream_res.stream_name << "\" / " << stream_res.width << "x"
-                            << stream_res.height << " / " << formats << endl;
-                        if (intrinsics.second == rs2_intrinsics{})
-                        {
-                            cout << "Intrinsic NOT available!\n\n";
-                        }
-                        else
-                        {
-                            print(intrinsics.second);
-                        }
-                    }
-                }
-            }
-
-            if (motion_intrinsics_map.size())
-            {
-                cout << "Motion Intrinsic Parameters:\n" << endl;
-                for (auto& kvp : motion_intrinsics_map)
-                {
-                    auto stream_res = kvp.first;
-                    for (auto& intrinsics : kvp.second)
-                    {
-                        auto formats = get_str_formats(intrinsics.first);
-                        cout << "Motion Intrinsic of \"" << stream_res.stream_name << "\"\t  " << formats << endl;
-                        if (intrinsics.second == rs2_motion_device_intrinsic{})
-                        {
-                            cout << "Intrinsic NOT available!\n\n";
-                        }
-                        else
-                        {
-                            print(intrinsics.second);
-                        }
-                    }
-                }
-            }
-
-            if (streams.size())
-            {
-                // Print Extrinsics
-                cout << "\nExtrinsic Parameters:" << endl;
-                rs2_extrinsics extrinsics{};
-                for (auto kvp1 = streams.begin(); kvp1 != streams.end(); ++kvp1)
-                {
-                    for (auto kvp2 = streams.begin(); kvp2 != streams.end(); ++kvp2)
-                    {
-                        cout << "Extrinsic from \"" << kvp1->second.stream_name() << "\"\t  " <<
-                                "To" << "\t  \"" << kvp2->second.stream_name() << "\" :\n";
-                        try
-                        {
-                            extrinsics = kvp1->second.get_extrinsics_to(kvp2->second);
-                            print(extrinsics);
-                        }
-                        catch (...)
-                        {
-                            cout << "N/A\n";
-                        }
-                    }
-                }
-            }
+        }
+        catch(const std::exception& e)
+        {
+            std::cout << e.what();
         }
     }
 


### PR DESCRIPTION
`rs-enumerate-devices` enhancements and fixes:
- Make the tool more robust to device create failure. Reproduced by running w/o udev-rules applied.
- Revert `-s` option to invoke a one-line description per device.
- Add `-S` to provide the device node data (used to be `-s`)
- Update documentation

libusb fix:
- Check return value on device open to prevent null de-referencing and segfault. Also applicable to T265 boot.

Addresses #5423