### PR TITLE
Fix SW update crash on Viewer

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -847,7 +847,7 @@ namespace rs2
         bool pause_required = false;
         std::shared_ptr< atomic_objects_in_frame > _detected_objects;
         std::shared_ptr<updates_model> _updates;
-        sw_update::dev_updates_profile::update_profile _updates_profile;
+        std::shared_ptr<sw_update::dev_updates_profile::update_profile >_updates_profile;
         calibration_model _calib_model;
     };
 

--- a/common/sw-update/dev-updates-profile.h
+++ b/common/sw-update/dev-updates-profile.h
@@ -64,6 +64,7 @@ namespace rs2
 
             versions_db_manager _versions_db;
             update_profile _update_profile;
+            bool _keep_trying;
         };
     }
 }

--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -38,13 +38,13 @@ namespace rs2
             "";
 #endif
 
-        bool versions_db_manager::query_versions(const std::string &device_name, component_part_type component, const update_policy_type policy, version& out_version)
+        versions_db_manager::query_status_type versions_db_manager::query_versions(const std::string &device_name, component_part_type component, const update_policy_type policy, version& out_version)
         {
             // Load server versions info on first access
             if (!init())
             {
                 out_version = 0;
-                return false;
+                return DB_LOAD_FAILURE;
             }
 
             std::string platform(PLATFORM);
@@ -52,7 +52,7 @@ namespace rs2
             std::string up_str(to_string(policy));
             std::string comp_str(to_string(component));
 
-            if (up_str.empty() || comp_str.empty()) return false;
+            if (up_str.empty() || comp_str.empty()) return NO_VERSION_FOUND;
 
             // Look for the required version
             auto res = std::find_if(_server_versions_vec.begin(), _server_versions_vec.end(),
@@ -65,17 +65,17 @@ namespace rs2
             {
                 auto version_str = (*res)["version"];
                 out_version = version(version_str);
-                return true;
+                return VERSION_FOUND;
             }
 
             out_version = 0;
-            return false; // Nothing found
+            return NO_VERSION_FOUND; // Nothing found
         }
 
         bool versions_db_manager::get_version_data_common(const component_part_type component, const version& version, const std::string& req_field, std::string& out)
         {
-            // Load server versions info on first access
-            if (!init()) return false;
+            // Check if server versions are loaded
+            if (!_server_versions_loaded) return false;
 
             std::string platform = PLATFORM;
 

--- a/common/sw-update/versions-db-manager.h
+++ b/common/sw-update/versions-db-manager.h
@@ -85,13 +85,14 @@ namespace rs2
             enum update_policy_type { EXPERIMENTAL, RECOMMENDED, ESSENTIAL };
             enum component_part_type { LIBREALSENSE, VIEWER, DEPTH_QUALITY_TOOL, FIRMWARE };
             enum update_source_type { FROM_FILE, FROM_SERVER };
+            enum query_status_type { VERSION_FOUND, NO_VERSION_FOUND, DB_LOAD_FAILURE };
 
             explicit versions_db_manager(const std::string &url, const bool use_url_as_local_path = false, http::user_callback_func_type download_callback = http::user_callback_func_type())
                 : _dev_info_url(url), _local_source_file(use_url_as_local_path), _server_versions_vec(), _server_versions_loaded(false), _download_cb_func(download_callback) {};
 
             ~versions_db_manager() {};
 
-            bool query_versions(const std::string &device_name, component_part_type component, const update_policy_type policy, version& out_version);
+            query_status_type query_versions(const std::string &device_name, component_part_type component, const update_policy_type policy, version& out_version);
             bool get_version_download_link(const component_part_type component, const version& version, std::string& dl_link) { return get_version_data_common(component, version, "link", dl_link); };
             bool get_version_release_notes(const component_part_type component, const version& version, std::string& version_release_notes_link) { return get_version_data_common(component, version, "release_notes_link", version_release_notes_link); };
             bool get_version_description(const component_part_type component, const version& version, std::string& version_description) { return get_version_data_common(component, version, "description", version_description); };


### PR DESCRIPTION
TODO - add tracking Jira ticket - Nir

When connecting a device the SW Update check if a new version is available,
> Use a weak ptr for the SW update detached thread
> Reduce the DB download tried to 1 (still 5 seconds timeout)
