### PR TITLE
named_mutex: release if exception occurs while locking.

### DIFF
--- a/unit-tests/unit-test-long.cpp
+++ b/unit-tests/unit-test-long.cpp
@@ -38,6 +38,8 @@ bool stream(std::string serial_number, sem_t* sem2, bool do_query)
     rs2::config cfg;
     cfg.enable_device(serial_number);
     std::cout << "pipe starting: " << serial_number << std::endl;
+    cfg.disable_all_streams();
+    cfg.enable_stream(RS2_STREAM_DEPTH, -1, 0, 0, RS2_FORMAT_Z16, 0);
     pipe.start(cfg);
     std::cout << "pipe started: " << serial_number << std::endl;
 


### PR DESCRIPTION
This fix the following issue: In realsense-viewer, Ubuntu with v4l, if camera is unplugged while streaming, the app freezes when 
the camera is plugged back in.
Also update live-test: multicam_streaming test: test streaming of depth only due to known issues with alternate streaming of color.

Tracked on: DSO-15623