### PR TITLE
Fix Viewer GUI freeze due to DFU and SW update pop ups interference

### DIFF
--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -541,8 +541,9 @@ namespace rs2
         output.add_log(model->severity, __FILE__, __LINE__, model->get_title());
     }
 
-    void notifications_model::draw(ux_window& win, int w, int h, std::string& error_message)
+    bool notifications_model::draw(ux_window& win, int w, int h, std::string& error_message)
     {
+        bool modal_notification_found = false;
         ImGui::PushFont(win.get_font());
 
         std::vector<std::function<void()>> follow_up;
@@ -570,6 +571,7 @@ namespace rs2
                 auto height = 60;
                 for (auto& noti : pending_notifications)
                 {
+                    modal_notification_found = modal_notification_found || noti->expanded;
                     if (pinned_drawn && noti->pinned && !noti->forced) 
                     {
                         continue;
@@ -664,6 +666,8 @@ namespace rs2
         }
         
         ImGui::PopFont();
+
+        return modal_notification_found;
     }
 
     version_upgrade_model::version_upgrade_model(int version) 

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -194,7 +194,7 @@ namespace rs2
                               std::function<void()> custom_action, 
                               bool use_custom_action = true);
         void add_notification(std::shared_ptr<notification_model> model);
-        void draw(ux_window& win, int w, int h, std::string& error_message);
+        bool draw(ux_window& win, int w, int h, std::string& error_message);
 
         notifications_model() {}
 

--- a/common/sw-update/http-downloader.cpp
+++ b/common/sw-update/http-downloader.cpp
@@ -138,7 +138,7 @@ namespace rs2
 
             if (CURLE_OK != res)
             {
-                LOG_ERROR("Download error from URL: " + url + "error info: " + std::string(curl_easy_strerror(res)));
+                LOG_ERROR("Download error from URL: " + url + ", error info: " + std::string(curl_easy_strerror(res)));
                 return false;
             }
             return true;
@@ -161,7 +161,8 @@ namespace rs2
 
             if (CURLE_OK != res)
             {
-                LOG_ERROR("Download error from URL: " + url + "error info: " + std::string(curl_easy_strerror(res)));            return false;
+                LOG_ERROR("Download error from URL: " + url + ", error info: " + std::string(curl_easy_strerror(res)));            
+                return false;
             }
             return true;
         }
@@ -190,7 +191,7 @@ namespace rs2
 
                 if (CURLE_OK != res)
                 {
-                    LOG_ERROR("Download error from URL: " + url + "error info: " + std::string(curl_easy_strerror(res)));            return false;
+                    LOG_ERROR("Download error from URL: " + url + ", error info: " + std::string(curl_easy_strerror(res)));
                     return false;
                 }
             }

