### PR TITLE
Fix backward button issue with viewer.

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3801,7 +3801,10 @@ namespace rs2
             }
             auto curr_frame = p.get_position();
             uint64_t step = uint64_t(1000.0 / (float)fps * 1e6);
-            p.seek(std::chrono::nanoseconds(curr_frame - step));
+            if (curr_frame >= step)
+            {
+                p.seek(std::chrono::nanoseconds(curr_frame - step));
+            }
         }
         if (ImGui::IsItemHovered())
         {


### PR DESCRIPTION
the function rs2_playback_seek behind the playback::seek function can't receive negative timestamps.
tracked on: DSO-15533