### PR TITLE
Fix for RS5-8921 pyrelsense crash after stopping sensors

### DIFF
--- a/src/mf/mf-uvc.h
+++ b/src/mf/mf-uvc.h
@@ -134,7 +134,7 @@ namespace librealsense
             CComPtr<IAMVideoProcAmp>                _video_proc = nullptr;
             std::unordered_map<int, CComPtr<IKsControl>>      _ks_controls;
 
-            manual_reset_event                      _is_flushed;
+            auto_reset_event                        _is_flushed;
             manual_reset_event                      _has_started;
             HRESULT                                 _readsample_result = S_OK;
 


### PR DESCRIPTION
Fix for RS5-8921 - use auto reset event instead of manual event instead