### PR TITLE
L500 device - block return to visual preset default option + cancel max_range on stream start

### DIFF
--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -334,32 +334,6 @@ namespace librealsense
             auto dp = std::find_if(requests.begin(), requests.end(), [](std::shared_ptr<stream_profile_interface> sp)
             {return sp->get_stream_type() == RS2_STREAM_DEPTH;});
 
-            if( supports_option( RS2_OPTION_VISUAL_PRESET ) )
-            {
-                // We want to set the default preset to Max Range (make sure laser power is 100%)
-                // NOTE: This becomes the "default", meaning that in the viewer the user will see "default"
-                // (with power at 88, set by FW!) and, when the sensor is turned on, it will change to Max
-                // Power (with power at 100, again by FW). It's weird but acceptable.
-                // (see RS5-7780)
-                try
-                {
-                    auto&& preset_option = get_option( RS2_OPTION_VISUAL_PRESET );
-                    if( preset_option.query() == RS2_L500_VISUAL_PRESET_DEFAULT )
-                    {
-                        LOG_INFO( "Switching visual preset to MAX_RANGE by default" );
-                        preset_option.set( RS2_L500_VISUAL_PRESET_MAX_RANGE );
-                    }
-                }
-                catch( std::exception const & e )
-                {
-                    LOG_ERROR( "Caught exception while trying to set Max Range preset: " << e.what() );
-                }
-                catch( ... )
-                {
-                    LOG_ERROR( "Caught unknown exception while trying to set Max Range preset!" );
-                }
-            }
-
             if (dp != requests.end() && supports_option(RS2_OPTION_SENSOR_MODE))
             {
                 auto&& sensor_mode_option = get_option(RS2_OPTION_SENSOR_MODE);

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -166,7 +166,7 @@ namespace librealsense
             move_to_custom();
             break;
         case RS2_L500_VISUAL_PRESET_DEFAULT:
-            LOG_ERROR("the API does not allow changing visual preset back to default");
+            LOG_ERROR("changing back to default is disabled by design");
             throw  invalid_value_exception(to_string() << "the Default preset signifies that the controls have not been changed \n"
                                                            "since initialization, the API does not support changing back to this state.\n"
                                                            "Please choose one of the other presets");

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -142,7 +142,8 @@ namespace librealsense
 
     void l500_options::change_preset(rs2_l500_visual_preset preset)
     {
-        if (preset != RS2_L500_VISUAL_PRESET_CUSTOM)
+        if ((preset != RS2_L500_VISUAL_PRESET_CUSTOM) &&
+            (preset != RS2_L500_VISUAL_PRESET_DEFAULT))
             reset_hw_controls();
 
         switch (preset)
@@ -163,6 +164,11 @@ namespace librealsense
             break;
         case RS2_L500_VISUAL_PRESET_CUSTOM:
             move_to_custom();
+            break;
+        case RS2_L500_VISUAL_PRESET_DEFAULT:
+            throw  invalid_value_exception(to_string() << "the Default preset signifies that the controls have not been changed \n"
+                                                           "since initialization, the API does not support changing back to this state.\n"
+                                                           "Please choose one of the other presets");
             break;
         default: break;
         };

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -166,8 +166,8 @@ namespace librealsense
             move_to_custom();
             break;
         case RS2_L500_VISUAL_PRESET_DEFAULT:
-            LOG_ERROR("changing back to default is disabled by design");
-            throw  invalid_value_exception(to_string() << "the Default preset signifies that the controls have not been changed \n"
+            LOG_ERROR("L515 Visual Preset option cannot be changed to Default");
+            throw  invalid_value_exception(to_string() << "The Default preset signifies that the controls have not been changed \n"
                                                            "since initialization, the API does not support changing back to this state.\n"
                                                            "Please choose one of the other presets");
             break;

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -166,6 +166,7 @@ namespace librealsense
             move_to_custom();
             break;
         case RS2_L500_VISUAL_PRESET_DEFAULT:
+            LOG_ERROR("the API does not allow changing visual preset back to default");
             throw  invalid_value_exception(to_string() << "the Default preset signifies that the controls have not been changed \n"
                                                            "since initialization, the API does not support changing back to this state.\n"
                                                            "Please choose one of the other presets");


### PR DESCRIPTION
**System requirement** - When the user try to return to visual preset "Default" he will get an error on the viewer + exception on the API
![image](https://user-images.githubusercontent.com/64067618/84887452-6db32600-b09e-11ea-837b-881c3203a5f8.png)

Tracked on: RS5-7898

