### PR TITLE
Set default values for color sensor controls for calibration 

### DIFF
--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -145,7 +145,7 @@ namespace librealsense
         // This should be done after registration of the device options
         if (_autocal)
         {
-            color_ep->init_calibration_controls();
+            color_ep->register_calibration_controls();
         }
 
         return color_ep;
@@ -386,17 +386,15 @@ namespace librealsense
             }
             if( is_opened() )
             {
-                LOG_DEBUG( "Closing color sensor..." );
+                AC_LOG( DEBUG, "Calibration color stream was on, Closing color sensor..." );
                 synthetic_sensor::close();
             }
 
-            restore_pre_calibration_controls_if_needed();
+            restore_pre_calibration_controls();
 
             set_sensor_state( sensor_state::CLOSED );
-            LOG_DEBUG( "Calibration color stream was on, turned it off" );
         }
 
-        LOG_DEBUG( "Opening color sensor..." );
         synthetic_sensor::open( requests );
         set_sensor_state( sensor_state::OWNED_BY_USER );
     }
@@ -409,7 +407,6 @@ namespace librealsense
         if( _state != sensor_state::OWNED_BY_USER )
             throw wrong_api_call_sequence_exception( "tried to close sensor without opening it" );
 
-        LOG_DEBUG("Closing color sensor...");
         synthetic_sensor::close();
         set_sensor_state(sensor_state::CLOSED);
     }
@@ -431,11 +428,11 @@ namespace librealsense
         // Allow calibration process to open the color stream only if it is not started by the user.
         if( _state == sensor_state::CLOSED )
         {
-            set_default_controls_for_calibration_if_needed();
+            set_calibration_controls_to_defaults();
 
             synthetic_sensor::open(requests);
             set_sensor_state(sensor_state::OWNED_BY_AUTO_CAL);
-            AC_LOG( INFO, "Starting color sensor stream -- for calibration" );
+            AC_LOG( DEBUG, "Starting color sensor stream -- for calibration" );
             delayed_start( make_frame_callback( [&]( frame_holder fref ) {} ) );
             return true;
         }
@@ -457,21 +454,19 @@ namespace librealsense
         
         if( _state == sensor_state::OWNED_BY_AUTO_CAL )
         {
+            AC_LOG(DEBUG, "Closing color sensor stream from calibration");
+
             if( is_streaming() )
             {
-                AC_LOG( INFO, "Stopping color sensor stream from calibration" );
                 delayed_stop();
-                AC_LOG( INFO, "Color sensor stream stopped" );
 
             }
             if (is_opened())
             {
-                LOG_DEBUG( "Closing color sensor..." );
                 synthetic_sensor::close();
-                LOG_DEBUG( "Color sensor closed" );
             }
 
-            restore_pre_calibration_controls_if_needed();
+            restore_pre_calibration_controls();
 
             // If we got here with no exception it means the start has succeeded.
             set_sensor_state( sensor_state::CLOSED );
@@ -499,7 +494,7 @@ namespace librealsense
     }
 
 
