### PR TITLE
Eliminate multiple MSVC warnings

### DIFF
--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -196,7 +196,7 @@ namespace rs2
 
             auto flash = upd.create_flash_backup([&](const float progress)
             {
-                _progress = ((ceil(progress * 5) / 5) * (30 - next_progress)) + next_progress;
+                _progress = int((ceil(progress * 5) / 5) * (30 - next_progress)) + next_progress;
             });
 
             auto temp = get_folder_path(special_folder::app_data);
@@ -221,7 +221,7 @@ namespace rs2
                 if (!check_for([this, serial, &dfu]() {
                     auto devs = _ctx.query_devices();
 
-                    for (int j = 0; j < devs.size(); j++)
+                    for (uint32_t j = 0; j < devs.size(); j++)
                     {
                         try
                         {
@@ -267,7 +267,7 @@ namespace rs2
 
             dfu.update(_fw, [&](const float progress)
             {
-                _progress = (ceil(progress * 10) / 10 * (90 - next_progress)) + next_progress;
+                _progress = int((ceil(progress * 10) / 10 * (90 - next_progress)) + next_progress);
             });
 
             log("Firmware Download completed, await DFU transition event");
@@ -279,7 +279,7 @@ namespace rs2
             auto upd = _dev.as<updatable>();
             upd.update_unsigned(_fw, [&](const float progress)
             {
-                _progress = (ceil(progress * 10) / 10 * (90 - next_progress)) + next_progress;
+                _progress = int((ceil(progress * 10) / 10 * (90 - next_progress)) + next_progress);
             });
             log("Firmware Update completed, waiting for device to reconnect");
         }
@@ -287,7 +287,7 @@ namespace rs2
         if (!check_for([this, serial, &dfu]() {
             auto devs = _ctx.query_devices();
 
-            for (int j = 0; j < devs.size(); j++)
+            for (uint32_t j = 0; j < devs.size(); j++)
             {
                 try
                 {
@@ -341,7 +341,7 @@ namespace rs2
 
             ImGui::SetCursorScreenPos({ float(x + 9), float(y + height - 67) });
 
-            ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1. - t));
+            ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1.f - t));
 
             if (update_state == RS2_FWU_STATE_INITIAL_PROMPT)
                 ImGui::Text("Firmware updates offer critical bug fixes and\nunlock new camera capabilities.");

--- a/common/measurement.cpp
+++ b/common/measurement.cpp
@@ -85,8 +85,8 @@ void measurement::add_point(interest_point p)
             state.polygons.clear();
         }
 
-        int last = state.points.size();
-        if (current_hovered_point == -1 || 
+        int last = int(state.points.size());
+        if (current_hovered_point == -1 ||
             current_hovered_point >= state.points.size())
         {
             state.points.push_back(p);
@@ -122,7 +122,7 @@ void measurement::add_point(interest_point p)
             log_function(to_string() << "Measured distance of " << length_to_string(dist.length()));
         }
 
-        last_hovered_point = state.points.size() - 1;
+        last_hovered_point = int(state.points.size() - 1);
 
         commit_state();
     }
@@ -186,18 +186,18 @@ void draw_sphere(const float3& pos, float r, int lats, int longs)
 {
     for(int i = 0; i <= lats; i++) 
     {
-        float lat0 = M_PI * (-0.5 + (float) (i - 1) / lats);
+        float lat0 = float(M_PI) * (-0.5f + (float) (i - 1) / lats);
         float z0  = sin(lat0);
         float zr0 =  cos(lat0);
 
-        float lat1 = M_PI * (-0.5 + (float) i / lats);
+        float lat1 = float(M_PI) * (-0.5f + (float) i / lats);
         float z1 = sin(lat1);
         float zr1 = cos(lat1);
 
         glBegin(GL_QUAD_STRIP);
         for(int j = 0; j <= longs; j++) 
         {
-            float lng = 2 * M_PI * (float) (j - 1) / longs;
+            float lng = 2.f * float(M_PI) * (float) (j - 1) / longs;
             float x = cos(lng);
             float y = sin(lng);
 
@@ -305,7 +305,7 @@ void measurement::draw_ruler(ux_window& win, float3 from, float3 to, float heigh
         // calculate center of the ruler line
         float3 ctr = from + (to - from) / 2;
         float distance = (to - from).length();
-        draw_label(win, ctr, distance, height);
+        draw_label(win, ctr, distance, int(height));
     }
 }
 
@@ -352,7 +352,7 @@ void measurement::update_input(ux_window& win, const rs2::rect& viewer_rect)
             if (rect_copy.contains(win.get_mouse().cursor))
             {
                 input_ctrl.click = true;
-                input_ctrl.click_time = glfwGetTime();
+                input_ctrl.click_time = float(glfwGetTime());
             }
         }
     }
@@ -478,8 +478,8 @@ void measurement::draw(ux_window& win)
         const int segments = 50;
         for (int i = 0; i < segments; i++)
         {
-            auto t1 = 2 * M_PI * ((float)i / segments);
-            auto t2 = 2 * M_PI * ((float)(i+1) / segments);
+            auto t1 = 2.f * float(M_PI) * ((float)i / segments);
+            auto t2 = 2.f * float(M_PI) * ((float)(i+1) / segments);
             float4 xy1 { cosf(t1) * size, sinf(t1) * size, 0.f, 1.f };
             xy1 = basis * xy1;
             xy1 = float4 { _picked.x + xy1.x, _picked.y + xy1.y, _picked.z  + xy1.z, 1.f };
@@ -556,7 +556,7 @@ void measurement::draw(ux_window& win)
 
         auto area = calculate_area(points);
 
-        draw_label(win, mid, area, win.framebuf_height(), true);
+        draw_label(win, mid, area, int(win.framebuf_height()), true);
     }
 
     for (int i = 0; i < state.edges.size(); i++)

--- a/common/measurement.h
+++ b/common/measurement.h
@@ -96,8 +96,8 @@ namespace rs2
             double selection_started = 0.0;
             float2 down_pos { 0.f, 0.f };
             int mouse_wheel = 0;
-            double click_time = 0.0;
-            float click_period() { return clamp((glfwGetTime() - click_time) * 10, 0.f, 1.f); }
+            float click_time = 0.f;
+            float click_period() { return clamp(float(glfwGetTime() - click_time) * 10, 0.f, 1.f); }
         };
         mouse_control input_ctrl;
         int id = 0;

--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -118,7 +118,7 @@ namespace rs2
                         &cbSecurityDescriptor,   // security descriptor 
                         &ftLastWriteTime);       // last write time 
 
-                    for (int i = 0; i < cSubKeys; i++)
+                    for (auto i = 0ul; i < cSubKeys; i++)
                     {
                         TCHAR achKey[MAX_KEY_LENGTH];
                         DWORD cbName = MAX_KEY_LENGTH;
@@ -133,7 +133,8 @@ namespace rs2
                         {
                             std::wstring suffix = achKey;
                             device_id rdid;
-                            if (parse_device_id(std::string(suffix.begin(), suffix.end()), &rdid))
+                            auto a = std::string(suffix.begin(), suffix.end());
+                            if (parse_device_id(a, &rdid))
                             {
                                 for (auto&& did : kvp.second)
                                 {
@@ -223,6 +224,7 @@ namespace rs2
                         CloseHandle(sei.hProcess);
                         if (exitCode)
                             throw std::runtime_error("Failed to set metadata registry keys!");
+                        return true;
                     }
                 }
                 else
@@ -287,7 +289,7 @@ namespace rs2
 
                 rs2::context ctx;
                 auto list = ctx.query_devices();
-                for (int i = 0; i < list.size(); i++)
+                for (uint32_t i = 0; i < list.size(); i++)
                 {
                     try
                     {

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1131,7 +1131,7 @@ namespace rs2
                 {
                     s->set_option( RS2_OPTION_SENSOR_MODE, resolution_from_width_height( res_values[ui.selected_res_id].first, res_values[ui.selected_res_id].second ) );
                 }
-                catch( not_implemented_error const & e )
+                catch( not_implemented_error const &)
                 {
                     // Just ignore for now: need to figure out a way to write to playback sensors...
                 }
@@ -1240,7 +1240,7 @@ namespace rs2
                         auto height = res_values[ui.selected_res_id].second;
                         auto res = resolution_from_width_height(width, height);
                         if (res >= RS2_SENSOR_MODE_VGA && res < RS2_SENSOR_MODE_COUNT)
-                            s->set_option(RS2_OPTION_SENSOR_MODE, res);
+                            s->set_option(RS2_OPTION_SENSOR_MODE, float(res));
                     }
                 }
                 ImGui::PopStyleColor();

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -135,7 +135,7 @@ namespace rs2
                 auto a = curr_progress_value / 100.f;
                 ImGui::GetWindowDrawList()->AddRectFilled({ float(pos.x + 3 - i), float(pos.y + 3 - i) },
                 { float(pos.x + filled_w + i), float(pos.y + 17 + i) },
-                    ImColor(alpha(light_blue, sqrt(a) * 0.02f)), i);
+                    ImColor(alpha(light_blue, sqrt(a) * 0.02f)), float(i));
             }
 
             ImGui::GetWindowDrawList()->AddRectFilled({ float(pos.x + 3), float(pos.y + 3) },
@@ -170,9 +170,9 @@ namespace rs2
     {
         ImVec4 c;
 
-        ImGui::PushStyleColor(ImGuiCol_Button, saturate(c, 1.3));
-        ImGui::PushStyleColor(ImGuiCol_ButtonActive, saturate(c, 0.9));
-        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(c, 1.5));
+        ImGui::PushStyleColor(ImGuiCol_Button, saturate(c, 1.3f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonActive, saturate(c, 0.9f));
+        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(c, 1.5f));
         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, white);
         c = alpha(white, 1 - t);
         ImGui::PushStyleColor(ImGuiCol_Text, c);
@@ -198,7 +198,7 @@ namespace rs2
     void notification_model::draw_text(const char* msg, int x, int y, int h)
     {
         std::string text_name = to_string() << "##notification_text_" << index;
-        ImGui::PushTextWrapPos(x + width - 100);
+        ImGui::PushTextWrapPos(x + width - 100.f);
         ImGui::PushStyleColor(ImGuiCol_FrameBg, transparent);
         ImGui::PushStyleColor(ImGuiCol_ScrollbarBg, transparent);
         ImGui::PushStyleColor(ImGuiCol_ScrollbarGrab, transparent);
@@ -232,7 +232,7 @@ namespace rs2
     {
         auto title = get_title();
         auto lines = static_cast<int>(std::count(title.begin(), title.end(), '\n') + 1);
-        return (lines + 1) * ImGui::GetTextLineHeight() + 5;
+        return int((lines + 1) * ImGui::GetTextLineHeight() + 5);
     }
 
     void process_notification_model::draw_pre_effect(int x, int y)
@@ -333,8 +333,8 @@ namespace rs2
             {
                 if (last_x > 100000)
                 {
-                    last_x = x + 500;
-                    last_y = y;
+                    last_x = x + 500.f;
+                    last_y = float(y);
                 }
                 last_moved = system_clock::now();
                 animating = true;
@@ -345,12 +345,12 @@ namespace rs2
 
             if (s < 1.f)
             {
-                x = s * x + (1 - s) * last_x;
-                y = s * y + (1 - s) * last_y;
+                x = int(s * x + (1 - s) * last_x);
+                y = int(s * y + (1 - s) * last_y);
             }
             else
             {
-                last_x = x; last_y = y;
+                last_x = float(x); last_y = float(y);
                 animating = false;
                 if (dismissed && !expanded) to_close = true;
             }
@@ -939,7 +939,7 @@ namespace rs2
 
             ImGui::SetCursorScreenPos({ float(x + 10), float(y + 35) });
 
-            ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1. - t));
+            ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1.f - t));
 
             std::string s = to_string() << "Saving 3D view to " <<
                 get_file_name(get_manager().get_filename());

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -320,9 +320,9 @@ namespace rs2
 
         auto calib_dev = _dev.as<auto_calibrated_device>();
         if (tare)
