### PR TITLE
[C#] Add L500 preset enum

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Types/Enums/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/Types/Enums/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(${LRS_DOTNET_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/RecordingMode.cs"
         "${CMAKE_CURRENT_LIST_DIR}/Rs400VisualPreset.cs"
         "${CMAKE_CURRENT_LIST_DIR}/Sr300VisualPreset.cs"
+        "${CMAKE_CURRENT_LIST_DIR}/L500VisualPreset.cs"
         "${CMAKE_CURRENT_LIST_DIR}/Stream.cs"
         "${CMAKE_CURRENT_LIST_DIR}/TimestampDomain.cs"
         "${CMAKE_CURRENT_LIST_DIR}/CameraInfo.cs"

--- a/wrappers/csharp/Intel.RealSense/Types/Enums/L500VisualPreset.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/Enums/L500VisualPreset.cs
@@ -1,0 +1,18 @@
+﻿// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+namespace Intel.RealSense
+{
+    /// <summary>
+    /// For L500 devices: provides optimized settings (presets) for specific types of usage.
+    /// </summary>
+    public enum L500VisualPreset
+    {
+        Custom = 0,
+        Default = 1,
+        NoAmbient = 2,
+        LowAmbient = 3,
+        MaxRange = 4,
+        ShortRange = 5,
+    }
+}


### PR DESCRIPTION
Add enum similar to `Rs400VisualPreset` to easily set `Option.VisualPreset` for L500 devices.