### PR TITLE
Added composite_identity_matcher; L515 uses it to not sync IMU

### DIFF
--- a/src/l500/l500-factory.cpp
+++ b/src/l500/l500-factory.cpp
@@ -151,6 +151,6 @@ namespace librealsense
         auto identity_accel = std::make_shared<identity_matcher>(_accel_stream->get_unique_id(), _accel_stream->get_stream_type());
 
         std::vector<std::shared_ptr<matcher>> depth_rgb_imu_matchers = {ts_depth_rgb, identity_gyro, identity_accel};
-        return std::make_shared<by_pass_composite_matcher>(depth_rgb_imu_matchers);
+        return std::make_shared<composite_identity_matcher>(depth_rgb_imu_matchers);
     }
 }

--- a/src/l500/l500-factory.cpp
+++ b/src/l500/l500-factory.cpp
@@ -142,13 +142,15 @@ namespace librealsense
 
     std::shared_ptr<matcher> rs515_device::create_matcher(const frame_holder & frame) const
     {
-        std::vector<stream_interface*> mm_streams = { _accel_stream.get(), _gyro_stream.get() };
+        std::vector<std::shared_ptr<matcher>> depth_rgb_matchers = { l500_depth::create_matcher(frame),
+            std::make_shared<identity_matcher>(_color_stream->get_unique_id(), _color_stream->get_stream_type())};
 
-        std::vector<std::shared_ptr<matcher>> matchers = { l500_depth::create_matcher(frame),
-            std::make_shared<identity_matcher>(_color_stream->get_unique_id(), _color_stream->get_stream_type()), 
-            matcher_factory::create(RS2_MATCHER_DEFAULT, mm_streams) };
+        auto ts_depth_rgb = std::make_shared<timestamp_composite_matcher>(depth_rgb_matchers);
 
-        return std::make_shared<timestamp_composite_matcher>(matchers);
+        auto identity_gyro = std::make_shared<identity_matcher>(_gyro_stream->get_unique_id(), _gyro_stream->get_stream_type());
+        auto identity_accel = std::make_shared<identity_matcher>(_accel_stream->get_unique_id(), _accel_stream->get_stream_type());
 
+        std::vector<std::shared_ptr<matcher>> depth_rgb_imu_matchers = {ts_depth_rgb, identity_gyro, identity_accel};
+        return std::make_shared<by_pass_composite_matcher>(depth_rgb_imu_matchers);
     }
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -599,10 +599,10 @@ namespace librealsense
         return abs(a - b) < ((float)gap / (float)2) ;
     }
 
-    by_pass_composite_matcher::by_pass_composite_matcher(std::vector<std::shared_ptr<matcher>> matchers) :composite_matcher(matchers, "BP: ")
+    composite_identity_matcher::composite_identity_matcher(std::vector<std::shared_ptr<matcher>> matchers) :composite_matcher(matchers, "CI: ")
     {}
 
-    void by_pass_composite_matcher::sync(frame_holder f, syncronization_environment env)
+    void composite_identity_matcher::sync(frame_holder f, syncronization_environment env)
     {
         LOG_DEBUG("by_pass_composite_matcher: " << _name << " " << frame_to_string(f));
         _callback(std::move(f), env);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -598,4 +598,13 @@ namespace librealsense
         auto gap = 1000.f / (float)fps;
         return abs(a - b) < ((float)gap / (float)2) ;
     }
+
+    by_pass_composite_matcher::by_pass_composite_matcher(std::vector<std::shared_ptr<matcher>> matchers) :composite_matcher(matchers, "BP: ")
+    {}
+
+    void by_pass_composite_matcher::sync(frame_holder f, syncronization_environment env)
+    {
+        LOG_DEBUG("by_pass_composite_matcher: " << _name << " " << frame_to_string(f));
+        _callback(std::move(f), env);
+    }
 }

--- a/src/sync.h
+++ b/src/sync.h
@@ -115,11 +115,11 @@ namespace librealsense
         composite_matcher(std::vector<std::shared_ptr<matcher>> matchers, std::string name);
 
 
