### PR TITLE
[swdev] Add API to break circular dependency with Active Object

### DIFF
--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -338,6 +338,15 @@ void rs2_software_sensor_update_read_only_option(rs2_sensor* sensor, rs2_option 
  * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
  */
 void rs2_software_sensor_add_option(rs2_sensor* sensor, rs2_option option, float min, float max, float step, float def, int is_writable, rs2_error** error);
+
+/**
+* Sensors hold the parent device in scope via a shared_ptr. This function detaches that so that the software sensor doesn't keep the software device alive.
+* Note that this is dangerous as it opens the door to accessing freed memory if care isn't taken.
+* \param[in] sensor         the software sensor
+* \param[out] error         if non-null, recieves any error that occurs during this call, otherwise, errors are ignored
+*/
+void rs2_software_sensor_detach(rs2_sensor* sensor, rs2_error** error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -229,6 +229,17 @@ namespace rs2
             rs2_software_sensor_on_notification(_sensor.get(), notif, &e);
             error::handle(e);
         }
+        /**
+        * Sensors hold the parent device in scope via a shared_ptr. This function detaches that so that the 
+        * software sensor doesn't keep the software device alive. Note that this is dangerous as it opens the
+        * door to accessing freed memory if care isn't taken.
+        */
+        void detach()
+        {
+            rs2_error * e = nullptr;
+            rs2_software_sensor_detach(_sensor.get(), &e);
+            error::handle(e);
+        }
 
     private:
         friend class software_device;

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -314,6 +314,7 @@ EXPORTS
     rs2_software_sensor_update_read_only_option
     rs2_software_sensor_add_option
     rs2_software_sensor_set_metadata
+    rs2_software_sensor_detach
 
     rs2_loopback_enable
     rs2_loopback_disable


### PR DESCRIPTION
the new detach() function should be called on all instances of rs2::software_sensor stored inside the Active Object. This will prevent them from keeping a reference to their parent device causing the following side effects:
1. rs2::context::get_sensor_parent will error if the instance is passed as the parameter.
2. this instance will not keep the parent device object alive. This breaks the circular dependancy between the active object, the sensors, and the device, but also means that it is possible to attempt to use the sensor after the underlying object has been destroyed. There are no checks in the SDK to prevent this from happening and so it is entirely on the software device's developer to make sure this doesn't happen. Making sure all the threads that use the sensors are closed before the active object's destructor completes, and then making the destructor run as part of the software device's on_destruction_callback should generally be enough to prevent illegal access to the sensors.

Another note on the detach API. This API call only has an effect above the hourglass, so if you get a new reference to the sensor (for example via rs2::device::first) that one won't be detached and will keep the parent device alive. (copies of the detached instance at the cpp level will also be detached)