### PR TITLE
tooltip text corrected

### DIFF
--- a/src/option.cpp
+++ b/src/option.cpp
@@ -102,7 +102,7 @@ const char* librealsense::uvc_pu_option::get_description() const
     case RS2_OPTION_ENABLE_AUTO_EXPOSURE: return "Enable / disable auto-exposure";
     case RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE: return "Enable / disable auto-white-balance";
     case RS2_OPTION_POWER_LINE_FREQUENCY: return "Power Line Frequency";
-    case RS2_OPTION_AUTO_EXPOSURE_PRIORITY: return "Limit exposure time when auto-exposure is ON to preserve constant fps rate";
+    case RS2_OPTION_AUTO_EXPOSURE_PRIORITY: return "Restrict Auto-Exposure to enforce constant FPS rate. Turn ON to remove the restrictions (may result in FPS drop)";
     default: return _ep.get_option_name(_id);
     }
 }


### PR DESCRIPTION
Tooltip text corrected so that the user would understand the implications of turning ON/OFF the Auto Exposure Priority button in realsense viewer.
Tracked on: DSO-13683