### PR TITLE
Android stability fixes

### DIFF
--- a/src/android/jni/device.cpp
+++ b/src/android/jni/device.cpp
@@ -57,7 +57,12 @@ Java_com_intel_realsense_librealsense_Device_nQuerySensors(JNIEnv *env, jclass t
         sensors.push_back(s);
     }
     jlongArray rv = env->NewLongArray(sensors.size());
-    env->SetLongArrayRegion(rv, 0, sensors.size(), reinterpret_cast<const jlong *>(sensors.data()));
+
+    for (auto i = 0; i < sensors.size(); i++)
+    {
+        env->SetLongArrayRegion(rv, i, 1, reinterpret_cast<const jlong *>(&sensors[i]));
+    }
+
     return rv;
 }
 

--- a/src/android/jni/sensor.cpp
+++ b/src/android/jni/sensor.cpp
@@ -36,8 +36,12 @@ Java_com_intel_realsense_librealsense_Sensor_nGetStreamProfiles(JNIEnv *env, jcl
         profiles.push_back(sp);
     }
 
+    // jlong is 64-bit, but pointer in profiles could be 32-bit, copy element by element
     jlongArray rv = env->NewLongArray(profiles.size());
-    env->SetLongArrayRegion(rv, 0, profiles.size(), reinterpret_cast<const jlong *>(profiles.data()));
+    for (auto i = 0; i < size; i++)
+    {
+        env->SetLongArrayRegion(rv, i, 1, reinterpret_cast<const jlong *>(&profiles[i]));
+    }
     return rv;
 }
 

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -20,11 +20,12 @@ namespace librealsense
 
         pipeline::~pipeline()
         {
-            try
-            {
-                unsafe_stop();
+            if (_active_profile) {
+                try {
+                    unsafe_stop();
+                }
+                catch (...) {}
             }
-            catch (...) {}
         }
 
         std::shared_ptr<profile> pipeline::start(std::shared_ptr<config> conf, frame_callback_ptr callback)
@@ -144,10 +145,13 @@ namespace librealsense
                 catch (...)
                 {
                 } // Stop will throw if device was disconnected. TODO - refactoring anticipated
+
+                // shared pointers initialized when pipeline running with _active_profile
+                // should be reset with _active_profile too
+                _active_profile.reset();
+                _prev_conf.reset();
+                _streams_callback.reset();
             }
-            _active_profile.reset();
-            _prev_conf.reset();
-            _streams_callback.reset();
         }
 
         std::shared_ptr<device_interface> pipeline::wait_for_device(const std::chrono::milliseconds& timeout, const std::string& serial)

--- a/src/uvc/uvc-device.cpp
+++ b/src/uvc/uvc-device.cpp
@@ -160,7 +160,7 @@ namespace librealsense
 
             stop_stream_cleanup(profile, elem);
 
-            if (_profiles.empty())
+            if (!_profiles.empty())
                 _streamers.clear();
         }
 

--- a/src/uvc/uvc-streamer.h
+++ b/src/uvc/uvc-streamer.h
@@ -44,6 +44,8 @@ namespace librealsense
             bool wait_for_first_frame(uint32_t timeout_ms);
 
         private:
+            std::mutex _running_mutex;
+            std::condition_variable _stopped_cv;
             bool _running = false;
             bool _frame_arrived = false;
             bool _publish_frames = true;

--- a/wrappers/android/tools/camera/src/main/AndroidManifest.xml
+++ b/wrappers/android/tools/camera/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         </activity>
         <activity
             android:name=".PreviewActivity"
