### PR TITLE
src/gl/CMakeLists.txt: disabled ldconfig for ROS build

### DIFF
--- a/src/ethernet/CMakeLists.txt
+++ b/src/ethernet/CMakeLists.txt
@@ -125,4 +125,6 @@ install(FILES "${CMAKE_BINARY_DIR}/config/realsense2-net.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
 
-install(CODE "execute_process(COMMAND ldconfig)")
+if(NOT ${ROS_BUILD_TYPE})
+    install(CODE "execute_process(COMMAND ldconfig)")
+endif()

--- a/src/gl/CMakeLists.txt
+++ b/src/gl/CMakeLists.txt
@@ -120,4 +120,6 @@ install(FILES "${CMAKE_BINARY_DIR}/config/realsense2-gl.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
 )
 
-install(CODE "execute_process(COMMAND ldconfig)")
+if(NOT ${ROS_BUILD_TYPE})
+    install(CODE "execute_process(COMMAND ldconfig)")
+endif()


### PR DESCRIPTION
This command is optional for ROS build.

Signed-off-by: Sharron LIU <sharron.xr.liu@gmail.com>