### PR TITLE
L515 update tagged profiles for usb2

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1088,19 +1088,6 @@ namespace rs2
 
             int selection_index{};
 
-            // TODO: Once GLSL parts are properly optimised
-            // and tested on all types of hardware
-            // make sure we use Full-HD YUY overriding the default
-            // This will lower CPU utilisation and generally be faster
-            // if (!usb2 && std::string(s->get_info(RS2_CAMERA_INFO_NAME)) == "RGB Camera")
-            // {
-            //     if (config_file::instance().get(configurations::performance::glsl_for_rendering))
-            //     {
-            //         resolution_constrain = std::make_pair(1920, 1080);
-            //         def_format = RS2_FORMAT_YUYV;
-            //     }
-            // }
-
             if (!show_single_fps_list)
             {
                 for (auto fps_array : fps_values_per_stream)

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1033,13 +1033,17 @@ namespace rs2
             reverse(begin(sensor_profiles), end(sensor_profiles));
             rs2_format def_format{ RS2_FORMAT_ANY };
             auto default_resolution = std::make_pair(1280, 720);
+            auto default_fps = 30;
             for (auto&& profile : sensor_profiles)
             {
                 std::stringstream res;
                 if (auto vid_prof = profile.as<video_stream_profile>())
                 {
                     if (profile.is_default())
+                    {
                         default_resolution = std::pair<int, int>(vid_prof.width(), vid_prof.height());
+                        default_fps = profile.fps();
+                    }
                     res << vid_prof.width() << " x " << vid_prof.height();
                     push_back_if_not_exists(res_values, std::pair<int, int>(vid_prof.width(), vid_prof.height()));
                     push_back_if_not_exists(resolutions, res.str());
@@ -1082,17 +1086,7 @@ namespace rs2
 
             show_single_fps_list = is_there_common_fps();
 
-            // set default selections. USB2 configuration requires low-res resolution/fps.
             int selection_index{};
-            bool usb2 = false;
-            if (dev.supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
-            {
-                std::string dev_usb_type(dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR));
-                usb2 = (std::string::npos != dev_usb_type.find("2."));
-            }
-
-            int fps_constrain = usb2 ? 15 : 30;
-            auto resolution_constrain = usb2 ? std::make_pair(640, 480) : default_resolution;
 
             // TODO: Once GLSL parts are properly optimised
             // and tested on all types of hardware
@@ -1111,7 +1105,7 @@ namespace rs2
             {
                 for (auto fps_array : fps_values_per_stream)
                 {
-                    if (get_default_selection_index(fps_array.second, fps_constrain, &selection_index))
+                    if (get_default_selection_index(fps_array.second, default_fps, &selection_index))
                     {
                         ui.selected_fps_id[fps_array.first] = selection_index;
                         break;
@@ -1120,7 +1114,7 @@ namespace rs2
             }
             else
             {
-                if (get_default_selection_index(shared_fps_values, fps_constrain, &selection_index))
+                if (get_default_selection_index(shared_fps_values, default_fps, &selection_index))
                     ui.selected_shared_fps_id = selection_index;
             }
 
@@ -1133,7 +1127,7 @@ namespace rs2
                 }
             }
 
-            get_default_selection_index(res_values, resolution_constrain, &selection_index);
+            get_default_selection_index(res_values, default_resolution, &selection_index);
             ui.selected_res_id = selection_index;
 
             // Have the various preset options automatically update based on the resolution of the

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -572,7 +572,7 @@ namespace librealsense
         uint32_t width = usb3mode ? 1280 : 960;
         uint32_t height = usb3mode ? 720 : 540;
 
-        tags.push_back({ RS2_STREAM_COLOR, -1, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_COLOR, -1, width, height, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 
         return tags;
     }

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -566,7 +566,14 @@ namespace librealsense
     {
         std::vector<tagged_profile> tags;
 
+        auto usb_spec = get_usb_spec();
+        bool usb3mode = (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined);
+
+        uint32_t width = usb3mode ? 1280 : 960;
+        uint32_t height = usb3mode ? 720 : 540;
+
         tags.push_back({ RS2_STREAM_COLOR, -1, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+
         return tags;
     }
 

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -126,9 +126,15 @@ namespace librealsense
     {
         std::vector<tagged_profile> tags;
 
-        tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-        tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-        tags.push_back({ RS2_STREAM_CONFIDENCE, -1, 640, 480, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET });
+        auto usb_spec = get_usb_spec();
+        bool usb3mode = (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined);
+
+        uint32_t width = usb3mode ? 640 : 320;
+        uint32_t height = usb3mode ? 480 : 240;
+
+        tags.push_back({ RS2_STREAM_DEPTH, -1, width, height, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_INFRARED, -1, width, height, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+        tags.push_back({ RS2_STREAM_CONFIDENCE, -1, width, height, RS2_FORMAT_RAW8, 30, profile_tag::PROFILE_TAG_SUPERSET });
         
         return tags;
     }

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -267,30 +267,6 @@ namespace librealsense
             }
         );
 
-        depth_sensor.register_processing_block(
-            { {RS2_FORMAT_Z16}, {RS2_FORMAT_Y8} },
-            { {RS2_FORMAT_Z16, RS2_STREAM_DEPTH} },
-            [=]() {
-                auto is_zo_enabled_opt = weak_is_zo_enabled_opt.lock();
-                auto z16rot = std::make_shared<identity_processing_block>();
-                auto y8rot = std::make_shared<identity_processing_block>();
-                auto sync = std::make_shared<syncer_process_unit>(); // is_zo_enabled_opt );
-                auto zo = std::make_shared<zero_order>(is_zo_enabled_opt);
-
-                auto cpb = std::make_shared<composite_processing_block>();
-                cpb->add(z16rot);
-                cpb->add(y8rot);
-                cpb->add(sync);
-                cpb->add(zo);
-                if( _autocal )
-                {
-                    //sync->add_enabling_option( _autocal->get_enabler_opt() );
-                    cpb->add( std::make_shared< ac_trigger::depth_processing_block >( _autocal ) );
-                }
-                cpb->add( std::make_shared< filtering_processing_block >( RS2_STREAM_DEPTH ) );
-                return cpb;
-            }
-        );
 
         depth_sensor.register_processing_block(
             { {RS2_FORMAT_Z16}, {RS2_FORMAT_Y8}, {RS2_FORMAT_RAW8} },
@@ -328,8 +304,6 @@ namespace librealsense
             { {RS2_FORMAT_Y8, RS2_STREAM_INFRARED, 0, 0, 0, 0, &rotate_resolution} },
             []() { return std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME); }
         );
-
-        depth_sensor.register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_Y8, RS2_STREAM_INFRARED));
 
         depth_sensor.register_processing_block(
             { {RS2_FORMAT_RAW8} },

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -337,7 +337,6 @@ namespace librealsense
             []() { return std::make_shared<confidence_rotation_transform>(); }
         );
 
-        depth_sensor.register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_RAW8, RS2_STREAM_CONFIDENCE));
 
         std::shared_ptr< freefall_option > freefall_opt;
         if( _fw_version >= firmware_version( "1.3.5.0" ) )

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -642,6 +642,19 @@ namespace librealsense
         return _hw_monitor->send(input);
     }
 
