### PR TITLE
Bundled firmware update no longer fail if backup step fail

### DIFF
--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -209,12 +209,20 @@ namespace rs2
                     std::ofstream file(temp.c_str(), std::ios::binary);
                     file.write((const char*)flash.data(), flash.size());
                     log_backup_status = "Backup completed and saved as '"  + temp + "'";
-
                 }
             }
-            catch (...)
+            catch (const std::exception& e)
             {
-                log_backup_status = "Warning! - Backup step encountered an issue, continue update without it.";
+                log_backup_status = "WARNING: backup failed; continuing without it...";
+                _viewer.not_model->output.add_log(RS2_LOG_SEVERITY_WARN,
+                    __FILE__,
+                    __LINE__,
+                    log_backup_status + ", Error: " + e.what());
+            }
+            catch ( ... )
+            {
+                log_backup_status = "WARNING: backup failed; continuing without it...";
+                _viewer.not_model->add_log(log_backup_status + ", Unknown error occurred");
             }
 
             log(log_backup_status);

--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -194,22 +194,30 @@ namespace rs2
         {
             log("Backing-up camera flash memory");
 
-            auto flash = upd.create_flash_backup([&](const float progress)
+            std::string log_backup_status;
+            try
             {
-                _progress = int((ceil(progress * 5) / 5) * (30 - next_progress)) + next_progress;
-            });
+                auto flash = upd.create_flash_backup([&](const float progress)
+                {
+                    _progress = int((ceil(progress * 5) / 5) * (30 - next_progress)) + next_progress;
+                });
 
-            auto temp = get_folder_path(special_folder::app_data);
-            temp += serial + "." + get_timestamped_file_name() + ".bin";
+                auto temp = get_folder_path(special_folder::app_data);
+                temp += serial + "." + get_timestamped_file_name() + ".bin";
 
+                {
+                    std::ofstream file(temp.c_str(), std::ios::binary);
+                    file.write((const char*)flash.data(), flash.size());
+                    log_backup_status = "Backup completed and saved as '"  + temp + "'";
+
+                }
+            }
+            catch (...)
             {
-                std::ofstream file(temp.c_str(), std::ios::binary);
-                file.write((const char*)flash.data(), flash.size());
+                log_backup_status = "Warning! - Backup step encountered an issue, continue update without it.";
             }
 
-            std::string log_line = "Backup completed and saved as '";
-            log_line += temp + "'";
-            log(log_line);
+            log(log_backup_status);
 
             next_progress = 40;
 


### PR DESCRIPTION
The flash backup was a mandatory step at the firmware update.
At this PR we allow to proceed with the update even if the backup step fail.

Example UI:
![image](https://user-images.githubusercontent.com/64067618/91748335-82488a00-ebc8-11ea-87fb-58222c1bc9bc.png)
