### PR TITLE
downgrade uvc warning messages

### DIFF
--- a/src/libusb/messenger-libusb.cpp
+++ b/src/libusb/messenger-libusb.cpp
@@ -39,7 +39,7 @@ namespace librealsense
             if(sts < 0)
             {
                 std::string strerr = strerror(errno);
-                LOG_WARNING("control_transfer returned error, index: " << index << ", error: " << strerr << ", number: " << int(errno));
+                LOG_DEBUG("control_transfer returned error, index: " << index << ", error: " << strerr << ", number: " << int(errno));
                 return libusb_status_to_rs(sts);
             }
             transferred = uint32_t(sts);

--- a/src/libusb/messenger-libusb.cpp
+++ b/src/libusb/messenger-libusb.cpp
@@ -39,7 +39,7 @@ namespace librealsense
             if(sts < 0)
             {
                 std::string strerr = strerror(errno);
-                LOG_DEBUG("control_transfer returned error, index: " << index << ", error: " << strerr << ", number: " << int(errno));
+                LOG_WARNING("control_transfer returned error, index: " << index << ", error: " << strerr << ", number: " << int(errno));
                 return libusb_status_to_rs(sts);
             }
             transferred = uint32_t(sts);

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -661,7 +661,7 @@ namespace librealsense
                              std::string buff = "";
                              for (int i = 0; i < response->get_actual_length(); i++)
                                  buff += std::to_string(response->get_buffer()[i]) + ", ";
-                             LOG_WARNING("interrupt event received: " << buff.c_str());
+                             LOG_DEBUG("interrupt event received: " << buff.c_str());
                          }
 
                          _action_dispatcher.invoke([this](dispatcher::cancellable_timer c)


### PR DESCRIPTION
Messages "interrupt event received: ", "control_transfer returned error" are being dealt with in the code. This PR downgrades these warning messages to debug level.