### PR TITLE
fix UI crash when disabling measurement

### DIFF
--- a/common/measurement.cpp
+++ b/common/measurement.cpp
@@ -13,6 +13,7 @@ void measurement::enable() {
 }
 void measurement::disable() { 
     state.points.clear(); 
+    state.edges.clear();
     measurement_active = false;
     config_file::instance().set(configurations::viewer::is_measuring, false);
 }


### PR DESCRIPTION
On the viewer/depth quality tool if a user pressed on "Measure" button while a measurement is active, the application crashed.
fixed on this PR.
