### PR TITLE
Improved Error Handling for SDK tools

### DIFF
--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -21,6 +21,11 @@
 
 #include <iostream>
 
+void glfw_error_callback(int error, const char* description)
+{
+    std::cerr << "GLFW Driver Error: " << description << "\n";
+}
+
 namespace rs2
 {
     void GLAPIENTRY MessageCallback(GLenum source,
@@ -204,6 +209,8 @@ namespace rs2
 
         if (!glfwInit())
             exit(1);
+
+        glfwSetErrorCallback(glfw_error_callback);
 
         _hand_cursor = glfwCreateStandardCursor(GLFW_HAND_CURSOR);
         _cross_cursor = glfwCreateStandardCursor(GLFW_CROSSHAIR_CURSOR);

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -10,6 +10,8 @@
 #include <vector>
 #include <algorithm>
 #include <iterator>
+#include <sstream>
+#include <iostream>
 
 #include "metadata-helper.h"
 
@@ -49,5 +51,16 @@ int CALLBACK WinMain(
     std::vector<const char*> argc;
     std::transform(args.begin(), args.end(), std::back_inserter(argc), [](const std::string& s) { return s.c_str(); });
 
-    return main(static_cast<int>(argc.size()), argc.data());
+    std::stringstream ss;
+    std::cerr.rdbuf(ss.rdbuf());
+
+    auto res = main(static_cast<int>(argc.size()), argc.data());
+    if (res == EXIT_FAILURE)
+    {
+        auto error = ss.str();
+        std::wstring ws(error.begin(), error.end());
+        MessageBox(NULL, ws.c_str(), L"Something went wrong...", MB_ICONERROR | MB_OK);
+    }
+
+    return res;
 }

--- a/common/windows-app-bootstrap.cpp
+++ b/common/windows-app-bootstrap.cpp
@@ -12,10 +12,131 @@
 #include <iterator>
 #include <sstream>
 #include <iostream>
+#include <csignal>
 
+#include "os.h"
 #include "metadata-helper.h"
+#include "rendering.h"
 
+// Use OS hook to modify message box behaviour
+// This lets us implement "report" functionality if Viewer is crashing
+HHOOK hhk;
+// When launching messagebox, replace standard Cancel button with "report"
+LRESULT CALLBACK cbtproc(INT code, WPARAM wParam, LPARAM lParam)
+{
+    HWND window = (HWND)wParam;
+    if (code == HCBT_ACTIVATE)
+    {
+        if (GetDlgItem(window, IDCANCEL) != NULL)
+        {
+            SetDlgItemText(window, IDCANCEL, L"Report");
+        }
+        UnhookWindowsHookEx(hhk);
+    }
+    else CallNextHookEx(hhk, code, wParam, lParam);
+    return 0;
+}
+
+bool should_intercept(int code)
+{
+    if (code == EXCEPTION_BREAKPOINT || code == EXCEPTION_SINGLE_STEP) return false;
+    return true;
+}
+
+std::string exception_code_to_string(int code)
+{
+    if (code == EXCEPTION_ACCESS_VIOLATION) return "Access Violation!";
+    else if (code == EXCEPTION_ARRAY_BOUNDS_EXCEEDED) return "Array out of bounds access error!";
+    else if (code == EXCEPTION_DATATYPE_MISALIGNMENT) return "Read / write of misaligned data!";
+    else if (code == EXCEPTION_FLT_DENORMAL_OPERAND) return "Denormal floating point operation!";
+    else if (code == EXCEPTION_FLT_DIVIDE_BY_ZERO) return "Unhandled floating point division by zero!";
+    else if (code == EXCEPTION_FLT_INEXACT_RESULT) return "Inexact floating point result!";
+    else if (code == EXCEPTION_FLT_INVALID_OPERATION) return "Invalid floating point operation!";
+    else if (code == EXCEPTION_FLT_OVERFLOW) return "Floating point overflow!";
+    else if (code == EXCEPTION_FLT_STACK_CHECK) return "Floating point stack overflow / underflow!";
+    else if (code == EXCEPTION_FLT_UNDERFLOW) return "Floating point underflow!";
+    else if (code == EXCEPTION_ILLEGAL_INSTRUCTION) return "Illegal CPU instruction!\nPossibly newer CPU architecture is required";
+    else if (code == EXCEPTION_IN_PAGE_ERROR) return "In page error!\nPossibly network connection error when running the program over network";
+    else if (code == EXCEPTION_INT_DIVIDE_BY_ZERO) return "Unhandled integer division by zero!";
+    else if (code == EXCEPTION_INT_OVERFLOW) return "Integer overflow!";
+    else if (code == EXCEPTION_INVALID_DISPOSITION) return "Invalid disposition error!";
+    else if (code == EXCEPTION_NONCONTINUABLE_EXCEPTION) return "Noncontinuable exception occured!";
+    else if (code == EXCEPTION_PRIV_INSTRUCTION) return "Error due to invalid call to priviledged instruction!";
+    else if (code == EXCEPTION_STACK_OVERFLOW) return "Stack overflow error!";
+    else return "Unknown error!";
+}
+
+// Show custom error message box with OK and Report options
+// Report will prompt new GitHub issue
+void report_error(std::string error)
+{
+    std::wstring ws(error.begin(), error.end());
+    SetWindowsHookEx(WH_CBT, &cbtproc, 0, GetCurrentThreadId());
+    auto button = MessageBox(NULL, ws.c_str(), L"Something went wrong...", MB_ICONERROR | MB_OKCANCEL);
+    if (button == IDCANCEL)
+    {
+        std::stringstream ss;
+        rs2_error* e = nullptr;
+
+        ss << "| | |\n";
+        ss << "|---|---|\n";
+        ss << "|**librealsense**|" << rs2::api_version_to_string(rs2_get_api_version(&e)) << (rs2::is_debug() ? " DEBUG" : " RELEASE") << "|\n";
+        ss << "|**OS**|" << rs2::get_os_name() << "|\n\n";
+        ss << "Intel RealSense Viewer / Depth Quality Tool has crashed with the following error message:\n";
+        ss << "```\n";
+        ss << error;
+        ss << "\n```";
+
+        std::string link = "https://github.com/IntelRealSense/librealsense/issues/new?body=" + rs2::url_encode(ss.str());
+        rs2::open_url(link.c_str());
+    }
+}
+
+// Global crash handler will be triggered when exception escapes from thread
+LONG WINAPI CrashHandler(EXCEPTION_POINTERS* ep)
+{
+    auto code = ep->ExceptionRecord->ExceptionCode;
+
+    if (should_intercept(code))
+    {
+        std::string error = "Unhandled exception escaping from a worker thread!\nError type: ";
+        error += exception_code_to_string(code);
+        report_error(error);
+    }
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+// Actual main - implemented in the cross-platform section of the App
 int main(int argv, const char** argc);
+
+int filter(unsigned int code, struct _EXCEPTION_POINTERS *ep)
+{
+    if (should_intercept(code))
+    {
+        auto error = exception_code_to_string(code);
+        std::cerr << "Program terminated due to an unrecoverable SEH exception:\n" << error;
+        return EXCEPTION_EXECUTE_HANDLER;
+    }
+    else return EXCEPTION_CONTINUE_SEARCH;
+}
+
+// Wrapper around main. Must be in a function without destructors (that does not require stack unwinding)
+int run_main(int argv, const char** argc)
+{
+    SetUnhandledExceptionFilter(CrashHandler);
+
+    int res = 0;
+    __try
+    {
+        res = main(argv, argc);
+    }
+    __except (filter(GetExceptionCode(), GetExceptionInformation()))
+    {
+        res = EXIT_FAILURE;
+    }
+    return res;
+}
 
 int CALLBACK WinMain(
     _In_ HINSTANCE hInstance,
@@ -51,15 +172,15 @@ int CALLBACK WinMain(
     std::vector<const char*> argc;
     std::transform(args.begin(), args.end(), std::back_inserter(argc), [](const std::string& s) { return s.c_str(); });
 
+    // Redirect CERR to string stream
     std::stringstream ss;
     std::cerr.rdbuf(ss.rdbuf());
 
-    auto res = main(static_cast<int>(argc.size()), argc.data());
+    int res = run_main(static_cast<int>(argc.size()), argc.data());
+    
     if (res == EXIT_FAILURE)
     {
-        auto error = ss.str();
-        std::wstring ws(error.begin(), error.end());
-        MessageBox(NULL, ws.c_str(), L"Something went wrong...", MB_ICONERROR | MB_OK);
+        report_error(ss.str());
     }
 
     return res;

--- a/tools/depth-quality/CMakeLists.txt
+++ b/tools/depth-quality/CMakeLists.txt
@@ -19,6 +19,13 @@ set( ELPP_FILES
     
 include(../../common/CMakeLists.txt)
 
+SET(DELAYED 
+    realsense2d.dll
+    realsense2-gld.dll
+    realsense2.dll
+    realsense2-gl.dll
+)
+
 if(BUILD_GRAPHICAL_EXAMPLES)
     set(RS_QUALITY_TOOL_CPP
         ${COMMON_SRC}
@@ -70,6 +77,10 @@ if(BUILD_GRAPHICAL_EXAMPLES)
                                              ../../third-party/tclap/include
                                              ../../third-party/tinyfiledialogs
                                              ${CMAKE_CURRENT_SOURCE_DIR}/res/)
+
+        list(TRANSFORM DELAYED PREPEND " /DELAYLOAD:")
+        string(REPLACE ";" " " LD_FLAGS_STR "${DELAYED}")
+        set_target_properties(rs-depth-quality PROPERTIES LINK_FLAGS "${LD_FLAGS_STR}")
 
     else()
         add_executable(rs-depth-quality 

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -53,6 +53,12 @@ if(BUILD_GRAPHICAL_EXAMPLES)
     ../../common/os.cpp
 )
 
+SET(DELAYED 
+    realsense2d.dll
+    realsense2-gld.dll
+    realsense2.dll
+    realsense2-gl.dll
+)
 
 if(DEFINED OpenCV_DIR  AND  IS_DIRECTORY ${OpenCV_DIR})
 
@@ -61,6 +67,17 @@ if(DEFINED OpenCV_DIR  AND  IS_DIRECTORY ${OpenCV_DIR})
     get_property(deps VARIABLE PROPERTY DEPENDENCIES)
     set(DEPENDENCIES ${deps} ${OpenCV_LIBS})
     include_directories( ../../wrappers/opencv )
+
+    list(APPEND DELAYED
+        opencv_highgui341.dll
+        opencv_core341.dll
+        opencv_imgproc341.dll
+        opencv_dnn341.dll
+        opencv_highgui341d.dll
+        opencv_core341d.dll
+        opencv_imgproc341d.dll
+        opencv_dnn341d.dll
+    )
 
 endif()
 if(DEFINED INTEL_OPENVINO_DIR  AND  IS_DIRECTORY ${INTEL_OPENVINO_DIR})
@@ -105,6 +122,18 @@ if(DEFINED INTEL_OPENVINO_DIR  AND  IS_DIRECTORY ${INTEL_OPENVINO_DIR})
     dl_vino_model( "age-gender-recognition-retail-0013.bin"  "206f6e97e53cd600fcac7d31e1c56accbbe461b9" )
     dl_vino_model( "age-gender-recognition-retail-0013.xml"  "2654d7f1638d575b8d1886f8128deae2ea79ee55" )
 
+    list(APPEND DELAYED
+        cpu_extension.dll
+        inference_engine.dll
+        libmmd.dll
+        mkl_tiny_tbb.dll
+        MKLDNNPlugin.dll
+        opencv_core412.dll
+        opencv_imgproc412.dll
+        svml_dispmd.dll
+        tbb.dll
+        tbbmalloc.dll
+    )
 endif()
 
 # config-ui
@@ -132,6 +161,10 @@ if(WIN32)
         ${CMAKE_CURRENT_SOURCE_DIR}/res/realsense-viewer.rc)
 
     source_group("OpenVINO" FILES ${OPENVINO_FILES})
+
+    list(TRANSFORM DELAYED PREPEND " /DELAYLOAD:")
+    string(REPLACE ";" " " LD_FLAGS_STR "${DELAYED}")
+    set_target_properties(realsense-viewer PROPERTIES LINK_FLAGS "${LD_FLAGS_STR}")
 
 else()
     add_executable(realsense-viewer

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -298,7 +298,7 @@ int main(int argc, const char** argv) try
     std::mutex m;
 
     std::weak_ptr<notifications_model> notifications = viewer_model.not_model;
-     rs2::log_to_callback( RS2_LOG_SEVERITY_INFO,
+    rs2::log_to_callback( RS2_LOG_SEVERITY_INFO,
         [notifications]( rs2_log_severity severity, rs2::log_message const& msg )
         {
             if (auto not_model = notifications.lock())
@@ -725,7 +725,7 @@ int main(int argc, const char** argv) try
         }
 
     return EXIT_SUCCESS;
-    }
+}
 catch (const error & e)
 {
     std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "):\n    " << e.what() << std::endl;


### PR DESCRIPTION
On Windows, the Viewer & DQT can silently fail in certain situations. This is clearly very bad user experience, hence this PR.

List of changes:
1. Get detailed error message out of GLFW, like in cases of broken OpenGL
2. Display top level exception as a popup message with an option to open new GitHub issue
3. Catch unhandled exceptions from all threads within the process
4. Catch SEH exceptions (similar to signals), covering Segmentation Faults, Illegal Instructions, and more cases not covered by regular C++ exception handler
5. Make all 3rd-party dependencies of the Viewer / DQT delay-loaded. This way when some DLL is missing, the error message is more detailed with an option to report the issue