### PR TITLE
Fix extrinsics related log_warnings while recording on L515

### DIFF
--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -164,7 +164,7 @@ namespace librealsense
                 return get_color_stream_extrinsic(*_color_extrinsics_table_raw);
             } );
         environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_color_stream, _color_extrinsic);
-        register_stream_to_extrinsic_group(*_depth_stream, 0);
+        register_stream_to_extrinsic_group(*_color_stream, 0);
 
 
         _color_device_idx = add_sensor(create_color_device(ctx, color_devs_info));

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -83,6 +83,7 @@ namespace librealsense
 
         register_stream_to_extrinsic_group(*_depth_stream, 0);
         register_stream_to_extrinsic_group(*_ir_stream, 0);
+        register_stream_to_extrinsic_group(*_confidence_stream, 0);
 
         auto error_control = std::unique_ptr<uvc_xu_option<int>>(new uvc_xu_option<int>(raw_depth_sensor, ivcam2::depth_xu, L500_ERROR_REPORTING, "Error reporting"));
 


### PR DESCRIPTION
Fix a log warning when recording RGB / Confidence streams on L515 devices

![image](https://user-images.githubusercontent.com/64067618/88639749-ca562780-d0c5-11ea-8697-2e42e82c0814.png)
