### PR TITLE
Fix imGui Font on MacOS

### DIFF
--- a/common/calibration-model.cpp
+++ b/common/calibration-model.cpp
@@ -207,15 +207,12 @@ void calibration_model::update(ux_window& window, std::string& error_message)
                     load_float3x4("intrinsic_right", table->intrinsic_right);
                     load_float3x4("world2left_rot", table->world2left_rot);
                     load_float3x4("world2right_rot", table->world2right_rot);
-                    
+
                     for (int i = 0; i < librealsense::ds::max_ds5_rect_resolutions; i++)
                     {
-                        auto xy = librealsense::ds::resolutions_list[(librealsense::ds::ds5_rect_resolutions)i];
-                        int w = xy.x; int h = xy.y;
-
                         table->rect_params[i].x = cf.get(std::string(to_string() << "rectified." << i << ".fx").c_str());
                         table->rect_params[i].y = cf.get(std::string(to_string() << "rectified." << i << ".fy").c_str());
-                        
+
                         table->rect_params[i].z = cf.get(std::string(to_string() << "rectified." << i << ".ppx").c_str());
                         table->rect_params[i].w = cf.get(std::string(to_string() << "rectified." << i << ".ppy").c_str());
                     }

--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -56,8 +56,6 @@ namespace rs2
 
     std::string get_available_firmware_version(int product_line)
     {
-        bool allow_rc_firmware = config_file::instance().get_or_default(configurations::update::allow_rc_firmware, false);
-
         if (product_line == RS2_PRODUCT_LINE_D400) return FW_D4XX_FW_IMAGE_VERSION;
         //else if (product_line == RS2_PRODUCT_LINE_SR300) return FW_SR3XX_FW_IMAGE_VERSION;
         else if (product_line == RS2_PRODUCT_LINE_L500) return FW_L5XX_FW_IMAGE_VERSION;
@@ -284,7 +282,7 @@ namespace rs2
             log("Firmware Update completed, waiting for device to reconnect");
         }
 
