### PR TITLE
L515 host perf mode refactoring

### DIFF
--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -399,7 +399,7 @@ namespace librealsense
 
             auto&& perf_opt = get_option(RS2_OPTION_HOST_PERFORMANCE);
             auto perf_mode = perf_opt.query();
-            LOG_INFO("Color host performance mode:" << perf_mode);
+            LOG_DEBUG("Color host performance mode:" << perf_mode);
             perf_opt.set(perf_mode);
         }
 

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -448,7 +448,7 @@ namespace librealsense
 
             auto&& perf_opt = get_option(RS2_OPTION_HOST_PERFORMANCE);
             auto perf_mode = perf_opt.query();
-            LOG_INFO("Depth and IR host performance mode:" << perf_mode);
+            LOG_DEBUG("Depth and IR host performance mode:" << perf_mode);
             perf_opt.set(perf_mode);
         }
 

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -112,15 +112,31 @@ namespace librealsense
             rs2_host_perf_mode launch_perf_mode = RS2_HOST_PERF_DEFAULT;
 
 #ifdef __ANDROID__
-            // android devices most likely low power low performance host
+            // android devices most likely low performance host
             launch_perf_mode = RS2_HOST_PERF_LOW;
 #else
             // other hosts use default settings from firmware, user still have the option to change later after launch
             launch_perf_mode = RS2_HOST_PERF_DEFAULT;
 #endif
+            //
+            // Registering RS2_OPTION_HOST_PERFORMANCE with initial host performance mode
+            // also define the TPROC USB granularity settings for each endpoint on the depth sensor at each performance mode
+            // host performance mode defined in rs2_host_perf_mode
+            // settings values are validated through many experiments, change with care
+            //
+            // Endpoint           RS2_HOST_PERF_DEFAULT    RS2_HOST_PERF_LOW     RS2_HOST_PERF_HIGH
+            //   2 (depth)                7 KB                16 KB                  7 KB
+            //   3 (IR)                   3 KB                12 KB                  3 KB
+            //   4 (confidence)           3 KB                 6 KB                  3 KB
+            //
+            // on low performance host, usb trb set to larger granularity to reduce number of transactions and improve performance
+            //
 
-            depth_sensor.register_option(RS2_OPTION_HOST_PERFORMANCE, std::make_shared<librealsense::float_option_with_description<rs2_host_perf_mode>>(option_range{ RS2_HOST_PERF_DEFAULT, RS2_HOST_PERF_COUNT - 1, 1, (float) launch_perf_mode }, "Optimize based on host performance, low power low performance host or high power high performance host"));
-
+            depth_sensor.register_option(RS2_OPTION_HOST_PERFORMANCE, std::make_shared<librealsense::host_perf_option>(
+                _hw_monitor.get(),
+                std::map<uint8_t, std::vector<uint8_t>>{ { 2, { 7, 16, 7 } }, { 3, {3, 12, 3} }, { 4, {3, 6, 3} } },
+                option_range{ RS2_HOST_PERF_DEFAULT, RS2_HOST_PERF_COUNT - 1, 1, (float)launch_perf_mode },
+                "Optimize depth sensor based on host performance, low performance host or high performance host"));
         }
 
         // attributes of md_capture_timing
@@ -430,59 +446,10 @@ namespace librealsense
             // please refer to following bug report for details
             // RS5-8011 [Android-L500 Hard failure] Device detach and disappear from system during stream
 