-            _new_calib = calib_dev.run_tare_calibration(ground_truth, json, [&](const float progress) {_progress = progress;}, 5000);
+            _new_calib = calib_dev.run_tare_calibration(ground_truth, json, [&](const float progress) {_progress = int(progress);}, 5000);
         else
-            _new_calib = calib_dev.run_on_chip_calibration(json, &_health, [&](const float progress) {_progress = progress;}, 5000);
+            _new_calib = calib_dev.run_on_chip_calibration(json, &_health, [&](const float progress) {_progress = int(progress);}, 5000);
     }
 
     void on_chip_calib_manager::process_flow(std::function<void()> cleanup, 
@@ -393,7 +393,7 @@ namespace rs2
 
             _viewer.is_3d_view = _in_3d_view;
 
-            _viewer.ground_truth_r = ground_truth;
+            _viewer.ground_truth_r = uint32_t(ground_truth);
             config_file::instance().set(configurations::viewer::ground_truth_r, ground_truth);
 
             _viewer.synchronization_enable = _synchronized;
@@ -516,7 +516,7 @@ namespace rs2
             else
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + 27) });
 
-            ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1. - t));
+            ImGui::PushStyleColor(ImGuiCol_Text, alpha(light_grey, 1.f - t));
 
             if (update_state == RS2_CALIB_STATE_INITIAL_PROMPT)
             {
@@ -570,7 +570,7 @@ namespace rs2
                     ImGui::SetCursorScreenPos({ float(x + 135), float(y + 30) });
 
                     std::string id = to_string() << "##avg_step_count_" << index;
-                    ImGui::PushItemWidth(width - 145);
+                    ImGui::PushItemWidth(width - 145.f);
                     ImGui::SliderInt(id.c_str(), &get_manager().average_step_count, 1, 30);
                     ImGui::PopItemWidth();
 
@@ -586,7 +586,7 @@ namespace rs2
 
                     id = to_string() << "##step_count_" << index;
 
-                    ImGui::PushItemWidth(width - 145);
+                    ImGui::PushItemWidth(width - 145.f);
                     ImGui::SliderInt(id.c_str(), &get_manager().step_count, 1, 30);
                     ImGui::PopItemWidth();
 
@@ -607,14 +607,14 @@ namespace rs2
                     std::vector<const char*> vals_cstr;
                     for (auto&& s : vals) vals_cstr.push_back(s.c_str());
 
-                    ImGui::PushItemWidth(width - 145);
-                    ImGui::Combo(id.c_str(), &get_manager().accuracy, vals_cstr.data(), vals.size());
-                   
+                    ImGui::PushItemWidth(width - 145.f);
+                    ImGui::Combo(id.c_str(), &get_manager().accuracy, vals_cstr.data(), int(vals.size()));
+
                     ImGui::SetCursorScreenPos({ float(x + 135), float(y + 35 + ImGui::GetTextLineHeightWithSpacing()) });
 
                     ImGui::PopItemWidth();
 
-                    draw_intrinsic_extrinsic(x, y + 3 * ImGui::GetTextLineHeightWithSpacing() - 10);
+                    draw_intrinsic_extrinsic(x, y + 3 * int(ImGui::GetTextLineHeightWithSpacing()) - 10);
 
                     ImGui::SetCursorScreenPos({ float(x + 9), float(y + 52 + 4 * ImGui::GetTextLineHeightWithSpacing()) });
                     id = to_string() << "Apply High-Accuracy Preset##apply_preset_" << index;
@@ -651,7 +651,7 @@ namespace rs2
                 char buff[MAX_SIZE];
                 memcpy(buff, gt.c_str(), gt.size() + 1);
 
-                ImGui::PushItemWidth(width - 145);
+                ImGui::PushItemWidth(width - 145.f);
                 if (ImGui::InputText(id.c_str(), buff, std::max((int)gt.size() + 1, 10)))
                 {
                     std::stringstream ss;
@@ -704,9 +704,9 @@ namespace rs2
                 std::vector<const char*> vals_cstr;
                 for (auto&& s : vals) vals_cstr.push_back(s.c_str());
 
-                ImGui::PushItemWidth(width - 145);
+                ImGui::PushItemWidth(width - 145.f);
 
-                ImGui::Combo(id.c_str(), &get_manager().speed, vals_cstr.data(), vals.size());
+                ImGui::Combo(id.c_str(), &get_manager().speed, vals_cstr.data(), int(vals.size()));
                 ImGui::PopItemWidth();
 
                 draw_intrinsic_extrinsic(x, y);

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -49,7 +49,7 @@ namespace rs2
 
         void update_last_used();
 
-        uint32_t ground_truth = 2500;
+        float ground_truth = 2500;
         int average_step_count = 20;
         int step_count = 20;
         int accuracy = 2;

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -1656,7 +1656,7 @@ namespace rs2
     inline float single_wave(float x)
     {
         auto c = clamp(x, 0.f, 1.f);
-        return 0.5f * (sinf(2.f * M_PI * c - M_PI_2) + 1.f);
+        return 0.5f * (sinf(2.f * float(M_PI) * c - float(M_PI_2)) + 1.f);
     }
 
     // convert 3d points into 2d viewport coordinates
@@ -1737,8 +1737,8 @@ namespace rs2
         p2d.z = clamp(p2d.z, -1.0, 1.0);
 
         // viewport coordinates
-        float x_vp = round((p2d.x + 1.0) / 2.0 * vp[2]) + vp[0];
-        float y_vp = round((p2d.y + 1.0) / 2.0 * vp[3]) + vp[1];
+        float x_vp = round((p2d.x + 1.f) / 2.f * vp[2]) + vp[0];
+        float y_vp = round((p2d.y + 1.f) / 2.f * vp[3]) + vp[1];
 
         float2 p_w;
         p_w.x = x_vp;

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -611,7 +611,7 @@ namespace rs2
 
         // ------------ Texture Selection --------------
 
-        auto t = single_wave((glfwGetTime() - texture_update_time) * 2.f);
+        auto t = single_wave(float(glfwGetTime() - texture_update_time) * 2);
         ImVec4 text_color = light_grey * (1.f - t) + light_blue * t;
 
         const auto tex_selection_popup = "Tex Selection";

--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -242,7 +242,7 @@ namespace rs2
         void update_unsigned(const std::vector<uint8_t>& image, T callback, int update_mode = RS2_UNSIGNED_UPDATE_MODE_UPDATE) const
         {
             rs2_error* e = nullptr;
-            rs2_update_firmware_unsigned_cpp(_dev.get(), image.data(), image.size(), new update_progress_callback<T>(std::move(callback)), update_mode, &e);
+            rs2_update_firmware_unsigned_cpp(_dev.get(), image.data(), int(image.size()), new update_progress_callback<T>(std::move(callback)), update_mode, &e);
             error::handle(e);
         }
     };
@@ -277,7 +277,7 @@ namespace rs2
         void update(const std::vector<uint8_t>& fw_image, T callback) const
         {
             rs2_error* e = nullptr;
-            rs2_update_firmware_cpp(_dev.get(), fw_image.data(), fw_image.size(), new update_progress_callback<T>(std::move(callback)), &e);
+            rs2_update_firmware_cpp(_dev.get(), fw_image.data(), int(fw_image.size()), new update_progress_callback<T>(std::move(callback)), &e);
             error::handle(e);
         }
     };
