### PR TITLE
L515 IMU Calibration and Motion Correction

### DIFF
--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -463,7 +463,8 @@ namespace librealsense
             }
             catch(const std::exception&)
             {
-                LOG_WARNING("IMU Calibration is not available, see the previous message");
+                // in case calibration table errors (invalid table, empty table, or corrupted table), data is invalid and default intrinsic and extrinsic will be used
+                LOG_WARNING("IMU Calibration is not available, default intrinsic and extrinsic will be used.");
             }
 
             std::shared_ptr<mm_calib_parser> prs = nullptr;

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -150,7 +150,7 @@ namespace librealsense
             else if (_pid == ds::RS455_PID)
             {
                 // D455 specific - Bosch BMI055
-                _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.03022f, -0.0074f, -0.01602f } };
+                _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.03022f, 0.0074f, 0.01602f } };
                 _imu_2_depth_rot = { { -1,0,0 },{ 0,1,0 },{ 0,0,-1 } };
             }
             else if (_pid == ds::RS405_PID)
@@ -299,7 +299,7 @@ namespace librealsense
             // up, z-axis acceleration is around +1g; 2) facing down, positive z-axis points down,
             // z-axis accleration would be around -1g
             rs2_extrinsics _def_extr;
-            _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ 0.01245f, -0.01642f, -0.00057f } };
+            _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ -0.01245f, 0.01642f, 0.00057f } };
             _imu_2_depth_rot = { { -1, 0, 0 },{ 0, 1, 0 },{ 0, 0, -1 } };
 
             // default intrinsic in case no valid calibration data is available

--- a/src/ds5/ds5-motion.h
+++ b/src/ds5/ds5-motion.h
@@ -138,6 +138,8 @@ namespace librealsense
                 }
             }
 
+            // TODO - review possibly refactor into a map if necessary
+            //
             // predefined platform specific extrinsic, IMU assembly transformation based on mechanical drawing (meters)
             rs2_extrinsics _def_extr;
 
@@ -169,9 +171,12 @@ namespace librealsense
             }
             else // unmapped configurations
             {
+                // IMU on new devices is oriented such that FW output is consistent with D435i
+                // use same rotation matrix as D435i so that librealsense output from unsupported
+                // devices will still be correctly aligned with depth coordinate system.
                 _def_extr = { { 1, 0, 0, 0, 1, 0, 0, 0, 1 },{ 0.f, 0.f, 0.f } };
                 _imu_2_depth_rot = { { -1,0,0 },{ 0,1,0 },{ 0,0,-1 } };
-                LOG_ERROR("Undefined platform with IMU, use default intrinsic/extrinsic data");
+                LOG_ERROR("Undefined platform with IMU, use default intrinsic/extrinsic data, PID: " << _pid);
             }
 
             // default intrinsic in case no valid calibration data is available

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -54,26 +54,6 @@ namespace librealsense
         hid_sensor& _ep;
     };
 