-            auto host_perf = get_option(RS2_OPTION_HOST_PERFORMANCE).query();
-
-            if (host_perf == RS2_HOST_PERF_LOW || host_perf == RS2_HOST_PERF_HIGH)
-            {
-                // TPROC USB Granularity and TRB threshold settings for improved performance and stability
-                // on hosts with weak cpu and system performance
-                // settings values are validated through many experiments, do not change
-
-                // on low power low performance host, usb trb set to larger granularity to reduce number of transactions
-                // and improve performance
-                int ep2_usb_trb = 7;           // 7 KB
-                int ep3_usb_trb = 3;           // 3 KB
-                int ep4_usb_trb = 3;           // 3 KB
-
-                if (host_perf == RS2_HOST_PERF_LOW)
-                {
-                    ep2_usb_trb = 16;          // 16 KB
-                    ep3_usb_trb = 12;          // 12 KB
-                    ep4_usb_trb = 6;           //  6 KB
-                }
-
-                try {
-                    // endpoint 2 (depth)
-                    command cmdTprocGranEp2(ivcam2::TPROC_USB_GRAN_SET, 2, ep2_usb_trb);
-                    _owner->_hw_monitor->send(cmdTprocGranEp2);
-
-                    command cmdTprocThresholdEp2(ivcam2::TPROC_TRB_THRSLD_SET, 2, 1);
-                    _owner->_hw_monitor->send(cmdTprocThresholdEp2);
-
-                    // endpoint 3 (IR)
-                    command cmdTprocGranEp3(ivcam2::TPROC_USB_GRAN_SET, 3, ep3_usb_trb);
-                    _owner->_hw_monitor->send(cmdTprocGranEp3);
-
-                    command cmdTprocThresholdEp3(ivcam2::TPROC_TRB_THRSLD_SET, 3, 1);
-                    _owner->_hw_monitor->send(cmdTprocThresholdEp3);
-
-                    // endpoint 4 (confidence)
-                    command cmdTprocGranEp4(ivcam2::TPROC_USB_GRAN_SET, 4, ep4_usb_trb);
-                    _owner->_hw_monitor->send(cmdTprocGranEp4);
-
-                    command cmdTprocThresholdEp4(ivcam2::TPROC_TRB_THRSLD_SET, 4, 1);
-                    _owner->_hw_monitor->send(cmdTprocThresholdEp4);
-
-                    LOG_DEBUG("Depth and IR usb tproc granularity and TRB threshold updated.");
-                } catch (...)
-                {
-                    LOG_WARNING("FAILED TO UPDATE depth usb tproc granularity and TRB threshold. performance and stability maybe impacted on certain platforms.");
-                }
-            }
-            else if (host_perf == RS2_HOST_PERF_DEFAULT)
-            {
-                LOG_DEBUG("Default host performance mode, Depth/IR/Confidence usb tproc granularity and TRB threshold not changed");
-            }
+            auto&& perf_opt = get_option(RS2_OPTION_HOST_PERFORMANCE);
+            auto perf_mode = perf_opt.query();
+            LOG_INFO("Depth and IR host performance mode:" << perf_mode);
+            perf_opt.set(perf_mode);
         }
 
         // The delay is here as a work around to a firmware bug [RS5-5453]

--- a/src/l500/l500-private.cpp
+++ b/src/l500/l500-private.cpp
@@ -228,7 +228,7 @@ namespace librealsense
                         command cmdTprocThresholdEp(ivcam2::TPROC_TRB_THRSLD_SET, ep, 1);
                         _hwm->send(cmdTprocThresholdEp);
 
-                        LOG_INFO("Endpoint " << ep << " usb tproc granularity updated to " << trb);
+                        LOG_DEBUG("Endpoint " << ep << " usb tproc granularity updated to " << trb);
                     }
                 }
                 catch (...)
@@ -238,11 +238,11 @@ namespace librealsense
             }
             else if (mode == RS2_HOST_PERF_DEFAULT)
             {
-                LOG_INFO("Default host performance mode, usb tproc granularity and TRB threshold not changed");
+                LOG_DEBUG("Default host performance mode, usb tproc granularity and TRB threshold not changed");
             }
             else
             {
-                LOG_INFO("Unsupported host performance mode: " << (int) mode);
+                LOG_DEBUG("Unsupported host performance mode: " << (int) mode);
             }
         }
 

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -532,6 +532,19 @@ namespace librealsense
             std::shared_ptr< freefall_option > _freefall_opt;
         };
 
+        /* For RS2_OPTION_HOST_PERFORMANCE */
+        class host_perf_option : public float_option_with_description<rs2_host_perf_mode>
+        {
+        public:
+            host_perf_option(hw_monitor* hwm, const std::map<uint8_t, std::vector<uint8_t>> ep_trb_map, option_range range, std::string description) : _hwm(hwm), _ep_trb_map(ep_trb_map), float_option_with_description<rs2_host_perf_mode>(range, description) {};
+
+            void set(float value) override;
+            void apply(rs2_host_perf_mode mode);
+        private:
+            hw_monitor * _hwm;
+            const std::map<uint8_t, std::vector<uint8_t>> _ep_trb_map;
+        };
+
         class ac_trigger;
     } // librealsense::ivcam2
 } // namespace librealsense


### PR DESCRIPTION
Follow on L515 stability workaround PR refactoring host performance mode option into customized class. Also allows change TRB settings before, at, and after sensor start. This enables usage changing settings with pipeline on android.

Tracked on: RS5-8011