### PR TITLE
Handle GCC minor warnings

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -56,7 +56,7 @@ static const ImVec4 yellowish = from_rgba(255, 253, 191, 255, true);
 static const ImVec4 green = from_rgba(0x20, 0xe0, 0x20, 0xff, true);
 static const ImVec4 dark_sensor_bg = from_rgba(0x1b, 0x21, 0x25, 170);
 static const ImVec4 red = from_rgba(233, 0, 0, 255, true);
-static const ImVec4 greenish = from_rgba(33, 104, 0, 255, 0xff);
+static const ImVec4 greenish = from_rgba(33, 104, 0, 255);
 
 // Helper class that lets smoothly animate between its values
 template<class T>

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -274,7 +274,7 @@ namespace rs2
         float& operator()(int i, int j) { return mat[i][j]; }
 
         //init rotation matrix from quaternion
-        matrix4(rs2_quaternion q)
+        matrix4(const rs2_quaternion& q)
         {
             mat[0][0] = 1 - 2*q.y*q.y - 2*q.z*q.z; mat[0][1] = 2*q.x*q.y - 2*q.z*q.w;     mat[0][2] = 2*q.x*q.z + 2*q.y*q.w;     mat[0][3] = 0.0f;
             mat[1][0] = 2*q.x*q.y + 2*q.z*q.w;     mat[1][1] = 1 - 2*q.x*q.x - 2*q.z*q.z; mat[1][2] = 2*q.y*q.z - 2*q.x*q.w;     mat[1][3] = 0.0f;
@@ -283,7 +283,7 @@ namespace rs2
         }
 
         //init translation matrix from vector
-        matrix4(rs2_vector t)
+        matrix4(const rs2_vector& t)
         {
             mat[0][0] = 1.0f; mat[0][1] = 0.0f; mat[0][2] = 0.0f; mat[0][3] = t.x;
             mat[1][0] = 0.0f; mat[1][1] = 1.0f; mat[1][2] = 0.0f; mat[1][3] = t.y;

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1688,14 +1688,14 @@ namespace rs2
             glPopAttrib();
         }
 
-        static auto x = -M_PI_2;
+        static const double x = -M_PI_2;
         static float _rx[4][4] = {
             { 1, 0, 0, 0 },
             { 0, float(cos(x)), float(-sin(x)), 0 },
             { 0, float(sin(x)), float(cos(x)), 0 },
             { 0, 0, 0, 1 }
         };
-        static auto z = M_PI;
+        static const double z = M_PI;
         static float _rz[4][4] = {
             { float(cos(z)), float(-sin(z)),0, 0 },
             { float(sin(z)), float(cos(z)), 0, 0 },

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1688,17 +1688,17 @@ namespace rs2
             glPopAttrib();
         }
 
