### PR TITLE
L515 motion correction 2

### DIFF
--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -203,7 +203,7 @@ namespace librealsense
             // TODO - need to check mechanical drawing for extrinsic and orientation
             // Bosch BMI055
             // L515 specific - BMI055 assembly transformation based on mechanical drawing (mm)
-            _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.00552f, 0.0051f, 0.01174f } };
+            _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.01245f, 0.01642f, 0.02093f } };
             _imu_2_depth_rot = { { 1,0,0 },{ 0,1,0 },{ 0,0,1 } };
         }
 

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -200,13 +200,13 @@ namespace librealsense
         {
             imu_calib_table = *(ds::check_calib<ds::dm_v2_calibration_table>(raw_data));
 
-            // TODO - parameters will need to check with mechanical drawing
+            // TODO - need to check mechanical drawing for extrinsic and orientation
             // Bosch BMI055
             // L515 specific - BMI055 assembly transformation based on mechanical drawing (mm)
             _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.00552f, 0.0051f, 0.01174f } };
             _imu_2_depth_rot = { { 1,0,0 },{ 0,1,0 },{ 0,0,1 } };
         }
-        l500_imu_calib_parser(const l500_imu_calib_parser&);
+
         virtual ~l500_imu_calib_parser() {}
 
         float3x3 imu_to_depth_alignment() { return _imu_2_depth_rot; }

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -54,26 +54,6 @@ namespace librealsense
         hid_sensor& _ep;
     };
 
-    class enable_motion_correction : public option_base
-    {
-    public:
-        void set(float value) override;
-
-        float query() const override;
-
-        bool is_enabled() const override { return true; }
-
-        const char* get_description() const override
-        {
-            return "Enable/Disable Automatic Motion Data Correction";
-        }
-
-        enable_motion_correction(sensor_base* mm_ep, const option_range& opt_range);
-
-    private:
-        std::atomic<bool>   _is_active;
-    };
-
     class enable_auto_exposure_option : public option_base
     {
     public:

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -560,7 +560,8 @@ namespace librealsense
         enum imu_eeprom_id : uint16_t
         {
             dm_v2_eeprom_id     = 0x0101,   // The pack alignment is Big-endian
-            tm1_eeprom_id       = 0x0002
+            tm1_eeprom_id       = 0x0002,
+            l500_eeprom_id      = 0x0105
         };
 
         struct depth_table_control

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -161,20 +161,20 @@ namespace librealsense
           _accel_stream(new stream(RS2_STREAM_ACCEL)),
          _gyro_stream(new stream(RS2_STREAM_GYRO))
     {
-		_imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
+        _imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
 
-		_mm_calib = std::make_shared<mm_calib_handler>(*_imu_eeprom_raw);
+        _mm_calib = std::make_shared<mm_calib_handler>(*_imu_eeprom_raw);
 
-		_accel_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
-		_gyro_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
-		// use predefined values extrinsics
-		_depth_to_imu = std::make_shared<lazy<rs2_extrinsics>>([this]() { return _mm_calib->get_extrinsic(RS2_STREAM_ACCEL); });
+        _accel_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
+        _gyro_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
+        // use predefined values extrinsics
+        _depth_to_imu = std::make_shared<lazy<rs2_extrinsics>>([this]() { return _mm_calib->get_extrinsic(RS2_STREAM_ACCEL); });
 
-		// Make sure all MM streams are positioned with the same extrinsics
-		environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_accel_stream, _depth_to_imu);
-		environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_accel_stream, *_gyro_stream);
-		register_stream_to_extrinsic_group(*_gyro_stream, 0);
-		register_stream_to_extrinsic_group(*_accel_stream, 0);
+        // Make sure all MM streams are positioned with the same extrinsics
+        environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_accel_stream, _depth_to_imu);
+        environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_accel_stream, *_gyro_stream);
+        register_stream_to_extrinsic_group(*_gyro_stream, 0);
+        register_stream_to_extrinsic_group(*_accel_stream, 0);
 
         auto hid_ep = create_hid_device(ctx, group.hid_devices);
         if (hid_ep)

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -93,6 +93,14 @@ namespace librealsense
         const l500_motion* _owner;
     };
 
