### PR TITLE
rs-fw-logger - enforce user input validation

### DIFF
--- a/tools/fw-logger/fw-logs-formating-options.cpp
+++ b/tools/fw-logger/fw-logs-formating-options.cpp
@@ -79,7 +79,7 @@ namespace fw_logger
         }
     }
 
-    std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> fw_logs_formating_options::get_enums() const
+    std::unordered_map<string, std::vector<kvp>> fw_logs_formating_options::get_enums() const
     {
         return _fw_logs_enum_names_list;
     }

--- a/tools/fw-logger/fw-logs-formating-options.cpp
+++ b/tools/fw-logger/fw-logs-formating-options.cpp
@@ -79,7 +79,7 @@ namespace fw_logger
         }
     }
 
-    std::unordered_map<std::string, std::vector<std::string>> fw_logs_formating_options::get_enums() const
+    std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> fw_logs_formating_options::get_enums() const
     {
         return _fw_logs_enum_names_list;
     }

--- a/tools/fw-logger/fw-logs-formating-options.h
+++ b/tools/fw-logger/fw-logs-formating-options.h
@@ -33,7 +33,7 @@ namespace fw_logger
         bool get_event_data(int id, fw_log_event* log_event_data) const;
         bool get_file_name(int id, std::string* file_name) const;
         bool get_thread_name(uint32_t thread_id, std::string* thread_name) const;
-        std::unordered_map<std::string, std::vector<std::string>> get_enums() const;
+        std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> get_enums() const;
         bool initialize_from_xml();
 
     private:
@@ -41,7 +41,7 @@ namespace fw_logger
         std::unordered_map<int, fw_log_event> _fw_logs_event_list;
         std::unordered_map<int, std::string> _fw_logs_file_names_list;
         std::unordered_map<int, std::string> _fw_logs_thread_names_list;
-        std::unordered_map<std::string, std::vector<std::string>> _fw_logs_enum_names_list;
+        std::unordered_map<std::string, std::vector<std::pair<int,std::string>>> _fw_logs_enum_names_list;
 
         std::string _xml_full_file_path;
     };

--- a/tools/fw-logger/fw-logs-formating-options.h
+++ b/tools/fw-logger/fw-logs-formating-options.h
@@ -14,12 +14,14 @@ namespace fw_logger
 {
     struct fw_log_event
     {
-        int num_of_params;
+        size_t num_of_params;
         std::string line;
 
         fw_log_event();
         fw_log_event(int input_num_of_params, const std::string& input_line);
     };
+
+    typedef std::pair<int,std::string> kvp;     // XML key/value pair
 
     class fw_logs_xml_helper;
 
@@ -33,7 +35,7 @@ namespace fw_logger
         bool get_event_data(int id, fw_log_event* log_event_data) const;
         bool get_file_name(int id, std::string* file_name) const;
         bool get_thread_name(uint32_t thread_id, std::string* thread_name) const;
-        std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> get_enums() const;
+        std::unordered_map<std::string, std::vector<kvp>> get_enums() const;
         bool initialize_from_xml();
 
     private:

--- a/tools/fw-logger/fw-logs-xml-helper.cpp
+++ b/tools/fw-logger/fw-logs-xml-helper.cpp
@@ -95,8 +95,8 @@ namespace fw_logger
     bool fw_logs_xml_helper::build_meta_data_structure(xml_node<> *xml_node_list_of_events, fw_logs_formating_options* logs_formating_options)
     {
         node_type res = none;
-        int id;
-        int num_of_params;
+        int id{};
+        int num_of_params{};
         string line;
 
         // loop through all elements in the Format.
@@ -111,11 +111,11 @@ namespace fw_logger
             }
             else if (res == file)
             {
-                logs_formating_options->_fw_logs_file_names_list.insert(pair<int, string>(id, line));
+                logs_formating_options->_fw_logs_file_names_list.insert(kvp(id, line));
             }
             else if (res == thread)
             {
-                logs_formating_options->_fw_logs_thread_names_list.insert(pair<int, string>(id, line));
+                logs_formating_options->_fw_logs_thread_names_list.insert(kvp(id, line));
             }
             else if (res == enums)
             {
@@ -127,7 +127,7 @@ namespace fw_logger
                         if (attr.compare("Name") == 0)
                         {
                             string name_attr_str(attribute->value(), attribute->value() + attribute->value_size());
-                            vector<std::pair<int,string>> values;
+                            vector<kvp> xml_kvp;
 
                             for (xml_node<>* enum_value_node = enum_node->first_node(); enum_value_node; enum_value_node = enum_value_node->next_sibling())
                             {
@@ -150,9 +150,9 @@ namespace fw_logger
                                         catch (...) {}
                                     }
                                 }
-                                values.push_back(std::make_pair(key, value_str));
+                                xml_kvp.push_back(std::make_pair(key, value_str));
                             }
-                            logs_formating_options->_fw_logs_enum_names_list.insert(pair<string, vector<std::pair<int, std::string>>>(name_attr_str, values));
+                            logs_formating_options->_fw_logs_enum_names_list.insert(pair<string, vector<kvp>>(name_attr_str, xml_kvp));
                         }
                     }
                 }

