### PR TITLE
enable usb weak host workaround to improve android stability

### DIFF
--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -96,7 +96,7 @@ extern "C" {
         RS2_OPTION_THERMAL_COMPENSATION, /**< Depth Thermal Compensation for selected D400 SKUs */
         RS2_OPTION_TRIGGER_CAMERA_ACCURACY_HEALTH, /**< Enable depth & color frame sync with periodic calibration for proper alignment */
         RS2_OPTION_RESET_CAMERA_ACCURACY_HEALTH,
-        RS2_OPTION_ENABLE_WEAK_USB_HOST_WA, /**< Enable workaround for weak USB hosts to improve performance and stability */
+        RS2_OPTION_HOST_PERFORMANCE, /**< Set host performance mode, optimize device settings for USB TRB granularity, larger TRB legth may improve performance and stability on low performance hosts */
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 
@@ -175,6 +175,16 @@ extern "C" {
         RS2_CAH_TRIGGER_COUNT        /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_cah_trigger;
     const char* rs2_cah_trigger_to_string( rs2_cah_trigger preset );
+
+    /** \brief values for RS2_OPTION_HOST_PERFORMANCE option. */
+    typedef enum rs2_host_perf_mode
+    {
+        RS2_HOST_PERF_DEFAULT = 0,  /**< no change in settings, use device defaults */
+        RS2_HOST_PERF_LOW = 1,      /**< low power low performance hosts, larger USB TRB granularity reduces number of transactions and improve performance and stability on weak hosts */
+        RS2_HOST_PERF_HIGH = 2,     /**< high power high performance hosts, smaller USB TRB granularity and  larger number of transactions */
+        RS2_HOST_PERF_COUNT         /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
+    } rs2_host_perf_mode;
+    const char* rs2_host_perf_mode_to_string( rs2_host_perf_mode perf );
 
     /**
     * check if an option is read-only

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -96,7 +96,7 @@ extern "C" {
         RS2_OPTION_THERMAL_COMPENSATION, /**< Depth Thermal Compensation for selected D400 SKUs */
         RS2_OPTION_TRIGGER_CAMERA_ACCURACY_HEALTH, /**< Enable depth & color frame sync with periodic calibration for proper alignment */
         RS2_OPTION_RESET_CAMERA_ACCURACY_HEALTH,
-        RS2_OPTION_HOST_PERFORMANCE, /**< Set host performance mode, optimize device settings for USB TRB granularity, larger TRB legth may improve performance and stability on low performance hosts */
+        RS2_OPTION_HOST_PERFORMANCE, /**< Set host performance mode to optimize device settings so host can keep up with workload, for example, USB transaction granularity, setting option to low performance host leads to larger USB transaction size and reduced number of transactions which improves performance and stability if host is relatively weak as compared to workload */
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 
@@ -180,8 +180,8 @@ extern "C" {
     typedef enum rs2_host_perf_mode
     {
         RS2_HOST_PERF_DEFAULT = 0,  /**< no change in settings, use device defaults */
-        RS2_HOST_PERF_LOW = 1,      /**< low power low performance hosts, larger USB TRB granularity reduces number of transactions and improve performance and stability on weak hosts */
-        RS2_HOST_PERF_HIGH = 2,     /**< high power high performance hosts, smaller USB TRB granularity and  larger number of transactions */
+        RS2_HOST_PERF_LOW = 1,      /**< low performance host mode, if host cannot keep up with workload, this option may improve stability, for example, it sets larger USB transaction granularity, reduces number of transactions and improve performance and stability on relatively weak hosts as compared to the workload */
+        RS2_HOST_PERF_HIGH = 2,     /**< high performance host mode, if host is strong as compared to the work and can handle workload without delay, this option sets smaller USB transactions granularity and as result larger number of transactions and workload on host, but reduces chance in device frame drops */
         RS2_HOST_PERF_COUNT         /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_host_perf_mode;
     const char* rs2_host_perf_mode_to_string( rs2_host_perf_mode perf );

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -96,6 +96,7 @@ extern "C" {
         RS2_OPTION_THERMAL_COMPENSATION, /**< Depth Thermal Compensation for selected D400 SKUs */
         RS2_OPTION_TRIGGER_CAMERA_ACCURACY_HEALTH, /**< Enable depth & color frame sync with periodic calibration for proper alignment */
         RS2_OPTION_RESET_CAMERA_ACCURACY_HEALTH,
+        RS2_OPTION_ENABLE_WEAK_USB_HOST_WA, /**< Enable workaround for weak USB hosts to improve performance and stability */
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -109,7 +109,7 @@ namespace librealsense
 #ifdef __ANDROID__
         // option to enable workaround for help weak usb hosts to support L515 devices
         // with improved performance and stability
-        if(_fw_version >= firmware_version( "1.4.0.66" ) )
+        if(_fw_version >= firmware_version( "1.5.1.0" ) )
         {
             color_ep->register_option(RS2_OPTION_ENABLE_WEAK_USB_HOST_WA, std::make_shared<librealsense::float_option>(option_range{ 0, 1, 1, 1 }));
         }
@@ -371,13 +371,17 @@ namespace librealsense
 #ifdef __ANDROID__
         if (supports_option(RS2_OPTION_ENABLE_WEAK_USB_HOST_WA))
         {
+            // option to improve performance and stability on weak android hosts
+            // please refer to following bug report for details
+            // RS5-8011 [Android-L500 Hard failure] Device detach and disappear from system during stream
+
             auto usb_perf_enabled = get_option(RS2_OPTION_ENABLE_WEAK_USB_HOST_WA).query();
 
             if (usb_perf_enabled)
             {
                 // TPROC USB Granularity and TRB threshold settings for improved performance and stability
                 // on hosts with weak cpu and system performance
-                // settings values are validated through many experiments, do not change unless
+                // settings values are validated through many experiments, do not change
                 try {
                     // endpoint 5 - 32KB
                     command cmdTprocGranEp5(ivcam2::TPROC_USB_GRAN_SET, 5, 32);
@@ -386,7 +390,7 @@ namespace librealsense
                     command cmdTprocThresholdEp5(ivcam2::TPROC_TRB_THRSLD_SET, 5, 1);
                     _owner->_hw_monitor->send(cmdTprocThresholdEp5);
 
-                    LOG_INFO("Color usb tproc granularity and TRB threshold updated.");
+                    LOG_DEBUG("Color usb tproc granularity and TRB threshold updated.");
                 } catch (...)
                 {
                     LOG_WARNING("Failed to update color usb tproc granularity and TRB threshold. performance and stability maybe impacted on certain platforms.");

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -108,7 +108,7 @@ namespace librealsense
         // option to enable workaround for help weak usb hosts to support L515 devices
         // with improved performance and stability
 #ifdef __ANDROID__
-        if(_fw_version >= firmware_version( "1.4.0.66" ) )
+        if(_fw_version >= firmware_version( "1.5.1.0" ) )
         {
             depth_sensor.register_option(RS2_OPTION_ENABLE_WEAK_USB_HOST_WA, std::make_shared<librealsense::float_option>(option_range{ 0, 1, 1, 1 }));
         }
@@ -386,13 +386,17 @@ namespace librealsense
 #ifdef __ANDROID__
         if (supports_option(RS2_OPTION_ENABLE_WEAK_USB_HOST_WA))
         {
+            // option to improve performance and stability on weak android hosts
+            // please refer to following bug report for details
+            // RS5-8011 [Android-L500 Hard failure] Device detach and disappear from system during stream
+
             auto usb_perf_enabled = get_option(RS2_OPTION_ENABLE_WEAK_USB_HOST_WA).query();
 
             if (usb_perf_enabled)
             {
                 // TPROC USB Granularity and TRB threshold settings for improved performance and stability
                 // on hosts with weak cpu and system performance
-                // settings values are validated through many experiments, do not change unless
+                // settings values are validated through many experiments, do not change
                 try {
                     // endpoint 2 - 16KB
                     command cmdTprocGranEp2(ivcam2::TPROC_USB_GRAN_SET, 2, 16);
@@ -408,7 +412,7 @@ namespace librealsense
                     command cmdTprocThresholdEp3(ivcam2::TPROC_TRB_THRSLD_SET, 3, 1);
                     _owner->_hw_monitor->send(cmdTprocThresholdEp3);
 
-                    LOG_INFO("Depth and IR usb tproc granularity and TRB threshold updated.");
+                    LOG_DEBUG("Depth and IR usb tproc granularity and TRB threshold updated.");
                 } catch (...)
                 {
                     LOG_WARNING("FAILED TO UPDATE depth usb tproc granularity and TRB threshold. performance and stability maybe impacted on certain platforms.");

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -60,6 +60,8 @@ namespace librealsense
             AMCSET                      = 0x2B, // Set options (L515)
             AMCGET                      = 0x2C, // Get options (L515)
             DELETE_TABLE                = 0x2E,
+            TPROC_TRB_THRSLD_SET        = 0x35, // TPROC TRB threshold
+            TPROC_USB_GRAN_SET          = 0x36, // TPROC USB granularity
             PFD                         = 0x3B, // Disable power features <Parameter1 Name="0 - Disable, 1 - Enable" />
             READ_TABLE                  = 0x43, // read table from flash, for example, read imu calibration table, read_table 0x243 0
             WRITE_TABLE                 = 0x44,
@@ -518,6 +520,5 @@ namespace librealsense
         };
 
         class ac_trigger;
-
     } // librealsense::ivcam2
 } // namespace librealsense

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -239,6 +239,7 @@ EXPORTS
     rs2_rs400_visual_preset_to_string
     rs2_l500_visual_preset_to_string
     rs2_sensor_mode_to_string
+    rs2_host_perf_mode_to_string
     rs2_is_enabled
     rs2_toggle_advanced_mode
     rs2_load_json

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1268,6 +1268,7 @@ const char* rs2_ambient_light_to_string( rs2_ambient_light ambient )            
 const char* rs2_cah_trigger_to_string( rs2_cah_trigger mode )                             { return get_string(mode); }
 const char* rs2_calibration_type_to_string(rs2_calibration_type type)                     { return get_string(type); }
 const char* rs2_calibration_status_to_string(rs2_calibration_status status)               { return get_string(status); }
+const char* rs2_host_perf_mode_to_string(rs2_host_perf_mode mode)                         { return get_string(mode); }
 
 void rs2_log_to_console(rs2_log_severity min_severity, rs2_error** error) BEGIN_API_CALL
 {

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -471,6 +471,19 @@ namespace librealsense
         else if (!_is_opened)
             throw wrong_api_call_sequence_exception("start_streaming(...) failed. UVC device was not opened!");
 
+        // RS2_OPTION_AUTO_EXPOSURE_PRIORITY will be disabled by default in firmware
+        // temporarily disable here to facilitate android stability tests
+#ifdef __ANDROID__
+        try {
+            if (supports_option(RS2_OPTION_AUTO_EXPOSURE_PRIORITY)) {
+                _device->set_pu(rs2_option::RS2_OPTION_AUTO_EXPOSURE_PRIORITY, 0.0);
+            }
+        } catch (...)
+        {
+            LOG_WARNING("disable RS2_OPTION_AUTO_EXPOSURE_PRIORITY failed.");
+        }
+#endif
+
         raise_on_before_streaming_changes(true); //Required to be just before actual start allow recording to work
         _source.set_callback(callback);
         _is_streaming = true;

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -471,19 +471,6 @@ namespace librealsense
         else if (!_is_opened)
             throw wrong_api_call_sequence_exception("start_streaming(...) failed. UVC device was not opened!");
 
-        // RS2_OPTION_AUTO_EXPOSURE_PRIORITY will be disabled by default in firmware
-        // temporarily disable here to facilitate android stability tests
-#ifdef __ANDROID__
-        try {
-            if (supports_option(RS2_OPTION_AUTO_EXPOSURE_PRIORITY)) {
-                _device->set_pu(rs2_option::RS2_OPTION_AUTO_EXPOSURE_PRIORITY, 0.0);
-            }
-        } catch (...)
-        {
-            LOG_WARNING("disable RS2_OPTION_AUTO_EXPOSURE_PRIORITY failed.");
-        }
-#endif
-
         raise_on_before_streaming_changes(true); //Required to be just before actual start allow recording to work
         _source.set_callback(callback);
         _is_streaming = true;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -240,6 +240,19 @@ namespace librealsense
 #undef CASE
     }
 
+    const char* get_string(rs2_host_perf_mode value)
+    {
+#define CASE(X) STRCASE(HOST_PERF, X)
+        switch (value)
+        {
+            CASE(DEFAULT)
+            CASE(LOW)
+            CASE(HIGH)
+        default: assert(!is_valid(value)); return UNKNOWN_VALUE;
+        }
+#undef CASE
+    }
+
     const char* get_string(rs2_extension value)
     {
 #define CASE(X) STRCASE(EXTENSION, X)
@@ -411,6 +424,7 @@ namespace librealsense
             CASE(THERMAL_COMPENSATION)
             CASE(TRIGGER_CAMERA_ACCURACY_HEALTH)
             CASE(RESET_CAMERA_ACCURACY_HEALTH)
+            CASE(HOST_PERFORMANCE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE
@@ -600,6 +614,7 @@ namespace librealsense
         }
 #undef CASE
     }
+
     std::string firmware_version::to_string() const
     {
         if (is_any) return "any";

--- a/src/types.h
+++ b/src/types.h
@@ -557,6 +557,7 @@ namespace librealsense
     RS2_ENUM_HELPERS_CUSTOMIZED(rs2_calibration_status, RS2_CALIBRATION_STATUS_FIRST, RS2_CALIBRATION_STATUS_LAST )
     RS2_ENUM_HELPERS_CUSTOMIZED(rs2_ambient_light, RS2_AMBIENT_LIGHT_NO_AMBIENT, RS2_AMBIENT_LIGHT_LOW_AMBIENT)
     RS2_ENUM_HELPERS(rs2_cah_trigger, CAH_TRIGGER)
+    RS2_ENUM_HELPERS(rs2_host_perf_mode, HOST_PERF)
 
 
     ////////////////////////////////////////////

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Option.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Option.java
@@ -75,7 +75,8 @@ public enum Option {
     EMITTER_ALWAYS_ON(71),
     THERMAL_COMPENSATION(72),
     TRIGGER_CAMERA_ACCURACY_HEALTH(73),
-    RESET_CAMERA_ACCURACY_HEALTH(74);
+    RESET_CAMERA_ACCURACY_HEALTH(74),
+    HOST_PERFORMANCE(75);
     private final int mValue;
 
     private Option(int value) { mValue = value; }

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -172,6 +172,7 @@ PYBIND11_MODULE(NAME, m) {
         .value("sensor_resolution_mode", RS2_OPTION_SENSOR_MODE)
         .value("emitter_always_on", RS2_OPTION_EMITTER_ALWAYS_ON)
         .value("thermal_compensation", RS2_OPTION_THERMAL_COMPENSATION)
+        .value("host_performance", RS2_OPTION_HOST_PERFORMANCE)
         .value("count", RS2_OPTION_COUNT);
 
     py::enum_<platform::power_state> power_state(m, "power_state");


### PR DESCRIPTION
Enable L515 android stability workaround. Current usb buffer settings in device require large number of small usb transactions from device to usb host controller, some hosts with relatively weak host cannot handle this many transactions quickly, results in stability issues, camera disappear from os enumeration or one of the streams dies during stream, etc. This workaround uses larger buffer settings to reduce the number of transaction and improve performance and stability.

Workaround is enabled by default for all android platforms. Requires additional firmware command support in new firmware release.

Tracked on: RS5-8011