### PR TITLE
SW Updates - Fix UI issue + allow use of local DB file

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -4437,8 +4437,17 @@ namespace rs2
             try
             {
 
-                auto server_url = config_file::instance().get(configurations::update::sw_updates_url);
-                sw_update::dev_updates_profile updates_profile(dev, server_url);
+                std::string server_url = config_file::instance().get(configurations::update::sw_updates_url);
+                bool use_local_file = false;
+                const std::string local_file_prefix = "file://";
+
+                // If URL contain a "file://"  prefix, we open it as local file and not downloading it from a server
+                if( server_url.find( local_file_prefix ) == 0 )
+                {
+                    use_local_file = true;
+                    server_url.erase( 0, local_file_prefix.length() );
+                }
+                sw_update::dev_updates_profile updates_profile(dev, server_url, use_local_file);
 
                 bool sw_update_required = updates_profile.retrieve_updates(versions_db_manager::LIBREALSENSE);
                 bool fw_update_required = updates_profile.retrieve_updates(versions_db_manager::FIRMWARE);

--- a/common/updates-model.cpp
+++ b/common/updates-model.cpp
@@ -37,10 +37,9 @@ void updates_model::draw(viewer_model& viewer, ux_window& window, std::string& e
     const auto window_name = "Updates Window";
      
     //Main window pop up only if essential updates exists
-    if (!popup_opened && updates_copy.size() && !ignore)
+    if (updates_copy.size() && !ignore)
     {
         ImGui::OpenPopup(window_name);
-        popup_opened = true;
     }
 
     position_params positions;
@@ -198,11 +197,9 @@ void updates_model::draw(viewer_model& viewer, ux_window& window, std::string& e
                     }
 
                     ImGui::CloseCurrentPopup();
-                    popup_opened = false;
                     emphasize_dismiss_text = false;
                     ignore = false;
                     _fw_update_state = fw_update_states::ready;
-                    ignore = false;
                     _fw_download_progress = 0;
                 }
             }

--- a/common/updates-model.h
+++ b/common/updates-model.h
@@ -100,7 +100,6 @@ namespace rs2
         std::shared_ptr<texture_buffer> _icon = nullptr;
         std::mutex _lock;
         bool emphasize_dismiss_text = false;
-        bool popup_opened = false;
 
         std::shared_ptr<firmware_update_manager> _fw_update = nullptr;
 

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -2798,6 +2798,11 @@ namespace rs2
                     {
                         official_url = false;
                     }
+                    if (ImGui::IsItemHovered())
+                    {
+                        ImGui::SetTooltip("%s", "Add file:// prefix to use a local DB file ");
+                    }
+
                     if (!official_url)
                     {
                         if (ImGui::InputText("##custom_server_url", custom_url, 255))


### PR DESCRIPTION
1. Overcome im_gui issue that cause an error pop_up closing the updates window. (always force open it unless no need)
2. Allow local version's DB file use. (Treat "file://" prefix as local file path)