### PR TITLE
on chip calibration bug fixes

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -157,6 +157,7 @@ namespace rs2
         namespace viewer
         {
             static const char* is_3d_view          { "viewer_model.is_3d_view" };
+            static const char* ground_truth_r      { "viewer_model.ground_truth_r" };
             static const char* continue_with_ui_not_aligned { "viewer_model.continue_with_ui_not_aligned" };
             static const char* continue_with_current_fw{ "viewer_model.continue_with_current_fw" };
             static const char* settings_tab        { "viewer_model.settings_tab" };

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -48,6 +48,7 @@ namespace rs2
         catch (...) {}
     }
 
+
     // Wait for next depth frame and return it
     rs2::depth_frame on_chip_calib_manager::fetch_depth_frame(invoker invoke)
     {
@@ -335,6 +336,10 @@ namespace rs2
         _in_3d_view = _viewer.is_3d_view;
         _viewer.is_3d_view = true;
 
+		config_file::instance().set(configurations::viewer::ground_truth_r, ground_truth);
+		//ground_truth = _viewer.ground_truth_r;
+
+
         auto calib_dev = _dev.as<auto_calibrated_device>();
         _old_calib = calib_dev.get_calibration_table();
 
@@ -390,6 +395,9 @@ namespace rs2
 
             _viewer.is_3d_view = _in_3d_view;
 
+            _viewer.ground_truth_r = ground_truth;
+			config_file::instance().set(configurations::viewer::ground_truth_r, ground_truth);
+
             _viewer.synchronization_enable = _synchronized;
 
             stop_viewer(invoke);
@@ -431,7 +439,7 @@ namespace rs2
         using namespace chrono;
 
         auto health = get_manager().get_health();
-        auto recommend_keep = health > 0.25;
+        auto recommend_keep = health > 0.25 || health < -0.25;  //TODO: check if need to add -025? 
         if (!recommend_keep && update_state == RS2_CALIB_STATE_CALIB_COMPLETE && !get_manager().tare)
         {
             auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
@@ -505,7 +513,9 @@ namespace rs2
 
             if (update_state == RS2_CALIB_STATE_TARE_INPUT || update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
                 ImGui::SetCursorScreenPos({ float(x + width - 30), float(y) });
-            else
+			else if (update_state == RS2_CALIB_STATE_FAILED)
+				ImGui::SetCursorScreenPos({ float(x + 2), float(y + 27) });
+			else
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
 
             ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1. - t));
@@ -557,7 +567,7 @@ namespace rs2
                     ImGui::Text("%s", "Avg Step Count:");
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Number of frames to average, Min = 1, Max = 30, Default = 10");
+                        ImGui::SetTooltip("%s", "Number of frames to average, Min = 1, Max = 30, Default = 20"); 
                     }
                     ImGui::SetCursorScreenPos({ float(x + 135), float(y + 30) });
 
@@ -572,7 +582,7 @@ namespace rs2
                     ImGui::Text("%s", "Step Count:");
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Max iteration steps, Min = 5, Max = 30, Default = 10");
+                        ImGui::SetTooltip("%s", "Max iteration steps, Min = 5, Max = 30, Default = 20");
                     }
                     ImGui::SetCursorScreenPos({ float(x + 135), float(y + 35 + ImGui::GetTextLineHeightWithSpacing()) });
 
@@ -636,6 +646,8 @@ namespace rs2
 
                 std::string id = to_string() << "##ground_truth_for_tare" << index;
 
+				get_manager().ground_truth = config_file::instance().get_or_default(configurations::viewer::ground_truth_r,2500);
+
                 std::string gt = to_string() << get_manager().ground_truth;
                 const int MAX_SIZE = 256;
                 char buff[MAX_SIZE];
@@ -649,6 +661,8 @@ namespace rs2
                     ss >> get_manager().ground_truth;
                 }
                 ImGui::PopItemWidth();
+
+				config_file::instance().set(configurations::viewer::ground_truth_r, get_manager().ground_truth);
 
                 auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 
@@ -689,6 +703,9 @@ namespace rs2
                 for (auto&& s : vals) vals_cstr.push_back(s.c_str());
 
                 ImGui::PushItemWidth(width - 145);
+
+				//get_manager().speed = 4;// TODO: ONLY IF D415
+
                 ImGui::Combo(id.c_str(), &get_manager().speed, vals_cstr.data(), vals.size());
                 ImGui::PopItemWidth();
 
