### PR TITLE
Fix the value of RS2_OPTION_FILTER_MAGNITUDE option in Unity wrapper

### DIFF
--- a/wrappers/unity/Assets/RealSenseSDK2.0/ProcessingPipe/PointCloudDepth.asset
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/ProcessingPipe/PointCloudDepth.asset
@@ -45,4 +45,4 @@ MonoBehaviour:
   enabled: 1
   TextureStream: 1
   TextureFormat: 1
-  _occlusionRemoval: 0
+  _occlusionRemoval: 1

--- a/wrappers/unity/Assets/RealSenseSDK2.0/ProcessingPipe/PointCloudDepthAndColor.asset
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/ProcessingPipe/PointCloudDepthAndColor.asset
@@ -27,4 +27,4 @@ MonoBehaviour:
   enabled: 1
   TextureStream: 2
   TextureFormat: 5
-  _occlusionRemoval: 0
+  _occlusionRemoval: 1

--- a/wrappers/unity/Assets/RealSenseSDK2.0/ProcessingPipe/PointCloudProcessingBlocks.asset
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/ProcessingPipe/PointCloudProcessingBlocks.asset
@@ -138,7 +138,7 @@ MonoBehaviour:
   enabled: 1
   TextureStream: 1
   TextureFormat: 5
-  _occlusionRemoval: 0
+  _occlusionRemoval: 1
 --- !u!114 &114947088938950326
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/ProcessingBlocks/RsPointCloud.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/ProcessingBlocks/RsPointCloud.cs
@@ -5,9 +5,8 @@ public class RsPointCloud : RsProcessingBlock
 {
     public enum OcclusionRemoval
     {
-        Off = 0,
-        Heuristic = 1,
-        Exhaustive = 2
+        Off = 1,
+        On = 2
     }
 
     public Stream TextureStream = Stream.Color;


### PR DESCRIPTION
The value of RS2_OPTION_FILTER_MAGNITUDE defined in Unity wrapper are wrong.
In the wrapper, there are 3 values in PointCloud processing block.
https://github.com/IntelRealSense/librealsense/blob/v2.35.2/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/ProcessingBlocks/RsPointCloud.cs#L6-L11
But in the core library, there are 2 value for it.
https://github.com/IntelRealSense/librealsense/blob/v2.35.2/src/proc/pointcloud.cpp#L239-L241

Fix https://github.com/IntelRealSense/librealsense/issues/6579 https://github.com/IntelRealSense/librealsense/issues/6647