### PR TITLE
CMakeLists: fixed multiple exports issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ if(IMPORT_DEPTH_CAM_FW)
 endif()
 
 include(CMake/embedd_udev_rules.cmake)
-include(CMake/install_config.cmake)
 
 if(${ROS_BUILD_TYPE})
     ament_package()


### PR DESCRIPTION
`CMake/install_config` was included twice during merging the
master branch. This patch fix the issue.

Signed-off-by: Sharron LIU <sharron.xr.liu@gmail.com>