### PR TITLE
add D455 product id to the list

### DIFF
--- a/wrappers/python/examples/python-rs400-advanced-mode-example.py
+++ b/wrappers/python/examples/python-rs400-advanced-mode-example.py
@@ -10,7 +10,7 @@ import pyrealsense2 as rs
 import time
 import json
 
-DS5_product_ids = ["0AD1", "0AD2", "0AD3", "0AD4", "0AD5", "0AF6", "0AFE", "0AFF", "0B00", "0B01", "0B03", "0B07","0B3A"]
+DS5_product_ids = ["0AD1", "0AD2", "0AD3", "0AD4", "0AD5", "0AF6", "0AFE", "0AFF", "0B00", "0B01", "0B03", "0B07", "0B3A", "0B5C"]
 
 def find_device_that_supports_advanced_mode() :
     ctx = rs.context()


### PR DESCRIPTION
Even though a hardcoded list of magic numbers is a bad practice, the example should work with the new D455 sensor.