-        virtual bool are_equivalent(frame_holder& a, frame_holder& b) = 0;
-        virtual bool is_smaller_than(frame_holder& a, frame_holder& b) = 0;
-        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing)  = 0;
-        virtual void clean_inactive_streams(frame_holder& f) = 0;
-        virtual void update_last_arrived(frame_holder& f, matcher* m) = 0;
+        virtual bool are_equivalent(frame_holder& a, frame_holder& b) {return false;}
+        virtual bool is_smaller_than(frame_holder& a, frame_holder& b)  {return false;}
+        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) {return false;}
+        virtual void clean_inactive_streams(frame_holder& f) {}
+        virtual void update_last_arrived(frame_holder& f, matcher* m) {}
 
         void dispatch(frame_holder f, syncronization_environment env) override;
         std::string frames_to_string(std::vector<librealsense::matcher*> matchers);
@@ -127,12 +127,20 @@ namespace librealsense
         std::shared_ptr<matcher> find_matcher(const frame_holder& f);
 
     protected:
-        virtual void update_next_expected(const frame_holder& f) = 0;
+        virtual void update_next_expected(const frame_holder& f) {}
 
         std::map<matcher*, single_consumer_frame_queue<frame_holder>> _frames_queue;
         std::map<stream_id, std::shared_ptr<matcher>> _matchers;
         std::map<matcher*, double> _next_expected;
         std::map<matcher*, rs2_timestamp_domain> _next_expected_domain;
+    };
+
+    class by_pass_composite_matcher : public composite_matcher
+    {
+    public:
+        by_pass_composite_matcher(std::vector<std::shared_ptr<matcher>> matchers);
+
+        void sync(frame_holder f, syncronization_environment env) override;
     };
 
     class frame_number_composite_matcher : public composite_matcher

--- a/src/sync.h
+++ b/src/sync.h
@@ -115,11 +115,11 @@ namespace librealsense
         composite_matcher(std::vector<std::shared_ptr<matcher>> matchers, std::string name);
 
 
-        virtual bool are_equivalent(frame_holder& a, frame_holder& b) {return false;}
-        virtual bool is_smaller_than(frame_holder& a, frame_holder& b)  {return false;}
-        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) {return false;}
-        virtual void clean_inactive_streams(frame_holder& f) {}
-        virtual void update_last_arrived(frame_holder& f, matcher* m) {}
+        virtual bool are_equivalent(frame_holder& a, frame_holder& b) = 0;
+        virtual bool is_smaller_than(frame_holder& a, frame_holder& b) = 0;
+        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) = 0;
+        virtual void clean_inactive_streams(frame_holder& f) = 0;
+        virtual void update_last_arrived(frame_holder& f, matcher* m) = 0;
 
         void dispatch(frame_holder f, syncronization_environment env) override;
         std::string frames_to_string(std::vector<librealsense::matcher*> matchers);
@@ -127,7 +127,7 @@ namespace librealsense
         std::shared_ptr<matcher> find_matcher(const frame_holder& f);
 
     protected:
-        virtual void update_next_expected(const frame_holder& f) {}
+        virtual void update_next_expected(const frame_holder& f) = 0;
 
         std::map<matcher*, single_consumer_frame_queue<frame_holder>> _frames_queue;
         std::map<stream_id, std::shared_ptr<matcher>> _matchers;
@@ -135,12 +135,21 @@ namespace librealsense
         std::map<matcher*, rs2_timestamp_domain> _next_expected_domain;
     };
 
-    class by_pass_composite_matcher : public composite_matcher
+    // composite matcher that does not synchronize between any frames, and instead just passes them on to callback
+    class composite_identity_matcher : public composite_matcher
     {
     public:
-        by_pass_composite_matcher(std::vector<std::shared_ptr<matcher>> matchers);
+        composite_identity_matcher(std::vector<std::shared_ptr<matcher>> matchers);
 
         void sync(frame_holder f, syncronization_environment env) override;
+        virtual bool are_equivalent(frame_holder& a, frame_holder& b) { return false; }
+        virtual bool is_smaller_than(frame_holder& a, frame_holder& b) { return false; }
+        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) { return false; }
+        virtual void clean_inactive_streams(frame_holder& f) {}
+        virtual void update_last_arrived(frame_holder& f, matcher* m) {}
+
+    protected:
+        virtual void update_next_expected(const frame_holder& f) {}
     };
 
     class frame_number_composite_matcher : public composite_matcher


### PR DESCRIPTION
Added composite_identity_matcher that passes frames to callback without synchronize them.
Tracked on: RS5-5558