### PR TITLE
L515 IMU intrinsic and extrinsic and motion correction rework

### DIFF
--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -311,14 +311,6 @@ namespace librealsense
         return auto_exposure;
     }
 
-    std::vector<uint8_t> ds5_motion::get_imu_eeprom_raw() const
-    {
-        const int offset = 0;
-        const int size = ds::eeprom_imu_table_size;
-        command cmd(ds::MMER, offset, size);
-        return _hw_monitor->send(cmd);
-    }
-
     ds5_motion::ds5_motion(std::shared_ptr<context> ctx,
                            const platform::backend_device_group& group)
         : device(ctx, group), ds5_device(ctx, group),
@@ -328,9 +320,7 @@ namespace librealsense
     {
         using namespace ds;
 
-        _imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
-
-        _mm_calib = std::make_shared<mm_calib_handler>(*_imu_eeprom_raw,_device_capabilities);
+        _mm_calib = std::make_shared<mm_calib_handler>(_hw_monitor, false, _device_capabilities);
 
         _accel_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
         _gyro_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
@@ -451,10 +441,15 @@ namespace librealsense
         _fisheye_device_idx = add_sensor(fisheye_ep);
     }
 
-    mm_calib_handler::mm_calib_handler(std::vector<uint8_t> imu_raw, ds::d400_caps dev_cap) :
-        _dev_cap(dev_cap)
+    mm_calib_handler::mm_calib_handler(std::shared_ptr<hw_monitor> hw_monitor, bool l515_imu_cal, ds::d400_caps dev_cap) :
+        _hw_monitor(hw_monitor), _l515_table_on_flash(l515_imu_cal), _dev_cap(dev_cap)
     {
-        _imu_eeprom_raw = imu_raw;
+        _imu_eeprom_raw = [this]() {
+            if (_l515_table_on_flash)
+                return get_imu_eeprom_raw_l515();
+            else
+                return get_imu_eeprom_raw();
+        };
 
         _calib_parser = [this]() {
 
@@ -462,9 +457,11 @@ namespace librealsense
             uint16_t calib_id = ds::dm_v2_eeprom_id; //assume DM V2 IMU as default platform
             bool valid = false;
 
+            if (_l515_table_on_flash) calib_id = ds::l500_eeprom_id;
+
             try
             {
-                raw = _imu_eeprom_raw;
+                raw = *_imu_eeprom_raw;
                 calib_id = *reinterpret_cast<uint16_t*>(raw.data());
                 valid = true;
             }
@@ -481,7 +478,7 @@ namespace librealsense
                 case ds::tm1_eeprom_id: // TM1 id
                     prs = std::make_shared<tm1_imu_calib_parser>(raw); break;
                 case ds::l500_eeprom_id: // L515
-                    prs = std::make_shared<l500_imu_calib_parser>(raw); break;
+                    prs = std::make_shared<l500_imu_calib_parser>(raw, valid); break;
                 default:
                     throw recoverable_exception(to_string() << "Motion Intrinsics unresolved - "
                                 << ((valid)? "device is not calibrated" : "invalid calib type "),
@@ -489,6 +486,22 @@ namespace librealsense
             }
             return prs;
         };
+    }
+
+    std::vector<uint8_t> mm_calib_handler::get_imu_eeprom_raw() const
+    {
+        const int offset = 0;
+        const int size = ds::eeprom_imu_table_size;
+        command cmd(ds::MMER, offset, size);
+        return _hw_monitor->send(cmd);
+    }
+
+    std::vector<uint8_t> mm_calib_handler::get_imu_eeprom_raw_l515() const
+    {
+       // read imu calibration table on L515
+       // READ_TABLE 0x243 0
+       command cmd(ds::READ_TABLE, 0x243, 0);
+       return _hw_monitor->send(cmd);
     }
 
     ds::imu_intrinsic mm_calib_handler::get_intrinsic(rs2_stream stream)