+    platform::usb_spec l500_device::get_usb_spec() const
+    {
+        if (!supports_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
+            return platform::usb_undefined;
+        auto str = get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
+        for (auto u : platform::usb_spec_names)
+        {
+            if (u.second.compare(str) == 0)
+                return u.first;
+        }
+        return platform::usb_undefined;
+    }
+
     notification l500_notification_decoder::decode(int value)
     {
         if (l500_fw_error_report.find(static_cast<uint8_t>(value)) != l500_fw_error_report.end())

--- a/src/l500/l500-device.h
+++ b/src/l500/l500-device.h
@@ -79,6 +79,8 @@ namespace librealsense
         void update_flash_internal(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, std::vector<uint8_t>& flash_backup,
             update_progress_callback_ptr callback, int update_mode);
 
+        platform::usb_spec get_usb_spec() const;
+
     protected:
         friend class l500_depth_sensor;
 

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -95,14 +95,10 @@ namespace librealsense
         else
         {
             // On USB2 we have only QVGA sensor mode
-            bool usb2 = false;
-            if(supports_info( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR ) )
-            {
-                std::string dev_usb_type( get_info( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR ) );
-                usb2 = ( std::string::npos != dev_usb_type.find( "2." ) );
-            }
+            auto usb_spec = get_usb_spec();
+            bool usb3mode = (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined);
 
-            auto default_sensor_mode = static_cast<float>(usb2 ? RS2_SENSOR_MODE_QVGA : RS2_SENSOR_MODE_VGA);
+            auto default_sensor_mode = static_cast<float>(usb3mode ? RS2_SENSOR_MODE_VGA : RS2_SENSOR_MODE_QVGA);
 
             auto resolution_option = std::make_shared<float_option_with_description<rs2_sensor_mode>>(option_range{ RS2_SENSOR_MODE_VGA,RS2_SENSOR_MODE_COUNT - 1,1, default_sensor_mode }, "Notify the sensor about the intended streaming mode. Required for preset ");
 


### PR DESCRIPTION
1. Remove raw resolutions processing blocks - **Tracked on RS5-8384**
2. Update L515 tagged profiles to support USB2 resolutions
3. Remove viewer resolutions + FPS constrains for USB 2 (behavior stayed the same due to tagged profiles)

