### PR TITLE
update imu calibration white paper public web link

### DIFF
--- a/tools/rs-imu-calibration/README.md
+++ b/tools/rs-imu-calibration/README.md
@@ -8,9 +8,12 @@ D435i and L515 cameras arrive from the factory with a calibrated IMU device. How
 
 The rs-imu-calibration tool is a code example that walks you through the calibration steps and saves the calibration coefficients to the EEPROM, to be applied automatically by the driver.
 
+Detailed information, including installation, procedure, and sample calibration demonstration, is described in the following white paper:
+  IMU Calibration Tool for Intel® RealSense™ Depth Camera White Paper
+  https://dev.intelrealsense.com/docs/imu-calibration-tool-for-intel-realsense-depth-camera
+
 ## Limitations
-While the tool achieves good overall results, it has limitations that may impact accuracy. Please refer to following white paper for further information:
-IMU Calibration Tool for Intel® RealSense™ Depth Camera White Paper (https://dev.intelrealsense.com/docs/depth-camera-imu-calibration)
+While the tool achieves good overall results, it has limitations that may impact accuracy. Please refer to the above white paper for further information.
 
 ## Command Line Parameters
 


### PR DESCRIPTION
The latest IMU white paper refresh was published to a different web link than previously documented in read.md. This change is to update the link. No impact to calibration script or user.