### PR TITLE
rs-convert converts frames using sensor callback

### DIFF
--- a/tools/convert/converter.hpp
+++ b/tools/convert/converter.hpp
@@ -23,7 +23,7 @@ namespace rs2 {
 
                 file.open(filename);
 
-                file << "Stream: " << rs2_stream_to_string(frm.get_profile().stream_type()) << "\nMetadata Attribute: Value\n";
+                file << "Stream: " << rs2_stream_to_string(frm.get_profile().stream_type()) << "\n";
 
                 // Record all the available metadata attributes
                 for (size_t i = 0; i < RS2_FRAME_METADATA_COUNT; i++)

--- a/tools/convert/converter.hpp
+++ b/tools/convert/converter.hpp
@@ -17,6 +17,27 @@ namespace rs2 {
     namespace tools {
         namespace converter {
 
+            void metadata_to_txtfile(const rs2::frame& frm, const std::string& filename)
+            {
+                std::ofstream file;
+
+                file.open(filename);
+
+                file << "Stream: " << rs2_stream_to_string(frm.get_profile().stream_type()) << "\nMetadata Attribute: Value\n";
+
+                // Record all the available metadata attributes
+                for (size_t i = 0; i < RS2_FRAME_METADATA_COUNT; i++)
+                {
+                    if (frm.supports_frame_metadata((rs2_frame_metadata_value)i))
+                    {
+                        file << rs2_frame_metadata_to_string((rs2_frame_metadata_value)i) << ": "
+                            << frm.get_frame_metadata((rs2_frame_metadata_value)i) << "\n";
+                    }
+                }
+
+                file.close();
+            }
+
             typedef unsigned long long frame_number_t;
 
             class converter_base {
@@ -63,7 +84,7 @@ namespace rs2 {
                 }
 
             public:
-                virtual void convert(rs2::frameset& frameset) = 0;
+                virtual void convert(rs2::frame& frame) = 0;
                 virtual std::string name() const = 0;
 
                 virtual std::string get_statistics()

--- a/tools/convert/converter.hpp
+++ b/tools/convert/converter.hpp
@@ -28,10 +28,11 @@ namespace rs2 {
                 // Record all the available metadata attributes
                 for (size_t i = 0; i < RS2_FRAME_METADATA_COUNT; i++)
                 {
-                    if (frm.supports_frame_metadata((rs2_frame_metadata_value)i))
+                    rs2_frame_metadata_value metadata_val = (rs2_frame_metadata_value)i;
+                    if (frm.supports_frame_metadata(metadata_val))
                     {
-                        file << rs2_frame_metadata_to_string((rs2_frame_metadata_value)i) << ": "
-                            << frm.get_frame_metadata((rs2_frame_metadata_value)i) << "\n";
+                        file << rs2_frame_metadata_to_string(metadata_val) << ": "
+                            << frm.get_frame_metadata(metadata_val) << "\n";
                     }
                 }
 

--- a/tools/convert/converters/converter-ply.hpp
+++ b/tools/convert/converters/converter-ply.hpp
@@ -27,31 +27,39 @@ namespace rs2 {
                     return "PLY converter";
                 }
 
-                void convert(rs2::frameset& frameset) override
+                void convert(rs2::frame& frame) override
                 {
                     rs2::pointcloud pc;
                     start_worker(
-                        [this, &frameset, pc]() mutable {
-                            auto frameDepth = frameset.get_depth_frame();
-                            auto frameColor = frameset.get_color_frame();
+                        [this, &frame, pc]() mutable {
+                        auto frameset = frame.as<rs2::frameset>();
+                        auto frameDepth = frameset.get_depth_frame();
+                        auto frameColor = frameset.get_color_frame();
 
-                            if (frameDepth && frameColor) {
-                                if (frames_map_get_and_set(rs2_stream::RS2_STREAM_ANY, frameDepth.get_frame_number())) {
-                                    return;
-                                }
-
-                                pc.map_to(frameColor);
-
-                                auto points = pc.calculate(frameDepth);
-
-                                std::stringstream filename;
-                                filename << _filePath
-                                    << "_" << frameDepth.get_frame_number()
-                                    << ".ply";
-
-                                points.export_to_ply(filename.str(), frameColor);
+                        if (frameDepth && frameColor) {
+                            if (frames_map_get_and_set(rs2_stream::RS2_STREAM_ANY, frameDepth.get_frame_number())) {
+                                return;
                             }
-                        });
+
+                            pc.map_to(frameColor);
+
+                            auto points = pc.calculate(frameDepth);
+
+                            std::stringstream filename;
+                            filename << _filePath
+                                << "_" << std::setprecision(14) << std::fixed << frameDepth.get_timestamp()
+                                << ".ply";
+
+                            points.export_to_ply(filename.str(), frameColor);
+
+                            std::stringstream metadata_file;
+                            metadata_file << _filePath
+                                << "_" << std::setprecision(14) << std::fixed << frameDepth.get_timestamp()
+                                << "_metadata.txt";
+
+                            metadata_to_txtfile(frameDepth, metadata_file.str());
+                        }
+                    });
                 }
             };
 

--- a/tools/convert/converters/converter-ply.hpp
+++ b/tools/convert/converters/converter-ply.hpp
@@ -32,33 +32,33 @@ namespace rs2 {
                     rs2::pointcloud pc;
                     start_worker(
                         [this, &frame, pc]() mutable {
-                        auto frameset = frame.as<rs2::frameset>();
-                        auto frameDepth = frameset.get_depth_frame();
-                        auto frameColor = frameset.get_color_frame();
+                            auto frameset = frame.as<rs2::frameset>();
+                            auto frameDepth = frameset.get_depth_frame();
+                            auto frameColor = frameset.get_color_frame();
 
-                        if (frameDepth && frameColor) {
-                            if (frames_map_get_and_set(rs2_stream::RS2_STREAM_ANY, frameDepth.get_frame_number())) {
-                                return;
+                            if (frameDepth && frameColor) {
+                                if (frames_map_get_and_set(rs2_stream::RS2_STREAM_ANY, frameDepth.get_frame_number())) {
+                                    return;
+                                }
+
+                                pc.map_to(frameColor);
+
+                                auto points = pc.calculate(frameDepth);
+
+                                std::stringstream filename;
+                                filename << _filePath
+                                    << "_" << std::setprecision(14) << std::fixed << frameDepth.get_timestamp()
+                                    << ".ply";
+
+                                points.export_to_ply(filename.str(), frameColor);
+
+                                std::stringstream metadata_file;
+                                metadata_file << _filePath
+                                    << "_metadata_" << std::setprecision(14) << std::fixed << frameDepth.get_timestamp()
+                                    << ".txt";
+
+                                metadata_to_txtfile(frameDepth, metadata_file.str());
                             }
-
-                            pc.map_to(frameColor);
-
-                            auto points = pc.calculate(frameDepth);
-
-                            std::stringstream filename;
-                            filename << _filePath
-                                << "_" << std::setprecision(14) << std::fixed << frameDepth.get_timestamp()
-                                << ".ply";
-
-                            points.export_to_ply(filename.str(), frameColor);
-
-                            std::stringstream metadata_file;
-                            metadata_file << _filePath
-                                << "_" << std::setprecision(14) << std::fixed << frameDepth.get_timestamp()
-                                << "_metadata.txt";
-
-                            metadata_to_txtfile(frameDepth, metadata_file.str());
-                        }
                     });
                 }
             };

--- a/tools/convert/converters/converter-png.hpp
+++ b/tools/convert/converters/converter-png.hpp
@@ -33,46 +33,53 @@ namespace rs2 {
                     return "PNG converter";
                 }
 
-                void convert(rs2::frameset& frameset) override
+                void convert(rs2::frame& frame) override
                 {
                     start_worker(
-                        [this, &frameset] {
-                            for (size_t i = 0; i < frameset.size(); i++) {
-                                rs2::video_frame frame = frameset[i].as<rs2::video_frame>();
-
-                                if (frame && (_streamType == rs2_stream::RS2_STREAM_ANY || frame.get_profile().stream_type() == _streamType)) {
-                                    if (frames_map_get_and_set(frame.get_profile().stream_type(), frame.get_frame_number())) {
-                                        continue;
-                                    }
-
-                                    if (frame.get_profile().stream_type() == rs2_stream::RS2_STREAM_DEPTH) {
-                                        frame = _colorizer.process(frame);
-                                    }
-
-                                    std::stringstream filename;
-                                    filename << _filePath
-                                        << "_" << frame.get_profile().stream_name()
-                                        << "_" << frame.get_frame_number()
-                                        << ".png";
-
-                                    std::string filenameS = filename.str();
-
-                                    add_sub_worker(
-                                        [filenameS, frame] {
-                                            stbi_write_png(
-                                                filenameS.c_str()
-                                                , frame.get_width()
-                                                , frame.get_height()
-                                                , frame.get_bytes_per_pixel()
-                                                , frame.get_data()
-                                                , frame.get_stride_in_bytes()
-                                            );
-                                        });
-                                }
+                        [this, &frame] {
+                        rs2::video_frame videoframe = frame.as<rs2::video_frame>();
+                        if (videoframe && (_streamType == rs2_stream::RS2_STREAM_ANY || videoframe.get_profile().stream_type() == _streamType)) {
+                            if (frames_map_get_and_set(videoframe.get_profile().stream_type(), videoframe.get_timestamp())) {
+                                return;
                             }
 
-                            wait_sub_workers();
-                        });
+
+                            if (videoframe.get_profile().stream_type() == rs2_stream::RS2_STREAM_DEPTH) {
+                                videoframe = _colorizer.process(videoframe);
+                            }
+
+                            std::stringstream filename;
+                            filename << _filePath
+                                << "_" << videoframe.get_profile().stream_name()
+                                << "_" << std::setprecision(14) << std::fixed << videoframe.get_timestamp()
+                                << ".png";
+
+                            std::string filenameS = filename.str();
+
+                            add_sub_worker(
+                                [filenameS, videoframe] {
+                                stbi_write_png(
+                                    filenameS.c_str()
+                                    , videoframe.get_width()
+                                    , videoframe.get_height()
+                                    , videoframe.get_bytes_per_pixel()
+                                    , videoframe.get_data()
+                                    , videoframe.get_stride_in_bytes()
+                                );
+                            });
+
+                            std::stringstream metadata_file;
+                            metadata_file << _filePath
+                                << "_" << videoframe.get_profile().stream_name()
+                                << "_" << std::setprecision(14) << std::fixed << videoframe.get_timestamp()
+                                << "_metadata.txt";
+
+                            metadata_to_txtfile(videoframe, metadata_file.str());
+
+                        }
+
+                        wait_sub_workers();
+                    });
                 }
             };
 

--- a/tools/convert/converters/converter-raw.hpp
+++ b/tools/convert/converters/converter-raw.hpp
@@ -74,7 +74,6 @@ namespace rs2 {
                                     }
 
                                     metadata_to_txtfile(videoframe, metadataS);
-
                             });
 
                             wait_sub_workers();

--- a/tools/convert/converters/converter-raw.hpp
+++ b/tools/convert/converters/converter-raw.hpp
@@ -30,43 +30,48 @@ namespace rs2 {
                     return "RAW converter";
                 }
 
-                void convert(rs2::frameset& frameset) override
+                void convert(rs2::frame& frame) override
                 {
                     start_worker(
-                        [this, &frameset] {
-                            for (size_t i = 0; i < frameset.size(); i++) {
-                                rs2::video_frame frame = frameset[i].as<rs2::video_frame>();
+                        [this, &frame] {
+                        rs2::video_frame videoframe = frame.as<rs2::video_frame>();
 
-                                if (frame && (_streamType == rs2_stream::RS2_STREAM_ANY || frame.get_profile().stream_type() == _streamType)) {
-                                    if (frames_map_get_and_set(frame.get_profile().stream_type(), frame.get_frame_number())) {
-                                        continue;
-                                    }
-
-                                    std::stringstream filename;
-                                    filename << _filePath
-                                        << "_" << frame.get_profile().stream_name()
-                                        << "_" << frame.get_frame_number()
-                                        << ".raw";
-
-                                    std::string filenameS = filename.str();
-
-                                    add_sub_worker(
-                                        [filenameS, frame] {
-                                            std::ofstream fs(filenameS, std::ios::binary | std::ios::trunc);
-
-                                            if (fs) {
-                                                fs.write(
-                                                    static_cast<const char *>(frame.get_data())
-                                                    , frame.get_stride_in_bytes() * frame.get_height());
-
-                                                fs.flush();
-                                            }
-                                        });
-                                }
+                        if (videoframe && (_streamType == rs2_stream::RS2_STREAM_ANY || videoframe.get_profile().stream_type() == _streamType)) {
+                            if (!frames_map_get_and_set(videoframe.get_profile().stream_type(), videoframe.get_frame_number())) {
+                                return;
                             }
 
-                            wait_sub_workers();
-                        });
+                            std::stringstream filename;
+                            filename << _filePath
+                                << "_" << videoframe.get_profile().stream_name()
+                                << "_" << std::setprecision(14) << std::fixed << videoframe.get_timestamp()
+                                << ".raw";
+
+                            std::string filenameS = filename.str();
+
+                            add_sub_worker(
+                                [filenameS, videoframe] {
+                                std::ofstream fs(filenameS, std::ios::binary | std::ios::trunc);
+
+                                if (fs) {
+                                    fs.write(
+                                        static_cast<const char *>(videoframe.get_data())
+                                        , videoframe.get_stride_in_bytes() * videoframe.get_height());
+
+                                    fs.flush();
+                                }
+                            });
+                            std::stringstream metadata_file;
+                            metadata_file << _filePath
+                                << "_" << videoframe.get_profile().stream_name()
+                                << "_" << std::setprecision(14) << std::fixed << videoframe.get_timestamp()
+                                << "_metadata.txt";
+
+                            metadata_to_txtfile(videoframe, metadata_file.str());
+                        }
+
+                        wait_sub_workers();
+                    });
                 }
             };
 

--- a/tools/convert/rs-convert.cpp
+++ b/tools/convert/rs-convert.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) try
     cmd.parse(argc, argv);
 
     vector<shared_ptr<rs2::tools::converter::converter_base>> converters;
