### PR TITLE
L515 - Add temperature fetcher thread

### DIFF
--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -917,16 +917,11 @@ bool output_model::user_defined_command( std::string command, device_models_list
         {
             if( auto dbg = dev.as< rs2::debug_protocol >() )
             {
-                if( dev.supports( RS2_CAMERA_INFO_FIRMWARE_VERSION ) )
-                {  // Verify minimal version for handling this command
-                    if( ! is_upgradeable( dev.get_info( RS2_CAMERA_INFO_FIRMWARE_VERSION ), "01.05.0.0" ) )
-                    {
-                        std::vector< uint8_t > special_command
-                            = { 'G', 'E', 'T', '-', 'N', 'E', 'S', 'T' };
-                        auto res = dbg.send_and_receive_raw_data( special_command );
-                        user_defined_command_activated = true;
-                    }
-                }
+                 // Verify minimal version for handling this command
+                 std::vector< uint8_t > special_command
+                     = { 'G', 'E', 'T', '-', 'N', 'E', 'S', 'T' };
+                 auto res = dbg.send_and_receive_raw_data( special_command );
+                 user_defined_command_activated = true;
             }
         }
     }

--- a/src/l500/ac-trigger.cpp
+++ b/src/l500/ac-trigger.cpp
@@ -1236,11 +1236,7 @@ namespace ivcam2 {
 
     double ac_trigger::read_temperature()
     {
-        auto hwm = _hwm.lock();
-        if( ! hwm )
-            throw std::runtime_error( "HW monitor is inaccessible - stopping algo" );
-
-        return _dev.get_color_sensor()->read_temperature();
+        return _dev.get_temperatures().HUM_temperature;
     }
 
 

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -268,35 +268,6 @@ namespace librealsense
                                               << height << " don't exist" );
     }
 
