### PR TITLE
added 'using std::abs' in types.h to avoid Linux bug

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -60,6 +60,11 @@ static const double r2d = 180 / pi;
 template<typename T> T deg2rad(T val) { return T(val * d2r); }
 template<typename T> T rad2deg(T val) { return T(val * r2d); }
 
+// global abs() is only defined for int for some GCC impl on Linux, meaning we may
+// get unwanted behavior without any warning whatsoever. Instead, we want to use the
+// C++ version in std!
+using std::abs;
+
 #pragma warning(disable: 4250)
 
 #ifdef ANDROID


### PR DESCRIPTION
This fixes a bug where compilation occurs on Ubuntu 16, where GCC decides to use abs(int) and this obviously causes bad results. The global ::abs() should really never be used, but I found no good way of removing it.

Tracked on RS5-8641