### PR TITLE
Cmake property fix for Ubuntu 16

### DIFF
--- a/src/compression/CMakeLists.txt
+++ b/src/compression/CMakeLists.txt
@@ -25,8 +25,9 @@ include_directories(${PROJECT_NAME}
     ../../third-party/easyloggingpp/src    
 )
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
-#set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
+#Disabled due to CMake 3.5.1 compatibility
+#target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_11)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 
 add_dependencies(${PROJECT_NAME} 
     libjpeg-turbo


### PR DESCRIPTION
Downgrade cxx_11 property for compression target - Cmake 3.5.1 non-compatibility