@@ -503,7 +516,7 @@ namespace librealsense
 
     const std::vector<uint8_t> mm_calib_handler::get_fisheye_calib_raw()
     {
-        auto fe_calib_table = (*(ds::check_calib<ds::tm1_eeprom>(_imu_eeprom_raw))).calibration_table.calib_model.fe_calibration;
+        auto fe_calib_table = (*(ds::check_calib<ds::tm1_eeprom>(*_imu_eeprom_raw))).calibration_table.calib_model.fe_calibration;
         uint8_t* fe_calib_ptr = reinterpret_cast<uint8_t*>(&fe_calib_table);
         return std::vector<uint8_t>(fe_calib_ptr, fe_calib_ptr+ ds::fisheye_calibration_table_size);
     }

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -196,15 +196,33 @@ namespace librealsense
     class l500_imu_calib_parser : public mm_calib_parser
     {
     public:
-        l500_imu_calib_parser(const std::vector<uint8_t>& raw_data)
+        l500_imu_calib_parser(const std::vector<uint8_t>& raw_data, bool valid = true)
         {
-            imu_calib_table = *(ds::check_calib<ds::dm_v2_calibration_table>(raw_data));
+            // default parser to be applied when no FW calibration is available
+            if (valid)
+                imu_calib_table = *(ds::check_calib<ds::dm_v2_calibration_table>(raw_data));
 
-            // TODO - need to check mechanical drawing for extrinsic and orientation
-            // Bosch BMI055
-            // L515 specific - BMI055 assembly transformation based on mechanical drawing (mm)
-            _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.01245f, 0.01642f, 0.02093f } };
-            _imu_2_depth_rot = { { 1,0,0 },{ 0,1,0 },{ 0,0,1 } };
+            // L515 specific
+            // Bosch BMI085 assembly transformation based on mechanical drawing (meters)
+            // device thickness 26 mm from front glass to back surface
+            // depth ground zero is 4.5mm from front glass into the device
+            // IMU reference in z direction is at 20.93mm from back surface
+            //
+            // IMU offset in Z direction = 4.5 mm - (26 mm - 20.93 mm) = 4.5 mm - 5.07mm = - 0.57mm
+            // IMU offset in x and Y direction (12.45mm, -16.42mm) from center
+            //
+            // coordinate system as reference, looking from back of the camera towards front,
+            // the positive x-axis points to the right, the positive y-axis points down, and the
+            // positive z-axis points forward.
+            // origin in the center but z-direction 4.5mm from front glass into the device
+            // the matrix below is such that output of motion data is consistent with convention
+            // that positive direction aligned with gravity leads to -1g and opposite direction
+            // leads to +1g, for example, positive z_aixs points forward away from front glass of
+            // the device, 1) if place the device flat on a table, facing up, positive z-axis points
+            // up, z-axis acceleration is around +1g; 2) facing down, positive z-axis points down,
+            // z-axis accleration would be around -1g
+            _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ 0.01245f, -0.01642f, -0.00057f } };
+            _imu_2_depth_rot = { { -1.0, 0, 0 },{ 0, 1.0, 0 },{ 0, 0, -1.0 } };
         }
 
         virtual ~l500_imu_calib_parser() {}
