### PR TITLE
Add QVGA sensor mode for usb2 support on L515

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -43,7 +43,9 @@ using namespace rs2::sw_update;
 
 static rs2_sensor_mode resolution_from_width_height(int width, int height)
 {
-    if ((width == 640 && height == 480) || (height == 640 && width == 480))
+    if ((width == 240 && height == 320) || (width == 320 && height == 240))
+        return RS2_SENSOR_MODE_QVGA;
+    else if ((width == 640 && height == 480) || (height == 640 && width == 480))
         return RS2_SENSOR_MODE_VGA;
     else if ((width == 1024 && height == 768) || (height == 768 && width == 1024))
         return RS2_SENSOR_MODE_XGA;
@@ -1237,7 +1239,7 @@ namespace rs2
                         auto width = res_values[ui.selected_res_id].first;
                         auto height = res_values[ui.selected_res_id].second;
                         auto res = resolution_from_width_height(width, height);
-                        if (res >= RS2_SENSOR_MODE_XGA && res < RS2_SENSOR_MODE_COUNT)
+                        if (res >= RS2_SENSOR_MODE_QVGA && res < RS2_SENSOR_MODE_COUNT)
                             s->set_option(RS2_OPTION_SENSOR_MODE, res);
                     }
                 }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1239,7 +1239,7 @@ namespace rs2
                         auto width = res_values[ui.selected_res_id].first;
                         auto height = res_values[ui.selected_res_id].second;
                         auto res = resolution_from_width_height(width, height);
-                        if (res >= RS2_SENSOR_MODE_QVGA && res < RS2_SENSOR_MODE_COUNT)
+                        if (res >= RS2_SENSOR_MODE_VGA && res < RS2_SENSOR_MODE_COUNT)
                             s->set_option(RS2_OPTION_SENSOR_MODE, res);
                     }
                 }

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -148,9 +148,9 @@ extern "C" {
     /** \brief For setting the camera_mode option */
     typedef enum rs2_sensor_mode
     {
-        RS2_SENSOR_MODE_QVGA,
         RS2_SENSOR_MODE_VGA,
         RS2_SENSOR_MODE_XGA,
+        RS2_SENSOR_MODE_QVGA,
         RS2_SENSOR_MODE_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_sensor_mode;
     const char* rs2_sensor_mode_to_string(rs2_sensor_mode preset);

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -148,6 +148,7 @@ extern "C" {
     /** \brief For setting the camera_mode option */
     typedef enum rs2_sensor_mode
     {
+        RS2_SENSOR_MODE_QVGA,
         RS2_SENSOR_MODE_VGA,
         RS2_SENSOR_MODE_XGA,
         RS2_SENSOR_MODE_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -266,7 +266,9 @@ namespace librealsense
 
     rs2_sensor_mode get_resolution_from_width_height(int width, int height)
     {
-        if ((width == 640 && height == 480) || (width == 480  && height == 640))
+        if ((width == 240 && height == 320) || (width == 320 && height == 240))
+            return RS2_SENSOR_MODE_QVGA;
+        else if ((width == 640 && height == 480) || (width == 480  && height == 640))
             return RS2_SENSOR_MODE_VGA;
         else if ((width == 1024 && height == 768) || (width == 768 && height == 1024))
             return RS2_SENSOR_MODE_XGA;

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -94,7 +94,7 @@ namespace librealsense
         }
         else
         {
-            auto resolution_option = std::make_shared<float_option_with_description<rs2_sensor_mode>>(option_range{ RS2_SENSOR_MODE_QVGA,RS2_SENSOR_MODE_XGA,1, RS2_SENSOR_MODE_XGA }, "Notify the sensor about the intended streaming mode. Required for preset ");
+            auto resolution_option = std::make_shared<float_option_with_description<rs2_sensor_mode>>(option_range{ RS2_SENSOR_MODE_VGA,RS2_SENSOR_MODE_COUNT - 1,1, RS2_SENSOR_MODE_XGA }, "Notify the sensor about the intended streaming mode. Required for preset ");
 
             depth_sensor.register_option(RS2_OPTION_SENSOR_MODE, resolution_option);
 

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -94,7 +94,7 @@ namespace librealsense
         }
         else
         {
-            auto resolution_option = std::make_shared<float_option_with_description<rs2_sensor_mode>>(option_range{ RS2_SENSOR_MODE_VGA,RS2_SENSOR_MODE_XGA,1, RS2_SENSOR_MODE_XGA }, "Notify the sensor about the intended streaming mode. Required for preset ");
+            auto resolution_option = std::make_shared<float_option_with_description<rs2_sensor_mode>>(option_range{ RS2_SENSOR_MODE_QVGA,RS2_SENSOR_MODE_XGA,1, RS2_SENSOR_MODE_XGA }, "Notify the sensor about the intended streaming mode. Required for preset ");
 
             depth_sensor.register_option(RS2_OPTION_SENSOR_MODE, resolution_option);
 


### PR DESCRIPTION
Support QVGA (240x320) resolution on L515 device

Tracked on Jira [RS5-7992]