@@ -353,7 +353,7 @@ namespace rs2
 
             rs2_error* e = nullptr;
             std::shared_ptr<const rs2_raw_data_buffer> list(
-                rs2_run_on_chip_calibration_cpp(_dev.get(), json_content.data(), json_content.size(), health, new update_progress_callback<T>(std::move(callback)), timeout_ms, &e),
+                rs2_run_on_chip_calibration_cpp(_dev.get(), json_content.data(), int(json_content.size()), health, new update_progress_callback<T>(std::move(callback)), timeout_ms, &e),
                 rs2_delete_raw_data);
             error::handle(e);
 
@@ -434,7 +434,7 @@ namespace rs2
 
             rs2_error* e = nullptr;
             std::shared_ptr<const rs2_raw_data_buffer> list(
-                rs2_run_tare_calibration_cpp(_dev.get(), ground_truth_mm, json_content.data(), json_content.size(), new update_progress_callback<T>(std::move(callback)), timeout_ms, &e),
+                rs2_run_tare_calibration_cpp(_dev.get(), ground_truth_mm, json_content.data(), int(json_content.size()), new update_progress_callback<T>(std::move(callback)), timeout_ms, &e),
                 rs2_delete_raw_data);
             error::handle(e);
 

--- a/include/librealsense2/hpp/rs_export.hpp
+++ b/include/librealsense2/hpp/rs_export.hpp
@@ -99,7 +99,7 @@ namespace rs2
                 if (fabs(verts[i].x) >= min_distance || fabs(verts[i].y) >= min_distance ||
                     fabs(verts[i].z) >= min_distance)
                 {
-                    idx_map[i] = new_verts.size();
+                    idx_map[int(i)] = int(new_verts.size());
                     new_verts.push_back({ verts[i].x, -1 * verts[i].y, -1 * verts[i].z });
                     if (use_texcoords)
                     {

--- a/src/ds5/advanced_mode/presets.h
+++ b/src/ds5/advanced_mode/presets.h
@@ -6,91 +6,91 @@
 
 namespace librealsense
 {
-    typedef struct
+    typedef struct laser_power_control
     {
         float laser_power;
         bool was_set = false;
     }laser_power_control;
 
-    typedef struct
+    typedef struct laser_state_control
     {
         int laser_state;
         bool was_set = false;
     }laser_state_control;
 
-    typedef struct
+    typedef struct exposure_control
     {
         float exposure;
         bool was_set = false;
     }exposure_control;
 
-    typedef struct
+    typedef struct auto_exposure_control
     {
         int auto_exposure;
         bool was_set = false;
     }auto_exposure_control;
-
-    typedef struct
+ 
+    typedef struct gain_control
     {
         float gain;
         bool was_set = false;
     }gain_control;
 
-    typedef struct
+    typedef struct backlight_compensation_control
     {
         int backlight_compensation;
         bool was_set = false;
     }backlight_compensation_control;
 
-    typedef struct
+    typedef struct brightness_control
     {
         float brightness;
         bool was_set = false;
     }brightness_control;
 
-    typedef struct
+    typedef struct contrast_control
     {
         float contrast;
         bool was_set = false;
     }contrast_control;
 
-    typedef struct
+    typedef struct gamma_control
     {
         float gamma;
         bool was_set = false;
     }gamma_control;
 
-    typedef struct
+    typedef struct hue_control
     {
         float hue;
         bool was_set = false;
     }hue_control;
 
-    typedef struct
+    typedef struct saturation_control
     {
         float saturation;
         bool was_set = false;
     }saturation_control;
 
-    typedef struct
+    typedef struct sharpness_control
     {
         float sharpness;
         bool was_set = false;
     }sharpness_control;
 
-    typedef struct
+    typedef struct white_balance_control
     {
         float white_balance;
         bool was_set = false;
     }white_balance_control;
 
-    typedef struct
+    typedef struct auto_white_balance_control
     {
         int auto_white_balance;
         bool was_set = false;
     }auto_white_balance_control;
 
-    typedef struct
+    typedef struct power_line_frequency_control
     {
         int power_line_frequency;
         bool was_set = false;

--- a/src/ds5/ds5-auto-calibration.cpp
+++ b/src/ds5/ds5-auto-calibration.cpp
@@ -213,7 +213,7 @@ namespace librealsense
                 LOG_WARNING(ex.what());
             }
             if (progress_callback)
-                progress_callback->on_update_progress(count++ * (2 * speed)); //curently this number does not reflect the actual progress
+                progress_callback->on_update_progress(count++ * (2.f * speed)); //curently this number does not reflect the actual progress
 
             now = std::chrono::high_resolution_clock::now();
 
@@ -310,7 +310,7 @@ namespace librealsense
             }
 
             if (progress_callback)
-                progress_callback->on_update_progress(count++ * (2 * speed)); //curently this number does not reflect the actual progress
+                progress_callback->on_update_progress(count++ * (2.f * speed)); //curently this number does not reflect the actual progress
 
             now = std::chrono::high_resolution_clock::now();
 
@@ -356,7 +356,7 @@ namespace librealsense
                 adv->set_all(old_preset_values);
             }
             else
-                advanced_mode->_preset_opt->set(old_preset);
+                advanced_mode->_preset_opt->set(static_cast<float>(old_preset));
         });
 
         return recover_preset;