+            android:launchMode="singleTop"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".SettingsActivity"

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/DetachedActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/DetachedActivity.java
@@ -53,6 +53,43 @@ public class DetachedActivity extends AppCompatActivity {
 
         requestPermissionsIfNeeded();
 
+        init();
+    }
+
+    private void requestPermissionsIfNeeded() {
+        ArrayList<String> permissions = new ArrayList<>();
+        if (!isCameraPermissionGranted()) {
+            permissions.add(Manifest.permission.CAMERA);
+        }
+
+        if (!isWritePermissionGranted()) {
+            permissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        }
+        if (!permissions.isEmpty())
+            ActivityCompat.requestPermissions(this, permissions.toArray(new String[permissions.size()]), PermissionsUtils.PERMISSIONS_REQUEST_ALL);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        if (isCameraPermissionGranted()) {
+            RsContext.init(getApplicationContext());
+            mRsContext.setDevicesChangedCallback(mListener);
+            validatedDevice();
+        }
+    }
+
+    private boolean isCameraPermissionGranted() {
+        return android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.O && ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private boolean isWritePermissionGranted() {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private synchronized void init()
+    {
         mPlaybackButton = findViewById(R.id.playbackButton);
         mPlaybackButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -77,44 +114,27 @@ public class DetachedActivity extends AppCompatActivity {
         mMinimalFirmwares.put(ProductLine.D400, MINIMAL_D400_FW_VERSION);
     }
 
-    private void requestPermissionsIfNeeded() {
-        ArrayList<String> permissions = new ArrayList<>();
-        if (!isCameraPermissionGranted()) {
-            permissions.add(Manifest.permission.CAMERA);
-        }
-
-        if (!isWritePermissionGranted()) {
-            permissions.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-        }
-        if (!permissions.isEmpty())
-            ActivityCompat.requestPermissions(this, permissions.toArray(new String[permissions.size()]), PermissionsUtils.PERMISSIONS_REQUEST_ALL);
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        mDetached = true;
-        if (isCameraPermissionGranted()) {
-            RsContext.init(getApplicationContext());
-            mRsContext.setDevicesChangedCallback(mListener);
-            validatedDevice();
-        }
-    }
-
-    private boolean isCameraPermissionGranted() {
-        return android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.O && ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
-    }
-
-    private boolean isWritePermissionGranted() {
-        return ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
-    }
-
     private synchronized void validatedDevice(){
         if(mUpdating)
             return;
         try(DeviceList dl = mRsContext.queryDevices()){
-            if(dl.getDeviceCount() == 0)
+            if(dl.getDeviceCount() == 0) {
+                init();
+
+                // kill preview activity if device disconnected
+                if (mDetached) {
+                    mDetached = false;
+
+                    Intent intent = new Intent(this, PreviewActivity.class);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                    intent.putExtra("keepalive", false);
+                    startActivity(intent);
+                }
+
                 return;
+            }
+
             try(Device d = dl.createDevice(0)){
                 if(d == null)
                     return;
@@ -127,10 +147,17 @@ public class DetachedActivity extends AppCompatActivity {
                 else {
                     if (!validateFwVersion(d))
                         return;
+
                     mDetached = false;
 
-                    finish();
+
+                    // launch preview activity and keep it alive
+                    // the activity is single top instance, can be killed later the same instance
+                    // to prevent issues with multiple instances
                     Intent intent = new Intent(this, PreviewActivity.class);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                    intent.putExtra("keepalive", true);
                     startActivity(intent);
                 }
             }
@@ -201,11 +228,8 @@ public class DetachedActivity extends AppCompatActivity {
 
         @Override
         public void onDeviceDetach() {
-            if(mDetached)
-                return;
-            finish();
-            Intent intent = new Intent(mAppContext, DetachedActivity.class);
-            startActivity(intent);
+            mDetached = true;
+            validatedDevice();
         }
     };
 }

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PreviewActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PreviewActivity.java
@@ -54,6 +54,8 @@ public class PreviewActivity extends AppCompatActivity {
     private boolean statsToggle = false;
     private boolean mShow3D = false;
 
+    boolean keepalive = true;
+
     public synchronized void toggleStats(){
         statsToggle = !statsToggle;
         if(statsToggle){
@@ -72,6 +74,15 @@ public class PreviewActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_preview);
+
+        keepalive = true;
+
+        Intent intent = this.getIntent();
+
+        if (intent != null && intent.getExtras() != null ) {
+            keepalive = intent.getExtras().getBoolean("keepalive");
+        }
+
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
         mGLSurfaceView = findViewById(R.id.glSurfaceView);
@@ -204,6 +215,11 @@ public class PreviewActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
+        if(keepalive == false)
+        {
+            return;
+        }
+
         mStreamingStats  = new StreamingStats();
         mStreamer = new Streamer(this, true, new Streamer.Listener() {
             @Override
@@ -298,4 +314,21 @@ public class PreviewActivity extends AppCompatActivity {
         }
         mFwLogsRunning = false;
     }
+
+    @Override
+    protected void onNewIntent(Intent intent)
+    {
+        super.onNewIntent(intent);
+
+        if (intent != null && intent.getExtras() != null ) {
+            keepalive = intent.getExtras().getBoolean("keepalive");
+        }
+
+        // destroy activity if requested
+        if(keepalive == false)
+        {
+            PreviewActivity.this.finish();
+        }
+    }
+
 }


### PR DESCRIPTION
fixes pipeline.stop() crash issue and camera app performance/stability issues::

1. fix pipe.stop() issues
   a) problem: null pointer segfault
       cause: thread synchronization in dispatcher
       fix: add additional lock in invoke_and_wait.

  b) problem: invalid address segfault in uvc_streamer, active_object, dispatcher flows
      cause: double release of memory in destructors due to synchronization issue in watchdog, active_object, dispatcher, and
primarily uvc_streamer.
      fix: add additional state check and synchronization.

  c) problem: invalid address segfault in pipeline flows
     cause: double release of memory in pipeline destructor to stop pipeline twice, the extra stop come from JNI code when handle is deleted and invokes destructor which tries to run stop() again.
     fix: do shared pointer reset when profile active (also this is when they are initialized).

   d) problem: invalid address segfault at various points depends on workload
      cause: uvc_streamer shared pointers cleared at the wrong time, not cleared when stream stopped, so it tries to stop the 
      streamer a second time during destruction
      fix: destroy uvc_streamers after stream is stopped and no active profiles

   e) problem: invalid address segfault in device info destructor through JNI stack
       cause: appears to be double releasing as JNI stack references the pointer
       fix: avoid delete in JNI, need to confirm it's released on native stack.

2. problem: invalid address segfault related to stream profiles
   cause: profile data array copy in JNI, jlong is 64-bit but pointer could be 32-bit, should not xcopy the entire buffer
   fix: copy array elements

3. problem: invalid address segfault related to query sensors
   cause: sensor data array copy in JNI, jlong is 64-bit but pointer could be 32-bit, should not xcopy the entire buffer
   fix: copy array elements

4. problem: camera app performance degradation and stability issues after repeated device disconnect/connect (JIRA DS5U-4588)
   app cannot recover if device disconnected in middle of starting streaming
   cause: activity operations executed multiple times due to activity instances and sequence issue
   fix: create single activity instance, manage its creation and destruction, and correct sequence.

Tracked on: RS5-8219, DSO-15293, DSO-15294, and DSO-15358