### PR TITLE
Fix sporadic spinning bug in rs-motion.cpp

### DIFF
--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -457,7 +457,7 @@ namespace rs2
         * In case the frame metadata is not configured:
         *   -   The function call provides the TIME_OF_ARRIVAL stamp.
         * In case the metadata is available the function returns:
-        *   -   `HW Timestamp` (SENSOR_TIMESTAMP or FRAME_TIMESTAMP), or
+        *   -   `HW Timestamp` (FRAME_TIMESTAMP), or
         *   -   `Global Timestamp`  Host-corrected derivative of `HW Timestamp` required for multi-sensor/device synchronization
         *   -   The user can select between the unmodified and the host-calculated Hardware Timestamp by toggling
         *       the `RS2_OPTION_GLOBAL_TIME_ENABLED` option.


### PR DESCRIPTION
If the first gyro frame is received before the first accel frame the "first" flag is cleared and the timestamp value is incorrect. This separates the flags to be method specific.
Addresses #4915