### PR TITLE
fix bug in fw logs api - wrong use of ptr to ptr

### DIFF
--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -449,12 +449,6 @@ void rs2_delete_fw_log_parsed_message(rs2_firmware_log_parsed_message* fw_log_pa
 int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_firmware_log_parsed_message* parsed_msg, rs2_error** error);
 
 /**
-* Delete RealSense firmware log parsed message
-* \param[in]  device    Realsense firmware log parsed message to delete
-*/
-void rs2_delete_fw_log_parsed_message(rs2_firmware_log_parsed_message* fw_log_parsed_msg);
-
-/**
 * \brief Gets RealSense firmware log parsed message.
 * \param[in] fw_log_parsed_msg      firmware log parsed message object
 * \param[out] error     If non-null, receives any error that occurs during this call, otherwise, errors are ignored.

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -363,7 +363,7 @@ rs2_firmware_log_message* rs2_create_fw_log_message(rs2_device* dev, rs2_error**
 * \param[out] error         If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return                   true for success, false for failure - failure happens if no firmware log was sent by the hardware monitor
 */
-int rs2_get_fw_log(rs2_device* dev, rs2_firmware_log_message** fw_log_msg, rs2_error** error);
+int rs2_get_fw_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_error** error);
 
 /**
 * \brief Gets RealSense flash log - this is a fw log that has been written in the device during the previous shutdown of the device
@@ -372,7 +372,7 @@ int rs2_get_fw_log(rs2_device* dev, rs2_firmware_log_message** fw_log_msg, rs2_e
 * \param[out] error         If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return                   true for success, false for failure - failure happens if no firmware log was sent by the hardware monitor
 */
-int rs2_get_flash_log(rs2_device* dev, rs2_firmware_log_message** fw_log_msg, rs2_error** error);
+int rs2_get_flash_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_error** error);
 
 /**
 * Delete RealSense firmware log message

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -512,7 +512,7 @@ namespace rs2
             rs2_error* e = nullptr;
             rs2_firmware_log_message* m = msg.get_message().get();
             bool fw_log_pulling_status =
-                rs2_get_fw_log(_dev.get(), &(m), &e);
+                rs2_get_fw_log(_dev.get(), m, &e);
 
             error::handle(e);
 
@@ -524,7 +524,7 @@ namespace rs2
             rs2_error* e = nullptr;
             rs2_firmware_log_message* m = msg.get_message().get();
             bool flash_log_pulling_status =
-                rs2_get_flash_log(_dev.get(), &(m), &e);
+                rs2_get_flash_log(_dev.get(), m, &e);
 
             error::handle(e);
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -3119,7 +3119,7 @@ rs2_firmware_log_message* rs2_create_fw_log_message(rs2_device* dev, rs2_error**
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, dev)
 
-int rs2_get_fw_log(rs2_device* dev, rs2_firmware_log_message** fw_log_msg, rs2_error** error) BEGIN_API_CALL
+int rs2_get_fw_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(fw_log_msg);
@@ -3129,13 +3129,13 @@ int rs2_get_fw_log(rs2_device* dev, rs2_firmware_log_message** fw_log_msg, rs2_e
     bool result = fw_loggerable->get_fw_log(binary_data);
     if (result)
     {
-        (*(*fw_log_msg)->firmware_log_binary_data.get()) = binary_data;
+        *(fw_log_msg->firmware_log_binary_data).get() = binary_data;
     }
     return result? 1 : 0;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, dev, fw_log_msg)
 
-int rs2_get_flash_log(rs2_device* dev, rs2_firmware_log_message** fw_log_msg, rs2_error** error)BEGIN_API_CALL
+int rs2_get_flash_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_error** error)BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(fw_log_msg);
@@ -3145,7 +3145,7 @@ int rs2_get_flash_log(rs2_device* dev, rs2_firmware_log_message** fw_log_msg, rs
     bool result = fw_loggerable->get_flash_log(binary_data);
     if (result)
     {
-        (*(*fw_log_msg)->firmware_log_binary_data.get()) = binary_data;
+        *(fw_log_msg->firmware_log_binary_data).get() = binary_data;
     }
     return result ? 1 : 0;
 }


### PR DESCRIPTION
Signature of methods rs2_get_fw_log and rs2_get_flasg_log corrected