### PR TITLE
W/A for EasyLogging on Linux

### DIFF
--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -702,6 +702,9 @@ namespace rs2
     {
         std::lock_guard<std::recursive_mutex> lock(m);
         if (!line.size()) return;
+        // Limit the notification window
+        while (log.size() > 200)
+            log.pop_front();
         if (line[line.size() - 1] != '\n') line += "\n";
         log.push_back(line);
         new_log = true;

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -195,7 +195,7 @@ namespace rs2
         std::recursive_mutex m;
         bool new_log = false;
 
-        std::vector<std::string> log;
+        std::deque<std::string> log;
         std::shared_ptr<notification_model> selected;
         std::chrono::system_clock::time_point last_snoozed;
     };

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -785,9 +785,9 @@ namespace rs2
     viewer_model::viewer_model(context &ctx_)
             : ppf(*this),
               ctx(ctx_),
+              frameset_alloc(this),
               synchronization_enable(true),
-              zo_sensors(0),
-              frameset_alloc(this)
+              zo_sensors(0)
     {
         syncer = std::make_shared<syncer_model>();
         reset_camera();
@@ -1677,7 +1677,7 @@ namespace rs2
                     ImGui::PushStyleColor( ImGuiCol_Text, ImColor( 1.f, 1.f, 1.f, a ) );
                     ImColor bg( dark_sensor_bg.x, dark_sensor_bg.y, dark_sensor_bg.z, dark_sensor_bg.w * a );
 
-                    if( object.mean_depth )
+                    if( fabs(object.mean_depth) > 0.f )
                     {
                         std::string str = to_string() << std::setprecision( 2 ) << object.mean_depth << " m";
                         auto size = ImGui::CalcTextSize( str.c_str() );
@@ -1688,7 +1688,7 @@ namespace rs2
                                 { bbox.x + size.x + 20, bbox.y + size.y + 6 },
                                 bg );
                             ImGui::SetCursorScreenPos( { bbox.x + 10, bbox.y + 3 } );
-                            ImGui::Text( str.c_str() );
+                            ImGui::Text("%s",  str.c_str() );
                             h -= size.y;
                         }
                     }
@@ -1702,7 +1702,7 @@ namespace rs2
                                 { bbox.x + bbox.w - 1, bbox.y + bbox.h - 1 },
                                 bg );
                             ImGui::SetCursorScreenPos( { bbox.x + bbox.w - size.x - 10, bbox.y + bbox.h - size.y - 4 } );
-                            ImGui::Text( object.name.c_str() );
+                            ImGui::Text("%s",  object.name.c_str() );
                             h -= size.y;
                         }
                     }

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -323,11 +323,14 @@ int main(int argc, const char** argv) try
     protected:
         void handle( const el::LogDispatchData* data ) noexcept override
         {
-            vm->not_model.add_log( 
-                data->logMessage()->logger()->logBuilder()->build(
-                    data->logMessage(),
-                    data->dispatchAction() == el::base::DispatchAction::NormalLog
-                ));
+            // TODO align LRS and Easyloging severity levels. W/A for easylogging on Linux
+            if (data->logMessage()->level() > el::Level::Debug)
+            {
+                vm->not_model.add_log(
+                    data->logMessage()->logger()->logBuilder()->build(
+                        data->logMessage(),
+                        data->dispatchAction() == el::base::DispatchAction::NormalLog));
+            }
         }
     };
     el::Helpers::installLogDispatchCallback< viewer_model_dispatcher >( "viewer_model_dispatcher" );


### PR DESCRIPTION
Filter log_to_callback to INFO or a higher level to avoid notification windows flooding.
Limit the notifications windows depth for constant size memory footprint.
Fix minor GCC warnings