@@ -751,7 +768,7 @@ namespace rs2
             {
                 auto health = get_manager().get_health();
 
-                auto recommend_keep = health > 0.25;
+                auto recommend_keep = health > 0.25 || health < -0.25;
 
                 ImGui::SetCursorScreenPos({ float(x + 15), float(y + 33) });
 
@@ -784,12 +801,14 @@ namespace rs2
 
                     ImGui::SetCursorScreenPos({ float(x + 172), float(y + 33) });
 
+
+			
                     if (!recommend_keep)
                     {
                         ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
                         ImGui::Text("%s", "(Good)");
                     }
-                    else if (health < 0.75f)
+                    else if (health < 0.75f && health > -0.75f)
                     {
                         ImGui::PushStyleColor(ImGuiCol_Text, yellowish);
                         ImGui::Text("%s", "(Can be Improved)");
@@ -807,6 +826,12 @@ namespace rs2
                             "[0, 0.15) - Good\n"
                             "[0.15, 0.25) - Can be Improved\n"
                             "[0.25, ) - Requires Calibration");
+						    /* TODO : CHECK IF NEEDED
+						ImGui::SetTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
+							"(-0.15, 0) - Good\n"
+							"(-0.25, -0.15] - Can be Improved\n"
+							"( , -0.25] - Requires Calibration");
+							*/
                     }
                 }
 
@@ -1130,6 +1155,7 @@ namespace rs2
         else if (update_state == RS2_CALIB_STATE_SELF_INPUT) return 110;
         else if (update_state == RS2_CALIB_STATE_TARE_INPUT) return 85;
         else if (update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED) return 210;
+		else if (update_state == RS2_CALIB_STATE_FAILED) return 110;
         else return 100;
     }
 

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -48,7 +48,6 @@ namespace rs2
         catch (...) {}
     }
 
-
     // Wait for next depth frame and return it
     rs2::depth_frame on_chip_calib_manager::fetch_depth_frame(invoker invoke)
     {
@@ -336,8 +335,7 @@ namespace rs2
         _in_3d_view = _viewer.is_3d_view;
         _viewer.is_3d_view = true;
 
-		config_file::instance().set(configurations::viewer::ground_truth_r, ground_truth);
-		//ground_truth = _viewer.ground_truth_r;
+        config_file::instance().set(configurations::viewer::ground_truth_r, ground_truth);
 
 
         auto calib_dev = _dev.as<auto_calibrated_device>();
@@ -396,7 +394,7 @@ namespace rs2
             _viewer.is_3d_view = _in_3d_view;
 
             _viewer.ground_truth_r = ground_truth;
-			config_file::instance().set(configurations::viewer::ground_truth_r, ground_truth);
+            config_file::instance().set(configurations::viewer::ground_truth_r, ground_truth);
 
             _viewer.synchronization_enable = _synchronized;
 
@@ -439,7 +437,7 @@ namespace rs2
         using namespace chrono;
 
         auto health = get_manager().get_health();
-        auto recommend_keep = health > 0.25 || health < -0.25;  
+        auto recommend_keep = fabs(health) > 0.25f;  
         if (!recommend_keep && update_state == RS2_CALIB_STATE_CALIB_COMPLETE && !get_manager().tare)
         {
             auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
@@ -513,9 +511,9 @@ namespace rs2
 
             if (update_state == RS2_CALIB_STATE_TARE_INPUT || update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
                 ImGui::SetCursorScreenPos({ float(x + width - 30), float(y) });
-			else if (update_state == RS2_CALIB_STATE_FAILED)
-				ImGui::SetCursorScreenPos({ float(x + 2), float(y + 27) });
-			else
+            else if (update_state == RS2_CALIB_STATE_FAILED)
+                ImGui::SetCursorScreenPos({ float(x + 2), float(y + 27) });
+            else
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
 
             ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1. - t));
@@ -646,7 +644,7 @@ namespace rs2
 
                 std::string id = to_string() << "##ground_truth_for_tare" << index;
 
-				get_manager().ground_truth = config_file::instance().get_or_default(configurations::viewer::ground_truth_r,2500);
+                get_manager().ground_truth = config_file::instance().get_or_default(configurations::viewer::ground_truth_r,2500);
 
                 std::string gt = to_string() << get_manager().ground_truth;
                 const int MAX_SIZE = 256;
@@ -662,7 +660,7 @@ namespace rs2
                 }
                 ImGui::PopItemWidth();
 