--- a/tools/fw-logger/fw-logs-xml-helper.cpp
+++ b/tools/fw-logger/fw-logs-xml-helper.cpp
@@ -127,21 +127,32 @@ namespace fw_logger
                         if (attr.compare("Name") == 0)
                         {
                             string name_attr_str(attribute->value(), attribute->value() + attribute->value_size());
-                            vector<string> values;
+                            vector<std::pair<int,string>> values;
 
                             for (xml_node<>* enum_value_node = enum_node->first_node(); enum_value_node; enum_value_node = enum_value_node->next_sibling())
                             {
+                                int key = 0;
+                                string value_str;
                                 for (xml_attribute<>* attribute = enum_value_node->first_attribute(); attribute; attribute = attribute->next_attribute())
                                 {
                                     string attr(attribute->name(), attribute->name() + attribute->name_size());
                                     if (attr.compare("Value") == 0)
                                     {
-                                        string value_str(attribute->value(), attribute->value() + attribute->value_size());
-                                        values.push_back(value_str);
+                                        value_str = std::string(attribute->value(), attribute->value() + attribute->value_size());
+                                    }
+                                    if (attr.compare("Key") == 0)
+                                    {
+                                        try
+                                        {
+                                            auto key_str = std::string(attribute->value());
+                                            key = std::stoi(key_str, nullptr);
+                                        }
+                                        catch (...) {}
                                     }
                                 }
+                                values.push_back(std::make_pair(key, value_str));
                             }
-                            logs_formating_options->_fw_logs_enum_names_list.insert(pair<string, vector<string>>(name_attr_str, values));
+                            logs_formating_options->_fw_logs_enum_names_list.insert(pair<string, vector<std::pair<int, std::string>>>(name_attr_str, values));
                         }
                     }
                 }

--- a/tools/fw-logger/string-formatter.cpp
+++ b/tools/fw-logger/string-formatter.cpp
@@ -4,6 +4,7 @@
 #include <regex>
 #include <sstream>
 #include <iomanip>
+#include <iostream>
 
 using namespace std;
 
@@ -99,7 +100,14 @@ namespace fw_logger
                     {
                         auto vec = _enums[enum_name];
                         regex e3 = e;
-                        auto res1 = regex_replace(back_inserter(destTemp), source_temp.begin(), source_temp.end(), e3, vec[exp_replace_it->second]);
+                        // Validate user's input is within the enumerated values
+                        if (exp_replace_it->second >=0 && exp_replace_it->second <vec.size())
+                            auto res1 = regex_replace(back_inserter(destTemp), source_temp.begin(), source_temp.end(), e3, vec[exp_replace_it->second]);
+                        else
+                        {
+                            std::cout << "Protocol Error recognized!\nImproper log message received: " << source_temp
+                                << ", invalid parameter: " << exp_replace_it->second << std::endl;
+                        }
                         source_temp = destTemp;
                     }
                 }

