### PR TITLE
Handle dynamic number of intrinsic tables for USB2 support

### DIFF
--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -154,7 +154,7 @@ namespace librealsense
             throw invalid_value_exception(to_string() << "L500 with RGB models are expected to include a single color device! - "
                 << color_devs_info.size() << " found");
 
-        _color_intrinsics_table_raw = [this]() { return get_raw_intrinsics_table(); };
+        _color_intrinsics_table = [this]() { return get_intrinsics_table(); };
         _color_extrinsics_table_raw = [this]() { return get_raw_extrinsics_table(); };
 
         // This lazy instance will get shared between all the extrinsics edges. If you ever need to override
@@ -183,13 +183,13 @@ namespace librealsense
     {
         using namespace ivcam2;
 
-        auto intrinsic = check_calib<intrinsic_rgb>( *_owner->_color_intrinsics_table_raw );
+        auto & intrinsic = *_owner->_color_intrinsics_table;
 
-        auto num_of_res = intrinsic->resolution.num_of_resolutions;
+        auto num_of_res = intrinsic.resolution.num_of_resolutions;
 
         for( auto i = 0; i < num_of_res; i++ )
         {
-            auto model = intrinsic->resolution.intrinsic_resolution[i];
+            auto model = intrinsic.resolution.intrinsic_resolution[i];
             if( model.height == profile.height && model.width == profile.width )
             {
                 rs2_intrinsics intrinsics;
@@ -272,7 +272,7 @@ namespace librealsense
 
         // Intrinsics are resolution-specific, so all the rest of the profile info is not
         // important
-        _owner->_color_intrinsics_table_raw.reset();
+        _owner->_color_intrinsics_table.reset();
     }
 
     void l500_color_sensor::override_extrinsics( rs2_extrinsics const& extr )
@@ -335,7 +335,7 @@ namespace librealsense
         ivcam2::write_fw_table( *_owner->_hw_monitor, table.table_id, table );
         AC_LOG( DEBUG, "    done" );
 
-        _owner->_color_intrinsics_table_raw.reset();
+        _owner->_color_intrinsics_table.reset();
 
          environment::get_instance().get_extrinsics_graph().override_extrinsics(
             *_owner->_depth_stream,
@@ -493,10 +493,44 @@ namespace librealsense
         return tags;
     }
 
-    std::vector<uint8_t> l500_color::get_raw_intrinsics_table() const
+    ivcam2::intrinsic_rgb l500_color::get_intrinsics_table() const
     {
-        AC_LOG( DEBUG, "RGB_INTRINSIC_GET" );
-        return _hw_monitor->send(command{ RGB_INTRINSIC_GET });
+        // Get RAW data from firmware
+        std::vector< uint8_t > response_vec = _hw_monitor->send(command{ RGB_INTRINSIC_GET });
+
+        if (response_vec.size() == 0)
+            throw invalid_value_exception("Calibration data invalid,buffer size is zero");
+
+        auto resolutions_rgb_table_ptr = reinterpret_cast<const ivcam2::intrinsic_rgb *>(response_vec.data());
+
+        // Get full maximum size of the resolution array and deduct the unused resolutions size from it
+        size_t expected_size = sizeof( ivcam2::intrinsic_rgb )
+                                - ( ( MAX_NUM_OF_RGB_RESOLUTIONS
+                                - resolutions_rgb_table_ptr->resolution.num_of_resolutions )
+                                * sizeof( pinhole_camera_model ) );
+
+        // Validate table size
+        if (expected_size > response_vec.size())
+        {
+            throw invalid_value_exception(
+                to_string() << "Calibration data invalid, buffer too small : expected "
+                << expected_size << " , actual: " << response_vec.size());
+        }
+
+        // Set a new memory allocated intrinsics struct (Full size 5 resolutions)
+        // Copy the relevant data from the dynamic resolution received from the FW
+        ivcam2::intrinsic_rgb  resolutions_rgb_table_output;
+        resolutions_rgb_table_output.common = resolutions_rgb_table_ptr->common;
+        resolutions_rgb_table_output.resolution.num_of_resolutions = resolutions_rgb_table_ptr->resolution.num_of_resolutions;
+        resolutions_rgb_table_output.resolution.reserved16 = resolutions_rgb_table_ptr->resolution.reserved16;
+        resolutions_rgb_table_output.resolution.reserved8 = resolutions_rgb_table_ptr->resolution.reserved8;
+
+        for (int i = 0; i < resolutions_rgb_table_output.resolution.num_of_resolutions; ++i)
+        {
+            resolutions_rgb_table_output.resolution.intrinsic_resolution[i] = resolutions_rgb_table_ptr->resolution.intrinsic_resolution[i];
+        }
+
+        return resolutions_rgb_table_output;
     }
     std::vector<uint8_t> l500_color::get_raw_extrinsics_table() const
     {

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -36,11 +36,11 @@ namespace librealsense
 
         uint8_t _color_device_idx = -1;
 
-        lazy<std::vector<uint8_t>> _color_intrinsics_table_raw;
+        lazy<ivcam2::intrinsic_rgb> _color_intrinsics_table;
         lazy<std::vector<uint8_t>> _color_extrinsics_table_raw;
         std::shared_ptr<lazy<rs2_extrinsics>> _color_extrinsic;
 
-        std::vector<uint8_t> get_raw_intrinsics_table() const;
+        ivcam2::intrinsic_rgb get_intrinsics_table() const;
         std::vector<uint8_t> get_raw_extrinsics_table() const;
     };
 

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -40,7 +40,7 @@ namespace librealsense
         lazy<std::vector<uint8_t>> _color_extrinsics_table_raw;
         std::shared_ptr<lazy<rs2_extrinsics>> _color_extrinsic;
 
-        ivcam2::intrinsic_rgb get_intrinsics_table() const;
+        ivcam2::intrinsic_rgb read_intrinsics_table() const;
         std::vector<uint8_t> get_raw_extrinsics_table() const;
     };
 

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -26,7 +26,8 @@ namespace librealsense
     class l500_depth : public virtual l500_device
     {
     public:
-        std::vector<uint8_t> get_raw_calibration_table() const;
+
+        ivcam2::intrinsic_depth get_calibration_table() const;
 
         l500_depth(std::shared_ptr<context> ctx,
             const platform::backend_device_group& group);
@@ -221,7 +222,7 @@ namespace librealsense
         ivcam2::intrinsic_depth get_intrinsic() const override
         {
             using namespace ivcam2;
-            return *check_calib<intrinsic_depth>(*_owner->_calib_table_raw);
+            return *_owner->_calib_table;
         }
 
         void create_snapshot(std::shared_ptr<depth_sensor>& snapshot) const override

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -27,7 +27,7 @@ namespace librealsense
     {
     public:
 
-        ivcam2::intrinsic_depth get_calibration_table() const;
+        ivcam2::intrinsic_depth read_intrinsics_table() const;
 
         l500_depth(std::shared_ptr<context> ctx,
             const platform::backend_device_group& group);

--- a/src/l500/l500-device.h
+++ b/src/l500/l500-device.h
@@ -87,7 +87,7 @@ namespace librealsense
 
         std::unique_ptr<polling_error_handler> _polling_error_handler;
 
-        lazy<std::vector<uint8_t>> _calib_table_raw;
+        lazy<ivcam2::intrinsic_depth> _calib_table;
         firmware_version _fw_version;
         std::shared_ptr<stream_interface> _depth_stream;
         std::shared_ptr<stream_interface> _ir_stream;

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -9,8 +9,8 @@
 #include "core/extension.h"
 #include "fw-update/fw-update-unsigned.h"
 
-static const int NUM_OF_RGB_RESOLUTIONS = 5;
-static const int NUM_OF_DEPTH_RESOLUTIONS = 2;
+static const int MAX_NUM_OF_RGB_RESOLUTIONS = 5;
+static const int MAX_NUM_OF_DEPTH_RESOLUTIONS = 5; 
 
 namespace librealsense
 {
@@ -261,21 +261,6 @@ namespace librealsense
             { DFU_error,                    "DFU error" },
         };
 
-        template<class T>
-        const T* check_calib(const std::vector<uint8_t>& raw_data)
-        {
-            using namespace std;
-
-            auto table = reinterpret_cast<const T*>(raw_data.data());
-
-            if (raw_data.size() < sizeof(T))
-            {
-                throw invalid_value_exception(to_string() << "Calibration data invald, buffer too small : expected " << sizeof(T) << " , actual: " << raw_data.size());
-            }
-
-            return table;
-        }
-
 #pragma pack(push, 1)
         struct pinhole_model
         {
@@ -318,7 +303,7 @@ namespace librealsense
             uint16_t reserved16;
             uint8_t reserved8;
             uint8_t num_of_resolutions;
-            intrinsic_per_resolution intrinsic_resolution[NUM_OF_DEPTH_RESOLUTIONS]; //Dynamic number of entries according to num of resolutions
+            intrinsic_per_resolution intrinsic_resolution[MAX_NUM_OF_DEPTH_RESOLUTIONS]; //Dynamic number of entries according to num of resolutions
         };
 
         struct orientation
@@ -341,7 +326,7 @@ namespace librealsense
             uint16_t reserved16;
             uint8_t reserved8;
             uint8_t num_of_resolutions;
-            pinhole_camera_model intrinsic_resolution[NUM_OF_RGB_RESOLUTIONS]; //Dynamic number of entries according to num of resolutions
+            pinhole_camera_model intrinsic_resolution[MAX_NUM_OF_RGB_RESOLUTIONS]; //Dynamic number of entries according to num of resolutions
         };
 
         struct rgb_common

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -121,7 +121,7 @@ namespace librealsense
         struct l500_depth_data
         {
             float num_of_resolution;
-            l500_data_per_resolution data[NUM_OF_DEPTH_RESOLUTIONS];
+            l500_data_per_resolution data[MAX_NUM_OF_DEPTH_RESOLUTIONS];
             float baseline;
         };
 


### PR DESCRIPTION
On L515 device we get 2 depth resolutions on USB3 and 1 on USB2.
This PR replace sharing the FW raw data vector with a physical preallocated full size buffer (Support up to 5 resolutions)

Same change apply for depth and color intrinsic tables handling.