### PR TITLE
Increase logs queue size on viewer

### DIFF
--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -91,7 +91,7 @@ output_model::~output_model()
     fw_logger.join();
 }
 
-output_model::output_model() : fw_logger([this](){ thread_loop(); })
+output_model::output_model() : fw_logger([this](){ thread_loop(); }) , incoming_log_queue(100)
 {
     is_output_open = config_file::instance().get_or_default(
             configurations::viewer::output_open, false);


### PR DESCRIPTION
The current queue is at default size of 10, that means that at a viewer cycle when the logs queue is full after 10 logs the output window will miss logs.

This PR increase the logs to 100 in order to display a peek of logs.