### PR TITLE
android-recover-both-usb-disconnect-fix

### DIFF
--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -178,7 +178,7 @@ namespace librealsense
                             {
                                 try{
                                     listen_to_interrupts();
-                                } catch(std::exception exception) {
+                                } catch(const std::exception& exception) {
                                     // this exception catching avoids crash when disconnecting 2 devices at once - bug seen in android os
                                     LOG_WARNING("rs_uvc_device exception in listen_to_interrupts method: " << exception.what());
                                 }

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -176,7 +176,12 @@ namespace librealsense
                             _messenger = _usb_device->open(_info.mi);
                             if (_messenger)
                             {
-                                listen_to_interrupts();
+                                try{
+                                    listen_to_interrupts();
+                                } catch(std::exception exception) {
+                                    // this exception catching avoids crash when disconnecting 2 devices at once - bug seen in android os
+                                    LOG_WARNING("rs_uvc_device exception in listen_to_interrupts method: " << exception.what());
+                                }
                                 _power_state = D0;
                             }
                             break;

--- a/wrappers/android/examples/multicam/src/main/java/com/intel/realsense/multicam/MainActivity.java
+++ b/wrappers/android/examples/multicam/src/main/java/com/intel/realsense/multicam/MainActivity.java
@@ -180,6 +180,7 @@ public class MainActivity extends AppCompatActivity {
             Log.d(TAG, "streaming started successfully");
         } catch (Exception e) {
             Log.d(TAG, "failed to start streaming");
+            mGLSurfaceView.clear();
         }
     }
 

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/DeviceWatcher.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/DeviceWatcher.java
@@ -80,11 +80,7 @@ class DeviceWatcher extends LrsClass {
         }
     }
 
-    private void removeDevice(UsbDesc desc) {
-        Log.d(TAG, "Removing device: " + desc.name);
-
-        nRemoveUsbDevice(desc.descriptor);
-        desc.connection.close();
+    private void updateListeners(){
         for(DeviceListener listener : mAppDeviceListener) {
             try {
                 listener.onDeviceDetach();
@@ -92,6 +88,14 @@ class DeviceWatcher extends LrsClass {
                 Log.e(TAG, e.getMessage());
             }
         }
+    }
+
+    private void removeDevice(UsbDesc desc) {
+        Log.d(TAG, "Removing device: " + desc.name);
+
+        nRemoveUsbDevice(desc.descriptor);
+        desc.connection.close();
+        updateListeners();
         Log.d(TAG, "Device: " + desc.name + " removed successfully");
     }
 
@@ -108,13 +112,7 @@ class DeviceWatcher extends LrsClass {
         mDescriptors.put(device.getDeviceName(), desc);
         nAddUsbDevice(desc.name, desc.descriptor);
 
-        for (DeviceListener listener : mAppDeviceListener){
-            try {
-                listener.onDeviceAttach();
-            } catch (Exception e){
-                Log.e(TAG, e.getMessage());
-            }
-        }
+        updateListeners();
         Log.d(TAG, "Device: " + desc.name + " added successfully");
     }
 

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/StreamProfile.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/StreamProfile.java
@@ -1,6 +1,5 @@
 package com.intel.realsense.librealsense;
 
-import android.util.Log;
 
 public class StreamProfile extends LrsClass {
     private StreamType mType;


### PR DESCRIPTION
Avoiding crash when disconnecting 2 devices' usb cables at once.
Exception was thrown and not caught.
Tracking on: DSO-14132 