-    double l500_color_sensor::read_temperature() const
-    {
-        auto & hwm = *_owner->_hw_monitor;
-
-        std::vector< byte > res;
-
-        try
-        {
-            res = hwm.send( command{ TEMPERATURES_GET } );
-        }
-        catch( std::exception const & e )
-        {
-            AC_LOG( ERROR,
-                    "Failed to get temperatures; hardware monitor in inaccessible: " << e.what() );
-            return 0.;
-        }
-
-        if( res.size() < sizeof( temperatures ) )  // New temperatures may get added by FW...
-        {
-            AC_LOG( ERROR,
-                    "Failed to get temperatures; result size= "
-                        << res.size() << "; expecting at least " << sizeof( temperatures ) );
-            return 0.;
-        }
-        auto const & ts = *( reinterpret_cast< temperatures * >( res.data() ) );
-        AC_LOG( DEBUG, "HUM temperture is currently " << ts.HUM_temperature << " degrees Celsius" );
-        return ts.HUM_temperature;
-    }
-
     rs2_intrinsics normalize( const rs2_intrinsics & intr )
     {
         auto res = intr;

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -65,7 +65,6 @@ namespace librealsense
         {
         }
         rs2_intrinsics get_raw_intrinsics( uint32_t width, uint32_t height ) const;
-        double read_temperature() const;
 
         rs2_intrinsics get_intrinsics( const stream_profile& profile ) const override;
 

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -279,7 +279,7 @@ namespace librealsense
 
     l500_depth_sensor::~l500_depth_sensor()
     {
-        _owner->stop_temperatures_fetcher();
+        _owner->stop_temperatures_reader();
     }
 
     int l500_depth_sensor::read_algo_version()
@@ -513,7 +513,7 @@ namespace librealsense
         _action_delayer.do_after_delay( [&]() {
             synthetic_sensor::start( std::make_shared< frame_filter >( callback, _user_requests ) );
 
-            _owner->start_temperatures_fetcher();
+            _owner->start_temperatures_reader();
 
             if( _owner->_autocal )
                 _owner->_autocal->start();
@@ -528,7 +528,7 @@ namespace librealsense
         if( _owner->_autocal )
             _owner->_autocal->stop();
 
-        _owner->stop_temperatures_fetcher();
+        _owner->stop_temperatures_reader();
 
     }
 

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -31,6 +31,8 @@ namespace librealsense
         l500_depth(std::shared_ptr<context> ctx,
             const platform::backend_device_group& group);
 
+        ~l500_depth() { stop_temperatures_reader(); }
+
         std::vector<tagged_profile> get_profiles_tags() const override;
 
         std::shared_ptr<matcher> create_matcher(const frame_holder& frame) const override;

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -98,6 +98,8 @@ namespace librealsense
             std::map< uint32_t, rs2_format > l500_depth_sourcc_to_rs2_format_map,
             std::map< uint32_t, rs2_stream > l500_depth_sourcc_to_rs2_stream_map
         );
+        
+        ~l500_depth_sensor();
 
         std::vector<rs2_option> get_supported_options() const override
         {

--- a/src/l500/l500-device.h
+++ b/src/l500/l500-device.h
@@ -79,6 +79,10 @@ namespace librealsense
         void update_flash_internal(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, std::vector<uint8_t>& flash_backup,
             update_progress_callback_ptr callback, int update_mode);
 
+        ivcam2::extended_temperatures get_temperatures();
+        void start_temperatures_fetcher();
+        void stop_temperatures_fetcher();
+
 
     protected:
 
@@ -108,6 +112,12 @@ namespace librealsense
 
         std::vector< calibration_change_callback_ptr > _calibration_change_callbacks;
         platform::usb_spec _usb_mode;
+
+        std::mutex _temperature_mutex;
+        std::atomic_bool _temperature_fetcher_on { false };  // Indicates if the temperature thread is working
+        std::atomic_bool _temperature_from_fetcher{ false }; // Indicates it the temperature value should be taking from the fetcher or by FW command
+        std::thread _temperature_fetcher;
+        std::shared_ptr<ivcam2::extended_temperatures> _temperatures;
     };
 
     class l500_notification_decoder : public notification_decoder

--- a/src/l500/l500-device.h
+++ b/src/l500/l500-device.h
@@ -79,12 +79,12 @@ namespace librealsense
         void update_flash_internal(std::shared_ptr<hw_monitor> hwm, const std::vector<uint8_t>& image, std::vector<uint8_t>& flash_backup,
             update_progress_callback_ptr callback, int update_mode);
 
-        ivcam2::extended_temperatures get_temperatures();
-        void start_temperatures_fetcher();
-        void stop_temperatures_fetcher();
+        ivcam2::extended_temperatures get_temperatures() const;
 
 
     protected:
+        void start_temperatures_reader();
+        void stop_temperatures_reader();
 
         friend class l500_depth_sensor;
 
@@ -113,11 +113,11 @@ namespace librealsense
         std::vector< calibration_change_callback_ptr > _calibration_change_callbacks;
         platform::usb_spec _usb_mode;
 
-        std::mutex _temperature_mutex;
-        std::atomic_bool _temperature_fetcher_on { false };  // Indicates if the temperature thread is working
-        std::atomic_bool _temperature_from_fetcher{ false }; // Indicates it the temperature value should be taking from the fetcher or by FW command
-        std::thread _temperature_fetcher;
-        std::shared_ptr<ivcam2::extended_temperatures> _temperatures;
+        mutable std::mutex _temperature_mutex;
+        std::atomic_bool _keep_reading_temperature{ false };  // If true temperature reading thread is working, otherwise indicate to the thread to stop
+        std::atomic_bool _have_temperatures{ false }; //  If true, then the _temperatures are valid and up-to-date.
+        std::thread _temperature_reader;
+        ivcam2::extended_temperatures _temperatures;
     };
 
     class l500_notification_decoder : public notification_decoder

