### PR TITLE
Add unit tests for L515 frame filter

### DIFF
--- a/unit-tests/sensor/frames/test-filter.cpp
+++ b/unit-tests/sensor/frames/test-filter.cpp
@@ -1,0 +1,62 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+// We have our own main
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
+
+#include "../../catch.h"
+
+#include <easylogging++.h>
+#ifdef BUILD_SHARED_LIBS
+// With static linkage, ELPP is initialized by librealsense, so doing it here will
+// create errors. When we're using the shared .so/.dll, the two are separate and we have
+// to initialize ours if we want to use the APIs!
+INITIALIZE_EASYLOGGINGPP
+#endif
+
+#include <librealsense2/rs.hpp>  // Include RealSense Cross Platform API
+
+
+TEST_CASE( "Sensor", "[frames-filter]" )
+{
+    try
+    {
+        // Create a Pipeline - this serves as a top-level API for streaming and processing frames
+        rs2::pipeline p;
+
+        // Configure and start the pipeline
+        p.start();
+
+        while( true )
+        {
+            // Block program until frames arrive
+            rs2::frameset frames = p.wait_for_frames();
+
+            // Try to get a frame of a depth image
+            rs2::depth_frame depth = frames.get_depth_frame();
+
+            // Get the depth frame's dimensions
+            float width = depth.get_width();
+            float height = depth.get_height();
+
+            // Query the distance from the camera to the object in the center of the image
+            float dist_to_center = depth.get_distance( width / 2, height / 2 );
+
+            // Print the distance
+            std::cout << "The camera is facing an object " << dist_to_center << " meters away \r";
+        }
+
+        // return EXIT_SUCCESS;
+    }
+    catch( const rs2::error & e )
+    {
+        std::cerr << "RealSense error calling " << e.get_failed_function() << "("
+                  << e.get_failed_args() << "):\n    " << e.what() << std::endl;
+    }
+    catch( const std::exception & e )
+    {
+        std::cerr << e.what() << std::endl;
+        return;
+    }
+}


### PR DESCRIPTION
**The unit test will test the L515 device frame filter.**
_Notes:_
* The test will end successfully if no L515 device is connected.
* If a L515 device is connected, it will open the depth stream and verify the first 100 frames are 
   depth frames only.
* The test has a timeout of 10 seconds before declare a failure.


This PR test bug [RS5-8734] ,  which was fix on PR [7269](https://github.com/IntelRealSense/librealsense/pull/7269)