-    class enable_motion_correction : public option_base
-    {
-    public:
-        void set(float value) override;
-
-        float query() const override;
-
-        bool is_enabled() const override { return true; }
-
-        const char* get_description() const override
-        {
-            return "Enable/Disable Automatic Motion Data Correction";
-        }
-
-        enable_motion_correction(sensor_base* mm_ep, const option_range& opt_range);
-
-    private:
-        std::atomic<bool>   _is_active;
-    };
-
     class enable_auto_exposure_option : public option_base
     {
     public:

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -190,7 +190,6 @@ namespace librealsense
             EN_ADV          = 0x2D,     // enable advanced mode
             UAMG            = 0X30,     // get advanced mode status
             PFD             = 0x3b,     // Disable power features <Parameter1 Name="0 - Disable, 1 - Enable" />
-            READ_TABLE      = 0x43,     // read table from flash, for example, read imu calibration table, read_table 0x243 0
             SETAEROI        = 0x44,     // set auto-exposure region of interest
             GETAEROI        = 0x45,     // get auto-exposure region of interest
             MMER            = 0x4F,     // MM EEPROM read ( from DS5 cache )

--- a/src/ds5/ds5-private.h
+++ b/src/ds5/ds5-private.h
@@ -190,6 +190,7 @@ namespace librealsense
             EN_ADV          = 0x2D,     // enable advanced mode
             UAMG            = 0X30,     // get advanced mode status
             PFD             = 0x3b,     // Disable power features <Parameter1 Name="0 - Disable, 1 - Enable" />
+            READ_TABLE      = 0x43,     // read table from flash, for example, read imu calibration table, read_table 0x243 0
             SETAEROI        = 0x44,     // set auto-exposure region of interest
             GETAEROI        = 0x45,     // get auto-exposure region of interest
             MMER            = 0x4F,     // MM EEPROM read ( from DS5 cache )
@@ -561,7 +562,8 @@ namespace librealsense
         enum imu_eeprom_id : uint16_t
         {
             dm_v2_eeprom_id     = 0x0101,   // The pack alignment is Big-endian
-            tm1_eeprom_id       = 0x0002
+            tm1_eeprom_id       = 0x0002,
+            l500_eeprom_id      = 0x0105
         };
 
         struct depth_table_control

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -123,7 +123,7 @@ namespace librealsense
         //  Motion intrinsic calibration presents is a prerequisite for motion correction.
         try
         {
-            // L515 motion correction with IMU supported from FW version 1.4.0.10
+            // L515 motion correction with IMU supported from FW version 01.04.01.00
             if (_fw_version >= firmware_version("1.4.1.0"))
             {
                 mm_correct_opt = std::make_shared<enable_motion_correction>(hid_ep.get(), option_range{ 0, 1, 1, 1 });

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -117,16 +117,31 @@ namespace librealsense
         hid_ep->get_option(RS2_OPTION_GLOBAL_TIME_ENABLED).set(0);
         hid_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);
 
+        // register pre-processing
+        std::shared_ptr<enable_motion_correction> mm_correct_opt = nullptr;
+
+        //  Motion intrinsic calibration presents is a prerequisite for motion correction.
+        try
+        {
+            // L515 motion correction with IMU supported from FW version 1.4.0.10
+            if (_fw_version >= firmware_version("1.4.1.0"))
+            {
+                mm_correct_opt = std::make_shared<enable_motion_correction>(hid_ep.get(), option_range{ 0, 1, 1, 1 });
+                hid_ep->register_option(RS2_OPTION_ENABLE_MOTION_CORRECTION, mm_correct_opt);
+            }
+        }
+        catch (...) {}
+
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
-            []() { return std::make_shared<acceleration_transform>(); }
+            [&, mm_correct_opt]() { return std::make_shared<acceleration_transform>(_mm_calib, mm_correct_opt); }
         );
 
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
-            []() { return std::make_shared<gyroscope_transform>(); }
+            [&, mm_correct_opt]() { return std::make_shared<gyroscope_transform>(_mm_calib, mm_correct_opt); }
         );
 
         return hid_ep;
@@ -137,6 +152,19 @@ namespace librealsense
           _accel_stream(new stream(RS2_STREAM_ACCEL)),
          _gyro_stream(new stream(RS2_STREAM_GYRO))
     {
+        _mm_calib = std::make_shared<mm_calib_handler>(_hw_monitor, true);
+        _accel_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_ACCEL); });
+        _gyro_intrinsic = std::make_shared<lazy<ds::imu_intrinsic>>([this]() { return _mm_calib->get_intrinsic(RS2_STREAM_GYRO); });
+
+        // use predefined extrinsics
+        _depth_to_imu = std::make_shared<lazy<rs2_extrinsics>>([this]() { return _mm_calib->get_extrinsic(RS2_STREAM_ACCEL); });
+
+        // Make sure all MM streams are positioned with the same extrinsics
+        environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_accel_stream, _depth_to_imu);
+        environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_accel_stream, *_gyro_stream);
+        register_stream_to_extrinsic_group(*_gyro_stream, 0);
+        register_stream_to_extrinsic_group(*_accel_stream, 0);
+
         auto hid_ep = create_hid_device(ctx, group.hid_devices);
         if (hid_ep)
         {
@@ -155,8 +183,15 @@ namespace librealsense
         return tags;
     }
 
