### PR TITLE
define SQLITE_HAVE_ISNAN so xcode 10 will compile

### DIFF
--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -43,6 +43,8 @@ macro(os_set_flags)
     else()
         set(BACKEND RS2_USE_V4L2_BACKEND)
     endif()
+
+    add_definitions(-DSQLITE_HAVE_ISNAN)
 endmacro()
 
 macro(os_target_config)


### PR DESCRIPTION
When trying to build librealsense using xcode 10 on macOS 10.14 I ran into the following build error: "SQLite will not work correctly with the -ffast-math option of GCC"

The following stackoverflow post suggests defining SQLITE_HAVE_ISNAN in order to fix that error: 
https://stackoverflow.com/questions/48917320/getting-gcc-error-when-using-sqlite-and-fast-math-sqlite-will-not-work-correct
