### PR TITLE
Disable creation of unnecessary log files

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -81,7 +81,12 @@ namespace librealsense
 
             // NOTE: you can only log to one file, so successive calls to log_to_file
             // will override one another!
-            defaultConf.setGlobally( el::ConfigurationType::Filename, filename );
+            if (minimum_file_severity != RS2_LOG_SEVERITY_NONE)
+            {
+                // Configure filename for logging only if the severity requires it, which
+                // prevents creation of empty log files that are not required.
+                defaultConf.setGlobally(el::ConfigurationType::Filename, filename);
+            }
             for (int i = minimum_file_severity; i < RS2_LOG_SEVERITY_NONE; i++)
             {
                 defaultConf.set(severity_to_level(static_cast<rs2_log_severity>(i)),


### PR DESCRIPTION
**OS:** Ubuntu 18.04
**SDK:** 2.34.0
**Device:** D415

**Issue Description:** I am experiencing a purely cosmetic issue, where calls to `log_to_console()` create log files, i.e. `yyyy-MM-dd-HH_mm_ss.log`, that remain empty because no logging to file with `log_to_file()` was requested. I suspect `log_to_callback()` to result in a similar behaviour as it also calls `open()` internally, but I have not tested my hypothesis. I assume that this behaviour is unintentional.

**Suggested Solution:** Configure filename for logging ONLY if it was requested, in which case `minimum_file_severity` is different than `RS2_LOG_SEVERITY_NONE`.