--- a/src/l500/l500-private.cpp
+++ b/src/l500/l500-private.cpp
@@ -75,15 +75,8 @@ namespace librealsense
         {
             if (!is_enabled())
                 throw wrong_api_call_sequence_exception("query option is allow only in streaming!");
-
-            auto res = _hw_monitor->send(command{ TEMPERATURES_GET });
-
-            if (res.size() < sizeof(temperatures))
-            {
-                throw std::runtime_error("Invalid result size!");
-            }
-
-            auto temperature_data = *(reinterpret_cast<temperatures*>((void*)res.data()));
+            
+            auto temperature_data = _l500_depth_dev->get_temperatures();
 
             switch (_option)
             {
@@ -102,10 +95,10 @@ namespace librealsense
             }
         }
 
-        l500_temperature_options::l500_temperature_options( hw_monitor * hw_monitor,
+        l500_temperature_options::l500_temperature_options(l500_device *l500_depth_dev,
                                                             rs2_option opt,
                                                             const std::string& description )
-            : _hw_monitor( hw_monitor )
+            :_l500_depth_dev(l500_depth_dev)
             , _option( opt )
             , _description( description )
         {

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -377,19 +377,29 @@ namespace librealsense
             double APD_temperature;
             double HUM_temperature;
             double AlgoTermalLddAvg_temperature;
+
+            temperatures()
+                : LDD_temperature(.0)
+                , MC_temperature(.0)
+                , MA_temperature(.0)
+                , APD_temperature(.0)
+                , HUM_temperature(.0)
+                , AlgoTermalLddAvg_temperature(.0) { }
         };
 
         //FW versions >= 1.5.0.0 added to the response vector the nest AVG value
-        struct extended_temperatures {
-            temperatures base_temperatures;
-            double nest_avg;
+        struct extended_temperatures : public temperatures 
+        {
+            double nest_avg; // NEST = Noise Estimation
+
+            extended_temperatures() : temperatures(), nest_avg(.0) {}
         };
 #pragma pack( pop )
 
         rs2_extrinsics get_color_stream_extrinsic(const std::vector<uint8_t>& raw_data);
-
+        
         bool try_fetch_usb_device(std::vector<platform::usb_device_info>& devices,
-                                         const platform::uvc_device_info& info, platform::usb_device_info& result);
+        const platform::uvc_device_info& info, platform::usb_device_info& result);
 
         class l500_temperature_options : public readonly_option
         {
@@ -402,13 +412,13 @@ namespace librealsense
 
             const char * get_description() const override { return _description.c_str(); }
 
-            explicit l500_temperature_options( hw_monitor * hw_monitor,
+            explicit l500_temperature_options(l500_device *l500_depth_dev,
                                                rs2_option opt,
                                                const std::string& description );
 
         private:
             rs2_option _option;
-            hw_monitor* _hw_monitor;
+            l500_device *_l500_depth_dev;
             std::string _description;
         };
 

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -379,12 +379,12 @@ namespace librealsense
             double AlgoTermalLddAvg_temperature;
 
             temperatures()
-                : LDD_temperature(.0)
-                , MC_temperature(.0)
-                , MA_temperature(.0)
-                , APD_temperature(.0)
-                , HUM_temperature(.0)
-                , AlgoTermalLddAvg_temperature(.0) { }
+                : LDD_temperature(0.)
+                , MC_temperature(0.)
+                , MA_temperature(0.)
+                , APD_temperature(0.)
+                , HUM_temperature(0.)
+                , AlgoTermalLddAvg_temperature(0.) { }
         };
 
         //FW versions >= 1.5.0.0 added to the response vector the nest AVG value


### PR DESCRIPTION
### L515 only
Periodic read of temperatures and noise estimation values once depth sensor is on.
a precondition for reflectivity tool + max range [RS5-9263]

**Description:**

- A new temperature fetcher thread is created on depth sensor start and closed on stop.
- All of temperature clients get it from a "get_temperatures" new function 
- get_temperatures function return the protected fetcher values or read directly from the FW is no fresh values from the thread
- N-Est values are exposed only on FW ver > 1.5.0.0

TBD - UT should be added in the future.