-        auto x = static_cast<float>(-M_PI / 2);
-        float _rx[4][4] = {
-            { 1 , 0, 0, 0 },
-            { 0, cos(x), -sin(x), 0 },
-            { 0, sin(x), cos(x), 0 },
+        static auto x = -M_PI_2;
+        static float _rx[4][4] = {
+            { 1, 0, 0, 0 },
+            { 0, float(cos(x)), float(-sin(x)), 0 },
+            { 0, float(sin(x)), float(cos(x)), 0 },
             { 0, 0, 0, 1 }
         };
-        auto z = static_cast<float>(M_PI);
-        float _rz[4][4] = {
-            { cos(z), -sin(z),0, 0 },
-            { sin(z), cos(z), 0, 0 },
+        static auto z = M_PI;
+        static float _rz[4][4] = {
+            { float(cos(z)), float(-sin(z)),0, 0 },
+            { float(sin(z)), float(cos(z)), 0, 0 },
             { 0 , 0, 1, 0 },
             { 0, 0, 0, 1 }
         };

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -94,8 +94,6 @@ namespace librealsense
         {rs_fourcc('U','Y','V','Y'), RS2_STREAM_COLOR}
     };
 
-    bool context::one_time_msg = false;
-
     context::context(backend_type type,
                      const char* filename,
                      const char* section,
@@ -103,9 +101,10 @@ namespace librealsense
                      std::string min_api_version)
         : _devices_changed_callback(nullptr, [](rs2_devices_changed_callback*){})
     {
-        if (!one_time_msg)
+        static bool version_logged=false;
+        if (!version_logged)
         {
-            one_time_msg = true;
+            version_logged = true;
             LOG_DEBUG("Librealsense " << std::string(std::begin(rs2_api_version),std::end(rs2_api_version)));
         }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -85,14 +85,16 @@ bool contains(const std::shared_ptr<librealsense::device_info>& first,
 
 namespace librealsense
 {
-    std::map<uint32_t, rs2_format> platform_color_fourcc_to_rs2_format = {
+    const std::map<uint32_t, rs2_format> platform_color_fourcc_to_rs2_format = {
         {rs_fourcc('Y','U','Y','2'), RS2_FORMAT_YUYV},
         {rs_fourcc('U','Y','V','Y'), RS2_FORMAT_UYVY}
     };
-    std::map<uint32_t, rs2_stream> platform_color_fourcc_to_rs2_stream = {
+    const std::map<uint32_t, rs2_stream> platform_color_fourcc_to_rs2_stream = {
         {rs_fourcc('Y','U','Y','2'), RS2_STREAM_COLOR},
         {rs_fourcc('U','Y','V','Y'), RS2_STREAM_COLOR}
     };
+
+    bool context::one_time_msg = false;
 
     context::context(backend_type type,
                      const char* filename,
@@ -101,7 +103,11 @@ namespace librealsense
                      std::string min_api_version)
         : _devices_changed_callback(nullptr, [](rs2_devices_changed_callback*){})
     {
-        LOG_DEBUG("Librealsense " << std::string(std::begin(rs2_api_version),std::end(rs2_api_version)));
+        if (!one_time_msg)
+        {
+            one_time_msg = true;
+            LOG_DEBUG("Librealsense " << std::string(std::begin(rs2_api_version),std::end(rs2_api_version)));
+        }
 
         switch(type)
         {

--- a/src/context.h
+++ b/src/context.h
@@ -151,7 +151,6 @@ namespace librealsense
         std::map<int, std::weak_ptr<const stream_interface>> _streams;
         std::map<int, std::map<int, std::weak_ptr<lazy<rs2_extrinsics>>>> _extrinsics;
         std::mutex _streams_mutex, _devices_changed_callbacks_mtx;
-        static bool one_time_msg;
     };
 
     class readonly_device_info : public device_info

--- a/src/context.h
+++ b/src/context.h
@@ -151,6 +151,7 @@ namespace librealsense
         std::map<int, std::weak_ptr<const stream_interface>> _streams;
         std::map<int, std::map<int, std::weak_ptr<lazy<rs2_extrinsics>>>> _extrinsics;
         std::mutex _streams_mutex, _devices_changed_callbacks_mtx;
+        static bool one_time_msg;
     };
 
     class readonly_device_info : public device_info

--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -54,7 +54,7 @@ namespace librealsense
             LOG_ERROR("Frame is not valid. Failed to downcast to librealsense::frame.");
             return 0;
         }
-        auto pin_index = 0;
+        auto pin_index = 0UL;
 
         if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
             pin_index = 1;
@@ -90,7 +90,7 @@ namespace librealsense
             LOG_ERROR("Frame is not valid. Failed to downcast to librealsense::frame.");
             return 0;
         }
-        auto pin_index = 0;
+        auto pin_index = 0UL;
 
         if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
             pin_index = 1;

--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -54,7 +54,7 @@ namespace librealsense
             LOG_ERROR("Frame is not valid. Failed to downcast to librealsense::frame.");
             return 0;
         }
-        auto pin_index = 0UL;
+        size_t pin_index = 0;
 
         if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
             pin_index = 1;
@@ -90,7 +90,7 @@ namespace librealsense
             LOG_ERROR("Frame is not valid. Failed to downcast to librealsense::frame.");
             return 0;
         }
-        auto pin_index = 0UL;
+        size_t pin_index = 0;
 
         if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
             pin_index = 1;

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -212,7 +212,7 @@ namespace librealsense
         public:
             float query() const override;
 
-            option_range get_range() const override { return option_range{ 0, 100, 0, 0 }; };
+            option_range get_range() const override { return option_range{ 0, 100, 0, 0 }; }
 
             bool is_enabled() const override { return true; }
 
@@ -228,7 +228,7 @@ namespace librealsense
         class l500_timestamp_reader : public frame_timestamp_reader
         {
             static const int pins = 3;
-            mutable std::vector<int64_t> counter;
+            mutable std::vector<size_t> counter;
             std::shared_ptr<platform::time_service> _ts;
             mutable std::recursive_mutex _mtx;
         public:
@@ -241,13 +241,13 @@ namespace librealsense
             void reset() override
             {
                 std::lock_guard<std::recursive_mutex> lock(_mtx);
-                for (auto i = 0; i < pins; ++i)
+                for (auto i = 0UL; i < pins; ++i)
                 {
                     counter[i] = 0;
                 }
             }
 
-            rs2_time_t get_frame_timestamp(const std::shared_ptr<frame_interface>& frame) override
+            rs2_time_t get_frame_timestamp(const std::shared_ptr<frame_interface>&) override
             {
                 std::lock_guard<std::recursive_mutex> lock(_mtx);
                 return _ts->get_time();
@@ -256,7 +256,7 @@ namespace librealsense
             unsigned long long get_frame_counter(const std::shared_ptr<frame_interface>& frame) const override
             {
                 std::lock_guard<std::recursive_mutex> lock(_mtx);
-                auto pin_index = 0;
+                auto pin_index = 0UL;
                 if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
                     pin_index = 1;
                 else if (frame->get_stream()->get_stream_type() == RS2_STREAM_CONFIDENCE)
@@ -265,7 +265,7 @@ namespace librealsense
                 return ++counter[pin_index];
             }
 
-            rs2_timestamp_domain get_frame_timestamp_domain(const std::shared_ptr<frame_interface>& frame) const override
+            rs2_timestamp_domain get_frame_timestamp_domain(const std::shared_ptr<frame_interface>&) const override
             {
                 return RS2_TIMESTAMP_DOMAIN_SYSTEM_TIME;
             }

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -241,7 +241,7 @@ namespace librealsense
             void reset() override
             {
                 std::lock_guard<std::recursive_mutex> lock(_mtx);
-                for (auto i = 0UL; i < pins; ++i)
+                for (size_t i = 0; i < pins; ++i)
                 {
                     counter[i] = 0;
                 }
@@ -256,7 +256,7 @@ namespace librealsense
             unsigned long long get_frame_counter(const std::shared_ptr<frame_interface>& frame) const override
             {
                 std::lock_guard<std::recursive_mutex> lock(_mtx);
-                auto pin_index = 0UL;
+                size_t pin_index = 0;
                 if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
                     pin_index = 1;
                 else if (frame->get_stream()->get_stream_type() == RS2_STREAM_CONFIDENCE)

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -258,7 +258,7 @@ namespace librealsense
                             auto sub = info.device_path.substr(0, info.device_path.find_first_of("{"));
                             std::transform(sub.begin(), sub.end(), sub.begin(), ::tolower);
                             return sub == path;
-                            
+
                         }), next.hid_devices.end());
 
                         /*if (data->_last != next)*/ data->_callback(data->_last, next);

--- a/src/tm2/tm-info.cpp
+++ b/src/tm2/tm-info.cpp
@@ -44,16 +44,19 @@ namespace librealsense
         std::shared_ptr<context> ctx,
         std::vector<platform::usb_device_info>& usb)
     {
+        std::vector<std::shared_ptr<device_info>> results;
         // We shouldn't talk to the device here, it might not
         // even be around anymore (this gets called with an out of
         // date list on disconnect).
         auto correct_pid = filter_by_product(usb, { 0x0B37 });
-        LOG_INFO("Picked " << correct_pid.size() << "/" << usb.size() << " devices");
+        if (correct_pid.size())
+        {
+            LOG_INFO("Picked " << correct_pid.size() << "/" << usb.size() << " devices");
 
-        std::vector<std::shared_ptr<device_info>> results;
+            for(auto & dev : correct_pid)
+                results.push_back(std::make_shared<tm2_info>(ctx, dev));
+        }
 
-        for(auto & dev : correct_pid)
-            results.push_back(std::make_shared<tm2_info>(ctx, dev));
         return results;
     }
 }

--- a/src/types.h
+++ b/src/types.h
@@ -581,13 +581,13 @@ namespace librealsense
     }
     inline bool operator==(const rs2_extrinsics& a, const rs2_extrinsics& b)
     {
-        for (int i = 0; i < 3; i++) 
-            if (a.translation[i] != b.translation[i]) 
+        for (int i = 0; i < 3; i++)
+            if (a.translation[i] != b.translation[i])
                 return false;
         for (int j = 0; j < 3; j++)
             for (int i = 0; i < 3; i++)
-                if (std::fabs(a.rotation[j * 3 + i] - b.rotation[j * 3 + i]) 
-                     > std::numeric_limits<float>::epsilon()) 
+                if (std::fabs(a.rotation[j * 3 + i] - b.rotation[j * 3 + i])
+                     > std::numeric_limits<float>::epsilon())
                     return false;
         return true;
     }


### PR DESCRIPTION
Remove redundant log messages. 
Add Librealsense version to the log once.
Resolve minor GCC warnings
Drop unnecessary in rgba mapping
