### PR TITLE
Fix SW update links

### DIFF
--- a/common/sw-update/dev-updates-profile.cpp
+++ b/common/sw-update/dev-updates-profile.cpp
@@ -71,9 +71,9 @@ namespace rs2
             bool query_ok = up_handler.query_versions(dev_name, part, policy, required_version);
             if (query_ok)
             {
-                //auto dl_link_ok = up_handler.get_version_download_link(part, required_version, result.download_link);
-                //auto rel_ok = up_handler.get_version_release_notes(part, required_version, result.release_page);
-                //auto desc_ok = up_handler.get_version_description(part, required_version, result.description);
+                up_handler.get_version_download_link(part, required_version, result.download_link);
+                up_handler.get_version_release_notes(part, required_version, result.release_page);
+                up_handler.get_version_description(part, required_version, result.description);
                 result.ver = required_version;
 
                 std::stringstream ss;


### PR DESCRIPTION
The SW Update links filling were mistakenly comment out on a LLVM unused variable warning fix

This PR undo it and removed the unused variables.