### PR TITLE
Hdr metadata renamed as options

### DIFF
--- a/src/hdr-config.cpp
+++ b/src/hdr-config.cpp
@@ -19,7 +19,9 @@ namespace librealsense
         _id(DEFAULT_HDR_ID),
         _sequence_size(DEFAULT_HDR_SEQUENCE_SIZE),
         _exposure_range(exposure_range),
-        _gain_range(gain_range)
+        _gain_range(gain_range),
+        _use_workaround(true),
+        _pre_hdr_exposure(0.f)
     {
         _hdr_sequence_params.clear();
         _hdr_sequence_params.resize(DEFAULT_HDR_SEQUENCE_SIZE);
@@ -46,7 +48,7 @@ namespace librealsense
             hdr_params params_0(0, exposure_default_value, gain_default_value);
             _hdr_sequence_params[0] = params_0;
 
-            float exposure_low_value = DEFAULT_CONFIG_LOW_EXPOSURE;
+            float exposure_low_value = _exposure_range.min;
             float gain_min_value = _gain_range.min;
             hdr_params params_1(1, exposure_low_value, gain_min_value);
             _hdr_sequence_params[1] = params_1;
@@ -170,7 +172,8 @@ namespace librealsense
     void hdr_config::set(rs2_option option, float value, option_range range)
     {
         if (value < range.min || value > range.max)
-            throw invalid_value_exception(to_string() << "hdr_config::set(...) failed! value: "<< value << " is out of the option range: [" << range.min << ", " << range.max << "].");
+            throw invalid_value_exception(to_string() << "hdr_config::set(...) failed! value: " << value <<
+                " is out of the option range: [" << range.min << ", " << range.max << "].");
 
         switch (option)
         {
@@ -243,6 +246,12 @@ namespace librealsense
                 // so that they could be reenabled after hdr disable
                 set_options_to_be_restored_after_disable();
 
+                if (_use_workaround)
+                {
+                    _pre_hdr_exposure = _sensor->get_option(RS2_OPTION_EXPOSURE).query();
+                    _sensor->get_option(RS2_OPTION_EXPOSURE).set(PRE_ENABLE_HDR_EXPOSURE);
+                }
+
                 _is_enabled = send_sub_preset_to_fw();
                 _has_config_changed = false;
             }
@@ -254,6 +263,15 @@ namespace librealsense
         {
             disable();
             _is_enabled = false;
+
+            if (_use_workaround)
+            {
+                // this sleep is needed to let the fw restore the manual exposure
+                std::this_thread::sleep_for(std::chrono::milliseconds(40));
+                auto exp = _sensor->get_option(RS2_OPTION_EXPOSURE).query();
+                if (_pre_hdr_exposure >= _exposure_range.min && _pre_hdr_exposure <= _exposure_range.max)
+                    _sensor->get_option(RS2_OPTION_EXPOSURE).set(_pre_hdr_exposure);
+            }
 
             // re-enabling options that were disabled in order to permit the hdr
             restore_options_after_disable();

--- a/src/hdr-config.cpp
+++ b/src/hdr-config.cpp
@@ -43,7 +43,7 @@ namespace librealsense
         if (!existing_subpreset_restored)
         {
             // setting default config
-            float exposure_default_value = _exposure_range.def;
+            float exposure_default_value = _exposure_range.def-1000.f; // D455 W/A
             float gain_default_value = _gain_range.def;
             hdr_params params_0(0, exposure_default_value, gain_default_value);
             _hdr_sequence_params[0] = params_0;

--- a/src/hdr-config.h
+++ b/src/hdr-config.h
@@ -31,7 +31,7 @@ namespace librealsense
     {
     public:
         hdr_config(hw_monitor& hwm, std::shared_ptr<sensor_base> depth_ep,
-        const option_range& exposure_range, const option_range& gain_range);
+            const option_range& exposure_range, const option_range& gain_range);
 
 
         float get(rs2_option option) const;
@@ -52,7 +52,8 @@ namespace librealsense
         const int DEFAULT_CURRENT_HDR_SEQUENCE_INDEX = -1;
         const int DEFAULT_HDR_SEQUENCE_SIZE = 2;
 
-        const float DEFAULT_CONFIG_LOW_EXPOSURE = 150.f;
+        // exposure value has been set to fit the 30 fps (default fps)
+        const float PRE_ENABLE_HDR_EXPOSURE = 30000.f;
 
         const uint8_t CONTROL_ID_LASER = 0;
         const uint8_t CONTROL_ID_EXPOSURE = 1;
@@ -84,6 +85,8 @@ namespace librealsense
         std::shared_ptr<sensor_base> _sensor;
         option_range _exposure_range;
         option_range _gain_range;
+        bool _use_workaround;
+        float _pre_hdr_exposure;
     };
 
 }

--- a/src/proc/hdr-merge.h
+++ b/src/proc/hdr-merge.h
@@ -27,20 +27,25 @@ namespace librealsense
         const int IR_UNDER_SATURATED_VALUE_Y16 = 0x14; // 20 (4 * IR_UNDER_SATURATED_VALUE_Y8)
         const int IR_OVER_SATURATED_VALUE_Y16 = 0x3eb; // 1003 (1023 - IR_UNDER_SATURATED_VALUE_Y16)
 
+        const int NUMBER_OF_FRAMES_WITHOUT_METADATA_FOR_WARNING = 20;
+
+        void reset_warning_counter_on_pipe_restart(const rs2::depth_frame& depth_frame);
         void discard_depth_merged_frame_if_needed(const rs2::frame& f);
-        
+
         bool check_frames_mergeability(const rs2::frameset first_fs, const rs2::frameset second_fs, bool& use_ir) const;
         bool should_ir_be_used_for_merging(const rs2::depth_frame& first_depth, const rs2::video_frame& first_ir,
             const rs2::depth_frame& second_depth, const rs2::video_frame& second_ir) const;
-        rs2::frame merging_algorithm(const rs2::frame_source& source, const rs2::frameset first_fs, 
+        rs2::frame merging_algorithm(const rs2::frame_source& source, const rs2::frameset first_fs,
             const rs2::frameset second_fs, const bool use_ir) const;
         template <typename T>
         bool is_infrared_valid(T ir_value, rs2_format ir_format) const;
         template <typename T>
-        void merge_frames_using_ir(uint16_t* new_data, uint16_t* d0, uint16_t* d1, 
+        void merge_frames_using_ir(uint16_t* new_data, uint16_t* d0, uint16_t* d1,
             const rs2::video_frame& first_ir, const rs2::video_frame& second_ir, int width_height_prod) const;
         void merge_frames_using_only_depth(uint16_t* new_data, uint16_t* d0, uint16_t* d1, int width_height_prod) const;
 
+        unsigned long long _previous_depth_frame_counter;
+        int _frames_without_requested_metadata_counter;
         std::map<int, rs2::frameset> _framesets;
         rs2::frame _depth_merged_frame;
     };


### PR DESCRIPTION
Triggered by DSO-15603
Correcting metadata params so that they will fit the options names for HDR feature