### PR TITLE
Improve get_gvd_field() implementation for bool type.

### DIFF
--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -275,10 +275,13 @@ namespace librealsense
                   param2(0),
                   param3(0),
                   param4(0),
-                  sizeOfSendCommandData(0),
-                  timeOut(5000),
-                  oneDirection(false),
-                  receivedCommandDataLength(0)
+                data{ 0 },
+                sizeOfSendCommandData(0),
+                timeOut(5000L),
+                oneDirection(false),
+                receivedCommandData{ 0 },
+                receivedCommandDataLength(0),
+                receivedOpcode{ 0 }
             {}
 
 
@@ -291,7 +294,9 @@ namespace librealsense
                   sizeOfSendCommandData(std::min((uint16_t)cmd.data.size(), HW_MONITOR_BUFFER_SIZE)),
                   timeOut(cmd.timeout_ms),
                   oneDirection(!cmd.require_response),
-                  receivedCommandDataLength(0)
+                receivedCommandData{ 0 },
+                receivedOpcode{ 0 },
+                receivedCommandDataLength(0U)
             {
                 librealsense::copy(data, cmd.data.data(), sizeOfSendCommandData);
             }
@@ -326,16 +331,37 @@ namespace librealsense
         static std::string get_module_serial_string(const std::vector<uint8_t>& buff, size_t index, size_t length = 6);
         bool is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const;
 
-        template <typename T>
-        T get_gvd_field(const std::vector<uint8_t>& data, size_t index)
-        {
-            T rv = 0;
-            if (index + sizeof(T) >= data.size())
-                throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
-                    std::to_string(data.size()) + ", index: " + std::to_string(index));
-            for (int i = 0; i < sizeof(T); i++)
-                rv += data[index + i] << (i * 8);
-            return rv;
-        }
+
+        /*
+            This function is currently only used with bools.
+            Wrong implementation for bools as += is an unsafe operation for a bool.
+            Could use a conditional template, but since the only use is as a bool, I used simplified function just for bools.
+
+            Notice the original implementation appears to have a boundary problem. It will throw one byte too soon.
+            i.e. if data.size()=2, T is uint16_t, it should work for index 0, but it would throw a runtime_error.
+            Should be a simple > in the if conditional.
+        */
+#if (0)
+            template <typename T>
+            T get_gvd_field(const std::vector<uint8_t>& data, size_t index)
+            {
+                T rv = 0;
+                if (index + sizeof(T) >= data.size())
+                    throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
+                        std::to_string(data.size()) + ", index: " + std::to_string(index));
+                for (int i = 0; i < sizeof(T); i++)
+                    rv += data[index + i] << (i * 8);
+                return rv;
+            }
+#else
+            bool get_gvd_field(const std::vector<uint8_t>& data, size_t index)
+            {
+
+                if (index >= data.size())
+                    throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
+                        std::to_string(data.size()) + ", index: " + std::to_string(index));
+                return data[index];
+            }
+#endif
     };
 }

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -331,37 +331,13 @@ namespace librealsense
         static std::string get_module_serial_string(const std::vector<uint8_t>& buff, size_t index, size_t length = 6);
         bool is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const;
 
+        bool get_gvd_field(const std::vector<uint8_t>& data, size_t index)
+        {
 
-        /*
-            This function is currently only used with bools.
-            Wrong implementation for bools as += is an unsafe operation for a bool.
-            Could use a conditional template, but since the only use is as a bool, I used simplified function just for bools.
-
-            Notice the original implementation appears to have a boundary problem. It will throw one byte too soon.
-            i.e. if data.size()=2, T is uint16_t, it should work for index 0, but it would throw a runtime_error.
-            Should be a simple > in the if conditional.
-        */
-#if (0)
-            template <typename T>
-            T get_gvd_field(const std::vector<uint8_t>& data, size_t index)
-            {
-                T rv = 0;
-                if (index + sizeof(T) >= data.size())
-                    throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
-                        std::to_string(data.size()) + ", index: " + std::to_string(index));
-                for (int i = 0; i < sizeof(T); i++)
-                    rv += data[index + i] << (i * 8);
-                return rv;
-            }
-#else
-            bool get_gvd_field(const std::vector<uint8_t>& data, size_t index)
-            {
-
-                if (index >= data.size())
-                    throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
-                        std::to_string(data.size()) + ", index: " + std::to_string(index));
-                return data[index];
-            }
-#endif
+            if (index >= data.size())
+                throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
+                    std::to_string(data.size()) + ", index: " + std::to_string(index));
+            return data[index];
+        }
     };
 }

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -331,9 +331,38 @@ namespace librealsense
         static std::string get_module_serial_string(const std::vector<uint8_t>& buff, size_t index, size_t length = 6);
         bool is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const;
 
