### PR TITLE
Move python bindings into separate cmake target

### DIFF
--- a/CMake/pyrealsense2Config.cmake.in
+++ b/CMake/pyrealsense2Config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+set(pyrealsense2_VERSION_MAJOR "@REALSENSE_VERSION_MAJOR@")
+set(pyrealsense2_VERSION_MINOR "@REALSENSE_VERSION_MINOR@")
+set(pyrealsense2_VERSION_PATCH "@REALSENSE_VERSION_PATCH@")
+
+set(pyrealsense2_VERSION ${realsense2_VERSION_MAJOR}.${realsense2_VERSION_MINOR}.${realsense2_VERSION_PATCH})
+
+include("${CMAKE_CURRENT_LIST_DIR}/pyrealsense2Targets.cmake")
+set(realsense2_LIBRARY pyrealsense2::pyrealsense2)

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -7,6 +7,10 @@ if (NOT BUILD_PYTHON_BINDINGS)
     message(WARNING "Python Bindings being built despite unset option because they are required for python documentation")
 endif()
 
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
+set(PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+
 set(DEPENDENCIES realsense2)
 
 add_subdirectory(third_party/pybind11)
@@ -36,8 +40,8 @@ set_target_properties(pyrealsense2 PROPERTIES VERSION
 set_target_properties(pyrealsense2 PROPERTIES FOLDER Wrappers/python)
 install(TARGETS pyrealsense2 EXPORT realsense2Targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}
+        ARCHIVE DESTINATION ${PYTHON_INSTALL_DIR}
 )
 
 set(RAW_RS
@@ -131,8 +135,8 @@ include_directories(pybackend2 ../../include)
 install(TARGETS pybackend2
         EXPORT realsense2Targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}
+        ARCHIVE DESTINATION ${PYTHON_INSTALL_DIR}
 )
 
 if (BUILD_PYTHON_DOCS)

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
 set(PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
 
 set(DEPENDENCIES realsense2)
 
@@ -127,6 +128,15 @@ set_target_properties(pybackend2 PROPERTIES
 set_target_properties(pybackend2 PROPERTIES FOLDER Wrappers/python)
 include_directories(pybackend2 ../../include)
 
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/pyrealsense2ConfigVersion.cmake"
+    VERSION ${REALSENSE_VERSION_STRING} COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(../../CMake/pyrealsense2Config.cmake.in pyrealsense2Config.cmake
+    INSTALL_DESTINATION ${CMAKECONFIG_PY_INSTALL_DIR}
+    INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/bin
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+)
+
 install(TARGETS pybackend2 pyrealsense2
         EXPORT pyrealsense2Targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -138,6 +148,15 @@ install(EXPORT pyrealsense2Targets
   FILE pyrealsense2Targets.cmake
   NAMESPACE pyrealsense2::
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+
+install(FILES "${CMAKE_BINARY_DIR}/wrappers/python/pyrealsense2Config.cmake"
+  DESTINATION ${CMAKECONFIG_PY_INSTALL_DIR}
+)
+
+install(FILES "${CMAKE_BINARY_DIR}/wrappers/python/pyrealsense2ConfigVersion.cmake"
+  DESTINATION ${CMAKECONFIG_PY_INSTALL_DIR}
+)
+
 
 if (BUILD_PYTHON_DOCS)
     add_subdirectory(docs)

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -7,10 +7,16 @@ if (NOT BUILD_PYTHON_BINDINGS)
     message(WARNING "Python Bindings being built despite unset option because they are required for python documentation")
 endif()
 
-find_package(Python REQUIRED COMPONENTS Interpreter Development)
-
-set(PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
-set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+if (CMAKE_VERSION VERSION_LESS 3.12)
+  find_package(PythonInterp REQUIRED)
+  find_package(PythonLibs REQUIRED)
+  set(PYTHON_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+  set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+else()
+  find_package(Python REQUIRED COMPONENTS Interpreter Development)
+  set(PYTHON_INSTALL_DIR "${Python_SITEARCH}/pyrealsense2" CACHE PATH "Installation directory for Python bindings")
+  set(CMAKECONFIG_PY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
+endif()
 
 set(DEPENDENCIES realsense2)
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -38,11 +38,6 @@ target_link_libraries(pyrealsense2 PRIVATE ${DEPENDENCIES})
 set_target_properties(pyrealsense2 PROPERTIES VERSION
     ${REALSENSE_VERSION_STRING} SOVERSION "${REALSENSE_VERSION_MAJOR}.${REALSENSE_VERSION_MINOR}")
 set_target_properties(pyrealsense2 PROPERTIES FOLDER Wrappers/python)
-install(TARGETS pyrealsense2 EXPORT realsense2Targets
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}
-        ARCHIVE DESTINATION ${PYTHON_INSTALL_DIR}
-)
 
 set(RAW_RS
     pybackend.cpp
@@ -132,12 +127,17 @@ set_target_properties(pybackend2 PROPERTIES
 set_target_properties(pybackend2 PROPERTIES FOLDER Wrappers/python)
 include_directories(pybackend2 ../../include)
 
-install(TARGETS pybackend2
-        EXPORT realsense2Targets
+install(TARGETS pybackend2 pyrealsense2
+        EXPORT pyrealsense2Targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}
         ARCHIVE DESTINATION ${PYTHON_INSTALL_DIR}
 )
+
+install(EXPORT pyrealsense2Targets
+  FILE pyrealsense2Targets.cmake
+  NAMESPACE pyrealsense2::
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/pyrealsense2")
 
 if (BUILD_PYTHON_DOCS)
     add_subdirectory(docs)


### PR DESCRIPTION
* Move python bindings into a separate cmake target so we can install them separately (see #6124).
* Also install the python bindings into python's sitearch, not in `/usr/lib64` (or `/usr/local/lib64`).

Resolves #6124.