### PR TITLE
Remove dependency on fts.h

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -38,7 +38,6 @@
 #include <linux/usb/video.h>
 #include <linux/uvcvideo.h>
 #include <linux/videodev2.h>
-#include <fts.h>
 #include <regex>
 #include <list>
 

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -36,7 +36,6 @@
 #include <linux/usb/video.h>
 #include <linux/uvcvideo.h>
 #include <linux/videodev2.h>
-#include <fts.h>
 #include <regex>
 #include <list>
 


### PR DESCRIPTION
`fts.h` is included in these two backend-v4l2 files but not actually used.

I found out about this while trying to get librealsense to compile with uClibc-ng rather than glibc, which offers optional support for `fts.h`. But since it is not (no longer?) actually used in this library, the best way forward seems to simply remove the include.