### PR TITLE
Ensure custom deleter is called by passing non-null pointer in ctor

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -879,8 +879,12 @@ namespace librealsense
                         bool md_extracted = false;
                         buffers_mgr buf_mgr(_use_memory_map);
                         // RAII to handle exceptions
-                        std::unique_ptr<int, std::function<void(int*)> > md_poller(nullptr,
-                            [this,&buf_mgr,&md_extracted,&fds](int* d){ if (!md_extracted) acquire_metadata(buf_mgr,fds);});
+                        std::unique_ptr<int, std::function<void(int*)> > md_poller(new int(0),
+                            [this,&buf_mgr,&md_extracted,&fds](int* d)
+                            {
+                                if (!md_extracted) acquire_metadata(buf_mgr,fds);
+                                delete d;
+                            });
 
                         if(FD_ISSET(_fd, &fds))
                         {


### PR DESCRIPTION
Custom deleters for `std::unique_ptr` are not invoked if the owned pointer is null.
Therefore, the function setup to `acquire_metadata` at the end of the scope will never fire.

Solution is to pass a valid pointer, and let the custom deleter delete the object.