-        if (!check_for([this, serial, &dfu]() {
+        if (!check_for([this, serial]() {
             auto devs = _ctx.query_devices();
 
             for (uint32_t j = 0; j < devs.size(); j++)

--- a/common/measurement.cpp
+++ b/common/measurement.cpp
@@ -454,7 +454,6 @@ void measurement::draw(ux_window& win)
         if (input_ctrl.mouse_down) size -= _picked.z * 0.01f;
         size += _picked.z * 0.01f * single_wave(input_ctrl.click_period());
 
-        auto end = _picked + _normal * size;
         auto axis1 = cross(vec3d{ _normal.x, _normal.y, _normal.z }, vec3d{ 0.f, 1.f, 0.f });
         auto faxis1 = float3 { axis1.x, axis1.y, axis1.z };
         faxis1.normalize();

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1649,7 +1649,6 @@ namespace rs2
             {
                 if (auto vid_prof = p.as<video_stream_profile>())
                 {
-                    auto key = std::make_tuple(p.fps(), vid_prof.width(), vid_prof.height());
                     if (check_profile(p, [&](stream_profile prof) { return (std::find_if(matching_profiles.begin(), matching_profiles.end(), [&](stream_profile sp)
                     { return (stream_id != p.unique_id() && sp.fps() == p.fps() && sp.as<video_stream_profile>().width() == vid_prof.width() &&
                         sp.as<video_stream_profile>().height() == vid_prof.height()); }) != matching_profiles.end()); },
@@ -1762,7 +1761,7 @@ namespace rs2
     {
         viewer.not_model->add_log("Stopping streaming");
 
-        for_each(stream_display_names.begin(), stream_display_names.end(), [this, &viewer](std::pair<int, std::string> kvp)
+        for_each(stream_display_names.begin(), stream_display_names.end(), [this](std::pair<int, std::string> kvp)
         {
             if ("Pose" == kvp.second)
             {
@@ -1853,7 +1852,7 @@ namespace rs2
         viewer.not_model->add_log(ss.str());
 
         // TODO  - refactor tm2 from viewer to subdevice
-        for_each(stream_display_names.begin(), stream_display_names.end(), [this, &viewer](std::pair<int, std::string> kvp)
+        for_each(stream_display_names.begin(), stream_display_names.end(), [this](std::pair<int, std::string> kvp)
         {
             if ("Pose" == kvp.second)
             {
@@ -4011,7 +4010,6 @@ namespace rs2
         duration -= mm;
         auto ss = duration_cast<seconds>(duration);
         duration -= ss;
-        auto ms = duration_cast<milliseconds>(duration);
 
         std::ostringstream stream;
         stream << std::setfill('0') << std::setw(hhh.count() >= 10 ? 2 : 1) << hhh.count() << ':' <<
@@ -4026,7 +4024,7 @@ namespace rs2
         auto pos = ImGui::GetCursorPos();
 
         auto p = dev.as<playback>();
-        rs2_playback_status current_playback_status = p.current_status();
+        //rs2_playback_status current_playback_status = p.current_status();
         int64_t playback_total_duration = p.get_duration().count();
         auto progress = p.get_position();
         double part = (1.0 * progress) / playback_total_duration;
@@ -4982,7 +4980,6 @@ namespace rs2
             // Disable depth stream on all sub devices
             for (auto&& sub : subdevices)
             {
-                int i = 0;
                 for (auto&& profile : sub->profiles)
                 {
                     if (profile.stream_type() == RS2_STREAM_DEPTH)
@@ -5709,7 +5706,7 @@ namespace rs2
             if (show_depth_only && !sub->s->is<depth_sensor>()) continue;
 
             const ImVec2 pos = ImGui::GetCursorPos();
-            const ImVec2 abs_pos = ImGui::GetCursorScreenPos();
+            //const ImVec2 abs_pos = ImGui::GetCursorScreenPos();
             //model_to_y[sub.get()] = pos.y;
             //model_to_abs_y[sub.get()] = abs_pos.y;
 
@@ -6032,7 +6029,6 @@ namespace rs2
                             ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
 
                             const ImVec2 pos = ImGui::GetCursorPos();
-                            const ImVec2 abs_pos = ImGui::GetCursorScreenPos();
 
                             draw_later.push_back([windows_width, &window, sub, pos, &viewer, this, pb]() {
                                 if (!sub->streaming || !sub->post_processing_enabled) ImGui::SetCursorPos({ windows_width - 35, pos.y - 3 });

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -498,7 +498,6 @@ namespace rs2
         const float len_x = 0.1f;
         const float len_y = 0.03f;
         const float len_z = 0.01f;
-        const float lens_radius = 0.005f;
         /*
         4--------------------------3
         /|                         /|
@@ -532,8 +531,6 @@ namespace rs2
             } };
 
         colored_cube camera_box{ { { f1,colors[0] },{ f2,colors[1] },{ f3,colors[2] },{ f4,colors[3] },{ f5,colors[4] },{ f6,colors[5] } } };
-        float3 center_left{ v5.x + len_x / 3, v6.y - len_y / 3, v5.z };
-        float3 center_right{ v6.x - len_x / 3, v6.y - len_y / 3, v5.z };
 
         std::vector<tracked_point> trajectory;
         std::vector<float2> boundary;
@@ -927,10 +924,6 @@ namespace rs2
         std::atomic<bool> render_thread_active; // True when render post processing filter rendering thread is active, False otherwise
         std::shared_ptr<std::thread> render_thread;              // Post processing filter rendering Thread running render_loop()
         void render_loop();                     // Post processing filter rendering function
-
-        int last_frame_number = 0;
-        double last_timestamp = 0;
-        int last_stream_id = 0;
 
         std::shared_ptr<gl::uploader> uploader; // GL element that helps pre-emptively copy frames to the GPU
     };

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -585,10 +585,6 @@ namespace rs2
                 }
             }
 
-            auto flags = ImGuiWindowFlags_NoResize |
-                ImGuiWindowFlags_NoMove |
-                ImGuiWindowFlags_NoCollapse |
-                ImGuiWindowFlags_NoTitleBar;
 
             ImGui::PushStyleColor(ImGuiCol_WindowBg, { 0, 0, 0, 0 });
             //ImGui::Begin("Notification parent window", nullptr, flags);

--- a/common/objects-in-frame.h
+++ b/common/objects-in-frame.h
@@ -15,11 +15,11 @@ struct object_in_frame
     size_t id;
 
     object_in_frame( size_t id, std::string const & name, rs2::rect bbox_color, rs2::rect bbox_depth, float depth )
-        : id( id )
-        , name( name )
-        , normalized_color_bbox( bbox_color )
-        , normalized_depth_bbox( bbox_depth )
-        , mean_depth( depth )
+    : normalized_color_bbox( bbox_color )
+    , normalized_depth_bbox( bbox_depth )
+    , name( name )
+    , mean_depth( depth )
+    , id( id )
     {
     }
 };

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -193,7 +193,6 @@ namespace rs2
             bool record,
             std::vector<single_metric_data>& samples)
         {
-            float TO_METERS = sensor.get_depth_scale();
             static const float TO_MM = 1000.f;
             static const float TO_PERCENT = 100.f;
 
@@ -216,10 +215,6 @@ namespace rs2
             {
                 // Find distance from point to the reconstructed plane
                 auto dist2plane = p.a*point.x + p.b*point.y + p.c*point.z + p.d;
-                // Project the point to plane in 3D and find distance to the intersection point
-                rs2::float3 plane_intersect = { float(point.x - dist2plane*p.a),
-                    float(point.y - dist2plane*p.b),
-                    float(point.z - dist2plane*p.c) };
 
                 // Store distance, disparity and gt- error
                 distances.push_back(dist2plane * TO_MM);
@@ -672,7 +667,7 @@ namespace rs2
                 ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 25) });
                 if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
                 {
-                    get_manager().restore_workspace([this](std::function<void()> a){ a(); });
+                    get_manager().restore_workspace([](std::function<void()> a){ a(); });
                     get_manager().reset();
                     get_manager().tare = true;
                     auto _this = shared_from_this();
@@ -754,7 +749,7 @@ namespace rs2
                 ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 25) });
                 if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
                 {
-                    get_manager().restore_workspace([this](std::function<void()> a){ a(); });
+                    get_manager().restore_workspace([](std::function<void()> a){ a(); });
                     get_manager().reset();
                     auto _this = shared_from_this();
                     auto invoke = [_this](std::function<void()> action) {
@@ -961,7 +956,7 @@ namespace rs2
                     }
                     else dismiss(false);
 
-                    get_manager().restore_workspace([this](std::function<void()> a) { a(); });
+                    get_manager().restore_workspace([](std::function<void()> a) { a(); });
                 }
                 if (recommend_keep || get_manager().tare)
                 {
@@ -1066,7 +1061,7 @@ namespace rs2
         if (!use_new_calib && get_manager().done()) 
             get_manager().apply_calib(false);
 
-        get_manager().restore_workspace([this](std::function<void()> a){ a(); });
+        get_manager().restore_workspace([](std::function<void()> a){ a(); });
 
         if (update_state != RS2_CALIB_STATE_TARE_INPUT)
             update_state = RS2_CALIB_STATE_INITIAL_PROMPT;

--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -973,13 +973,11 @@ void stream_dashboard::draw_dashboard(ux_window& win, rect& r)
         else has_room = false;
     }
     ticks_x -= 3;
-    
-    auto total = 0;
+
     for (int i = 0; i < ticks_x; i++)
     {
         auto x = min_x + i * (gap_x / ticks_x);
         std::string x_label = to_string() << std::fixed << std::setprecision(2) << x;
-        auto y_pixel = ImGui::GetTextLineHeight() + i * (height_y / ticks_y);
         ImGui::SetCursorPos(ImVec2( 15 + max_y_label_width+ i * (graph_width / ticks_x), r.h - ImGui::GetTextLineHeight() ));
         ImGui::Text("%s", x_label.c_str());
 

--- a/common/output-model.h
+++ b/common/output-model.h
@@ -156,9 +156,6 @@ namespace rs2
         bool info_highlighted = false;
         bool drops_highlighted = false;
 
-        rs2_log_severity min_severity = RS2_LOG_SEVERITY_DEBUG;
-        rs2_log_severity max_severity = RS2_LOG_SEVERITY_FATAL;
-
         int number_of_errors = 0;
         int number_of_warnings = 0;
         int number_of_info = 0;

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -887,7 +887,7 @@ namespace rs2
             }),
                 _measurements.end());
             auto trues = std::count_if(_measurements.begin(), _measurements.end(),
-                [this](std::pair<clock::time_point, bool> pair) {
+                [](std::pair<clock::time_point, bool> pair) {
                 return pair.second;
             });
             return size_t(trues) / (float)_measurements.size(); 
@@ -1019,7 +1019,6 @@ namespace rs2
                     {
                         // Upload vertices
                         data = pc.get_vertices();
-                        auto v = pc.get_vertices();
                         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, width, height, 0, GL_RGB, GL_FLOAT, data);
                     }
                     else
@@ -1747,8 +1746,7 @@ namespace rs2
         auto mvp = pc * vc * fc;
 
         // test - origin (0, 0, -1.0, 1) should be translated into (0, 0, 0, 0) at this point
-        float4 origin{ 0.f, 0.f, -1.f, 1.f };
-        float4 projected = mvp * origin;
+        //float4 origin{ 0.f, 0.f, -1.f, 1.f };
 
         // translate 3d vertex into 2d windows coordinates
         float4 p3d;

--- a/common/sw-update/dev-updates-profile.cpp
+++ b/common/sw-update/dev-updates-profile.cpp
@@ -71,9 +71,9 @@ namespace rs2
             bool query_ok = up_handler.query_versions(dev_name, part, policy, required_version);
             if (query_ok)
             {
-                auto dl_link_ok = up_handler.get_version_download_link(part, required_version, result.download_link);
-                auto rel_ok = up_handler.get_version_release_notes(part, required_version, result.release_page);
-                auto desc_ok = up_handler.get_version_description(part, required_version, result.description);
+                //auto dl_link_ok = up_handler.get_version_download_link(part, required_version, result.download_link);
+                //auto rel_ok = up_handler.get_version_release_notes(part, required_version, result.release_page);
+                //auto desc_ok = up_handler.get_version_description(part, required_version, result.description);
                 result.ver = required_version;
 
                 std::stringstream ss;

--- a/common/sw-update/http-downloader.cpp
+++ b/common/sw-update/http-downloader.cpp
@@ -79,7 +79,6 @@ namespace rs2
             if (input_stream && output)
             {
                 std::ofstream &out_stream(*static_cast<std::ofstream*> (output));
-                uint8_t* source_bytes(static_cast<uint8_t*>(input_stream));
 
                 size_t num_of_bytem(nmemb*size);
                 out_stream.write((char *)input_stream, num_of_bytem);

--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -85,7 +85,7 @@ namespace rs2
 
             // Look for the required version
             auto res = std::find_if(_server_versions_vec.begin(), _server_versions_vec.end(),
-                [this, version, component_str, platform](std::unordered_map<std::string, std::string> version_map)
+                [version, component_str, platform](std::unordered_map<std::string, std::string> version_map)
             {
                 return (versions_db_manager::version(version_map["version"]) == version && component_str == version_map["component"] && (platform == version_map["platform"] || version_map["platform"] == "*"));
             });

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -75,7 +75,8 @@ namespace rs2
         config_file::instance().set_default(configurations::viewer::hwlogger_xml, "./HWLoggerEvents.xml");
 
 #ifdef __APPLE__
-        config_file::instance().set_default(configurations::performance::font_oversample, 8);
+
+        config_file::instance().set_default(configurations::performance::font_oversample, 2);
         config_file::instance().set_default(configurations::performance::enable_msaa, true);
         config_file::instance().set_default(configurations::performance::msaa_samples, 4);
         // On Mac-OS, mixing OpenGL 2 with OpenGL 3 is not supported by the driver

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -373,8 +373,6 @@ namespace rs2
         auto font = win.get_font();
         auto large_font = win.get_large_font();
 
-        const float combo_box_width = 200;
-
         // Draw pose header if pose stream exists
         bool pose_render = false;
 
@@ -981,10 +979,6 @@ namespace rs2
 
     void rs2::viewer_model::show_popup(const ux_window& window, const popup& p)
     {
-        auto flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
-            ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar |
-            ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysVerticalScrollbar;
-
         auto font_14 = window.get_font();
 
         ImGui_ScopePushFont(font_14);
@@ -1453,14 +1447,12 @@ namespace rs2
         static const auto colored_ruler_width = 20;
         const auto left_x_colored_ruler = stream_width - left_x_colored_ruler_offset;
         const auto right_x_colored_ruler = stream_width - (left_x_colored_ruler_offset - colored_ruler_width);
-        const auto first_rgb = rgb_per_distance_vec.begin()->rgb_val;
         assert((bottom_y_ruler - top_y_ruler) != 0.f);
         const auto ratio = (bottom_y_ruler - top_y_ruler) / ruler_length;
 
         // Draw numbered ruler
         float y_ruler_val = top_y_ruler;
         static const auto numbered_ruler_width = 20.f;
-        const auto numbered_ruler_height = bottom_y_ruler - top_y_ruler;
 
         const auto right_x_numbered_ruler = right_x_colored_ruler + numbered_ruler_width;
         static const auto hovered_numbered_ruler_opac = 0.8f;
@@ -1840,7 +1832,6 @@ namespace rs2
                     auto depth_vid_profile = stream_mv.profile.as<video_stream_profile>();
                     auto depth_width = depth_vid_profile.width();
                     auto depth_height = depth_vid_profile.height();
-                    auto num_of_pixels = depth_width * depth_height;
                     auto depth_data = static_cast<const uint16_t*>(frame.get_data());
                     auto textured_depth_data = static_cast<const uint8_t*>(textured_frame.get_data());
                     static const auto skip_pixels_factor = 30;

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -47,10 +47,10 @@ void auto_exposure_state::set_auto_exposure_step(float value)
 }
 
 auto_exposure_mechanism::auto_exposure_mechanism(option& gain_option, option& exposure_option, const auto_exposure_state& auto_exposure_state)
-    : _auto_exposure_algo(auto_exposure_state),
-      _keep_alive(true), _frames_counter(0),
-      _skip_frames(auto_exposure_state.skip_frames), _data_queue(queue_size),
-      _gain_option(gain_option), _exposure_option(exposure_option)
+    : _gain_option(gain_option), _exposure_option(exposure_option),
+      _auto_exposure_algo(auto_exposure_state),
+      _keep_alive(true), _data_queue(queue_size), _frames_counter(0),
+      _skip_frames(auto_exposure_state.skip_frames)
 {
     _exposure_thread = std::make_shared<std::thread>(
                 [this]()

--- a/src/algo.h
+++ b/src/algo.h
@@ -94,7 +94,7 @@ namespace librealsense
         float exposure = 10.0f, gain = 2.0f, target_exposure = 0.0f;
         uint8_t under_exposure_limit = 5, over_exposure_limit = 250; int under_exposure_noise_limit = 50, over_exposure_noise_limit = 50;
         int direction = 0, prev_direction = 0; float hysteresis = 0.075f;// 05;
-        float eps = 0.01f, minimal_exposure_step = 0.01f;
+        float eps = 0.01f;
         std::atomic<float> exposure_step;
         auto_exposure_state state; float flicker_cycle; bool anti_flicker_mode = true;
         region_of_interest roi{};

--- a/src/algo/depth-to-rgb-calibration/calibration-types.h
+++ b/src/algo/depth-to-rgb-calibration/calibration-types.h
@@ -59,7 +59,7 @@ namespace depth_to_rgb_calibration {
         double mat[3][3];
         double3x3 transpose()
         {
-            double3x3 res = { 0 };
+            double3x3 res = { {0} };
 
             for( auto i = 0; i < 3; i++ )
             {
@@ -73,7 +73,7 @@ namespace depth_to_rgb_calibration {
 
         double3x3 operator*( const double3x3 & other )
         {
-            double3x3 res = { 0 };
+            double3x3 res = { {0} };
 
             for( auto i = 0; i < 3; i++ )
             {

--- a/src/algo/depth-to-rgb-calibration/k-to-dsm.h
+++ b/src/algo/depth-to-rgb-calibration/k-to-dsm.h
@@ -42,12 +42,12 @@ namespace depth_to_rgb_calibration {
 
         rs2_dsm_params_double() = default;
         rs2_dsm_params_double( rs2_dsm_params const & obj )
-            : h_scale( obj.h_scale )
+            : model( rs2_dsm_correction_model( obj.model ) )
+            , h_scale( obj.h_scale )
             , v_scale( obj.v_scale )
             , h_offset( obj.h_offset )
             , v_offset( obj.v_offset )
             , rtd_offset( obj.rtd_offset )
-            , model( rs2_dsm_correction_model( obj.model ) )
         {
             //todo: flags
         }
@@ -62,7 +62,7 @@ namespace depth_to_rgb_calibration {
             o.model = model;
         }
     };
-    
+
     std::ostream & operator<<( std::ostream &, rs2_dsm_params_double const & );
 
 #pragma pack(push, 1)

--- a/src/algo/depth-to-rgb-calibration/optimizer.cpp
+++ b/src/algo/depth-to-rgb-calibration/optimizer.cpp
@@ -1162,9 +1162,6 @@ std::pair< std::vector<double2>, std::vector<double>> calc_rc(
     auto ppx = (double)yuy_intrin.ppx;
     auto ppy = (double)yuy_intrin.ppy;
 
-    auto & r = yuy_extrin.rotation;
-    auto & t = yuy_extrin.translation;
-
    /* double mat[3][4] = {
         fx*(double)r[0] + ppx * (double)r[2], fx*(double)r[3] + ppx * (double)r[5], fx*(double)r[6] + ppx * (double)r[8], fx*(double)t[0] + ppx * (double)t[2],
         fy*(double)r[1] + ppy * (double)r[2], fy*(double)r[4] + ppy * (double)r[5], fy*(double)r[7] + ppy * (double)r[8], fy*(double)t[1] + ppy * (double)t[2],

--- a/src/archive.h
+++ b/src/archive.h
@@ -98,11 +98,10 @@ namespace librealsense
         std::vector<byte> data;
         frame_additional_data additional_data;
         std::shared_ptr<metadata_parser_map> metadata_parsers = nullptr;
-        explicit frame() : ref_count(0), _kept(false), owner(nullptr), on_release() {}
+        explicit frame() : ref_count(0), owner(nullptr), on_release(),_kept(false) {}
         frame(const frame& r) = delete;
         frame(frame&& r)
-            : ref_count(r.ref_count.exchange(0)), _kept(r._kept.exchange(false)),
-            owner(r.owner), on_release()
+            : ref_count(r.ref_count.exchange(0)), owner(r.owner), on_release(), _kept(r._kept.exchange(false))
         {
             *this = std::move(r);
             if (owner) metadata_parsers = owner->get_md_parsers();

--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -28,7 +28,7 @@ class single_consumer_queue
     std::atomic<bool> _was_flushed;
 public:
     explicit single_consumer_queue<T>(unsigned int cap = QUEUE_MAX_SIZE)
-        : _queue(), _mutex(), _deq_cv(), _enq_cv(), _cap(cap), _need_to_flush(false), _was_flushed(false), _accepting(true)
+        : _queue(), _mutex(), _deq_cv(), _enq_cv(), _cap(cap), _accepting(true), _need_to_flush(false), _was_flushed(false)
     {}
 
     void enqueue(T&& item)
@@ -409,7 +409,7 @@ class watchdog
 {
 public:
     watchdog(std::function<void()> operation, uint64_t timeout_ms) :
-            _operation(std::move(operation)), _timeout_ms(timeout_ms)
+            _timeout_ms(timeout_ms), _operation(std::move(operation))
     {
         _watcher = std::make_shared<active_object<>>([this](dispatcher::cancellable_timer cancellable_timer)
         {
@@ -440,7 +440,6 @@ private:
     uint64_t _timeout_ms;
     bool _kicked = false;
     bool _running = false;
-    bool _blocker = true;
     std::function<void()> _operation;
     std::shared_ptr<active_object<>> _watcher;
 };

--- a/src/core/serialization.h
+++ b/src/core/serialization.h
@@ -139,7 +139,7 @@ namespace librealsense
         public:
             serialized_option(device_serializer::nanoseconds time, sensor_identifier id, rs2_option opt_id, std::shared_ptr<librealsense::option> o) :
                 serialized_data(time),
-                sensor_id(id), option_id(opt_id), option(o)
+                sensor_id(id), option(o), option_id(opt_id)
             {}
             sensor_identifier sensor_id;
             std::shared_ptr<librealsense::option> option;

--- a/src/frame-archive.h
+++ b/src/frame-archive.h
@@ -166,7 +166,7 @@ namespace librealsense
             std::shared_ptr<platform::time_service> ts,
             std::shared_ptr<metadata_parser_map> parsers)
             : max_frame_queue_size(in_max_frame_queue_size),
-            mutex(), recycle_frames(true), _time_service(ts),
+            recycle_frames(true), mutex(), _time_service(ts),
             _metadata_parsers(parsers)
         {
             published_frames_count = 0;

--- a/src/gl/pc-shader.cpp
+++ b/src/gl/pc-shader.cpp
@@ -451,8 +451,6 @@ namespace librealsense
                     }
                     _durations.push_back(now);
 
-                    const auto fps = _durations.size();
-
                     //scoped_timer t("pointcloud_renderer.gl");
 
                     GLint curr_tex;

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -66,7 +66,6 @@ namespace librealsense
     private:
         bool try_get(const frame& frm, rs2_metadata_type& result) const
         {
-            auto pair_size = (sizeof(rs2_frame_metadata_value) + sizeof(rs2_metadata_type));
             const uint8_t* pos = frm.additional_data.metadata_blob.data();
             while (pos <= frm.additional_data.metadata_blob.data() + frm.additional_data.metadata_blob.size())
             {
@@ -340,7 +339,7 @@ namespace librealsense
     {
     public:
         ds5_md_attribute_actual_fps(bool discrete = true, attrib_modifyer  exposure_mod = [](const rs2_metadata_type& param) {return param; })
-            :_exposure_modifyer(exposure_mod), _discrete(discrete), _fps_values{ 6, 15, 30, 60, 90 }
+            : _fps_values{ 6, 15, 30, 60, 90 } , _exposure_modifyer(exposure_mod), _discrete(discrete)
         {}
 
         rs2_metadata_type get(const librealsense::frame & frm) const override

--- a/src/types.h
+++ b/src/types.h
@@ -648,7 +648,7 @@ namespace librealsense
             uint32_t w = 0, uint32_t h = 0,
             uint32_t framerate = 0,
             resolution_func res_func = [](resolution res) { return res; }) :
-            format(fmt), stream(strm), index(idx), height(h), width(w), stream_resolution(res_func), fps(framerate)
+            format(fmt), stream(strm), index(idx), width(w), height(h), fps(framerate), stream_resolution(res_func)
         {}
 
         rs2_format format;

--- a/third-party/imgui/imgui.cpp
+++ b/third-party/imgui/imgui.cpp
@@ -6536,7 +6536,6 @@ bool ImGui::SliderBehavior(const ImRect& frame_bb, ImGuiID id, float* v, float v
                 bb.Min.x -= 0.5;
                 bb.Max.x += 0.5;
             }
-            float grab_paddingl = 2.0f;
             //Vertical fills from down upwards
             fill_br.Min = bb.Min;
             fill_br.Min.y = grab_bb.Min.y;

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -154,8 +154,6 @@ bool refresh_devices(std::mutex& m,
         return false;
     try
     {
-        auto prev_size = current_connected_devices.size();
-
         //Remove disconnected
         auto dev_itr = begin(current_connected_devices);
         while (dev_itr != end(current_connected_devices))
@@ -522,7 +520,6 @@ int main(int argc, const char** argv) try
 
                     ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 5);
 
-                    bool connect = false;
                     static char ip_input[255];
                     std::copy(ip_address.begin(), ip_address.end(), ip_input);
                     ip_input[ip_address.size()] = '\0';


### PR DESCRIPTION
Adding new imGui font results in artifact similar to #4558
Handle LLVM warnings:
 - remove unused variables
 - re-order ctor init lists to rectify potential out-of order value initialization