-    rs2_motion_device_intrinsic l500_motion::get_motion_intrinsics(rs2_stream) const
+    rs2_motion_device_intrinsic l500_motion::get_motion_intrinsics(rs2_stream stream) const
     {
-        return rs2_motion_device_intrinsic();
+        if (stream == RS2_STREAM_ACCEL)
+            return create_motion_intrinsics(**_accel_intrinsic);
+
+        if (stream == RS2_STREAM_GYRO)
+            return create_motion_intrinsics(**_gyro_intrinsic);
+
+        throw std::runtime_error(to_string() << "Motion Intrinsics unknown for stream " << rs2_stream_to_string(stream) << "!");
+
     }
 }

--- a/src/l500/l500-motion.h
+++ b/src/l500/l500-motion.h
@@ -36,6 +36,8 @@ namespace librealsense
         std::shared_ptr<lazy<ds::imu_intrinsic>> _gyro_intrinsic;
         std::shared_ptr<lazy<rs2_extrinsics>>   _depth_to_imu;                  // Mechanical installation pose
 
+        uint16_t _pid;    // product PID
+
     protected:
         std::shared_ptr<stream_interface> _accel_stream;
         std::shared_ptr<stream_interface> _gyro_stream;

--- a/src/l500/l500-motion.h
+++ b/src/l500/l500-motion.h
@@ -8,6 +8,7 @@
 #include "device.h"
 #include "stream.h"
 #include "l500/l500-device.h"
+#include "../ds5/ds5-motion.h"
 
 namespace librealsense
 {
@@ -22,13 +23,18 @@ namespace librealsense
 
         std::vector<tagged_profile> get_profiles_tags() const override;
 
-        rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
+        rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream stream) const;
 
     private:
 
         friend class l500_hid_sensor;
 
         optional_value<uint8_t> _motion_module_device_idx;
+
+        std::shared_ptr<mm_calib_handler>        _mm_calib;
+        std::shared_ptr<lazy<ds::imu_intrinsic>> _accel_intrinsic;
+        std::shared_ptr<lazy<ds::imu_intrinsic>> _gyro_intrinsic;
+        std::shared_ptr<lazy<rs2_extrinsics>>   _depth_to_imu;                  // Mechanical installation pose
 
     protected:
         std::shared_ptr<stream_interface> _accel_stream;

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -39,6 +39,8 @@ namespace librealsense
 
         const int REGISTER_CLOCK_0 = 0x9003021c;
 
+        const uint16_t L515_IMU_TABLE   = 0x0243;  // IMU calibration table on L515
+
         enum fw_cmd : uint8_t
         {
             MRD                         = 0x01, //"Read Tensilica memory ( 32bit ). Output : 32bit dump"
@@ -54,6 +56,7 @@ namespace librealsense
             AMCSET                      = 0x2B, // Set options (L515)
             AMCGET                      = 0x2C, // Get options (L515)
             PFD                         = 0x3B, // Disable power features <Parameter1 Name="0 - Disable, 1 - Enable" />
+            READ_TABLE                  = 0x43, // read table from flash, for example, read imu calibration table, read_table 0x243 0
             DPT_INTRINSICS_GET          = 0x5A,
             TEMPERATURES_GET            = 0x6A,
             DPT_INTRINSICS_FULL_GET     = 0x7F,

--- a/src/option.h
+++ b/src/option.h
@@ -551,4 +551,24 @@ namespace librealsense
        float                   _manual_value;
        std::function<void(const option&)> _recording_function = [](const option&) {};
    };
+
+   class enable_motion_correction : public option_base
+   {
+   public:
+       void set(float value) override;
+
+       float query() const override;
+
+       bool is_enabled() const override { return true; }
+
+       const char* get_description() const override
+       {
+           return "Enable/Disable Automatic Motion Data Correction";
+       }
+
+       enable_motion_correction(sensor_base* mm_ep, const option_range& opt_range);
+
+   private:
+       std::atomic<bool>   _is_active;
+   };
 }

--- a/src/proc/motion-transform.cpp
+++ b/src/proc/motion-transform.cpp
@@ -62,7 +62,6 @@ namespace librealsense
         }
         else
         {
-            // TODO Define L500 base transformation alignment
             _imu2depth_cs_alignment_matrix = { {1,0,0},{0,1,0}, {0,0,1} };
         }
     }

