### PR TITLE
Fix bug - RSUSB messaging takes 20 msec

### DIFF
--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -273,7 +273,7 @@ public:
 
         //wait
         std::unique_lock<std::mutex> lk(_blocking_invoke_mutex);
-        while(_blocking_invoke_cv.wait_for(lk, std::chrono::milliseconds(10), [&](){ return !done && !exit_condition(); }));
+        _blocking_invoke_cv.wait(lk, [&](){ return done || exit_condition(); });
     }
 
     void start()

--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -36,6 +36,7 @@ namespace librealsense
         CLinearCoefficients(unsigned int buffer_size);
         void reset();
         void add_value(CSample val);
+        void add_const_y_coefs(double dy);
         void update_linear_coefs(double x);
         double calc_value(double x) const;
         bool is_full() const;
@@ -79,6 +80,7 @@ namespace librealsense
         mutable std::recursive_mutex _read_mtx; // Watch only 1 reader at a time.
         mutable std::recursive_mutex _enable_mtx; // Watch only 1 start/stop operation at a time.
         CLinearCoefficients _coefs;
+        double _min_command_delay;
         bool _is_ready;
     };
 


### PR DESCRIPTION
fix condition on waiting for signal in concurrency.h invoke_and_wait function. Was waiting until timeout and missing the signal.
#6206 