### PR TITLE
C6294 ill defined for loop fix 

### DIFF
--- a/src/winusb/handle-winusb.h
+++ b/src/winusb/handle-winusb.h
@@ -70,7 +70,7 @@ namespace librealsense
                 _handles[desc.bInterfaceNumber] = ah;
                 _descriptors[desc.bInterfaceNumber] = desc;
 
-                for (UCHAR interface_number = 0; interface_number < 256; interface_number++) {
+                for (UCHAR interface_number = 0; true; interface_number++) {
                     WINUSB_INTERFACE_HANDLE h;
                     USB_INTERFACE_DESCRIPTOR descriptor;
 


### PR DESCRIPTION
for loop uses a UCHAR but compares to 256 (which in not within the ra…nge of UCHAR) so the conditional is always true which generates a compiler warning. Change the conditional to true to avoid the warning and does not change functionality.