--- a/src/gl/align-gl.cpp
+++ b/src/gl/align-gl.cpp
@@ -9,7 +9,9 @@
 #include "align-gl.h"
 #include "option.h"
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif // NOMINMAX
 
 #include <glad/glad.h>
 
@@ -96,10 +98,10 @@ void build_opengl_projection_for_intrinsics(matrix4& frustum,
     
     // These parameters define the final viewport that is rendered into by
     // the camera.
-    double L = 0;
-    double R = img_width;
-    double B = 0;
-    double T = img_height;
+    int L = 0;
+    int R = img_width;
+    int B = 0;
+    int T = img_height;
     
     // near and far clipping planes, these only matter for the mapping from
     // world-space z-coordinate into the depth coordinate for OpenGL
@@ -117,21 +119,21 @@ void build_opengl_projection_for_intrinsics(matrix4& frustum,
     // [-1, 1].  OpenGL then maps coordinates in NDC to the current
     // viewport
     matrix4 ortho;
-    ortho(0,0) =  2.0/(R-L); ortho(0,3) = -(R+L)/(R-L);
-    ortho(1,1) =  2.0/(T-B); ortho(1,3) = -(T+B)/(T-B);
-    ortho(2,2) = -2.0/(F-N); ortho(2,3) = -(F+N)/(F-N);
-    ortho(3,3) =  1.0;
-    
+    ortho(0,0) =  2.f/(R-L);        ortho(0,3) = float(-(R+L)/(R-L));
+    ortho(1,1) =  2.f/(T-B);        ortho(1,3) = float(-(T+B)/(T-B));
+    ortho(2,2) = -2.f/float(F-N);   ortho(2,3) = float(-(F+N)/(F-N));
+    ortho(3,3) =  1.f;
+
     // construct a projection matrix, this is identical to the 
     // projection matrix computed for the intrinsicx, except an
     // additional row is inserted to map the z-coordinate to
-    // OpenGL. 
+    // OpenGL.
     matrix4 tproj;
-    tproj(0,0) = alpha; tproj(0,1) = skew; tproj(0,2) = u0;
-                        tproj(1,1) = beta; tproj(1,2) = v0;
-                                           tproj(2,2) = -(N+F); tproj(2,3) = -N*F;
-                                           tproj(3,2) = 1.0;
-    
+    tproj(0,0) = float(alpha);  tproj(0,1) = float(skew);  tproj(0,2) = 0.f;
+    tproj(1,1) = float(beta);   tproj(1,2) = float(v0);
+    tproj(2,2) = float(-(N+F)); tproj(2,3) = float(-N*F);
+    tproj(3,2) = 1.f;
+
     // resulting OpenGL frustum is the product of the orthographic
     // mapping to normalized device coordinates and the augmented
     // camera intrinsic matrix

--- a/src/gl/colorizer-gl.cpp
+++ b/src/gl/colorizer-gl.cpp
@@ -11,7 +11,9 @@
 #include "colorizer-gl.h"
 #include "option.h"
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif // NOMINMAX
 
 #include <glad/glad.h>
 
@@ -181,7 +183,7 @@ namespace librealsense
 
         void colorizer::populate_floating_histogram(float* f, int* hist)
         {
-            float total = hist[MAX_DEPTH-1];
+            float total = float(hist[MAX_DEPTH-1]);
             for (int i = 0; i < MAX_DEPTH; i++)
                 f[i] = hist[i] / total;
         }

--- a/src/gl/pc-shader.cpp
+++ b/src/gl/pc-shader.cpp
@@ -552,9 +552,9 @@ namespace librealsense
                                 ox = (xy.x / wh.x) * 2 - 1;
                                 oy = (xy.y / wh.y) * 2 - 1;
 
-                                auto p = frustum(left/(0.5*wh.x), right/(0.5*wh.x), 
-                                    bottom/(0.5*wh.y), top/(0.5*wh.y), near_plane, far_plae, 
-                                    ox * (0.5*wh.x), oy * (0.5*wh.y));
+                                auto p = frustum(left/(0.5f*wh.x), right/(0.5f*wh.x),
+                                    bottom / (0.5f * wh.y), top / (0.5f * wh.y), near_plane, far_plae,
+                                    ox * (0.5f * wh.x), oy * (0.5f * wh.y));
 
                                 auto fbo_width = 3;
                                 auto fbo_height = 3;
@@ -621,7 +621,6 @@ namespace librealsense
                                     if (rgba.a > 0)
                                     {
                                         std::vector<rs2::float3> pos_floats(size);
-                                        rs2::float2 w_pos;
                                         for (int i = 0; i < size; i++)
                                         {
                                             auto pos = pos_halfs[i];

--- a/src/gl/synthetic-stream-gl.cpp
+++ b/src/gl/synthetic-stream-gl.cpp
@@ -8,7 +8,9 @@
 
 #include <GLFW/glfw3.h>
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif // NOMINMAX
 
 #include <glad/glad.h>
 

--- a/src/gl/upload.cpp
+++ b/src/gl/upload.cpp
@@ -12,7 +12,9 @@
 #include "option.h"
 #include "context.h"
 
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif // NOMINMAX
 
 #include <glad/glad.h>
 

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -351,7 +351,7 @@ namespace librealsense
                     }
                 }
                 
-                sensor_mode_option.set(get_resolution_from_width_height(vs->get_width(), vs->get_height()));
+                sensor_mode_option.set(float(get_resolution_from_width_height(vs->get_width(), vs->get_height())));
             }
 
 

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -378,7 +378,7 @@ namespace librealsense
         {
             command cmdFES(ivcam2::FES);
             cmdFES.require_response = false;
-            cmdFES.param1 = sector_index;
+            cmdFES.param1 = int(sector_index);
             cmdFES.param2 = 1;
             auto res = hwm->send(cmdFES);
 
@@ -390,7 +390,7 @@ namespace librealsense
                 int packet_size = std::min((int)(HW_MONITOR_COMMAND_SIZE - (i % HW_MONITOR_COMMAND_SIZE)), (int)(ivcam2::FLASH_SECTOR_SIZE - i));
                 command cmdFWB(ivcam2::FWB);
                 cmdFWB.require_response = false;
-                cmdFWB.param1 = index;
+                cmdFWB.param1 = int(index);
                 cmdFWB.param2 = packet_size;
                 cmdFWB.data.assign(image.data() + index, image.data() + index + packet_size);
                 res = hwm->send(cmdFWB);
@@ -406,7 +406,7 @@ namespace librealsense
         update_progress_callback_ptr callback, float continue_from, float ratio)
     {
         auto first_table_offset = fs.tables.front().offset;
-        float total_size = fs.app_size + tables_size;
+        float total_size = float(fs.app_size + tables_size);
 
         float app_ratio = fs.app_size / total_size * ratio;
         float tables_ratio = tables_size / total_size * ratio;
@@ -424,7 +424,7 @@ namespace librealsense
         // update read-write section
         auto first_table_offset = flash_image_info.read_write_section.tables.front().offset;
         auto tables_size = flash_image_info.header.read_write_start_address + flash_image_info.header.read_write_size - first_table_offset;
-        update_section(hwm, merged_image, flash_image_info.read_write_section, tables_size, callback, 0, update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY ? 0.5 : 1.0);
+        update_section(hwm, merged_image, flash_image_info.read_write_section, tables_size, callback, 0, update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY ? 0.5f : 1.f);
 
         if (update_mode == RS2_UNSIGNED_UPDATE_MODE_READ_ONLY)
         {

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -13,7 +13,7 @@ namespace librealsense
 
     float l500_hw_options::query() const
     {
-        return query(_resolution->query());
+        return query(int(_resolution->query()));
     }
 
     void l500_hw_options::set(float value)
@@ -35,7 +35,7 @@ namespace librealsense
         auto max = _hw_monitor->send(command{ AMCGET, _type, get_max });
         auto step = _hw_monitor->send(command{ AMCGET, _type, get_step });
 
-        auto def = query(_resolution->query());
+        auto def = query(int(_resolution->query()));
 
         if (min.size() < sizeof(int32_t) || max.size() < sizeof(int32_t) || step.size() < sizeof(int32_t))
         {
@@ -74,7 +74,7 @@ namespace librealsense
         }
 
         auto val = *(reinterpret_cast<int32_t*>((void*)res.data()));
-        return val;
+        return float(val);
     }
 
     l500_options::l500_options(std::shared_ptr<context> ctx, const platform::backend_device_group & group) :
@@ -89,8 +89,8 @@ namespace librealsense
             depth_sensor.register_option
             (RS2_OPTION_VISUAL_PRESET, std::make_shared<uvc_xu_option<int >>(raw_depth_sensor, ivcam2::depth_xu, ivcam2::L500_AMBIENT,
                 "Change the depth ambient light to ambient: 1 for no ambient and 2 for low ambient",
-                std::map<float, std::string>{ { RS2_AMBIENT_LIGHT_NO_AMBIENT, "No Ambient"},
-                { RS2_AMBIENT_LIGHT_LOW_AMBIENT, "Low Ambient" }}));
+                std::map<float, std::string>{ { float(RS2_AMBIENT_LIGHT_NO_AMBIENT), "No Ambient"},
+                { float(RS2_AMBIENT_LIGHT_LOW_AMBIENT), "Low Ambient" }}));
         }
         else
         {

--- a/src/proc/rates-printer.cpp
+++ b/src/proc/rates-printer.cpp
@@ -27,7 +27,7 @@ namespace librealsense
     {
         auto period = std::chrono::milliseconds(1000 / _render_rate).count();
         auto curr_time = std::chrono::steady_clock::now();
-        double diff = std::chrono::duration_cast<std::chrono::milliseconds>(curr_time - _last_print_time).count();
+        auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(curr_time - _last_print_time).count();
 
         if (diff < period)
             return;
@@ -45,11 +45,11 @@ namespace librealsense
         }
     }
 
