### PR TITLE
Update patch-arch.sh based on #4271

### DIFF
--- a/scripts/patch-arch.sh
+++ b/scripts/patch-arch.sh
@@ -41,8 +41,13 @@ cd $KERNEL_NAME
 
 echo "RealSense patch..."
 
-# Apply our RealSense specific patch
+# TODO: The patches should be chosen to fit to the kernel version
+
+# Apply our RealSense specific camera formats patch
 patch -p1 < ../../realsense-camera-formats.patch
+
+# Apply our RealSense specific metadata patch
+patch -p1 < ../../realsense-metadata-bionic-5.patch
 
 # Prepare to compile modules
 

--- a/scripts/patch-arch.sh
+++ b/scripts/patch-arch.sh
@@ -8,9 +8,10 @@ SRC_VERSION_NAME=linux
 FULL_NAME=$( uname -r | tr "-" "\n")
 read -a VERSION <<< $FULL_NAME
 
-SRC_VERSION_ID=${VERSION[0]}  ## e.g. : 4.5.6
-SRC_VERSION_REL=${VERSION[1]} ## e.g. : 1
-LINUX_TYPE=${VERSION[2]}      ## e.g. : ARCH
+SRC_VERSION_ID=${VERSION[0]}             ## e.g. : 4.5.6
+SRC_VERSION_MAJOR=${SRC_VERSION_ID:0:1}  ## e.g. : 4
+SRC_VERSION_REL=${VERSION[1]}            ## e.g. : 1
+LINUX_TYPE=${VERSION[2]}                 ## e.g. : ARCH
 
 LINUX_BRANCH=archlinux-$SRC_VERSION_ID
 KERNEL_NAME=linux-$SRC_VERSION_ID
@@ -22,9 +23,9 @@ mkdir kernel
 cd kernel
 
 ## Get the kernel
-wget https://www.kernel.org/pub/linux/kernel/v4.x/$KERNEL_NAME.tar.xz
-wget https://www.kernel.org/pub/linux/kernel/v4.x/$PATCH_NAME.xz
-wget https://www.kernel.org/pub/linux/kernel/v4.x/$PATCH_NAME.sign
+wget https://www.kernel.org/pub/linux/kernel/v${SRC_VERSION_MAJOR}.x/$KERNEL_NAME.tar.xz
+wget https://www.kernel.org/pub/linux/kernel/v${SRC_VERSION_MAJOR}.x/$PATCH_NAME.xz
+#wget https://www.kernel.org/pub/linux/kernel/v${SRC_VERSION_MAJOR}.x/$PATCH_NAME.sign
 
 echo "Extract the kernel"
 tar xf $KERNEL_NAME.tar.xz
@@ -94,7 +95,7 @@ if [ -e $MODULE_NAME.xz ]; then
 
     # compress
     xz uvcvideo.ko
-    sudo cp uvcvideo.ko.xz $MODULE_NAME
+    sudo cp uvcvideo.ko.xz $MODULE_NAME.xz
 fi
 
 if [ -e $MODULE_NAME.gz ]; then


### PR DESCRIPTION
Installing librealsense on Manjaro Linux, I ran into the exact issues described in #4271 from a year ago. This PR proposes to update `patch-arch.sh` accordingly. Notice that it does not update the actual patch file. This may still need adaptation depending on the kernel version that is used (which however seemed to be rather trivial in my case for kernel 5.6.16).