### PR TITLE
Fix time domain handling

### DIFF
--- a/src/ds5/ds5-timestamp.cpp
+++ b/src/ds5/ds5-timestamp.cpp
@@ -59,10 +59,7 @@ namespace librealsense
         if (frame->get_stream()->get_format() == RS2_FORMAT_Z16)
             pin_index = 1;
 
-        if(!_has_metadata[pin_index])
-        {
-           _has_metadata[pin_index] = has_metadata(frame);
-        }
+        _has_metadata[pin_index] = has_metadata(frame);
 
         auto md = (librealsense::metadata_intel_basic*)(f->additional_data.metadata_blob.data());
         if(_has_metadata[pin_index] && md)


### PR DESCRIPTION
Track and update metadata presence continuously to handle cases where v4l driver produces zeros
Tracked on: DSO-13182, DSO-14314