--- a/common/updates-model.cpp
+++ b/common/updates-model.cpp
@@ -37,7 +37,7 @@ void updates_model::draw(viewer_model& viewer, ux_window& window, std::string& e
     const auto window_name = "Updates Window";
      
     //Main window pop up only if essential updates exists
-    if (updates_copy.size() && !ignore)
+    if (updates_copy.size())
     {
         ImGui::OpenPopup(window_name);
     }
@@ -134,12 +134,12 @@ void updates_model::draw(viewer_model& viewer, ux_window& window, std::string& e
             // ===========================================================================
             // Draw Software update Pane
             // ===========================================================================
-            sw_update_needed = draw_software_section(window_name, update, positions, window);
+            sw_update_needed = draw_software_section(window_name, update, positions, window, error_message);
 
             // ===========================================================================
             // Draw Firmware update Pane
             // ===========================================================================
-            fw_update_needed = draw_firmware_section(viewer, window_name, update, positions, window);
+            fw_update_needed = draw_firmware_section(viewer, window_name, update, positions, window, error_message);
 
         }
         else 
@@ -234,7 +234,7 @@ void updates_model::draw(viewer_model& viewer, ux_window& window, std::string& e
 
 }
 
-bool updates_model::draw_software_section(const char * window_name, update_profile_model& selected_profile, position_params& pos, ux_window& window)
+bool updates_model::draw_software_section(const char * window_name, update_profile_model& selected_profile, position_params& pos, ux_window& window, std::string& error_message)
 {
     bool essential_sw_update_needed(false);
     bool recommended_sw_update_needed(false);
@@ -493,7 +493,7 @@ bool updates_model::draw_software_section(const char * window_name, update_profi
     }
     return essential_sw_update_needed;
 }
-bool updates_model::draw_firmware_section(viewer_model& viewer, const char * window_name, update_profile_model& selected_profile, position_params& pos, ux_window& window)
+bool updates_model::draw_firmware_section(viewer_model& viewer, const char * window_name, update_profile_model& selected_profile, position_params& pos, ux_window& window, std::string& error_message)
 {
     bool essential_fw_update_needed(false);
     bool recommended_fw_update_needed(false);
@@ -782,6 +782,12 @@ bool updates_model::draw_firmware_section(viewer_model& viewer, const char * win
                 _fw_update_state = fw_update_states::failed_updating;
                 _fw_image.clear();
                 _fw_download_progress = 0;
+            }
+            // Verify an error window will not pop up. ImGui cannot handle 2 PopUpModals in parallel.
+            if (!error_message.empty())
+            {
+                LOG_ERROR("error caught during update process, details: " + error_message);
+                error_message.clear();
             }
 
         }

--- a/common/updates-model.h
+++ b/common/updates-model.h
@@ -88,8 +88,8 @@ namespace rs2
             position_params() :w(0.0f), h(0.0f), orig_pos(), x0(0.0f), y0(0.0f) {}
         };
 
-        bool draw_software_section(const char * window_name, update_profile_model& selected_profile, position_params& pos_params , ux_window& window);
-        bool draw_firmware_section(viewer_model& viewer, const char * window_name, update_profile_model& selected_profile, position_params& pos_params, ux_window& window);
+        bool draw_software_section(const char * window_name, update_profile_model& selected_profile, position_params& pos_params , ux_window& window, std::string& error_message);
+        bool draw_firmware_section(viewer_model& viewer, const char * window_name, update_profile_model& selected_profile, position_params& pos_params, ux_window& window, std::string& error_message);
 
 
         int selected_index = 0;

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1373,7 +1373,7 @@ namespace rs2
 
         draw_viewport(viewer_rect, window, devices, error_message, texture_frame, p);
 
-        not_model->draw(window, 
+        modal_notification_on = not_model->draw(window,
             static_cast<int>(window.width()), static_cast<int>(window.height()),
             error_message);
 
@@ -3241,7 +3241,8 @@ namespace rs2
         ux_window& window, int devices, std::string& error_message, 
         std::shared_ptr<texture_buffer> texture, points points)
     {
-        updates->draw(*this, window, error_message);
+        if (!modal_notification_on)
+            updates->draw(*this, window, error_message);
 
         static bool first = true;
         if (first)

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -179,6 +179,7 @@ namespace rs2
         bool show_help_screen = false;
         bool occlusion_invalidation = true;
         bool glsl_available = false;
+        bool modal_notification_on = false; // a notification which was expanded
 
         press_button_model trajectory_button{ u8"\uf1b0", u8"\uf1b0","Draw trajectory", "Stop drawing trajectory", true };
         press_button_model grid_object_button{ u8"\uf1cb", u8"\uf1cb",  "Configure Grid", "Configure Grid", false };
@@ -250,5 +251,6 @@ namespace rs2
         skybox _skybox;
 
         measurement _measurements;
+        
     };
 }


### PR DESCRIPTION
Both processes try to open a popup modal from the same popup tree level,
ImGui does not support it.

Action taken:
1. Handle error message during SW update process (Do not allow pop up from inside a pop up)
2. Display SW update popup only when no other expended notification is being displayed.

Fix issue [RS5-8934]