### PR TITLE
Small bug fixes related to AC 

### DIFF
--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Option.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/Option.java
@@ -84,7 +84,7 @@ public enum Option {
     SEQUENCE_ID(79),
     HUMIDITY_TEMPERATURE(80),
     ENABLE_MAX_USABLE_RANGE(81),
-    ALTERNATE_IR(82),
+    ALTERNATE_IR(82);
 
     private final int mValue;
 


### PR DESCRIPTION
1. change rgb inrinsics to raw also if we cant read thermal table.
2. use double instead of float when scaling
3. Fixed c&p bug on write_matlab_camera_params_file