-				config_file::instance().set(configurations::viewer::ground_truth_r, get_manager().ground_truth);
+                config_file::instance().set(configurations::viewer::ground_truth_r, get_manager().ground_truth);
 
                 auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 
@@ -766,7 +764,7 @@ namespace rs2
             {
                 auto health = get_manager().get_health();
 
-                auto recommend_keep = health > 0.25 || health < -0.25;
+                auto recommend_keep = fabs(health) > 0.25f;
 
                 ImGui::SetCursorScreenPos({ float(x + 15), float(y + 33) });
 
@@ -800,13 +798,12 @@ namespace rs2
                     ImGui::SetCursorScreenPos({ float(x + 172), float(y + 33) });
 
 
-			
                     if (!recommend_keep)
                     {
                         ImGui::PushStyleColor(ImGuiCol_Text, light_blue);
                         ImGui::Text("%s", "(Good)");
                     }
-                    else if (health < 0.75f && health > -0.75f)
+                    else if (fabs(health) < 0.75f)
                     {
                         ImGui::PushStyleColor(ImGuiCol_Text, yellowish);
                         ImGui::Text("%s", "(Can be Improved)");
@@ -821,15 +818,9 @@ namespace rs2
                     if (ImGui::IsItemHovered())
                     {
                         ImGui::SetTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
-                            "[0, 0.15) - Good\n"
-                            "[0.15, 0.25) - Can be Improved\n"
-                            "[0.25, ) - Requires Calibration");
-						    /* TODO : CHECK IF NEEDED
-						ImGui::SetTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
-							"(-0.15, 0) - Good\n"
-							"(-0.25, -0.15] - Can be Improved\n"
-							"( , -0.25] - Requires Calibration");
-							*/
+                            "[0, 0.25) - Good\n"
+                            "[0.25, 0.75) - Can be Improved\n"
+                            "[0.75, ) - Requires Calibration");
                     }
                 }
 
@@ -1153,7 +1144,7 @@ namespace rs2
         else if (update_state == RS2_CALIB_STATE_SELF_INPUT) return 110;
         else if (update_state == RS2_CALIB_STATE_TARE_INPUT) return 85;
         else if (update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED) return 210;
-		else if (update_state == RS2_CALIB_STATE_FAILED) return 110;
+        else if (update_state == RS2_CALIB_STATE_FAILED) return 110;
         else return 100;
     }
 

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -439,7 +439,7 @@ namespace rs2
         using namespace chrono;
 
         auto health = get_manager().get_health();