-    rates_printer::profile::profile() : _counter(0), _last_frame_number(0), _acctual_fps(0)
+    rates_printer::profile::profile() : _counter(0), _last_frame_number(0), _actual_fps(0)
     {
     }
 
-    int rates_printer::profile::last_frame_number()
+    unsigned long long rates_printer::profile::last_frame_number()
     {
         return _last_frame_number;
     }
@@ -61,7 +61,7 @@ namespace librealsense
 
     float rates_printer::profile::get_fps()
     {
-        return _acctual_fps;
+        return _actual_fps;
     }
 
     void rates_printer::profile::on_frame_arrival(const rs2::frame& f)
@@ -79,8 +79,8 @@ namespace librealsense
         auto oldest = _time_points[0];
         if (_time_points.size() > _stream_profile.fps())
             _time_points.erase(_time_points.begin());
-        double diff = std::chrono::duration_cast<std::chrono::milliseconds>(curr_time - oldest).count() / 1000.0;
+        auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(curr_time - oldest).count() / 1000.f;
         if (diff > 0)
-            _acctual_fps = _time_points.size() / diff;
+            _actual_fps = _time_points.size() / diff;
     }
 }

--- a/src/proc/rates-printer.h
+++ b/src/proc/rates-printer.h
@@ -24,12 +24,12 @@ namespace librealsense
             rs2::stream_profile _stream_profile;
             int _counter;
             std::vector<std::chrono::steady_clock::time_point> _time_points;
