### PR TITLE
Fix crash when connecting L515 device to the Viewer application

### DIFF
--- a/src/core/info.h
+++ b/src/core/info.h
@@ -30,7 +30,7 @@ namespace librealsense
         void create_snapshot(std::shared_ptr<info_interface>& snapshot) const override;
         void enable_recording(std::function<void(const info_interface&)> record_action) override;
         void update(std::shared_ptr<extension_snapshot> ext) override;
-    protected:
+    private:
         std::map<rs2_camera_info, std::string> _camera_info;
     };
 

--- a/src/core/info.h
+++ b/src/core/info.h
@@ -30,7 +30,7 @@ namespace librealsense
         void create_snapshot(std::shared_ptr<info_interface>& snapshot) const override;
         void enable_recording(std::function<void(const info_interface&)> record_action) override;
         void update(std::shared_ptr<extension_snapshot> ext) override;
-    private:
+    protected:
         std::map<rs2_camera_info, std::string> _camera_info;
     };
 

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -566,8 +566,7 @@ namespace librealsense
     {
         std::vector<tagged_profile> tags;
 
-        auto usb_spec = get_usb_spec();
-        bool usb3mode = (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined);
+        bool usb3mode = (_usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined);
 
         uint32_t width = usb3mode ? 1280 : 960;
         uint32_t height = usb3mode ? 720 : 540;

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -126,8 +126,7 @@ namespace librealsense
     {
         std::vector<tagged_profile> tags;
 
-        auto usb_spec = get_usb_spec();
-        bool usb3mode = (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined);
+        bool usb3mode = (_usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined);
 
         uint32_t width = usb3mode ? 640 : 320;
         uint32_t height = usb3mode ? 480 : 240;

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -109,10 +109,10 @@ namespace librealsense
 
         using namespace platform;
 
-        auto usb_mode = raw_depth_sensor.get_usb_specification();
-        if (usb_spec_names.count(usb_mode) && (usb_undefined != usb_mode))
+        _usb_mode = raw_depth_sensor.get_usb_specification();
+        if (usb_spec_names.count(_usb_mode) && (usb_undefined != _usb_mode))
         {
-            auto usb_type_str = usb_spec_names.at(usb_mode);
+            auto usb_type_str = usb_spec_names.at(_usb_mode);
             register_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR, usb_type_str);
         }
 
@@ -640,23 +640,6 @@ namespace librealsense
         }
 
         return _hw_monitor->send(input);
-    }
-
-    platform::usb_spec l500_device::get_usb_spec() const
-    {   
-        auto it = _camera_info.find(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
-        if (it == _camera_info.end())
-        {
-            return platform::usb_undefined;
-        }
-            
-        auto str = it->second;
-        for (auto u : platform::usb_spec_names)
-        {
-            if (u.second.compare(str) == 0)
-                return u.first;
-        }
-        return platform::usb_undefined;
     }
 
     notification l500_notification_decoder::decode(int value)

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -643,10 +643,14 @@ namespace librealsense
     }
 
     platform::usb_spec l500_device::get_usb_spec() const
-    {
-        if (!supports_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
+    {   
+        auto it = _camera_info.find(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
+        if (it == _camera_info.end())
+        {
             return platform::usb_undefined;
-        auto str = get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
+        }
+            
+        auto str = it->second;
         for (auto u : platform::usb_spec_names)
         {
             if (u.second.compare(str) == 0)

--- a/src/l500/l500-device.h
+++ b/src/l500/l500-device.h
@@ -79,9 +79,9 @@ namespace librealsense
         void update_flash_internal(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, std::vector<uint8_t>& flash_backup,
             update_progress_callback_ptr callback, int update_mode);
 
-        platform::usb_spec get_usb_spec() const;
 
     protected:
+
         friend class l500_depth_sensor;
 
         std::shared_ptr<hw_monitor> _hw_monitor;
@@ -107,6 +107,7 @@ namespace librealsense
         std::vector<rs2_option> _advanced_options;
 
         std::vector< calibration_change_callback_ptr > _calibration_change_callbacks;
+        platform::usb_spec _usb_mode;
     };
 
     class l500_notification_decoder : public notification_decoder

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -95,8 +95,7 @@ namespace librealsense
         else
         {
             // On USB2 we have only QVGA sensor mode
-            auto usb_spec = get_usb_spec();
-            bool usb3mode = (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined);
+            bool usb3mode = (_usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined);
 
             auto default_sensor_mode = static_cast<float>(usb3mode ? RS2_SENSOR_MODE_VGA : RS2_SENSOR_MODE_QVGA);
 


### PR DESCRIPTION
On Jenkins builds the Viewer & unit-tests crash when connecting a L515 device.

Fixes an issue caused on [PR 7126](https://github.com/IntelRealSense/librealsense/pull/7126/files) caused by a virtual function call from inside L515 ctor -- replaced with a member variable.

We managed to reproduce only from **VS2015** builds (RelWithDebInfo static Win32).