-        auto recommend_keep = health > 0.25 || health < -0.25;  //TODO: check if need to add -025? 
+        auto recommend_keep = health > 0.25 || health < -0.25;  
         if (!recommend_keep && update_state == RS2_CALIB_STATE_CALIB_COMPLETE && !get_manager().tare)
         {
             auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
@@ -703,8 +703,6 @@ namespace rs2
                 for (auto&& s : vals) vals_cstr.push_back(s.c_str());
 
                 ImGui::PushItemWidth(width - 145);
-
-				//get_manager().speed = 4;// TODO: ONLY IF D415
 
                 ImGui::Combo(id.c_str(), &get_manager().speed, vals_cstr.data(), vals.size());
                 ImGui::PopItemWidth();

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -797,7 +797,6 @@ namespace rs2
 
                     ImGui::SetCursorScreenPos({ float(x + 172), float(y + 33) });
 
-
                     if (!recommend_keep)
                     {
                         ImGui::PushStyleColor(ImGuiCol_Text, light_blue);

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -26,8 +26,8 @@ namespace rs2
             : process_manager("On-Chip Calibration"), _model(model),
              _dev(dev), _sub(sub), _viewer(viewer)
         {
-			auto dev_name = dev.get_info(RS2_CAMERA_INFO_NAME);
-			if (!strcmp(dev_name, "Intel RealSense D415")) { speed = 4; }
+                auto dev_name = dev.get_info(RS2_CAMERA_INFO_NAME);
+                if (!strcmp(dev_name, "Intel RealSense D415")) { speed = 4; }
         }
 
         bool allow_calib_keep() const { return true; }

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -10,120 +10,120 @@
 
 namespace rs2
 {
-	class viewer_model;
-	class subdevice_model;
-	struct subdevice_ui_selection;
+    class viewer_model;
+    class subdevice_model;
+    struct subdevice_ui_selection;
 
-	// On-chip Calibration manager owns the background thread
-	// leading the calibration process
-	// It is controlled by autocalib_notification_model UI object
-	// that invokes the process when needed
-	class on_chip_calib_manager : public process_manager
-	{
-	public:
-		on_chip_calib_manager(viewer_model& viewer, std::shared_ptr<subdevice_model> sub,
-			device_model& model, device dev)
-			: process_manager("On-Chip Calibration"), _model(model),
-			_dev(dev), _sub(sub), _viewer(viewer)
-		{
+    // On-chip Calibration manager owns the background thread
+    // leading the calibration process
+    // It is controlled by autocalib_notification_model UI object
+    // that invokes the process when needed
+    class on_chip_calib_manager : public process_manager
+    {
+    public:
+        on_chip_calib_manager(viewer_model& viewer, std::shared_ptr<subdevice_model> sub,
+            device_model& model, device dev)
+            : process_manager("On-Chip Calibration"), _model(model),
+             _dev(dev), _sub(sub), _viewer(viewer)
+        {
 			auto dev_name = dev.get_info(RS2_CAMERA_INFO_NAME);
 			if (!strcmp(dev_name, "Intel RealSense D415")) { speed = 4; }
-		}
+        }
 
-		bool allow_calib_keep() const { return true; }
+        bool allow_calib_keep() const { return true; }
 
-		// Get health number from the calibration summary
-		float get_health() const { return _health; }
+        // Get health number from the calibration summary
+        float get_health() const { return _health; }
 
-		// Write new calibration to the device
-		void keep();
+        // Write new calibration to the device
+        void keep();
 
-		// Restore Viewer UI to how it was before auto-calib
-		void restore_workspace(invoker invoke);
+        // Restore Viewer UI to how it was before auto-calib
+        void restore_workspace(invoker invoke);
+        
+        // Ask the firmware to use one of the before/after calibration tables
+        void apply_calib(bool old);
 
-		// Ask the firmware to use one of the before/after calibration tables
-		void apply_calib(bool old);
+        // Get depth metrics for before/after calibration tables
+        std::pair<float, float> get_metric(bool use_new);
 
-		// Get depth metrics for before/after calibration tables
-		std::pair<float, float> get_metric(bool use_new);
+        void update_last_used();
 
-		void update_last_used();
+        uint32_t ground_truth = 2500;
+        int average_step_count = 20;
+        int step_count = 20;
+        int accuracy = 2;
+        int speed = 3;
+        bool tare = false;
+        bool intrinsic_scan = true;
+        bool apply_preset = true;
 
-		uint32_t ground_truth = 2500;
-		int average_step_count = 20;
-		int step_count = 20;
-		int accuracy = 2;
-		int speed = 3;
-		bool tare = false;
-		bool intrinsic_scan = true;
-		bool apply_preset = true;
+        void calibrate();
 
-		void calibrate();
+    private:
 
-	private:
+        std::vector<uint8_t> safe_send_command(const std::vector<uint8_t>& cmd, const std::string& name);
 
-		std::vector<uint8_t> safe_send_command(const std::vector<uint8_t>& cmd, const std::string& name);
+        rs2::depth_frame fetch_depth_frame(invoker invoke);
 
-		rs2::depth_frame fetch_depth_frame(invoker invoke);
+        std::pair<float, float> get_depth_metrics(invoker invoke);
 
-		std::pair<float, float> get_depth_metrics(invoker invoke);
+        void process_flow(std::function<void()> cleanup, invoker invoke) override;
 
-		void process_flow(std::function<void()> cleanup, invoker invoke) override;
+        float _health = -1.0f;
+        device _dev;
 
-		float _health = -1.0f;
-		device _dev;
+        bool _was_streaming = false;
+        bool _synchronized = false;
+        bool _post_processing = false;
+        std::shared_ptr<subdevice_ui_selection> _ui { nullptr };
+        bool _in_3d_view = false;
 
-		bool _was_streaming = false;
-		bool _synchronized = false;
-		bool _post_processing = false;
-		std::shared_ptr<subdevice_ui_selection> _ui{ nullptr };
-		bool _in_3d_view = false;
+        viewer_model& _viewer;
+        std::shared_ptr<subdevice_model> _sub;
 
-		viewer_model& _viewer;
-		std::shared_ptr<subdevice_model> _sub;
+        std::vector<uint8_t> _old_calib, _new_calib;
+        std::vector<std::pair<float, float>> _metrics;
+        device_model& _model;
 
-		std::vector<uint8_t> _old_calib, _new_calib;
-		std::vector<std::pair<float, float>> _metrics;
-		device_model& _model;
+        bool _restored = true;
 
-		bool _restored = true;
+        void stop_viewer(invoker invoke);
+        void start_viewer(int w, int h, int fps, invoker invoke);
+    };
 
-		void stop_viewer(invoker invoke);
-		void start_viewer(int w, int h, int fps, invoker invoke);
-	};
+    // Auto-calib notification model is managing the UI state-machine
+    // controling auto-calibration
+    struct autocalib_notification_model : public process_notification_model
+    {
+        enum auto_calib_ui_state
+        {
+            RS2_CALIB_STATE_INITIAL_PROMPT,  // First screen, would you like to run Health-Check?
+            RS2_CALIB_STATE_FAILED,          // Failed, show _error_message
+            RS2_CALIB_STATE_COMPLETE,        // After write, quick blue notification
+            RS2_CALIB_STATE_CALIB_IN_PROCESS,// Calibration in process... Shows progressbar
+            RS2_CALIB_STATE_CALIB_COMPLETE,  // Calibration complete, show before/after toggle and metrics
+            RS2_CALIB_STATE_TARE_INPUT,      // Collect input parameters for Tare calib
+            RS2_CALIB_STATE_TARE_INPUT_ADVANCED,      // Collect input parameters for Tare calib
+            RS2_CALIB_STATE_SELF_INPUT,      // Collect input parameters for Self calib
+        };
 
-	// Auto-calib notification model is managing the UI state-machine
-	// controling auto-calibration
-	struct autocalib_notification_model : public process_notification_model
-	{
-		enum auto_calib_ui_state
-		{
-			RS2_CALIB_STATE_INITIAL_PROMPT,  // First screen, would you like to run Health-Check?
-			RS2_CALIB_STATE_FAILED,          // Failed, show _error_message
-			RS2_CALIB_STATE_COMPLETE,        // After write, quick blue notification
-			RS2_CALIB_STATE_CALIB_IN_PROCESS,// Calibration in process... Shows progressbar
-			RS2_CALIB_STATE_CALIB_COMPLETE,  // Calibration complete, show before/after toggle and metrics
-			RS2_CALIB_STATE_TARE_INPUT,      // Collect input parameters for Tare calib
-			RS2_CALIB_STATE_TARE_INPUT_ADVANCED,      // Collect input parameters for Tare calib
-			RS2_CALIB_STATE_SELF_INPUT,      // Collect input parameters for Self calib
-		};
+        autocalib_notification_model(std::string name,
+            std::shared_ptr<on_chip_calib_manager> manager, bool expaned);
 
-		autocalib_notification_model(std::string name,
-			std::shared_ptr<on_chip_calib_manager> manager, bool expaned);
+        on_chip_calib_manager& get_manager() { 
+            return *std::dynamic_pointer_cast<on_chip_calib_manager>(update_manager); 
+        }
 
-		on_chip_calib_manager& get_manager() {
-			return *std::dynamic_pointer_cast<on_chip_calib_manager>(update_manager);
-		}
+        void set_color_scheme(float t) const override;
+        void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
+        void draw_dismiss(ux_window& win, int x, int y) override;
+        void draw_expanded(ux_window& win, std::string& error_message) override;
+        void draw_intrinsic_extrinsic(int x, int y);
+        int calc_height() override;
+        void dismiss(bool snooze) override;
 
-		void set_color_scheme(float t) const override;
-		void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
-		void draw_dismiss(ux_window& win, int x, int y) override;
-		void draw_expanded(ux_window& win, std::string& error_message) override;
-		void draw_intrinsic_extrinsic(int x, int y);
-		int calc_height() override;
-		void dismiss(bool snooze) override;
-
-		bool use_new_calib = true;
-		std::string _error_message = "";
-	};
+        bool use_new_calib = true;
+        std::string _error_message = "";
+    };
 }

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -10,118 +10,120 @@
 
 namespace rs2
 {
-    class viewer_model;
-    class subdevice_model;
-    struct subdevice_ui_selection;
+	class viewer_model;
+	class subdevice_model;
+	struct subdevice_ui_selection;
 
-    // On-chip Calibration manager owns the background thread
-    // leading the calibration process
-    // It is controlled by autocalib_notification_model UI object
-    // that invokes the process when needed
-    class on_chip_calib_manager : public process_manager
-    {
-    public:
-        on_chip_calib_manager(viewer_model& viewer, std::shared_ptr<subdevice_model> sub,
-            device_model& model, device dev)
-            : process_manager("On-Chip Calibration"), _model(model),
-             _dev(dev), _sub(sub), _viewer(viewer)
-        {
-        }
+	// On-chip Calibration manager owns the background thread
+	// leading the calibration process
+	// It is controlled by autocalib_notification_model UI object
+	// that invokes the process when needed
+	class on_chip_calib_manager : public process_manager
+	{
+	public:
+		on_chip_calib_manager(viewer_model& viewer, std::shared_ptr<subdevice_model> sub,
+			device_model& model, device dev)
+			: process_manager("On-Chip Calibration"), _model(model),
+			_dev(dev), _sub(sub), _viewer(viewer)
+		{
+			auto dev_name = dev.get_info(RS2_CAMERA_INFO_NAME);
+			if (!strcmp(dev_name, "Intel RealSense D415")) { speed = 4; }
+		}
 
-        bool allow_calib_keep() const { return true; }
+		bool allow_calib_keep() const { return true; }
 
-        // Get health number from the calibration summary
-        float get_health() const { return _health; }
+		// Get health number from the calibration summary
+		float get_health() const { return _health; }
 
-        // Write new calibration to the device
-        void keep();
+		// Write new calibration to the device
+		void keep();
 
-        // Restore Viewer UI to how it was before auto-calib
-        void restore_workspace(invoker invoke);
-        
-        // Ask the firmware to use one of the before/after calibration tables
-        void apply_calib(bool old);
+		// Restore Viewer UI to how it was before auto-calib
+		void restore_workspace(invoker invoke);
 
-        // Get depth metrics for before/after calibration tables
-        std::pair<float, float> get_metric(bool use_new);
+		// Ask the firmware to use one of the before/after calibration tables
+		void apply_calib(bool old);
 
-        void update_last_used();
+		// Get depth metrics for before/after calibration tables
+		std::pair<float, float> get_metric(bool use_new);
 
-        uint32_t ground_truth = 2500;
-        int average_step_count = 20;
-        int step_count = 20;
-        int accuracy = 2;
-        int speed = 3;
-        bool tare = false;
-        bool intrinsic_scan = true;
-        bool apply_preset = true;
+		void update_last_used();
 
-        void calibrate();
+		uint32_t ground_truth = 2500;
+		int average_step_count = 20;
+		int step_count = 20;
+		int accuracy = 2;
+		int speed = 3;
+		bool tare = false;
+		bool intrinsic_scan = true;
+		bool apply_preset = true;
 
-    private:
+		void calibrate();
 
-        std::vector<uint8_t> safe_send_command(const std::vector<uint8_t>& cmd, const std::string& name);
+	private:
 
-        rs2::depth_frame fetch_depth_frame(invoker invoke);
+		std::vector<uint8_t> safe_send_command(const std::vector<uint8_t>& cmd, const std::string& name);
 
-        std::pair<float, float> get_depth_metrics(invoker invoke);
+		rs2::depth_frame fetch_depth_frame(invoker invoke);
 
-        void process_flow(std::function<void()> cleanup, invoker invoke) override;
+		std::pair<float, float> get_depth_metrics(invoker invoke);
 
-        float _health = -1.0f;
-        device _dev;
+		void process_flow(std::function<void()> cleanup, invoker invoke) override;
 
-        bool _was_streaming = false;
-        bool _synchronized = false;
-        bool _post_processing = false;
-        std::shared_ptr<subdevice_ui_selection> _ui { nullptr };
-        bool _in_3d_view = false;
+		float _health = -1.0f;
+		device _dev;
 
-        viewer_model& _viewer;
-        std::shared_ptr<subdevice_model> _sub;
+		bool _was_streaming = false;
+		bool _synchronized = false;
+		bool _post_processing = false;
+		std::shared_ptr<subdevice_ui_selection> _ui{ nullptr };
+		bool _in_3d_view = false;
 
-        std::vector<uint8_t> _old_calib, _new_calib;
-        std::vector<std::pair<float, float>> _metrics;
-        device_model& _model;
+		viewer_model& _viewer;
+		std::shared_ptr<subdevice_model> _sub;
 
-        bool _restored = true;
+		std::vector<uint8_t> _old_calib, _new_calib;
+		std::vector<std::pair<float, float>> _metrics;
+		device_model& _model;
 
-        void stop_viewer(invoker invoke);
-        void start_viewer(int w, int h, int fps, invoker invoke);
-    };
+		bool _restored = true;
 
-    // Auto-calib notification model is managing the UI state-machine
-    // controling auto-calibration
-    struct autocalib_notification_model : public process_notification_model
-    {
-        enum auto_calib_ui_state
-        {
-            RS2_CALIB_STATE_INITIAL_PROMPT,  // First screen, would you like to run Health-Check?
-            RS2_CALIB_STATE_FAILED,          // Failed, show _error_message
-            RS2_CALIB_STATE_COMPLETE,        // After write, quick blue notification
-            RS2_CALIB_STATE_CALIB_IN_PROCESS,// Calibration in process... Shows progressbar
-            RS2_CALIB_STATE_CALIB_COMPLETE,  // Calibration complete, show before/after toggle and metrics
-            RS2_CALIB_STATE_TARE_INPUT,      // Collect input parameters for Tare calib
-            RS2_CALIB_STATE_TARE_INPUT_ADVANCED,      // Collect input parameters for Tare calib
-            RS2_CALIB_STATE_SELF_INPUT,      // Collect input parameters for Self calib
-        };
+		void stop_viewer(invoker invoke);
+		void start_viewer(int w, int h, int fps, invoker invoke);
+	};
 
-        autocalib_notification_model(std::string name,
-            std::shared_ptr<on_chip_calib_manager> manager, bool expaned);
+	// Auto-calib notification model is managing the UI state-machine
+	// controling auto-calibration
+	struct autocalib_notification_model : public process_notification_model
+	{
+		enum auto_calib_ui_state
+		{
+			RS2_CALIB_STATE_INITIAL_PROMPT,  // First screen, would you like to run Health-Check?
+			RS2_CALIB_STATE_FAILED,          // Failed, show _error_message
+			RS2_CALIB_STATE_COMPLETE,        // After write, quick blue notification
+			RS2_CALIB_STATE_CALIB_IN_PROCESS,// Calibration in process... Shows progressbar
+			RS2_CALIB_STATE_CALIB_COMPLETE,  // Calibration complete, show before/after toggle and metrics
+			RS2_CALIB_STATE_TARE_INPUT,      // Collect input parameters for Tare calib
+			RS2_CALIB_STATE_TARE_INPUT_ADVANCED,      // Collect input parameters for Tare calib
+			RS2_CALIB_STATE_SELF_INPUT,      // Collect input parameters for Self calib
+		};
 
-        on_chip_calib_manager& get_manager() { 
-            return *std::dynamic_pointer_cast<on_chip_calib_manager>(update_manager); 
-        }
+		autocalib_notification_model(std::string name,
+			std::shared_ptr<on_chip_calib_manager> manager, bool expaned);
 
-        void set_color_scheme(float t) const override;
-        void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
-        void draw_dismiss(ux_window& win, int x, int y) override;
-        void draw_expanded(ux_window& win, std::string& error_message) override;
-        void draw_intrinsic_extrinsic(int x, int y);
-        int calc_height() override;
-        void dismiss(bool snooze) override;
+		on_chip_calib_manager& get_manager() {
+			return *std::dynamic_pointer_cast<on_chip_calib_manager>(update_manager);
+		}
 
-        bool use_new_calib = true;
-        std::string _error_message = "";
-    };
+		void set_color_scheme(float t) const override;
+		void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
+		void draw_dismiss(ux_window& win, int x, int y) override;
+		void draw_expanded(ux_window& win, std::string& error_message) override;
+		void draw_intrinsic_extrinsic(int x, int y);
+		int calc_height() override;
+		void dismiss(bool snooze) override;
+
+		bool use_new_calib = true;
+		std::string _error_message = "";
+	};
 }

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -38,7 +38,7 @@ namespace rs2
         config_file::instance().set_default(configurations::viewer::log_to_file, false);
         config_file::instance().set_default(configurations::viewer::log_severity, 2);
         config_file::instance().set_default(configurations::viewer::metric_system, true);
-		config_file::instance().set_default(configurations::viewer::ground_truth_r, 2500);
+        config_file::instance().set_default(configurations::viewer::ground_truth_r, 2500);
 
         config_file::instance().set_default(configurations::record::compression_mode, 2); // Let the device decide
         config_file::instance().set_default(configurations::record::default_path, get_folder_path(special_folder::user_documents));

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -38,6 +38,7 @@ namespace rs2
         config_file::instance().set_default(configurations::viewer::log_to_file, false);
         config_file::instance().set_default(configurations::viewer::log_severity, 2);
         config_file::instance().set_default(configurations::viewer::metric_system, true);
+		config_file::instance().set_default(configurations::viewer::ground_truth_r, 2500);
 
         config_file::instance().set_default(configurations::record::compression_mode, 2); // Let the device decide
         config_file::instance().set_default(configurations::record::default_path, get_folder_path(special_folder::user_documents));

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -757,8 +757,8 @@ namespace rs2
 
         is_3d_view = config_file::instance().get_or_default(
             configurations::viewer::is_3d_view, false);
-		
-		ground_truth_r = config_file::instance().get_or_default(
+
+        ground_truth_r = config_file::instance().get_or_default(
             configurations::viewer::ground_truth_r, 2500);
 
         metric_system = config_file::instance().get_or_default(

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -757,6 +757,9 @@ namespace rs2
 
         is_3d_view = config_file::instance().get_or_default(
             configurations::viewer::is_3d_view, false);
+		
+		ground_truth_r = config_file::instance().get_or_default(
+            configurations::viewer::ground_truth_r, 2500);
 
         metric_system = config_file::instance().get_or_default(
             configurations::viewer::metric_system, true);

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -135,6 +135,8 @@ namespace rs2
         bool paused = false;
         bool metric_system = true;
 
+		uint32_t ground_truth_r = 2500;
+
         enum export_type
         {
             ply

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -134,8 +134,7 @@ namespace rs2
         bool is_3d_view = false;
         bool paused = false;
         bool metric_system = true;
-
-		uint32_t ground_truth_r = 2500;
+        uint32_t ground_truth_r = 2500;
 
         enum export_type
         {

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -251,7 +251,6 @@ namespace librealsense
         int data_sampling = DEFAULT_SAMPLING;
         int apply_preset = 1;
 
-
         if (json.size() > 0)
         {
             auto jsn = parse_json(json);

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -251,6 +251,7 @@ namespace librealsense
         int data_sampling = DEFAULT_SAMPLING;
         int apply_preset = 1;
 
+
         if (json.size() > 0)
         {
             auto jsn = parse_json(json);
@@ -310,7 +311,7 @@ namespace librealsense
             }
 
             if (progress_callback)
-                progress_callback->on_update_progress(count * (2 * speed)); //curently this number does not reflect the actual progress
+                progress_callback->on_update_progress(count++ * (2 * speed)); //curently this number does not reflect the actual progress
 
             now = std::chrono::high_resolution_clock::now();
 

--- a/src/hw-monitor.cpp
+++ b/src/hw-monitor.cpp
@@ -152,7 +152,7 @@ namespace librealsense
         if (opCodeAsUint32 != opCodeXmit)
         {
             auto err_type = static_cast<hwmon_response>(opCodeAsUint32);
-            throw invalid_value_exception(to_string() << "hwmon command 0x" << std::hex << opCodeXmit << " failed.\n Error type: "
+            throw invalid_value_exception(to_string() << "hwmon command 0x" << std::hex << opCodeXmit << " failed.\nError type: "
                 << hwmon_error2str(err_type) << " (" << std::dec <<(int)err_type  << ").");
         }
 

--- a/src/hw-monitor.cpp
+++ b/src/hw-monitor.cpp
@@ -152,7 +152,7 @@ namespace librealsense
         if (opCodeAsUint32 != opCodeXmit)
         {
             auto err_type = static_cast<hwmon_response>(opCodeAsUint32);
-            throw invalid_value_exception(to_string() << "hwmon command 0x" << std::hex << opCodeXmit << " failed. Error type: "
+            throw invalid_value_exception(to_string() << "hwmon command 0x" << std::hex << opCodeXmit << " failed.\n Error type: "
                 << hwmon_error2str(err_type) << " (" << std::dec <<(int)err_type  << ").");
         }
 


### PR DESCRIPTION
1. OCC health check error for values <0  is now based on error magnitude.
2. On-Chip cal More Options, White Wall is set as default for D415
3. Tare-cal, The Avg step default values when you hover on the name are now compatible with the number shown (20). 
4. Tare is set to last value the user typed.
5. Error messages is shifted slightly to the left and the box is bigger.  
6. Progress bar during Tare is updated
DSO-14650 