-	shared_ptr<rs2::tools::converter::converter_ply> plyconverter;
+    shared_ptr<rs2::tools::converter::converter_ply> plyconverter;
 
     rs2_stream streamType = switchDepth.isSet() ? rs2_stream::RS2_STREAM_DEPTH
         : switchColor.isSet() ? rs2_stream::RS2_STREAM_COLOR

--- a/tools/convert/rs-convert.cpp
+++ b/tools/convert/rs-convert.cpp
@@ -13,6 +13,8 @@
 #include "converters/converter-ply.hpp"
 #include "converters/converter-bin.hpp"
 
+#include <mutex>
+
 
 using namespace std;
 using namespace TCLAP;
@@ -70,77 +72,145 @@ int main(int argc, char** argv) try
                 , streamType));
     }
 
-    if (outputFilenamePly.isSet()) {
-        converters.push_back(
-            make_shared<rs2::tools::converter::converter_ply>(
-                outputFilenamePly.getValue()));
-    }
-
     if (outputFilenameBin.isSet()) {
         converters.push_back(
             make_shared<rs2::tools::converter::converter_bin>(
                 outputFilenameBin.getValue()));
     }
 
-    if (converters.empty()) {
+    if (converters.empty() && !outputFilenamePly.isSet()) {
         throw runtime_error("output not defined");
     }
 
-    // Since we are running in blocking "non-real-time" mode,
-    // we don't want to prevent process termination if some of the frames
-    // did not find a match and hence were not serviced
-    auto pipe = std::shared_ptr<rs2::pipeline>(
-        new rs2::pipeline(), [](rs2::pipeline*) {});
+    auto plyconverter = make_shared<rs2::tools::converter::converter_ply>(
+        outputFilenamePly.getValue());
 
-    rs2::config cfg;
-    cfg.enable_device_from_file(inputFilename.getValue());
-    pipe->start(cfg);
+    //in order to convert frames into ply we need synced depth and color frames, 
+    //therefore we use pipeline
+    if (outputFilenamePly.isSet()) {
 
-    auto device = pipe->get_active_profile().get_device();
-    rs2::playback playback = device.as<rs2::playback>();
-    playback.set_real_time(false);
+        // Since we are running in blocking "non-real-time" mode,
+        // we don't want to prevent process termination if some of the frames
+        // did not find a match and hence were not serviced
+        auto pipe = std::shared_ptr<rs2::pipeline>(
+            new rs2::pipeline(), [](rs2::pipeline*) {});
 
-    auto duration = playback.get_duration();
-    int progress = 0;
-    auto frameNumber = 0ULL;
-    
-    rs2::frameset frameset;
-    uint64_t posLast = playback.get_position();
-    while (pipe->try_wait_for_frames(&frameset, 1000)) 
-    {
-        int posP = static_cast<int>(posLast * 100. / duration.count());
+        rs2::config cfg;
+        cfg.enable_device_from_file(inputFilename.getValue());
+        pipe->start(cfg);
 
-        if (posP > progress) {
-            progress = posP;
-            cout << posP << "%" << "\r" << flush;
+        auto device = pipe->get_active_profile().get_device();
+        rs2::playback playback = device.as<rs2::playback>();
+        playback.set_real_time(false);
+
+        auto duration = playback.get_duration();
+        int progress = 0;
+        auto frameNumber = 0ULL;
+
+        rs2::frameset frameset;
+        uint64_t posLast = playback.get_position();
+
+        while (pipe->try_wait_for_frames(&frameset, 1000))
+        {
+            int posP = static_cast<int>(posLast * 100. / duration.count());
+
+            if (posP > progress) {
+                progress = posP;
+                cout << posP << "%" << "\r" << flush;
+            }
+
+            frameNumber = frameset[0].get_frame_number();
+            plyconverter->convert(frameset);
+            plyconverter->wait();
+
+            const uint64_t posCurr = playback.get_position();
+            if (static_cast<int64_t>(posCurr - posLast) < 0) {
+                break;
+            }
+            posLast = posCurr;
         }
+    }
 
+    // for every converter other than ply,
+    // we get the frames from playback sensors 
+    // and convert them one by one
+    if (!converters.empty()) {
+        rs2::context ctx;
+        auto playback = ctx.load_device(inputFilename.getValue());
+        playback.set_real_time(false);
+        std::vector<rs2::sensor> sensors = playback.query_sensors();
 
+        rs2::frameset frameset;
+        auto frameNumber = 0ULL;
+        std::mutex mutex;
 
-        frameNumber = frameset[0].get_frame_number();
+        auto duration = playback.get_duration();
+        int progress = 0;
+        uint64_t posLast = playback.get_position();
 
-        for_each(converters.begin(), converters.end(),
-            [&frameset] (shared_ptr<rs2::tools::converter::converter_base>& converter) {
-                converter->convert(frameset);
+        for (auto sensor : sensors) {
+            if (!sensor.get_stream_profiles().size())
+            {
+                continue;
+            }
+
+            sensor.open(sensor.get_stream_profiles());
+            sensor.start([&](rs2::frame frame)
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                for_each(converters.begin(), converters.end(),
+                    [&frame](shared_ptr<rs2::tools::converter::converter_base>& converter) {
+                    converter->convert(frame);
+                });
+
+                for_each(converters.begin(), converters.end(),
+                    [](shared_ptr<rs2::tools::converter::converter_base>& converter) {
+                    converter->wait();
+                });
             });
 
-        for_each(converters.begin(), converters.end(),
-            [] (shared_ptr<rs2::tools::converter::converter_base>& converter) {
-                converter->wait();
-            });
-        const uint64_t posCurr = playback.get_position();
-        if(static_cast<int64_t>(posCurr - posLast) < 0){
-            break;
         }
-        posLast = posCurr;
+
+        cout << "\r    \r";
+        while (true)
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            int posP = static_cast<int>(posLast * 100. / duration.count());
+
+            if (posP > progress) {
+                progress = posP;
+                cout << posP << "%" << "\r" << flush;
+            }
+
+            const uint64_t posCurr = playback.get_position();
+            if (static_cast<int64_t>(posCurr - posLast) < 0) {
+                break;
+            }
+            posLast = posCurr;
+        }
+
+        for (auto sensor : sensors) {
+            if (!sensor.get_stream_profiles().size())
+            {
+                continue;
+            }
+            sensor.stop();
+            sensor.close();
+        }
     }
 
     cout << endl;
 
+    //print statistics for ply converter. 
+    if (outputFilenamePly.isSet()) {
+        cout << plyconverter->get_statistics() << endl;
+    }
+
     for_each(converters.begin(), converters.end(),
-        [] (shared_ptr<rs2::tools::converter::converter_base>& converter) {
-            cout << converter->get_statistics() << endl;
-        });
+        [](shared_ptr<rs2::tools::converter::converter_base>& converter) {
+        cout << converter->get_statistics() << endl;
+    });
+
 
     return EXIT_SUCCESS;
 }

--- a/tools/convert/rs-convert.cpp
+++ b/tools/convert/rs-convert.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv) try
 
         }
 
-        //we need to clear the output of ply progress (100%) before writing
+        //we need to clear the output of ply progress ("100%") before writing
         //the progress of the other converters in the same line
         cout << "\r    \r";
 

--- a/tools/convert/rs-convert.cpp
+++ b/tools/convert/rs-convert.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv) try
 
         }
 
-        //we need to clear the output of ply progress before writing
+        //we need to clear the output of ply progress (100%) before writing
         //the progress of the other converters in the same line
         cout << "\r    \r";
 

--- a/tools/convert/rs-convert.cpp
+++ b/tools/convert/rs-convert.cpp
@@ -170,7 +170,8 @@ int main(int argc, char** argv) try
 
         }
 
-        //clears output in case ply wrote to it
+        //we need to clear the output of ply progress before writing
+        //the progress of the other converters in the same line
         cout << "\r    \r";
 
         while (true)


### PR DESCRIPTION
1) the tool now names frames based on frame timestamp (instead of frame number)
2) the tool creates metadata text file for the frame
3) the tool converts frames by running over sensors and using sensor callback (instead of wait_for_frames), for ply converter it still uses wait_for_frames since we need synced frames