--- a/tools/fw-logger/string-formatter.cpp
+++ b/tools/fw-logger/string-formatter.cpp
@@ -1,6 +1,7 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 #include "string-formatter.h"
+#include "fw-logs-formating-options.h"
 #include <regex>
 #include <sstream>
 #include <iomanip>
@@ -10,7 +11,7 @@ using namespace std;
 
 namespace fw_logger
 {
-    string_formatter::string_formatter(std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> enums)
+    string_formatter::string_formatter(std::unordered_map<std::string, std::vector<kvp>> enums)
         :_enums(enums)
     {
     }
@@ -20,14 +21,14 @@ namespace fw_logger
     {
     }
 
-    bool string_formatter::generate_message(const string& source, int num_of_params, const uint32_t* params, string* dest)
+    bool string_formatter::generate_message(const string& source, size_t num_of_params, const uint32_t* params, string* dest)
     {
         map<string, string> exp_replace_map;
         map<string, int> enum_replace_map;
 
         if (params == nullptr && num_of_params > 0) return false;
 
-        for (int i = 0; i < num_of_params; i++)
+        for (size_t i = 0; i < num_of_params; i++)
         {
             string regular_exp[3];
             string replacement[3];
@@ -102,7 +103,7 @@ namespace fw_logger
                         regex e3 = e;
                         // Verify user's input is within the enumerated range
                         int val = exp_replace_it->second;
-                        auto it = std::find_if(vec.begin(), vec.end(), [val](std::pair<int, std::string>& kvp){ return kvp.first == val; });
+                        auto it = std::find_if(vec.begin(), vec.end(), [val](kvp& entry){ return entry.first == val; });
                         if (it != vec.end())
                         {
                             regex_replace(back_inserter(destTemp), source_temp.begin(), source_temp.end(), e3, it->second);
@@ -112,7 +113,7 @@ namespace fw_logger
                             stringstream s;
                             s << "Protocol Error recognized!\nImproper log message received: " << source_temp
                                 << ", invalid parameter: " << exp_replace_it->second << ".\n The range of supported values is \n";
-                            for_each(vec.begin(), vec.end(), [&s](std::pair<int, std::string>& kvp) { s << kvp.first << ":" << kvp.second << " ,"; });
+                            for_each(vec.begin(), vec.end(), [&s](kvp& entry) { s << entry.first << ":" << entry.second << " ,"; });
                             std::cout << s.str().c_str() << std::endl;;
                         }
                         source_temp = destTemp;

--- a/tools/fw-logger/string-formatter.h
+++ b/tools/fw-logger/string-formatter.h
@@ -15,7 +15,7 @@ namespace fw_logger
         string_formatter(std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> enums);
         ~string_formatter(void);
 
-        bool generate_message(const std::string& source, int num_of_params, const uint32_t* params, std::string* dest);
+        bool generate_message(const std::string& source, size_t num_of_params, const uint32_t* params, std::string* dest);
 
     private:
         bool replace_params(const std::string& source, const std::map<std::string, std::string>& exp_replace_map, const std::map<std::string, int>& enum_replace_map, std::string* dest);

--- a/tools/fw-logger/string-formatter.h
+++ b/tools/fw-logger/string-formatter.h
@@ -12,7 +12,7 @@ namespace fw_logger
     class string_formatter
     {
     public:
-        string_formatter(std::unordered_map<std::string, std::vector<std::string>> enums);
+        string_formatter(std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> enums);
         ~string_formatter(void);
 
         bool generate_message(const std::string& source, int num_of_params, const uint32_t* params, std::string* dest);
@@ -20,6 +20,6 @@ namespace fw_logger
     private:
         bool replace_params(const std::string& source, const std::map<std::string, std::string>& exp_replace_map, const std::map<std::string, int>& enum_replace_map, std::string* dest);
 
-        std::unordered_map<std::string, std::vector<std::string>> _enums;
+        std::unordered_map<std::string, std::vector<std::pair<int, std::string>>> _enums;
     };
 }


### PR DESCRIPTION
Check user-provided input during regex operations to avoid buffer overflow.
Tracked on: DSO-14405