+    std::vector<uint8_t> l500_motion::get_imu_eeprom_raw() const
+    {
+        // read imu calibration table on L515
+        // READ_TABLE 0x243 0
+        command cmd(ivcam2::READ_TABLE, 0x243, 0);
+        return _hw_monitor->send(cmd);
+    }
+
     std::shared_ptr<synthetic_sensor> l500_motion::create_hid_device(std::shared_ptr<context> ctx, const std::vector<platform::hid_device_info>& all_hid_infos)
     {
         if (all_hid_infos.empty())
@@ -117,16 +125,32 @@ namespace librealsense
         hid_ep->get_option(RS2_OPTION_GLOBAL_TIME_ENABLED).set(0);
         hid_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
 
+        // register pre-processing
+        bool enable_imu_correction = false;
+        std::shared_ptr<enable_motion_correction> mm_correct_opt = nullptr;
+
+        //  Motion intrinsic calibration presents is a prerequisite for motion correction.
+        try
+        {
+            // Writing to log to dereference underlying structure
+            LOG_INFO("Accel Sensitivity:" << (**_accel_intrinsic).sensitivity);
+            LOG_INFO("Gyro Sensitivity:" << (**_gyro_intrinsic).sensitivity);
+
+            mm_correct_opt = std::make_shared<enable_motion_correction>(hid_ep.get(), option_range{ 0, 1, 1, 1 });
+            hid_ep->register_option(RS2_OPTION_ENABLE_MOTION_CORRECTION, mm_correct_opt);
+        }
+        catch (...) {}
+
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
-            []() { return std::make_shared<acceleration_transform>(); }
+            [&, mm_correct_opt]() { return std::make_shared<acceleration_transform>(_mm_calib, mm_correct_opt); }
         );
 
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
-            []() { return std::make_shared<gyroscope_transform>(); }
+            [&, mm_correct_opt]() { return std::make_shared<gyroscope_transform>(_mm_calib, mm_correct_opt); }
         );
 
         return hid_ep;
@@ -137,6 +161,21 @@ namespace librealsense
           _accel_stream(new stream(RS2_STREAM_ACCEL)),
          _gyro_stream(new stream(RS2_STREAM_GYRO))
     {
+		_imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
+
+		_mm_calib = std::make_shared<mm_calib_handler>(*_imu_eeprom_raw);
+
+		_accel_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
+		_gyro_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
+		// use predefined values extrinsics
+		_depth_to_imu = std::make_shared<lazy<rs2_extrinsics>>([this]() { return _mm_calib->get_extrinsic(RS2_STREAM_ACCEL); });
+
+		// Make sure all MM streams are positioned with the same extrinsics
+		environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_accel_stream, _depth_to_imu);
+		environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_accel_stream, *_gyro_stream);
+		register_stream_to_extrinsic_group(*_gyro_stream, 0);
+		register_stream_to_extrinsic_group(*_accel_stream, 0);
+
         auto hid_ep = create_hid_device(ctx, group.hid_devices);
         if (hid_ep)
         {

--- a/src/l500/l500-motion.h
+++ b/src/l500/l500-motion.h
@@ -8,6 +8,7 @@
 #include "device.h"
 #include "stream.h"
 #include "l500/l500-device.h"
+#include "../ds5/ds5-motion.h"
 
 namespace librealsense
 {
@@ -29,6 +30,14 @@ namespace librealsense
         friend class l500_hid_sensor;
 
         optional_value<uint8_t> _motion_module_device_idx;
+
+        std::vector<uint8_t> get_imu_eeprom_raw() const;
+        lazy<std::vector<uint8_t>> _imu_eeprom_raw;
+
+        std::shared_ptr<mm_calib_handler>        _mm_calib;
+        std::shared_ptr<lazy<ds::imu_intrinsic>> _accel_intrinsic;
+        std::shared_ptr<lazy<ds::imu_intrinsic>> _gyro_intrinsic;
+        std::shared_ptr<lazy<rs2_extrinsics>>   _depth_to_imu;                  // Mechanical installation pose
 
     protected:
         std::shared_ptr<stream_interface> _accel_stream;

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -54,6 +54,7 @@ namespace librealsense
             AMCSET                      = 0x2B, // Set options (L515)
             AMCGET                      = 0x2C, // Get options (L515)
             PFD                         = 0x3B, // Disable power features <Parameter1 Name="0 - Disable, 1 - Enable" />
+            READ_TABLE                  = 0x43, // read table from flash, for example, read imu calibration table, read_table 0x243 0
             DPT_INTRINSICS_GET          = 0x5A,
             TEMPERATURES_GET            = 0x6A,
             DPT_INTRINSICS_FULL_GET     = 0x7F,

--- a/src/option.h
+++ b/src/option.h
@@ -551,4 +551,24 @@ namespace librealsense
        float                   _manual_value;
        std::function<void(const option&)> _recording_function = [](const option&) {};
    };
+
+   class enable_motion_correction : public option_base
+   {
+   public:
+       void set(float value) override;
+
+       float query() const override;
+
+       bool is_enabled() const override { return true; }
+
+       const char* get_description() const override
+       {
+           return "Enable/Disable Automatic Motion Data Correction";
+       }
+
+       enable_motion_correction(sensor_base* mm_ep, const option_range& opt_range);
+
+   private:
+       std::atomic<bool>   _is_active;
+   };
 }

--- a/src/proc/motion-transform.cpp
+++ b/src/proc/motion-transform.cpp
@@ -62,7 +62,6 @@ namespace librealsense
         }
         else
         {
-            // TODO Define L500 base transformation alignment
             _imu2depth_cs_alignment_matrix = { {1,0,0},{0,1,0}, {0,0,1} };
         }
     }


### PR DESCRIPTION
support L515 imu calibration intrinsic and motion correction. both extrinsic and imu orientation parameters to be determined with mechanical team, work in progress, will be in a separate PR.

L515 imu calibration table uses same data format as D435i, but with different version and table id (0x243) as required by L515 FW.