### PR TITLE
Fix DFU update crash on L515

### DIFF
--- a/src/l500/l500-fw-update-device.cpp
+++ b/src/l500/l500-fw-update-device.cpp
@@ -21,14 +21,15 @@ namespace librealsense
 
     std::string l500_update_device::parse_serial_number(const std::vector<uint8_t>& buffer) const
     {
-        if (buffer.size() != sizeof(serial_number_data))
+        // Note that we are using a specific serial_number_data struct then the generic one.
+        // See comment in the struct definition for more details
+        if (buffer.size() != sizeof(l500_update_device::serial_number_data))
             throw std::runtime_error("DFU - failed to parse serial number!");
 
-        auto rev = buffer;
-
+        const auto serial_num_data = (l500_update_device::serial_number_data *)buffer.data();
         std::stringstream rv;
-        for (auto i = 0; i < ivcam2::module_serial_size; i++)
-            rv << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(rev[i]);
+        for (auto i = 0; i < ivcam2::module_asic_serial_size; i++)
+            rv << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(serial_num_data->serial[i]);
 
         return rv.str();
     }

--- a/src/l500/l500-fw-update-device.h
+++ b/src/l500/l500-fw-update-device.h
@@ -10,6 +10,14 @@ namespace librealsense
     class l500_update_device : public update_device
     {
     public:
+        // The L515 device EEPROM has different bytes order then D4xx device.
+        // this struct overrides the generic serial_number_data struct at fw-update-device.h
+        struct serial_number_data
+        {
+            uint8_t spare[2];
+            uint8_t serial[6];
+        };
+
         l500_update_device(std::shared_ptr<context> ctx, bool register_device_notifications, std::shared_ptr<platform::usb_device> usb_device);
         virtual ~l500_update_device() = default;
 


### PR DESCRIPTION
DFU update on L515 is generating an exception and fails the update process.
The Asic serial number structure retrieved from the DFU FW has reversed bytes order then expected.

This PR address this issue and treat the data at the real FW implementation order.

Tracked on [RS5-8843]