+        /**
+            \brief This function can be used to extract any type of field from a buffer.
+            
+            Generic implementation to return any type field.
+
+            \param [in] data Pointer to the data buffer in which the field is stored.
+            \param [in] index Number of bytes into the buffer where the field starts.
+            \returns Field of arbitrary size
+        */
+        template <typename T>
+        T get_gvd_field(const std::vector<uint8_t>& data, size_t index)
+        {
+            T rv = 0;
+            if (index + sizeof(T) >= data.size())
+                throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
+                    std::to_string(data.size()) + ", index: " + std::to_string(index));
+            for (int i = 0; i < sizeof(T); i++)
+                rv += data[index + i] << (i * CHAR_BITS);
+            return rv;
+        }
+        /*
+            \brief Specific specialization which returns a bool field.
+
+            This specialization is required as bool is implementation specific and '+=' operation used in default template is not safe for bool.
+
+            \param [in] data Pointer to the data buffer in which the field is stored.
+            \param [in] index Number of bytes into the buffer where the field starts.
+            \returns bool field value.
+        */
+        template <> 
         bool get_gvd_field(const std::vector<uint8_t>& data, size_t index)
         {
-
             if (index >= data.size())
                 throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
                     std::to_string(data.size()) + ", index: " + std::to_string(index));

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -5,6 +5,7 @@
 
 #include "sensor.h"
 #include <mutex>
+#include <cstring>
 #include "command_transfer.h"
 
 namespace librealsense
@@ -344,29 +345,12 @@ namespace librealsense
         T get_gvd_field(const std::vector<uint8_t>& data, size_t index)
         {
             T rv = 0;
-            if (index + sizeof(T) >= data.size())
+            if (index + sizeof(T) >= data.size()) {
                 throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
                     std::to_string(data.size()) + ", index: " + std::to_string(index));
-            for (int i = 0; i < sizeof(T); i++)
-                rv += data[index + i] << (i * CHAR_BITS);
+            }
+            (void)std::memcpy(&rv, &data[index], sizeof(T));
             return rv;
-        }
-        /*
-            \brief Specific specialization which returns a bool field.
-
-            This specialization is required as bool is implementation specific and '+=' operation used in default template is not safe for bool.
-
-            \param [in] data Pointer to the data buffer in which the field is stored.
-            \param [in] index Number of bytes into the buffer where the field starts.
-            \returns bool field value.
-        */
-        template <> 
-        bool get_gvd_field(const std::vector<uint8_t>& data, size_t index)
-        {
-            if (index >= data.size())
-                throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
-                    std::to_string(data.size()) + ", index: " + std::to_string(index));
-            return data[index];
         }
     };
 }

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -90,7 +90,7 @@ namespace librealsense
         auto fwv = _hw_monitor->get_firmware_version_string(gvd_buff, fw_version_offset);
         _fw_version = firmware_version(fwv);
 
-        _is_locked = _hw_monitor->get_gvd_field(gvd_buff, is_camera_locked_offset);
+        _is_locked = _hw_monitor->get_gvd_field<bool>(gvd_buff, is_camera_locked_offset);
 
         // TODO: flash lock is not suuported yet.
         // reporting lock to the application blocks flash FW update.
@@ -399,7 +399,7 @@ namespace librealsense
         // update read-write section
         auto first_table_offset = flash_image_info.read_write_section.tables.front().offset;
         auto tables_size = flash_image_info.header.read_write_start_address + flash_image_info.header.read_write_size - first_table_offset;
-        update_section(hwm, merged_image, flash_image_info.read_write_section, tables_size, callback, 0, update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY ? 0.5 : 1.0);
+        update_section(hwm, merged_image, flash_image_info.read_write_section, tables_size, callback, 0, update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY ? 0.5F : 1.0F);
 
         if (update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY)
         {

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -90,7 +90,7 @@ namespace librealsense
         auto fwv = _hw_monitor->get_firmware_version_string(gvd_buff, fw_version_offset);
         _fw_version = firmware_version(fwv);
 
-        _is_locked = _hw_monitor->get_gvd_field<bool>(gvd_buff, is_camera_locked_offset);
+        _is_locked = _hw_monitor->get_gvd_field(gvd_buff, is_camera_locked_offset);
 
         // TODO: flash lock is not suuported yet.
         // reporting lock to the application blocks flash FW update.
@@ -360,7 +360,7 @@ namespace librealsense
             for (int i = 0; i < ivcam2::FLASH_SECTOR_SIZE; )
             {
                 auto index = sector_index * ivcam2::FLASH_SECTOR_SIZE + i;
-                if (index >= offset + size)
+                if (index >= size_t(offset) + size)
                     break;
                 int packet_size = std::min((int)(HW_MONITOR_COMMAND_SIZE - (i % HW_MONITOR_COMMAND_SIZE)), (int)(ivcam2::FLASH_SECTOR_SIZE - i));
                 command cmdFWB(ivcam2::FWB);


### PR DESCRIPTION
Change get_gvd_field() implementation from a template to just the bool case.
Template can be restored if bool is conditional to avoid unsafe '+='. See #5736 for other problem that should be fixed before using this function for anything beyond bools.

Improve class initialization.
Cast to size_t() to avoid compiler warn about overflow.