### PR TITLE
hdr workaround correction

### DIFF
--- a/src/hdr-config.cpp
+++ b/src/hdr-config.cpp
@@ -250,6 +250,7 @@ namespace librealsense
                 {
                     try {
                         _pre_hdr_exposure = _sensor->get_option(RS2_OPTION_EXPOSURE).query();
+                        set_sequence_index(0.f);
                         _sensor->get_option(RS2_OPTION_EXPOSURE).set(PRE_ENABLE_HDR_EXPOSURE);
                     } catch (...) {
                         LOG_WARNING("HDR: enforced exposure failed");
@@ -275,6 +276,7 @@ namespace librealsense
                 if (_pre_hdr_exposure >= _exposure_range.min && _pre_hdr_exposure <= _exposure_range.max)
                 {
                     try {
+                        set_sequence_index(0.f);
                         _sensor->get_option(RS2_OPTION_EXPOSURE).set(_pre_hdr_exposure);
                     } catch (...) {
                         LOG_WARNING("HDR failed to restore manual exposure");

--- a/src/hdr-config.cpp
+++ b/src/hdr-config.cpp
@@ -249,8 +249,10 @@ namespace librealsense
                 if (_use_workaround)
                 {
                     try {
-                        _pre_hdr_exposure = _sensor->get_option(RS2_OPTION_EXPOSURE).query();
+                        // the following statement is needed in order to get/set the UVC exposure 
+                        // instead of one of the hdr's configuration exposure
                         set_sequence_index(0.f);
+                        _pre_hdr_exposure = _sensor->get_option(RS2_OPTION_EXPOSURE).query();
                         _sensor->get_option(RS2_OPTION_EXPOSURE).set(PRE_ENABLE_HDR_EXPOSURE);
                     } catch (...) {
                         LOG_WARNING("HDR: enforced exposure failed");
@@ -276,6 +278,8 @@ namespace librealsense
                 if (_pre_hdr_exposure >= _exposure_range.min && _pre_hdr_exposure <= _exposure_range.max)
                 {
                     try {
+                        // the following statement is needed in order to get the UVC exposure 
+                        // instead of one of the hdr's configuration exposure
                         set_sequence_index(0.f);
                         _sensor->get_option(RS2_OPTION_EXPOSURE).set(_pre_hdr_exposure);
                     } catch (...) {


### PR DESCRIPTION
Correcting workaround that has been implemented for HDR.
Without this correction, the HDR configuration may not be the one configured by the user