--- a/tools/rs-imu-calibration/README.md
+++ b/tools/rs-imu-calibration/README.md
@@ -30,7 +30,7 @@ The script runs you through the 6 main orientations of the camera.
 For each direction there are the following steps:
 *	**Rotation:**<br>
   *	The script prints the following line, describing how to orient the camera:<br>
-`Align to direction:  [ 0. -1.  0.]   Upright facing out`<br>
+`Align to direction:  [ 0. -1.  0.]   Mounting screw pointing down, device facing out`<br>
   *	Then it prints the status (rotate) and the difference from the desired orientation:<br>
   `Status.rotate:           [ 1.0157 -0.1037  0.9945]:                 [False False False]`<br>
   *	You have to bring the numbers to [0,0,0] and then you are in the right direction and the script moves on to the next status.<br><br>
@@ -60,6 +60,7 @@ That’s it. At the end a confirmation message appears:<br>
 `SUCCESS: saved calibration to camera.`
 
 **NOTICE:**<br>
+Press ESC key to abort the calibration process.
 CTRL-C isn’t working so press CTRL-Z and then `kill -9 %1` if you want to terminate in the middle…
 
 **Appendix A:**<br>

--- a/tools/rs-imu-calibration/rs-imu-calibration.py
+++ b/tools/rs-imu-calibration/rs-imu-calibration.py
@@ -588,10 +588,16 @@ def main():
                 [0,  g,  0], [-g,  0, 0],
                 [0,  0, -g], [ 0,  0, g]]
 
-        buckets_labels = ["Upright facing out", "USB cable up facing out", "Upside down facing out", "USB cable pointed down", "Viewing direction facing down", "Viewing direction facing up"]
-
-        if product_line == 'L500':
-            buckets_labels = ["Mounting screw pointing down, device facing out", "Mounting screw pointing left, device facing out", "Mounting screw pointing up, device facing out", "Mounting screw pointing right, device facing out", "Viewing direction facing down", "Viewing direction facing up"]
+        # all D400 and L500 cameras with IMU equipped with a mounting screw at the bottom of the device
+        # when device is in normal use position upright facing out, mount screw is pointing down, aligned with positive Y direction in depth coordinate system
+        # IMU output on each of these devices is transformed into the depth coordinate system, i.e.,
+        # looking from back of the camera towards front, the positive x-axis points to the right, the positive y-axis points down, and the positive z-axis points forward.
+        # output of motion data is consistent with convention that positive direction aligned with gravity leads to -1g and opposite direction leads to +1g, for example,
+        # positive z_aixs points forward away from front glass of the device,
+        #  1) if place the device flat on a table, facing up, positive z-axis points up, z-axis acceleration is around +1g
+        #  2) facing down, positive z-axis points down, z-axis accleration would be around -1g
+        #
+        buckets_labels = ["Mounting screw pointing down, device facing out", "Mounting screw pointing left, device facing out", "Mounting screw pointing up, device facing out", "Mounting screw pointing right, device facing out", "Viewing direction facing down", "Viewing direction facing up"]
 
         gyro_bais = np.zeros(3, np.float32)
         old_settings = None

--- a/tools/rs-imu-calibration/rs-imu-calibration.py
+++ b/tools/rs-imu-calibration/rs-imu-calibration.py
@@ -579,7 +579,7 @@ def main():
         buckets_labels = ["Upright facing out", "USB cable up facing out", "Upside down facing out", "USB cable pointed down", "Viewing direction facing down", "Viewing direction facing up"]
 
         if product_line == 'L500':
-            buckets_labels = ["Mounting Screw Down facing out", "Mounting Screw Right facing out", "Mounting Screw Up facing out", "Mounting Screw Left facing out", "Viewing direction facing up", "Viewing direction facing down"]
+            buckets_labels = ["Mounting screw pointing down, device facing out", "Mounting screw pointing left, device facing out", "Mounting screw pointing up, device facing out", "Mounting screw pointing right, device facing out", "Viewing direction facing down", "Viewing direction facing up"]
 
         gyro_bais = np.zeros(3, np.float32)
         old_settings = None


### PR DESCRIPTION
1) support L515 IMU calibration and motion correction
2) updated L515 extrinsic
3) keep lazy design, use default intrinsic in case valid calibration data is not available on device
4) calibration instruction aligned for all D400 and L515 devices with IMU
Tracked on: RS5-7834