### PR TITLE
Improve the message at the end of the recording

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3758,7 +3758,7 @@ namespace rs2
             sub_dev_model->_is_being_recorded = false;
         }
         is_recording = false;
-        notification_data nd{ to_string() << "Saved recording to: " << saved_to_filename,
+        notification_data nd{ to_string() << "Saved recording to:\n" << saved_to_filename,
             RS2_LOG_SEVERITY_INFO,
             RS2_NOTIFICATION_CATEGORY_UNKNOWN_ERROR };
         viewer.not_model->add_notification(nd);


### PR DESCRIPTION
split the message of "saved recording to..." in order to see the first part of it on the small pop up message.
Tracked on: RS5-8698