### PR TITLE
Make firmware URL overrideable

### DIFF
--- a/common/fw/CMakeLists.txt
+++ b/common/fw/CMakeLists.txt
@@ -8,7 +8,8 @@ file(READ "firmware-version.h" ver)
 
 message(STATUS "Fetching recommended firmwares:")
 
-set(REALSENSE_FIRMWARE_URL "http://realsense-hw-public.s3.amazonaws.com" CACHE STRING)
+set(REALSENSE_FIRMWARE_URL "http://realsense-hw-public.s3.amazonaws.com" CACHE STRING
+    "URL to download firmware binaries from")
 
 string(REGEX MATCH "D4XX_RC_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
 set(D4XX_RC_VERSION ${CMAKE_MATCH_1})

--- a/common/fw/CMakeLists.txt
+++ b/common/fw/CMakeLists.txt
@@ -8,30 +8,32 @@ file(READ "firmware-version.h" ver)
 
 message(STATUS "Fetching recommended firmwares:")
 
+set(REALSENSE_FIRMWARE_URL "http://realsense-hw-public.s3.amazonaws.com" CACHE STRING)
+
 string(REGEX MATCH "D4XX_RC_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
 set(D4XX_RC_VERSION ${CMAKE_MATCH_1})
 message(STATUS "D4XX_RC_VERSION: ${D4XX_RC_VERSION}")
 set(D4XX_RC_SHA1 be77db800142110b35d1cc7f12dfc77e75ed9c8a)
-set(D4XX_RC_URL "http://realsense-hw-public.s3-eu-west-1.amazonaws.com/Releases/RS4xx/FW")
+set(D4XX_RC_URL "${REALSENSE_FIRMWARE_URL}/Releases/RS4xx/FW")
 
 string(REGEX MATCH "D4XX_RECOMMENDED_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
 set(D4XX_FW_VERSION ${CMAKE_MATCH_1})
 message(STATUS "D4XX_FW_VERSION: ${D4XX_FW_VERSION}")
 set(D4XX_FW_SHA1 be77db800142110b35d1cc7f12dfc77e75ed9c8a)
-set(D4XX_FW_URL "http://realsense-hw-public.s3-eu-west-1.amazonaws.com/Releases/RS4xx/FW")
+set(D4XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/RS4xx/FW")
 
 
 string(REGEX MATCH "SR3XX_RECOMMENDED_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
 set(SR3XX_FW_VERSION ${CMAKE_MATCH_1})
 message(STATUS "SR3XX_FW_VERSION: ${SR3XX_FW_VERSION}")
 set(SR3XX_FW_SHA1 55237dba5d7db20e7c218975375d05b4210e9460)
-set(SR3XX_FW_URL "http://realsense-hw-public.s3-eu-west-1.amazonaws.com/Releases/SR300/FW")
+set(SR3XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/SR300/FW")
 
 string(REGEX MATCH "T26X_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
 set(T26X_FW_VERSION ${CMAKE_MATCH_1})
 message(STATUS "T26X_FW_VERSION: ${T26X_FW_VERSION}")
 set(T26X_FW_SHA1 fb857641b003977478c4e5855658803e13a784c7)
-set(T26X_FW_URL "http://realsense-hw-public.s3.amazonaws.com/Releases/TM2/FW/target/${T26X_FW_VERSION}")
+set(T26X_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/TM2/FW/target/${T26X_FW_VERSION}")
 
 add_library(${PROJECT_NAME} STATIC empty.c)
 


### PR DESCRIPTION
Change as proposed in #5114. This permits the firmware binaries to be mirrored on-site for more restrictive CI environments that do not permit external network access at build time.

Closes: #5114