### PR TITLE
Fix ctrl+Num keys not rendering on viewer terminal

### DIFF
--- a/third-party/imgui/imgui_impl_glfw.cpp
+++ b/third-party/imgui/imgui_impl_glfw.cpp
@@ -139,9 +139,6 @@ void ImGui_ImplGlFw_KeyCallback(GLFWwindow*, int key, int, int action, int mods)
     if (action == GLFW_RELEASE)
         io.KeysDown[key] = false;
 
-    if (mods && GLFW_MOD_CONTROL) io.KeysDown[GLFW_KEY_LEFT_CONTROL] = true;
-    else io.KeysDown[GLFW_KEY_LEFT_CONTROL] = false;
-
     (void)mods; // Modifiers are not reliable across systems
     io.KeyCtrl = io.KeysDown[GLFW_KEY_LEFT_CONTROL] || io.KeysDown[GLFW_KEY_RIGHT_CONTROL];
     io.KeyShift = io.KeysDown[GLFW_KEY_LEFT_SHIFT] || io.KeysDown[GLFW_KEY_RIGHT_SHIFT];


### PR DESCRIPTION
Viewer application does not support special keys like '_' (all of shift + Num keys) as inputs
The code that was removed on this PR is the reason.
It was inserted as part of the terminal feature to allow copy-paste capabillity.

When removing it I tested in windows + Linux that the copy-paste capability still works.
and now so does the special keys
