### PR TITLE
Hdr metadata seq id only

### DIFF
--- a/examples/hdr/rs-hdr.cpp
+++ b/examples/hdr/rs-hdr.cpp
@@ -113,8 +113,8 @@ int main(int argc, char * argv[]) try
 
         auto depth_frame = data.get_depth_frame();
 
-        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE) ||
-            !depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID))
+        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE) ||
+            !depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID))
         {
             ++frames_without_hdr_metadata_params;
             if (frames_without_hdr_metadata_params > 20)
@@ -127,9 +127,9 @@ int main(int argc, char * argv[]) try
             continue;
         }
 
-        auto hdr_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_ID);
-        auto hdr_seq_size = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE);
-        auto hdr_seq_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID);
+        auto hdr_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_NAME);
+        auto hdr_seq_size = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE);
+        auto hdr_seq_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
         auto exp = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE);
 
         std::cout << "frame hdr metadata: hdr_seq_id = "<< hdr_seq_id << ", exposure = " << exp << std::endl;

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -62,9 +62,9 @@ typedef enum rs2_frame_metadata_value
     RS2_FRAME_METADATA_FRAME_LED_POWER                      , /**< Led power value 0-360. */
     RS2_FRAME_METADATA_RAW_FRAME_SIZE                       , /**< The number of transmitted payload bytes, not including metadata */
     RS2_FRAME_METADATA_GPIO_INPUT_DATA                      , /**< GPIO input data */
-    RS2_FRAME_METADATA_SUBPRESET_ID                         , /**< sub-preset id */
-    RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID                , /**< sub-preset sequence id */
-    RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE              , /**< sub-preset sequence size */
+    RS2_FRAME_METADATA_SEQUENCE_NAME                         , /**< sub-preset id */
+    RS2_FRAME_METADATA_SEQUENCE_ID                , /**< sub-preset sequence id */
+    RS2_FRAME_METADATA_SEQUENCE_SIZE              , /**< sub-preset sequence size */
     RS2_FRAME_METADATA_COUNT
 } rs2_frame_metadata_value;
 const char* rs2_frame_metadata_to_string(rs2_frame_metadata_value metadata);

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -950,7 +950,7 @@ namespace librealsense
             // attributes of md_capture_timing
             auto md_prop_offset = offsetof(metadata_raw, mode) + offsetof(md_depth_mode, depth_y_mode) + offsetof(md_depth_y_normal_mode, intel_configuration);
 
-            depth_sensor.register_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE,
+            depth_sensor.register_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE,
                 make_attribute_parser(&md_configuration::sub_preset_info,
                     md_configuration_attributes::sub_preset_info_attribute, md_prop_offset ,
                 [](const rs2_metadata_type& param) {
@@ -959,7 +959,7 @@ namespace librealsense
                             >> md_configuration::SUB_PRESET_BIT_OFFSET_SEQUENCE_SIZE;
                     }));
 
-            depth_sensor.register_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID,
+            depth_sensor.register_metadata(RS2_FRAME_METADATA_SEQUENCE_ID,
                 make_attribute_parser(&md_configuration::sub_preset_info,
                     md_configuration_attributes::sub_preset_info_attribute, md_prop_offset ,
                 [](const rs2_metadata_type& param) {
@@ -968,7 +968,7 @@ namespace librealsense
                             >> md_configuration::SUB_PRESET_BIT_OFFSET_SEQUENCE_ID;
                     }));
 
-            depth_sensor.register_metadata(RS2_FRAME_METADATA_SUBPRESET_ID,
+            depth_sensor.register_metadata(RS2_FRAME_METADATA_SEQUENCE_NAME,
                 make_attribute_parser(&md_configuration::sub_preset_info,
                     md_configuration_attributes::sub_preset_info_attribute, md_prop_offset,
                     [](const rs2_metadata_type& param) {

--- a/src/proc/hdr-merge.cpp
+++ b/src/proc/hdr-merge.cpp
@@ -23,11 +23,11 @@ namespace librealsense
         if (!depth_frame)
             return false;
 
-        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE))
+        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE))
             return false;
-        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID))
+        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID))
             return false;
-        auto depth_seq_size = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE);
+        auto depth_seq_size = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE);
         if (depth_seq_size != 2)
             return false;
 
@@ -51,7 +51,7 @@ namespace librealsense
         auto depth_frame = fs.get_depth_frame();
 
         // 2. add the frameset to vector of framesets
-        auto depth_seq_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID);
+        auto depth_seq_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
 
         // condition added to ensure that frames are saved in the right order
         // to prevent for example the saving of frame with sequence id 1 before
