### PR TITLE
travis-ci update nodeJs version to  10.15.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
       sudo: required
       dist: xenial
       python: "2.7"
-      node_js: "6"
+      node_js: "10"
       env: LRS_BUILD_NODEJS=true
       script:
         - cmake .. -DBUILD_PYTHON_BINDINGS=true -DBUILD_NODEJS_BINDINGS=true -DPYBIND11_PYTHON_VERSION=2.7 -DCHECK_FOR_UPDATES=true
@@ -100,7 +100,8 @@ matrix:
 before_install:
   - cd scripts && ./api_check.sh && cd ..
   - if [[ "$LRS_BUILD_NODEJS" == "true" ]]; then
-      nvm use 6;
+      nvm install 10.15.3;
+      nvm use 10.15.3;
       npm install -g node-gyp;
       npm install -g mocha;
       git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git;


### PR DESCRIPTION
regression on travis-cs nodeJs build,
mocha latest verison no longer support NodeJs version 6

https://github.com/mochajs/mocha/releases
#4164: Mocha v8.0.0 now requires Node.js v10.0.0 or newer. Mocha no longer supports the Node.js v8.x line ("Carbon"), which entered End-of-Life at the end of 2019
 