### PR TITLE
remove false libusb error message.

### DIFF
--- a/src/libusb/messenger-libusb.cpp
+++ b/src/libusb/messenger-libusb.cpp
@@ -99,7 +99,7 @@ namespace librealsense
         {
             auto nr = reinterpret_cast<libusb_transfer*>(request->get_native_request());
             auto sts = libusb_cancel_transfer(nr);
-            if (sts < 0)
+            if (sts < 0 && sts != LIBUSB_ERROR_NOT_FOUND)
             {
                 std::string strerr = strerror(errno);
                 LOG_WARNING("usb_request_cancel returned error, endpoint: " << (int)request->get_endpoint()->get_address() << " error: " << strerr << ", number: " << (int)errno);


### PR DESCRIPTION
LIBUSB_ERROR_NOT_FOUND is returned from libusb_cancel_transfer means that the endpoint does not exist. Probably been closed by someone else already. This is not an error.
See here: https://nxmnpg.lemoda.net/3/libusb_cancel_transfer