@@ -245,15 +245,15 @@ namespace librealsense
                 // checking sequence id of first depth and ir are the same
                 if (use_ir)
                 {
-                    auto depth_seq_id = first_depth.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID);
-                    auto ir_seq_id = first_ir.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID);
+                    auto depth_seq_id = first_depth.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
+                    auto ir_seq_id = first_ir.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
                     use_ir = (depth_seq_id == ir_seq_id);
 
                     // checking sequence id of second depth and ir are the same
                     if (use_ir)
                     {
-                        depth_seq_id = second_depth.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID);
-                        ir_seq_id = second_ir.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID);
+                        depth_seq_id = second_depth.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
+                        ir_seq_id = second_ir.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
                         use_ir = (depth_seq_id == ir_seq_id);
 
                         // checking both ir have the same format

--- a/src/proc/sequence_id_filter.cpp
+++ b/src/proc/sequence_id_filter.cpp
@@ -34,11 +34,11 @@ namespace librealsense
         if (!depth_frame)
             return false;
 
-        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE))
+        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE))
             return false;
-        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID))
+        if (!depth_frame.supports_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID))
             return false;
-        int depth_sequ_size = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_SIZE);
+        int depth_sequ_size = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE);
         if (depth_sequ_size == 0)
             return false;
 
@@ -64,7 +64,7 @@ namespace librealsense
 
         // 1. check hdr seq id in metadata
         auto depth_frame = f.as<rs2::depth_frame>();
-        int seq_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SUBPRESET_SEQUENCE_ID);
+        int seq_id = depth_frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
 
 
         if (is_selected_id(seq_id + 1))

--- a/src/proc/sequence_id_filter.h
+++ b/src/proc/sequence_id_filter.h
@@ -19,10 +19,11 @@ namespace librealsense
         rs2::frame process_frame(const rs2::frame_source& source, const rs2::frame& f) override;
 
     private:
-        bool is_selected_id(int stream_index);
+        bool is_selected_id(int stream_index) const;
 
         float _selected_stream_id;
-        rs2::frame _last_frame[3];
+        // key is pair of sequence id and unique id
+        std::map<std::pair<int, int>, rs2::frame> _last_frames;
     };
     MAP_EXTENSION(RS2_EXTENSION_SEQUENCE_ID_FILTER, librealsense::sequence_id_filter);
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -553,9 +553,9 @@ namespace librealsense
             CASE(FRAME_LED_POWER)
             CASE(RAW_FRAME_SIZE)
             CASE(GPIO_INPUT_DATA)
-            CASE(SUBPRESET_ID)
-            CASE(SUBPRESET_SEQUENCE_ID)
-            CASE(SUBPRESET_SEQUENCE_SIZE)
+            CASE(SEQUENCE_NAME)
+            CASE(SEQUENCE_ID)
+            CASE(SEQUENCE_SIZE)
         default: assert(!is_valid(value)); return UNKNOWN_VALUE;
         }
 #undef CASE

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FrameMetadata.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FrameMetadata.java
@@ -31,7 +31,12 @@ public enum FrameMetadata {
     POWER_LINE_FREQUENCY(27),
     LOW_LIGHT_COMPENSATION(28),
     FRAME_EMITTER_MODE(29),
-    FRAME_LED_POWER(30);
+    FRAME_LED_POWER(30),
+    RAW_FRAME_SIZE(31),
+    GPIO_INPUT_DATA(32),
+    SEQUENCE_NAME(33),
+    SEQUENCE_ID(34),
+    SEQUENCE_SIZE(35);
     private final int mValue;
 
     private FrameMetadata(int value) { mValue = value; }

--- a/wrappers/python/pyrs_processing.cpp
+++ b/wrappers/python/pyrs_processing.cpp
@@ -181,7 +181,8 @@ void init_processing(py::module &m) {
     hdr_merge.def(py::init<>());
 
     py::class_<rs2::sequence_id_filter, rs2::filter> sequence_id_filter(m, "sequence_id_filter", "Splits depth frames with different sequence ID");
-    sequence_id_filter.def(py::init<>());
+    sequence_id_filter.def(py::init<>())
+        .def(py::init<float>(), "sequence_id"_a);
     // rs2::rates_printer
     /** end rs_processing.hpp **/
 }


### PR DESCRIPTION
Triggered by DSO-15603
- Correcting metadata params so that they will fit the options names for HDR feature
- Sequence-id-filter working on all streams and not only on depth stream