@@ -213,6 +231,9 @@ namespace librealsense
 
         ds::imu_intrinsic get_intrinsic(rs2_stream stream)
         {
+            if (1 != imu_calib_table.intrinsic_valid)
+                throw std::runtime_error(to_string() << "Depth Module V2 intrinsic invalidated : " << rs2_stream_to_string(stream) << " !");
+
             ds::dm_v2_imu_intrinsic in_intr;
             switch (stream)
             {
@@ -249,7 +270,7 @@ namespace librealsense
     class mm_calib_handler
     {
     public:
-        mm_calib_handler(std::vector<uint8_t> imu_raw, ds::d400_caps dev_cap = ds::d400_caps::CAP_UNDEFINED);
+        mm_calib_handler(std::shared_ptr<hw_monitor> hw_monitor, bool l515_imu_cal, ds::d400_caps dev_cap = ds::d400_caps::CAP_UNDEFINED);
         ~mm_calib_handler() {}
 
         ds::imu_intrinsic get_intrinsic(rs2_stream);
@@ -258,10 +279,14 @@ namespace librealsense
         float3x3 imu_to_depth_alignment() { return (*_calib_parser)->imu_to_depth_alignment(); }
 
     private:
+        std::shared_ptr<hw_monitor> _hw_monitor;
         ds::d400_caps                   _dev_cap;
         lazy< std::shared_ptr<mm_calib_parser>> _calib_parser;
-        std::vector<uint8_t>      _imu_eeprom_raw;
+        lazy<std::vector<uint8_t>>      _imu_eeprom_raw;
+        std::vector<uint8_t>            get_imu_eeprom_raw() const;
+        std::vector<uint8_t>            get_imu_eeprom_raw_l515() const;
         lazy<std::vector<uint8_t>>      _fisheye_calibration_table_raw;
+        bool _l515_table_on_flash = false;
     };
 
     class ds5_motion : public virtual ds5_device
@@ -288,9 +313,6 @@ namespace librealsense
 
         optional_value<uint8_t> _fisheye_device_idx;
         optional_value<uint8_t> _motion_module_device_idx;
-
-        std::vector<uint8_t> get_imu_eeprom_raw() const;
-        lazy<std::vector<uint8_t>> _imu_eeprom_raw;
 
         std::shared_ptr<mm_calib_handler>        _mm_calib;
         std::shared_ptr<lazy<ds::imu_intrinsic>> _accel_intrinsic;

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -190,6 +190,7 @@ namespace librealsense
             EN_ADV          = 0x2D,     // enable advanced mode
             UAMG            = 0X30,     // get advanced mode status
             PFD             = 0x3b,     // Disable power features <Parameter1 Name="0 - Disable, 1 - Enable" />
+            READ_TABLE      = 0x43,     // read table from flash, for example, read imu calibration table, read_table 0x243 0
             SETAEROI        = 0x44,     // set auto-exposure region of interest
             GETAEROI        = 0x45,     // get auto-exposure region of interest
             MMER            = 0x4F,     // MM EEPROM read ( from DS5 cache )

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -93,26 +93,6 @@ namespace librealsense
         const l500_motion* _owner;
     };
 
-    std::vector<uint8_t> l500_motion::get_imu_eeprom_raw() const
-    {
-        // read imu calibration table on L515
-        // READ_TABLE 0x243 0
-        command cmd(ivcam2::READ_TABLE, 0x243, 0);
-
-        std::vector<uint8_t> res;
-
-        try
-        {
-            res = _hw_monitor->send(cmd);
-        }
-        catch (std::exception &e) {
-            LOG_WARNING(e.what());
-        }
-        catch (...) {}
-
-        return res;
-    }
-
     std::shared_ptr<synthetic_sensor> l500_motion::create_hid_device(std::shared_ptr<context> ctx, const std::vector<platform::hid_device_info>& all_hid_infos)
     {
         if (all_hid_infos.empty())
@@ -138,14 +118,18 @@ namespace librealsense
         hid_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
 
         // register pre-processing
-        bool enable_imu_correction = false;
         std::shared_ptr<enable_motion_correction> mm_correct_opt = nullptr;
 
         //  Motion intrinsic calibration presents is a prerequisite for motion correction.
         try
         {
-            if (_mm_calib)
+            // L515 motion correction with IMU supported from FW version 1.4.0.10
+            if (_fw_version >= firmware_version("1.4.1.0"))
             {
+                // Writing to log to dereference underlying structure
+                LOG_INFO("Accel Sensitivity:" << (**_accel_intrinsic).sensitivity);
+                LOG_INFO("Gyro Sensitivity:" << (**_gyro_intrinsic).sensitivity);
+
                 mm_correct_opt = std::make_shared<enable_motion_correction>(hid_ep.get(), option_range{ 0, 1, 1, 1 });
                 hid_ep->register_option(RS2_OPTION_ENABLE_MOTION_CORRECTION, mm_correct_opt);
             }
@@ -172,17 +156,12 @@ namespace librealsense
           _accel_stream(new stream(RS2_STREAM_ACCEL)),
          _gyro_stream(new stream(RS2_STREAM_GYRO))
     {
-        _imu_eeprom_raw = [this]() { return get_imu_eeprom_raw(); };
+        _mm_calib = std::make_shared<mm_calib_handler>(_hw_monitor, true);
+        _accel_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
+        _gyro_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
 
-        if (!_imu_eeprom_raw->empty())
-        {
-            _mm_calib = std::make_shared<mm_calib_handler>(*_imu_eeprom_raw);
-
-            _accel_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
-            _gyro_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
-            // use predefined values extrinsics
-            _depth_to_imu = std::make_shared<lazy<rs2_extrinsics>>([this]() { return _mm_calib->get_extrinsic(RS2_STREAM_ACCEL); });
-        }
+        // use predefined extrinsics
+        _depth_to_imu = std::make_shared<lazy<rs2_extrinsics>>([this]() { return _mm_calib->get_extrinsic(RS2_STREAM_ACCEL); });
 
         // Make sure all MM streams are positioned with the same extrinsics
         environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_accel_stream, _depth_to_imu);
@@ -208,8 +187,15 @@ namespace librealsense
         return tags;
     }
 
-    rs2_motion_device_intrinsic l500_motion::get_motion_intrinsics(rs2_stream) const
+    rs2_motion_device_intrinsic l500_motion::get_motion_intrinsics(rs2_stream stream) const
     {
-        return rs2_motion_device_intrinsic();
+        if (stream == RS2_STREAM_ACCEL)
+            return create_motion_intrinsics(**_accel_intrinsic);
+
+        if (stream == RS2_STREAM_GYRO)
+            return create_motion_intrinsics(**_gyro_intrinsic);
+
+        throw std::runtime_error(to_string() << "Motion Intrinsics unknown for stream " << rs2_stream_to_string(stream) << "!");
+
     }
 }

--- a/src/l500/l500-motion.h
+++ b/src/l500/l500-motion.h
@@ -23,16 +23,13 @@ namespace librealsense
 
         std::vector<tagged_profile> get_profiles_tags() const override;
 
-        rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
+        rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream stream) const;
 
     private:
 
         friend class l500_hid_sensor;
 
         optional_value<uint8_t> _motion_module_device_idx;
