### PR TITLE
Fix documentation in C API examples

### DIFF
--- a/examples/C/color/rs-color.c
+++ b/examples/C/color/rs-color.c
@@ -16,7 +16,7 @@
 //                                     These parameters are reconfigurable                                        //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #define STREAM          RS2_STREAM_COLOR  // rs2_stream is a types of data provided by RealSense device           //
-#define FORMAT          RS2_FORMAT_RGB8   // rs2_format is identifies how binary data is encoded within a frame   //
+#define FORMAT          RS2_FORMAT_RGB8   // rs2_format identifies how binary data is encoded within a frame      //
 #define WIDTH           640               // Defines the number of columns for each frame                         //
 #define HEIGHT          480               // Defines the number of lines for each frame                           //
 #define FPS             30                // Defines the rate of frames per second                                //

--- a/examples/C/depth/rs-depth.c
+++ b/examples/C/depth/rs-depth.c
@@ -17,7 +17,7 @@
 //                                     These parameters are reconfigurable                                        //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #define STREAM          RS2_STREAM_DEPTH  // rs2_stream is a types of data provided by RealSense device           //
-#define FORMAT          RS2_FORMAT_Z16    // rs2_format is identifies how binary data is encoded within a frame   //
+#define FORMAT          RS2_FORMAT_Z16    // rs2_format identifies how binary data is encoded within a frame      //
 #define WIDTH           640               // Defines the number of columns for each frame or zero for auto resolve//
 #define HEIGHT          0                 // Defines the number of lines for each frame or zero for auto resolve  //
 #define FPS             30                // Defines the rate of frames per second                                //

--- a/examples/C/distance/rs-distance.c
+++ b/examples/C/distance/rs-distance.c
@@ -17,7 +17,7 @@
 //                                     These parameters are reconfigurable                                        //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #define STREAM          RS2_STREAM_DEPTH  // rs2_stream is a types of data provided by RealSense device           //
-#define FORMAT          RS2_FORMAT_Z16    // rs2_format is identifies how binary data is encoded within a frame   //
+#define FORMAT          RS2_FORMAT_Z16    // rs2_format identifies how binary data is encoded within a frame      //
 #define WIDTH           640               // Defines the number of columns for each frame or zero for auto resolve//
 #define HEIGHT          0                 // Defines the number of lines for each frame or zero for auto resolve  //
 #define FPS             30                // Defines the rate of frames per second                                //


### PR DESCRIPTION
Fix some comments in the documentation of C API examples.