### PR TITLE
Fix what appears to be a copy/paste redundant code problem. Issue #5733

### DIFF
--- a/src/proc/zero-order.cpp
+++ b/src/proc/zero-order.cpp
@@ -44,7 +44,7 @@ namespace librealsense
     std::vector <T> get_zo_point_values(const T* frame_data_in, const rs2_intrinsics& intrinsics, int zo_point_x, int zo_point_y, int patch_r)
     {
         std::vector<T> values;
-        values.reserve((patch_r + 2UL) *(patch_r + 2UL));
+        values.reserve((patch_r + 2ULL) *(patch_r + 2ULL));
 
         for (auto i = zo_point_y - 1 - patch_r; i <= (zo_point_y + patch_r) && i < intrinsics.height; i++)
         {
@@ -145,14 +145,14 @@ namespace librealsense
     {
         std::vector<double> rtd(size_t(intrinsics.height)*intrinsics.width);
         z2rtd(vertices, rtd.data(), intrinsics, int(options.baseline));
-        double rtd_zo_value; // \\todo Not sure why try_get_zo_rtd_ir_point_values() returns a double and detect_zero_order() uses a float. Which is best representation?
+        double rtd_zo_value; 
         uint8_t ir_zo_value;
 
         if (try_get_zo_rtd_ir_point_values(rtd.data(), depth_data_in, ir_data, intrinsics, 
             options,zo_point_x, zo_point_y, &rtd_zo_value, &ir_zo_value))
         {
             detect_zero_order(rtd.data(), depth_data_in, ir_data, zero_pixel, intrinsics,
-                options, float(rtd_zo_value), ir_zo_value);
+                options, rtd_zo_value, ir_zo_value);
             return true;
         }
         return false;

--- a/src/proc/zero-order.cpp
+++ b/src/proc/zero-order.cpp
@@ -44,7 +44,7 @@ namespace librealsense
     std::vector <T> get_zo_point_values(const T* frame_data_in, const rs2_intrinsics& intrinsics, int zo_point_x, int zo_point_y, int patch_r)
     {
         std::vector<T> values;
-        values.reserve((patch_r + 2) *(patch_r + 2));
+        values.reserve((patch_r + 2UL) *(patch_r + 2UL));
 
         for (auto i = zo_point_y - 1 - patch_r; i <= (zo_point_y + patch_r) && i < intrinsics.height; i++)
         {
@@ -103,7 +103,7 @@ namespace librealsense
             return val == 0;
         }), values_ir.end());
 
-        if ((values_rtd.size() == 0) || (values_ir.size() == 0))
+        if (values_rtd.empty() || values_ir.empty())
             return false;
 
         *rtd_zo_value = get_zo_point_value(values_rtd);
@@ -115,14 +115,14 @@ namespace librealsense
     template<class T>
     void detect_zero_order(const double * rtd, const uint16_t* depth_data_in, const uint8_t* ir_data, T zero_pixel,
        const rs2_intrinsics& intrinsics, const zero_order_options& options,
-       float zo_value, uint8_t iro_value)
+       double zo_value, uint8_t iro_value)
     {
-        const int ir_dynamic_range = 256;
+        const double ir_dynamic_range = 256.0;
 
-        auto r = (double)std::exp((ir_dynamic_range / 2.0 + options.threshold_offset - iro_value) / (double)options.threshold_scale);
+        double r = std::exp((ir_dynamic_range / 2.0 + options.threshold_offset - iro_value) / (double)options.threshold_scale);
 
-        auto res = (1 + r);
-        auto i_threshold_relative = (double)options.ir_threshold / res;
+        double res = (1.0 + r);
+        double i_threshold_relative = options.ir_threshold / res;
         for (auto i = 0; i < intrinsics.height*intrinsics.width; i++)
         {
             double rtd_val = rtd[i];
@@ -130,8 +130,8 @@ namespace librealsense
 
             bool zero = (depth_data_in[i] > 0) && 
                         (ir_val < i_threshold_relative) &&
-                        (rtd_val > double(zo_value - float(options.rtd_low_threshold))) && 
-                        (rtd_val < double(zo_value + float(options.rtd_high_threshold)));
+                        (rtd_val > (zo_value - options.rtd_low_threshold)) && 
+                        (rtd_val < (zo_value + options.rtd_high_threshold));
 
             zero_pixel(i, zero);
         }
@@ -143,7 +143,7 @@ namespace librealsense
         rs2_intrinsics intrinsics,
         const zero_order_options& options, int zo_point_x, int zo_point_y)
     {
-        std::vector<double> rtd(intrinsics.height*intrinsics.width);
+        std::vector<double> rtd(size_t(intrinsics.height)*intrinsics.width);
         z2rtd(vertices, rtd.data(), intrinsics, int(options.baseline));
         double rtd_zo_value; // \\todo Not sure why try_get_zo_rtd_ir_point_values() returns a double and detect_zero_order() uses a float. Which is best representation?
         uint8_t ir_zo_value;
@@ -159,7 +159,8 @@ namespace librealsense
     }
 
     zero_order::zero_order(std::shared_ptr<bool_option> is_enabled_opt)
-       : generic_processing_block("Zero Order Fix"), _first_frame(true), _is_enabled_opt(is_enabled_opt)
+       : generic_processing_block("Zero Order Fix"), _first_frame(true), _is_enabled_opt(is_enabled_opt),
+        _resolutions_depth { 0 }
     {
         auto ir_threshold = std::make_shared<ptr_option<uint8_t>>(
             0,

--- a/src/proc/zero-order.h
+++ b/src/proc/zero-order.h
@@ -30,7 +30,8 @@ namespace librealsense
             z_max(Z_MAX_VALUE),
             ir_min(IR_MIN_VALUE),
             threshold_offset(THRESHOLD_OFFSET),
-            threshold_scale(THRESHOLD_SCALE)
+            threshold_scale(THRESHOLD_SCALE),
+            read_baseline(false)
         {}
 
         uint8_t                 ir_threshold;


### PR DESCRIPTION
#5733 Change second conditional to test values_ir.size().

        if ((values_rtd.size() == 0) || (values_ir.size() == 0))

Also correct some casting and replace auto with the exact types where appropriate. Why use auto's when the exact type is known at this level?  
The coding distinctions between float and double don't seem very tight. Looks like floats would work for most of this.