-    void l500_color_sensor::set_default_controls_for_calibration_if_needed()
+    void l500_color_sensor::set_calibration_controls_to_defaults()
     {
         for (auto && calib_control : _calib_controls)
         {
@@ -508,17 +503,23 @@ namespace librealsense
             auto curr_val = control.query();
             if (curr_val != calib_control.default_value)
             {
-                LOG_INFO( "Calibration changed option: " << rs2_option_to_string( calib_control.option )
+                AC_LOG(DEBUG, "Calibration - changed option: " << rs2_option_to_string( calib_control.option ) << " value,"
                                               << " from: " << curr_val
                                               << " to: " << calib_control.default_value );
                 calib_control.need_to_restore = true;
                 calib_control.previous_value = curr_val;
                 control.set(calib_control.default_value);
             }
+            else
+            {
+                AC_LOG(DEBUG, "Calibration - no need to changed option: " << rs2_option_to_string(calib_control.option) << " value,"
+                    << " current value is: " << curr_val
+                    << " which is the default value");
+            }
         }
     }
 
-    void l500_color_sensor::restore_pre_calibration_controls_if_needed()
+    void l500_color_sensor::restore_pre_calibration_controls()
     {
         for (auto && calib_control : _calib_controls)
         {
@@ -528,10 +529,22 @@ namespace librealsense
             if( calib_control.need_to_restore &&
                 ( curr_val == calib_control.default_value ) )
             {
-                LOG_INFO("Calibration restored option: " << rs2_option_to_string(calib_control.option)
+                AC_LOG(DEBUG, "Calibration - restored option: " << rs2_option_to_string(calib_control.option) << " value,"
                     << " from: " << curr_val
                     << " to: " << calib_control.previous_value);
                 control.set(calib_control.previous_value);
+            }
+            else
+            {
+                std::stringstream ss;
+                ss << "Calibration - no need to restore option : "
+                   << rs2_option_to_string( calib_control.option ) << " value, "
+                   << " current value is: " << curr_val;
+
+                if( curr_val == calib_control.default_value ) ss << " which is the default value";
+                else  ss << " which is the user value";
+
+                AC_LOG(DEBUG, ss.str());
             }
             calib_control.need_to_restore = false;
         }
@@ -539,21 +552,15 @@ namespace librealsense
 
     void l500_color_sensor::register_calibration_controls()
     {
-        _calib_controls.push_back({ RS2_OPTION_ENABLE_AUTO_EXPOSURE });
-        _calib_controls.push_back({ RS2_OPTION_BACKLIGHT_COMPENSATION });
-        _calib_controls.push_back({ RS2_OPTION_BRIGHTNESS });
-        _calib_controls.push_back({ RS2_OPTION_CONTRAST });
-    }
-
-    void l500_color_sensor::read_calibration_controls_defaults()
-    {
-        for (auto && calib_control : _calib_controls)
+        for( auto && option : { RS2_OPTION_ENABLE_AUTO_EXPOSURE,
+                                RS2_OPTION_BACKLIGHT_COMPENSATION,
+                                RS2_OPTION_BRIGHTNESS,
+                                RS2_OPTION_CONTRAST } )
         {
-            auto && control = get_option(calib_control.option);
-            calib_control.default_value = control.get_range().def;
+            auto && control = get_option(option);
+            _calib_controls.push_back({ option, control.get_range().def });
         }
     }
-
 
     std::vector<tagged_profile> l500_color::get_profiles_tags() const
     {

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -131,11 +131,8 @@ namespace librealsense
         // Stops the color sensor if was opened by the calibration process, otherwise does nothing
         void stop_stream_for_calibration();
 
-        void init_calibration_controls()
-        {
-            register_calibration_controls();
-            read_calibration_controls_defaults();
-        }
+        // Sets the calibration controls needed to be controlled calibration
+        void register_calibration_controls();
         
     private:
         l500_color* const _owner;
@@ -152,14 +149,14 @@ namespace librealsense
 
         struct calibration_control
         {
-            rs2_option option;
-            float default_value;
+            const rs2_option option;
+            const float default_value;
             float previous_value;  
             bool need_to_restore;
 
-            calibration_control(rs2_option opt)
+            calibration_control(rs2_option opt, float def)
                 : option(opt)
-                , default_value(0.0f)
+                , default_value(def)
                 , previous_value(0.0f)
                 , need_to_restore(false) {}
         };
@@ -195,11 +192,9 @@ namespace librealsense
 
 
         // For better results the CAH process require default values to some of the RGB sensor controls
-        // This function handle the setting / restoring process of this controls
-        void set_default_controls_for_calibration_if_needed();
-        void restore_pre_calibration_controls_if_needed();
-        void register_calibration_controls();
-        void read_calibration_controls_defaults();
+        // This functions handle the setting / restoring process of this controls
+        void set_calibration_controls_to_defaults();
+        void restore_pre_calibration_controls();
     };
 
 }


### PR DESCRIPTION
For better results the CAH process require default values to some of the RGB sensor controls
When the CAH process need to open the color sensor, it will check and set the sensor controls to it's default values if needed.
When the CAH need to stop the color sensor or if the user will open the sensor while CAH opened it, it will restore the values to it's previous ones if needed.
