### PR TITLE
Fix sensor mode exception on QVGA resolution (USB2)

### DIFF
--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -94,7 +94,17 @@ namespace librealsense
         }
         else
         {
-            auto resolution_option = std::make_shared<float_option_with_description<rs2_sensor_mode>>(option_range{ RS2_SENSOR_MODE_VGA,RS2_SENSOR_MODE_COUNT - 1,1, RS2_SENSOR_MODE_XGA }, "Notify the sensor about the intended streaming mode. Required for preset ");
+            // On USB2 we have only QVGA sensor mode
+            bool usb2 = false;
+            if(supports_info( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR ) )
+            {
+                std::string dev_usb_type( get_info( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR ) );
+                usb2 = ( std::string::npos != dev_usb_type.find( "2." ) );
+            }
+
+            auto default_sensor_mode = static_cast<float>(usb2 ? RS2_SENSOR_MODE_QVGA : RS2_SENSOR_MODE_VGA);
+
+            auto resolution_option = std::make_shared<float_option_with_description<rs2_sensor_mode>>(option_range{ RS2_SENSOR_MODE_VGA,RS2_SENSOR_MODE_COUNT - 1,1, default_sensor_mode }, "Notify the sensor about the intended streaming mode. Required for preset ");
 
             depth_sensor.register_option(RS2_OPTION_SENSOR_MODE, resolution_option);
 


### PR DESCRIPTION
Sensor default mode change from XGA to
USB3 -> VGA
USB2 -> QVGA

Tracked on [RS5-8352]