-            int _last_frame_number;
-            float _acctual_fps;
+            unsigned long long _last_frame_number;
+            float _actual_fps;
             std::chrono::steady_clock::time_point _last_time;
         public:
             profile();
-            int last_frame_number();
+            unsigned long long last_frame_number();
             rs2::stream_profile get_stream_profile();
             float get_fps();
             void on_frame_arrival(const rs2::frame& f);

--- a/src/proc/sse/sse-pointcloud.cpp
+++ b/src/proc/sse/sse-pointcloud.cpp
@@ -175,8 +175,8 @@ namespace librealsense
         auto fy = _mm_set_ps1(other_intrinsics.fy);
         auto ppx = _mm_set_ps1(other_intrinsics.ppx);
         auto ppy = _mm_set_ps1(other_intrinsics.ppy);
-        auto w = _mm_set_ps1(other_intrinsics.width);
-        auto h = _mm_set_ps1(other_intrinsics.height);
+        auto w = _mm_set_ps1(float(other_intrinsics.width));
+        auto h = _mm_set_ps1(float(other_intrinsics.height));
         auto mask_inv_brown_conrady = _mm_set_ps1(RS2_DISTORTION_INVERSE_BROWN_CONRADY);
         auto zero = _mm_set_ps1(0);
         auto one = _mm_set_ps1(1);

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -164,7 +164,7 @@ namespace librealsense
         auto stream_selector = std::make_shared<ptr_option<int>>(RS2_STREAM_ANY, RS2_STREAM_COUNT, 1, RS2_STREAM_ANY, (int*)&_stream_filter.stream, "Stream type");
         for (int s = RS2_STREAM_ANY; s < RS2_STREAM_COUNT; s++)
         {
-            stream_selector->set_description(s, "Process - " + std::string (rs2_stream_to_string((rs2_stream)s)));
+            stream_selector->set_description(float(s), "Process - " + std::string (rs2_stream_to_string((rs2_stream)s)));
         }
         stream_selector->on_set([this, stream_selector](float val)
         {
@@ -180,7 +180,7 @@ namespace librealsense
         auto format_selector = std::make_shared<ptr_option<int>>(RS2_FORMAT_ANY, RS2_FORMAT_COUNT, 1, RS2_FORMAT_ANY, (int*)&_stream_filter.format, "Stream format");
         for (int f = RS2_FORMAT_ANY; f < RS2_FORMAT_COUNT; f++)
         {
-            format_selector->set_description(f, "Process - " + std::string(rs2_format_to_string((rs2_format)f)));
+            format_selector->set_description(float(f), "Process - " + std::string(rs2_format_to_string((rs2_format)f)));
         }
         format_selector->on_set([this, format_selector](float val)
         {

--- a/tools/convert/converters/converter-bin.hpp
+++ b/tools/convert/converters/converter-bin.hpp
@@ -44,8 +44,8 @@ namespace rs2 {
                             shift--;
                         }
 
-                        f = f - 1.0;
-                        uint32_t mantissa = f * ((1U << 23) + 0.5f);
+                        f = f - 1.f;
+                        uint32_t mantissa = uint32_t(f * ((1U << 23) + 0.5f));
                         uint32_t exponent = shift + ((1 << 7) - 1);
 
                         ieee754 = (sign << 31) | (exponent << 23) | mantissa;


### PR DESCRIPTION
Not mandatory but greatly reduces the warnings clutter and therefore improves awareness
 - static casts
 - unused variables
 - excessive #define usage

Pending AC merge