-
-        std::vector<uint8_t> get_imu_eeprom_raw() const;
-        lazy<std::vector<uint8_t>> _imu_eeprom_raw;
 
         std::shared_ptr<mm_calib_handler>        _mm_calib;
         std::shared_ptr<lazy<ds::imu_intrinsic>> _accel_intrinsic;

--- a/tools/rs-imu-calibration/rs-imu-calibration.py
+++ b/tools/rs-imu-calibration/rs-imu-calibration.py
@@ -579,7 +579,7 @@ def main():
         buckets_labels = ["Upright facing out", "USB cable up facing out", "Upside down facing out", "USB cable pointed down", "Viewing direction facing down", "Viewing direction facing up"]
 
         if product_line == 'L500':
-            buckets_labels = ["Mounting Screw Down facing out", "Mounting Screw Right facing out", "Mounting Screw Up facing out", "Mounting Screw Left facing out", "Viewing direction facing up", "Viewing direction facing down"]
+            buckets_labels = ["Mounting screw pointing down, device facing out", "Mounting screw pointing left, device facing out", "Mounting screw pointing up, device facing out", "Mounting screw pointing right, device facing out", "Viewing direction facing down", "Viewing direction facing up"]
 
         gyro_bais = np.zeros(3, np.float32)
         old_settings = None


### PR DESCRIPTION
1) L515 IMU motion correction rework
2) same motion correction option behavior as prior 2.35 release, i.e., on devices without valid intrinsic data, option does not appear. once calibrated, motion correction option would appear automatically.
3) updated extrinsic and calibration script included.