### PR TITLE
Added Intrinsic private property getters in Android wrapper

### DIFF
--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Intrinsic.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Intrinsic.java
@@ -34,8 +34,12 @@ public class Intrinsic {
 
     public int getWidth() {return mWidth;}
     public int getHeight() {return mHeight;}
+    public float getPpx() {return mPpx;}
+    public float getPpy() {return mPpy;}
+    public float getFx() {return mFx;}
+    public float getFy() {return mFy;}
     public DistortionType getModel() {return mModel;}
-
+    public float[] getCoeffs() {return mCoeffs;}
 
     public void SetModel(){
         this.mModel = DistortionType.values()[mModelValue];


### PR DESCRIPTION
I happen to have to get the focal length values for per pixel size calculations at specific distances.
The property is private in Intrinsic.java, so I added getters to be able to fetch the values in code.

Android-specific!