### PR TITLE
Fix bug: Detach event was sent instead of Attach event

### DIFF
--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/DeviceWatcher.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/DeviceWatcher.java
@@ -80,10 +80,18 @@ class DeviceWatcher extends LrsClass {
         }
     }
 
-    private void updateListeners(){
+    private enum UpdateListenersType {
+        ATTACH,
+        DETACH
+    }
+
+    private void updateListeners(UpdateListenersType type){
         for(DeviceListener listener : mAppDeviceListener) {
             try {
-                listener.onDeviceDetach();
+                if (type == UpdateListenersType.ATTACH)
+                    listener.onDeviceAttach();
+                else
+                    listener.onDeviceDetach();
             } catch (Exception e) {
                 Log.e(TAG, e.getMessage());
             }
@@ -95,7 +103,7 @@ class DeviceWatcher extends LrsClass {
 
         nRemoveUsbDevice(desc.descriptor);
         desc.connection.close();
-        updateListeners();
+        updateListeners(UpdateListenersType.DETACH);
         Log.d(TAG, "Device: " + desc.name + " removed successfully");
     }
 
@@ -112,7 +120,7 @@ class DeviceWatcher extends LrsClass {
         mDescriptors.put(device.getDeviceName(), desc);
         nAddUsbDevice(desc.name, desc.descriptor);
 
-        updateListeners();
+        updateListeners(UpdateListenersType.ATTACH);
         Log.d(TAG, "Device: " + desc.name + " added successfully");
     }
 


### PR DESCRIPTION
When device was connected, event "device detached" was sent instead of "device attached".
Tracked on: DSO-15065
Addresses #6452