### PR TITLE
Fw logger tool adding sleep

### DIFF
--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -454,7 +454,7 @@ int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg
 * \param[out] error             If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return                       number of fw logs already polled from device but not by user yet
 */
-int rs2_get_num_of_fw_logs(rs2_device* dev, rs2_error** error);
+unsigned int rs2_get_number_of_fw_logs(rs2_device* dev, rs2_error** error);
 /**
 * \brief Gets RealSense firmware log parsed message.
 * \param[in] fw_log_parsed_msg      firmware log parsed message object
@@ -504,12 +504,12 @@ unsigned int rs2_get_fw_log_parsed_line(rs2_firmware_log_parsed_message* fw_log_
 unsigned int rs2_get_fw_log_parsed_timestamp(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error);
 
 /**
-* \brief Gets RealSense firmware log parsed message sequence
+* \brief Gets RealSense firmware log parsed message sequence id - cyclic number of FW log with [0..15] range
 * \param[in] fw_log_parsed_msg      firmware log parsed message object
 * \param[out] error                 If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return                           sequence of the firmware log parsed message
 */
-unsigned int rs2_get_fw_log_parsed_sequence(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error);
+unsigned int rs2_get_fw_log_parsed_sequence_id(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error);
 
 /**
 * \brief Creates RealSense terminal parser.

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -449,10 +449,10 @@ void rs2_delete_fw_log_parsed_message(rs2_firmware_log_parsed_message* fw_log_pa
 int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_firmware_log_parsed_message* parsed_msg, rs2_error** error);
 
 /**
-* \brief Returns number of fw logs already polled from device
+* \brief Returns number of fw logs already polled from device but not by user yet
 * \param[in] dev                Device from which the FW log will be taken
 * \param[out] error             If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
-* \return                       number of fw logs already polled from device
+* \return                       number of fw logs already polled from device but not by user yet
 */
 int rs2_get_num_of_fw_logs(rs2_device* dev, rs2_error** error);
 /**

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -448,7 +448,12 @@ void rs2_delete_fw_log_parsed_message(rs2_firmware_log_parsed_message* fw_log_pa
 */
 int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_firmware_log_parsed_message* parsed_msg, rs2_error** error);
 
-
+/**
+* \brief Returns number of fw logs already polled from device
+* \param[in] dev                Device from which the FW log will be taken
+* \param[out] error             If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
+* \return                       number of fw logs already polled from device
+*/
 int rs2_get_num_of_fw_logs(rs2_device* dev, rs2_error** error);
 /**
 * \brief Gets RealSense firmware log parsed message.

--- a/include/librealsense2/h/rs_internal.h
+++ b/include/librealsense2/h/rs_internal.h
@@ -448,6 +448,8 @@ void rs2_delete_fw_log_parsed_message(rs2_firmware_log_parsed_message* fw_log_pa
 */
 int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_firmware_log_parsed_message* parsed_msg, rs2_error** error);
 
+
+int rs2_get_num_of_fw_logs(rs2_device* dev, rs2_error** error);
 /**
 * \brief Gets RealSense firmware log parsed message.
 * \param[in] fw_log_parsed_msg      firmware log parsed message object
@@ -495,6 +497,14 @@ unsigned int rs2_get_fw_log_parsed_line(rs2_firmware_log_parsed_message* fw_log_
 * \return                           timestamp of the firmware log parsed message
 */
 unsigned int rs2_get_fw_log_parsed_timestamp(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error);
+
+/**
+* \brief Gets RealSense firmware log parsed message sequence
+* \param[in] fw_log_parsed_msg      firmware log parsed message object
+* \param[out] error                 If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
+* \return                           sequence of the firmware log parsed message
+*/
+unsigned int rs2_get_fw_log_parsed_sequence(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error);
 
 /**
 * \brief Creates RealSense terminal parser.

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -465,10 +465,10 @@ namespace rs2
             return timestamp;
         }
 
-        uint32_t sequence() const
+        uint32_t sequence_id() const
         {
             rs2_error* e = nullptr;
-            uint32_t sequence(rs2_get_fw_log_parsed_sequence(_parsed_fw_log.get(), &e));
+            uint32_t sequence(rs2_get_fw_log_parsed_sequence_id(_parsed_fw_log.get(), &e));
             error::handle(e);
             return sequence;
         }
@@ -559,10 +559,10 @@ namespace rs2
             return parsingResult;
         }
 
-        int get_num_of_fw_logs() const
+        unsigned int get_number_of_fw_logs() const
         {
             rs2_error* e = nullptr;
-            int num_of_fw_logs = rs2_get_num_of_fw_logs(_dev.get(), &e);
+            unsigned int num_of_fw_logs = rs2_get_number_of_fw_logs(_dev.get(), &e);
             error::handle(e);
 
             return num_of_fw_logs;

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -559,7 +559,7 @@ namespace rs2
             return parsingResult;
         }
 
-        int get_num_of_fw_logs()
+        int get_num_of_fw_logs() const
         {
             rs2_error* e = nullptr;
             int num_of_fw_logs = rs2_get_num_of_fw_logs(_dev.get(), &e);

--- a/include/librealsense2/hpp/rs_internal.hpp
+++ b/include/librealsense2/hpp/rs_internal.hpp
@@ -465,6 +465,14 @@ namespace rs2
             return timestamp;
         }
 
+        uint32_t sequence() const
+        {
+            rs2_error* e = nullptr;
+            uint32_t sequence(rs2_get_fw_log_parsed_sequence(_parsed_fw_log.get(), &e));
+            error::handle(e);
+            return sequence;
+        }
+
         const std::shared_ptr<rs2_firmware_log_parsed_message> get_message() const { return _parsed_fw_log; }
 
     private:
@@ -549,6 +557,15 @@ namespace rs2
             error::handle(e);
 
             return parsingResult;
+        }
+
+        int get_num_of_fw_logs()
+        {
+            rs2_error* e = nullptr;
+            int num_of_fw_logs = rs2_get_num_of_fw_logs(_dev.get(), &e);
+            error::handle(e);
+
+            return num_of_fw_logs;
         }
     };
 

--- a/src/android/jni/fw_logger.cpp
+++ b/src/android/jni/fw_logger.cpp
@@ -46,14 +46,14 @@ Java_com_intel_realsense_librealsense_FwLogger_nGetFlashLog(JNIEnv *env, jobject
 }
 
 extern "C"
-JNIEXPORT jint JNICALL
-Java_com_intel_realsense_librealsense_FwLogger_nGetNumOfFwLogs(JNIEnv *env, jobject instance,
+JNIEXPORT jlong JNICALL
+Java_com_intel_realsense_librealsense_FwLogger_nGetNumberOfFwLogs(JNIEnv *env, jobject instance,
                                                             jlong fw_logger_handle) {
     rs2_error* e = NULL;
-    int numOfFwLogsPolledFromDevice = rs2_get_num_of_fw_logs(reinterpret_cast<rs2_device*>(fw_logger_handle), &e);
+    unsigned int numOfFwLogsPolledFromDevice = rs2_get_number_of_fw_logs(reinterpret_cast<rs2_device*>(fw_logger_handle), &e);
     handle_error(env, e);
 
-    return (jint)numOfFwLogsPolledFromDevice;
+    return (jlong)(unsigned long long)numOfFwLogsPolledFromDevice;
 }
 
 extern "C"
@@ -211,9 +211,9 @@ Java_com_intel_realsense_librealsense_FwLogParsedMsg_nGetTimestamp(JNIEnv *env, 
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_com_intel_realsense_librealsense_FwLogParsedMsg_nGetSequence(JNIEnv *env, jclass clazz, jlong handle) {
+Java_com_intel_realsense_librealsense_FwLogParsedMsg_nGetSequenceId(JNIEnv *env, jclass clazz, jlong handle) {
     rs2_error* e = NULL;
-    int sequence = rs2_get_fw_log_parsed_sequence(reinterpret_cast<rs2_firmware_log_parsed_message*>(handle), &e);
+    unsigned int sequence = rs2_get_fw_log_parsed_sequence_id(reinterpret_cast<rs2_firmware_log_parsed_message*>(handle), &e);
     handle_error(env, e);
     return (jint)sequence;
 }

--- a/src/android/jni/fw_logger.cpp
+++ b/src/android/jni/fw_logger.cpp
@@ -46,6 +46,17 @@ Java_com_intel_realsense_librealsense_FwLogger_nGetFlashLog(JNIEnv *env, jobject
 }
 
 extern "C"
+JNIEXPORT jint JNICALL
+Java_com_intel_realsense_librealsense_FwLogger_nGetNumOfFwLogs(JNIEnv *env, jobject instance,
+                                                            jlong fw_logger_handle) {
+    rs2_error* e = NULL;
+    int numOfFwLogsPolledFromDevice = rs2_get_num_of_fw_logs(reinterpret_cast<rs2_device*>(fw_logger_handle), &e);
+    handle_error(env, e);
+
+    return (jint)numOfFwLogsPolledFromDevice;
+}
+
+extern "C"
 JNIEXPORT jboolean JNICALL
 Java_com_intel_realsense_librealsense_FwLogger_nInitParser(JNIEnv *env, jclass clazz,
                                                                jlong fw_logger_handle,
@@ -197,5 +208,13 @@ Java_com_intel_realsense_librealsense_FwLogParsedMsg_nGetTimestamp(JNIEnv *env, 
     unsigned int timestamp = rs2_get_fw_log_parsed_timestamp(reinterpret_cast<rs2_firmware_log_parsed_message*>(handle), &e);
     handle_error(env, e);
     return (jlong)(unsigned long long)timestamp;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_intel_realsense_librealsense_FwLogParsedMsg_nGetSequence(JNIEnv *env, jclass clazz, jlong handle) {
+    rs2_error* e = NULL;
+    int sequence = rs2_get_fw_log_parsed_sequence(reinterpret_cast<rs2_firmware_log_parsed_message*>(handle), &e);
+    handle_error(env, e);
+    return (jint)sequence;
 }
 

--- a/src/firmware_logger_device.cpp
+++ b/src/firmware_logger_device.cpp
@@ -38,7 +38,7 @@ namespace librealsense
         return result;
     }
 
-    int firmware_logger_device::get_num_of_fw_logs() const
+    unsigned int firmware_logger_device::get_number_of_fw_logs() const
     {
         return _fw_logs.size();
     }

--- a/src/firmware_logger_device.cpp
+++ b/src/firmware_logger_device.cpp
@@ -38,6 +38,10 @@ namespace librealsense
         return result;
     }
 
+    int firmware_logger_device::get_num_of_fw_logs() const
+    {
+        return _fw_logs.size();
+    }
 
     void firmware_logger_device::get_fw_logs_from_hw_monitor()
     {

--- a/src/firmware_logger_device.h
+++ b/src/firmware_logger_device.h
@@ -16,7 +16,7 @@ namespace librealsense
     public:
         virtual bool get_fw_log(fw_logs::fw_logs_binary_data& binary_data) = 0;
         virtual bool get_flash_log(fw_logs::fw_logs_binary_data& binary_data) = 0;
-        virtual int get_num_of_fw_logs() const = 0;
+        virtual unsigned int get_number_of_fw_logs() const = 0;
         virtual bool init_parser(std::string xml_content) = 0;
         virtual bool parse_log(const fw_logs::fw_logs_binary_data* fw_log_msg, fw_logs::fw_log_data* parsed_msg) = 0;
         virtual ~firmware_logger_extensions() = default;
@@ -33,7 +33,7 @@ namespace librealsense
         bool get_fw_log(fw_logs::fw_logs_binary_data& binary_data) override;
         bool get_flash_log(fw_logs::fw_logs_binary_data& binary_data) override;
         
-        int get_num_of_fw_logs() const override;
+        unsigned int get_number_of_fw_logs() const override;
 
         bool init_parser(std::string xml_content) override;
         bool parse_log(const fw_logs::fw_logs_binary_data* fw_log_msg, fw_logs::fw_log_data* parsed_msg) override;

--- a/src/firmware_logger_device.h
+++ b/src/firmware_logger_device.h
@@ -16,6 +16,7 @@ namespace librealsense
     public:
         virtual bool get_fw_log(fw_logs::fw_logs_binary_data& binary_data) = 0;
         virtual bool get_flash_log(fw_logs::fw_logs_binary_data& binary_data) = 0;
+        virtual int get_num_of_fw_logs() const = 0;
         virtual bool init_parser(std::string xml_content) = 0;
         virtual bool parse_log(const fw_logs::fw_logs_binary_data* fw_log_msg, fw_logs::fw_log_data* parsed_msg) = 0;
         virtual ~firmware_logger_extensions() = default;
@@ -31,6 +32,8 @@ namespace librealsense
 
         bool get_fw_log(fw_logs::fw_logs_binary_data& binary_data) override;
         bool get_flash_log(fw_logs::fw_logs_binary_data& binary_data) override;
+        
+        int get_num_of_fw_logs() const override;
 
         bool init_parser(std::string xml_content) override;
         bool parse_log(const fw_logs::fw_logs_binary_data* fw_log_msg, fw_logs::fw_log_data* parsed_msg) override;

--- a/src/fw-logs/fw-log-data.cpp
+++ b/src/fw-logs/fw-log-data.cpp
@@ -69,6 +69,11 @@ namespace librealsense
             return _timestamp;
         }
 
+        uint32_t fw_log_data::get_sequence() const
+        {
+            return _sequence;
+        }
+
         rs2_log_severity fw_logs_binary_data::get_severity() const
         {
             const fw_log_binary* log_binary = reinterpret_cast<const fw_log_binary*>(logs_buffer.data());

--- a/src/fw-logs/fw-log-data.cpp
+++ b/src/fw-logs/fw-log-data.cpp
@@ -69,7 +69,7 @@ namespace librealsense
             return _timestamp;
         }
 
-        uint32_t fw_log_data::get_sequence() const
+        uint32_t fw_log_data::get_sequence_id() const
         {
             return _sequence;
         }

--- a/src/fw-logs/fw-log-data.h
+++ b/src/fw-logs/fw-log-data.h
@@ -102,7 +102,7 @@ namespace librealsense
             const std::string& get_thread_name() const;
             uint32_t get_line() const;
             uint32_t get_timestamp() const;
-            uint32_t get_sequence() const;
+            uint32_t get_sequence_id() const;
         };
     }
 }

--- a/src/fw-logs/fw-log-data.h
+++ b/src/fw-logs/fw-log-data.h
@@ -102,6 +102,7 @@ namespace librealsense
             const std::string& get_thread_name() const;
             uint32_t get_line() const;
             uint32_t get_timestamp() const;
+            uint32_t get_sequence() const;
         };
     }
 }

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -373,6 +373,7 @@ EXPORTS
 
     rs2_create_fw_log_message
     rs2_delete_fw_log_message
+    rs2_get_num_of_fw_logs
     rs2_get_fw_log
     rs2_get_flash_log
     rs2_fw_log_message_severity
@@ -389,6 +390,7 @@ EXPORTS
     rs2_get_fw_log_parsed_severity
     rs2_get_fw_log_parsed_line
     rs2_get_fw_log_parsed_timestamp
+    rs2_get_fw_log_parsed_sequence
     
     rs2_create_terminal_parser
     rs2_delete_terminal_parser

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -373,7 +373,7 @@ EXPORTS
 
     rs2_create_fw_log_message
     rs2_delete_fw_log_message
-    rs2_get_num_of_fw_logs
+    rs2_get_number_of_fw_logs
     rs2_get_fw_log
     rs2_get_flash_log
     rs2_fw_log_message_severity
@@ -390,7 +390,7 @@ EXPORTS
     rs2_get_fw_log_parsed_severity
     rs2_get_fw_log_parsed_line
     rs2_get_fw_log_parsed_timestamp
-    rs2_get_fw_log_parsed_sequence
+    rs2_get_fw_log_parsed_sequence_id
     
     rs2_create_terminal_parser
     rs2_delete_terminal_parser

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -3237,12 +3237,12 @@ int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, dev, fw_log_msg)
 
-int rs2_get_num_of_fw_logs(rs2_device* dev, rs2_error** error) BEGIN_API_CALL
+unsigned int rs2_get_number_of_fw_logs(rs2_device* dev, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
 
     auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
-    return fw_loggerable->get_num_of_fw_logs();
+    return fw_loggerable->get_number_of_fw_logs();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, dev)
 
@@ -3295,10 +3295,10 @@ unsigned int rs2_get_fw_log_parsed_timestamp(rs2_firmware_log_parsed_message* fw
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, fw_log_parsed_msg)
 
-unsigned int rs2_get_fw_log_parsed_sequence(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error) BEGIN_API_CALL
+unsigned int rs2_get_fw_log_parsed_sequence_id(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(fw_log_parsed_msg);
-    return fw_log_parsed_msg->firmware_log_parsed->get_sequence();
+    return fw_log_parsed_msg->firmware_log_parsed->get_sequence_id();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, fw_log_parsed_msg)
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -3237,6 +3237,15 @@ int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, dev, fw_log_msg)
 
+int rs2_get_num_of_fw_logs(rs2_device* dev, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(dev);
+
+    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    return fw_loggerable->get_num_of_fw_logs();
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, dev)
+
 void rs2_delete_fw_log_parsed_message(rs2_firmware_log_parsed_message* fw_log_parsed_msg) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(fw_log_parsed_msg);
@@ -3286,6 +3295,12 @@ unsigned int rs2_get_fw_log_parsed_timestamp(rs2_firmware_log_parsed_message* fw
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, fw_log_parsed_msg)
 
+unsigned int rs2_get_fw_log_parsed_sequence(rs2_firmware_log_parsed_message* fw_log_parsed_msg, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL(fw_log_parsed_msg);
+    return fw_log_parsed_msg->firmware_log_parsed->get_sequence();
+}
+HANDLE_EXCEPTIONS_AND_RETURN(0, fw_log_parsed_msg)
 
 rs2_terminal_parser* rs2_create_terminal_parser(const char* xml_content, rs2_error** error) BEGIN_API_CALL
 {

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -3131,7 +3131,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(, dev, json_content, content_size)
 rs2_firmware_log_message* rs2_create_fw_log_message(rs2_device* dev, rs2_error** error)BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(dev);
-    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    auto fw_logger = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
     
     return new rs2_firmware_log_message{ std::make_shared <librealsense::fw_logs::fw_logs_binary_data>() };
 }
@@ -3141,10 +3141,10 @@ int rs2_get_fw_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2_er
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(fw_log_msg);
-    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    auto fw_logger = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
 
     fw_logs::fw_logs_binary_data binary_data;
-    bool result = fw_loggerable->get_fw_log(binary_data);
+    bool result = fw_logger->get_fw_log(binary_data);
     if (result)
     {
         *(fw_log_msg->firmware_log_binary_data).get() = binary_data;
@@ -3157,10 +3157,10 @@ int rs2_get_flash_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg, rs2
 {
     VALIDATE_NOT_NULL(dev);
     VALIDATE_NOT_NULL(fw_log_msg);
-    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    auto fw_logger = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
 
     fw_logs::fw_logs_binary_data binary_data;
-    bool result = fw_loggerable->get_flash_log(binary_data);
+    bool result = fw_logger->get_flash_log(binary_data);
     if (result)
     {
         *(fw_log_msg->firmware_log_binary_data).get() = binary_data;
@@ -3206,9 +3206,9 @@ int rs2_init_fw_log_parser(rs2_device* dev, const char* xml_content,rs2_error** 
 {
     VALIDATE_NOT_NULL(xml_content);
     
-    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    auto fw_logger = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
 
-    return (fw_loggerable->init_parser(xml_content)) ? 1 : 0;
+    return (fw_logger->init_parser(xml_content)) ? 1 : 0;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, xml_content)
 
@@ -3216,7 +3216,7 @@ rs2_firmware_log_parsed_message* rs2_create_fw_log_parsed_message(rs2_device* de
 {
     VALIDATE_NOT_NULL(dev);
 
-    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    auto fw_logger = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
 
     return new rs2_firmware_log_parsed_message{ std::make_shared <librealsense::fw_logs::fw_log_data>() };
 }
@@ -3228,9 +3228,9 @@ int rs2_parse_firmware_log(rs2_device* dev, rs2_firmware_log_message* fw_log_msg
     VALIDATE_NOT_NULL(fw_log_msg);
     VALIDATE_NOT_NULL(parsed_msg);
 
-    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    auto fw_logger = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
 
-    bool parsing_result = fw_loggerable->parse_log(fw_log_msg->firmware_log_binary_data.get(),
+    bool parsing_result = fw_logger->parse_log(fw_log_msg->firmware_log_binary_data.get(),
         parsed_msg->firmware_log_parsed.get());
 
     return parsing_result ? 1 : 0;
@@ -3241,8 +3241,8 @@ unsigned int rs2_get_number_of_fw_logs(rs2_device* dev, rs2_error** error) BEGIN
 {
     VALIDATE_NOT_NULL(dev);
 
-    auto fw_loggerable = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
-    return fw_loggerable->get_number_of_fw_logs();
+    auto fw_logger = VALIDATE_INTERFACE(dev->device, librealsense::firmware_logger_extensions);
+    return fw_logger->get_number_of_fw_logs();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, dev)
 

--- a/tools/fw-logger/readme.md
+++ b/tools/fw-logger/readme.md
@@ -6,10 +6,10 @@ If you are suspecting that you have an issue that is related to the camera’s f
 In order to run this, ensure that your camera is streaming. This can be done using the [realsense-viewer](https://github.com/IntelRealSense/librealsense/tree/development/tools/realsense-viewer) or [rs-capture Sample](https://github.com/IntelRealSense/librealsense/tree/development/examples/capture)
 
 ## Command Line Parameters
-|Flag   |Description   |Default|
-|---|---|---|
+|Flag   |Description   |Default| Range|
+|---|---|---|---|
 |`-l <xml-path>`|xml file ful path, used to parse the logs||
-|`-s <sleep-duration-in-ms>`|sleep duration between each log message polling| 25 ||
+|`-p <polling-interval-in-ms>`|logs polling interval (in milliseconds)| 100 | 25-300|
 |`-f`|collect flash logs instead of firmware logs||
 
 ## Usage

--- a/tools/fw-logger/readme.md
+++ b/tools/fw-logger/readme.md
@@ -9,6 +9,7 @@ In order to run this, ensure that your camera is streaming. This can be done usi
 |Flag   |Description   |Default|
 |---|---|---|
 |`-l <xml-path>`|xml file ful path, used to parse the logs||
+|`-s <sleep-duration-in-ms>`|sleep duration between each log message polling| 25 ||
 |`-f`|collect flash logs instead of firmware logs||
 
 ## Usage

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -100,29 +100,10 @@ int main(int argc, char* argv[])
             }
 
             bool are_there_remaining_flash_logs_to_pull = true;
-            std::chrono::steady_clock::time_point time_of_previous_polling_ms;
-            bool is_first_iteration = true;;
+            auto time_of_previous_polling_ms = std::chrono::high_resolution_clock::now();
 
             while (hub.is_connected(dev))
             {
-                auto num_of_messages = fw_log_device.get_num_of_fw_logs();
-                if (is_first_iteration)
-                {
-                    is_first_iteration = false;
-                    time_of_previous_polling_ms = std::chrono::high_resolution_clock::now();
-                }
-                else if (num_of_messages == 0)
-                {
-                    auto current_time = std::chrono::high_resolution_clock::now();
-                    auto time_since_previous_polling_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - time_of_previous_polling_ms).count();
-                    //std::cout << "current_time - time_of_previous_polling_ms = " << time_since_previous_polling_ms << ", polling_interval_ms = " << polling_interval_ms << std::endl;
-                    if (time_since_previous_polling_ms < polling_interval_ms)
-                    {
-                        //std::cout << "sleeping_time = " << polling_interval_ms - time_since_previous_polling_ms << std::endl;
-                        std::this_thread::sleep_for(chrono::milliseconds(polling_interval_ms - time_since_previous_polling_ms));
-                    }
-                    time_of_previous_polling_ms = std::chrono::high_resolution_clock::now();
-                }
                 if (are_flash_logs_requested && !are_there_remaining_flash_logs_to_pull)
                 {
                     should_loop_end = true;
@@ -174,6 +155,19 @@ int main(int argc, char* argv[])
                     {
                         are_there_remaining_flash_logs_to_pull = false;
                     }
+                }
+                auto num_of_messages = fw_log_device.get_num_of_fw_logs();
+                if (num_of_messages == 0)
+                {
+                    auto current_time = std::chrono::high_resolution_clock::now();
+                    auto time_since_previous_polling_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - time_of_previous_polling_ms).count();
+                    //std::cout << "current_time - time_of_previous_polling_ms = " << time_since_previous_polling_ms << ", polling_interval_ms = " << polling_interval_ms << std::endl;
+                    if (time_since_previous_polling_ms < polling_interval_ms)
+                    {
+                        //std::cout << "sleeping_time = " << polling_interval_ms - time_since_previous_polling_ms << std::endl;
+                        std::this_thread::sleep_for(chrono::milliseconds(polling_interval_ms - time_since_previous_polling_ms));
+                    }
+                    time_of_previous_polling_ms = std::chrono::high_resolution_clock::now();
                 }
             }
         }

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -161,10 +161,8 @@ int main(int argc, char* argv[])
                 {
                     auto current_time = std::chrono::high_resolution_clock::now();
                     auto time_since_previous_polling_ms = std::chrono::duration_cast<std::chrono::milliseconds>(current_time - time_of_previous_polling_ms).count();
-                    //std::cout << "current_time - time_of_previous_polling_ms = " << time_since_previous_polling_ms << ", polling_interval_ms = " << polling_interval_ms << std::endl;
                     if (time_since_previous_polling_ms < polling_interval_ms)
                     {
-                        //std::cout << "sleeping_time = " << polling_interval_ms - time_since_previous_polling_ms << std::endl;
                         std::this_thread::sleep_for(chrono::milliseconds(polling_interval_ms - time_since_previous_polling_ms));
                     }
                     time_of_previous_polling_ms = std::chrono::high_resolution_clock::now();

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
                         bool parsing_result = fw_log_device.parse_log(log_message, parsed_log);
                         
                         stringstream sstr;
-                        sstr << datetime_string() << " " << parsed_log.timestamp() << " " << parsed_log.sequence()
+                        sstr << datetime_string() << " " << parsed_log.timestamp() << " " << parsed_log.sequence_id()
                             << " " << parsed_log.severity() << " " << parsed_log.thread_name()
                             << " " << parsed_log.file_name() << " " << parsed_log.line()
                             << " " << parsed_log.message();
@@ -156,7 +156,7 @@ int main(int argc, char* argv[])
                         are_there_remaining_flash_logs_to_pull = false;
                     }
                 }
-                auto num_of_messages = fw_log_device.get_num_of_fw_logs();
+                auto num_of_messages = fw_log_device.get_number_of_fw_logs();
                 if (num_of_messages == 0)
                 {
                     auto current_time = std::chrono::high_resolution_clock::now();

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -148,9 +148,9 @@ int main(int argc, char* argv[])
                         
                         stringstream sstr;
                         sstr << datetime_string() << " " << parsed_log.timestamp() << " " << parsed_log.sequence()
-                            << " " << parsed_log.severity() << " " << parsed_log.message()
-                            << " " << parsed_log.thread_name() << " " << parsed_log.file_name()
-                            << " " << parsed_log.line();
+                            << " " << parsed_log.severity() << " " << parsed_log.thread_name()
+                            << " " << parsed_log.file_name() << " " << parsed_log.line()
+                            << " " << parsed_log.message();
                         
                         fw_log_lines.push_back(sstr.str());
                     }

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -46,10 +46,13 @@ string datetime_string()
 
 int main(int argc, char* argv[])
 {
+    int default_sleep_ms = 25;
     CmdLine cmd("librealsense rs-fw-logger example tool", ' ', RS2_API_VERSION_STR);
     ValueArg<string> xml_arg("l", "load", "Full file path of HW Logger Events XML file", false, "", "Load HW Logger Events XML file");
+    ValueArg<int> sleep_arg("s", "sleep", "Sleep between each log message pulling (in milliseconds)", false, default_sleep_ms, "");
     SwitchArg flash_logs_arg("f", "flash", "Flash Logs Request", false);
     cmd.add(xml_arg); 
+    cmd.add(sleep_arg);
     cmd.add(flash_logs_arg);
     cmd.parse(argc, argv);
 
@@ -57,6 +60,9 @@ int main(int argc, char* argv[])
 
     auto use_xml_file = false;
     auto xml_full_file_path = xml_arg.getValue();
+    auto sleep_ms = sleep_arg.getValue();
+    if (sleep_ms < 0 || sleep_ms > 200)
+        sleep_ms = default_sleep_ms;
 
     bool are_flash_logs_requested = flash_logs_arg.isSet();
 
@@ -94,7 +100,7 @@ int main(int argc, char* argv[])
 
             while (hub.is_connected(dev))
             {
-                this_thread::sleep_for(chrono::milliseconds(25));
+                this_thread::sleep_for(chrono::milliseconds(sleep_ms));
 
                 if (are_flash_logs_requested && !are_there_remaining_flash_logs_to_pull)
                 {

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -62,7 +62,10 @@ int main(int argc, char* argv[])
     auto xml_full_file_path = xml_arg.getValue();
     auto polling_interval_ms = polling_interval_arg.getValue();
     if (polling_interval_ms < 25 || polling_interval_ms > 300)
+    {
+        std::cout << "Polling interval time provided: " << polling_interval_ms << "ms, is not in the valid range [25,300]. Default value " << default_polling_interval_ms << "ms is used." << std::endl;
         polling_interval_ms = default_polling_interval_ms;
+    }
 
     bool are_flash_logs_requested = flash_logs_arg.isSet();
 

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -94,6 +94,8 @@ int main(int argc, char* argv[])
 
             while (hub.is_connected(dev))
             {
+                this_thread::sleep_for(chrono::milliseconds(25));
+
                 if (are_flash_logs_requested && !are_there_remaining_flash_logs_to_pull)
                 {
                     should_loop_end = true;

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
     auto use_xml_file = false;
     auto xml_full_file_path = xml_arg.getValue();
     auto sleep_ms = sleep_arg.getValue();
-    if (sleep_ms < 0 || sleep_ms > 200)
+    if (sleep_ms < 1 || sleep_ms > 200)
         sleep_ms = default_sleep_ms;
 
     bool are_flash_logs_requested = flash_logs_arg.isSet();

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogParsedMsg.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogParsedMsg.java
@@ -17,6 +17,7 @@ public class FwLogParsedMsg extends LrsClass {
     public String getSeverity() {return nGetSeverity(mHandle);}
     public int getLine() {return nGetLine(mHandle);}
     public long getTimestamp(){return nGetTimestamp(mHandle);}
+    public int getSequence() {return nGetSequence(mHandle);}
 
 
     private native static void nRelease(long handle);
@@ -26,4 +27,5 @@ public class FwLogParsedMsg extends LrsClass {
     private native static String nGetSeverity(long handle);
     private native static int nGetLine(long handle);
     private native static long nGetTimestamp(long handle);
+    private native static int nGetSequence(long handle);
 }

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogParsedMsg.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogParsedMsg.java
@@ -17,7 +17,7 @@ public class FwLogParsedMsg extends LrsClass {
     public String getSeverity() {return nGetSeverity(mHandle);}
     public int getLine() {return nGetLine(mHandle);}
     public long getTimestamp(){return nGetTimestamp(mHandle);}
-    public int getSequence() {return nGetSequence(mHandle);}
+    public int getSequence() {return nGetSequenceId(mHandle);}
 
 
     private native static void nRelease(long handle);
@@ -27,5 +27,5 @@ public class FwLogParsedMsg extends LrsClass {
     private native static String nGetSeverity(long handle);
     private native static int nGetLine(long handle);
     private native static long nGetTimestamp(long handle);
-    private native static int nGetSequence(long handle);
+    private native static int nGetSequenceId(long handle);
 }

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogParsedMsg.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogParsedMsg.java
@@ -17,7 +17,7 @@ public class FwLogParsedMsg extends LrsClass {
     public String getSeverity() {return nGetSeverity(mHandle);}
     public int getLine() {return nGetLine(mHandle);}
     public long getTimestamp(){return nGetTimestamp(mHandle);}
-    public int getSequence() {return nGetSequenceId(mHandle);}
+    public int getSequenceId() {return nGetSequenceId(mHandle);}
 
 
     private native static void nRelease(long handle);

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogger.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogger.java
@@ -44,8 +44,8 @@ public class FwLogger extends Device {
         return new FwLogMsg(nGetFlashLog(mHandle));
     }
 
-    public int getNumOfFwLogsPolledFromDevice() {
-        return nGetNumOfFwLogs(mHandle);
+    public long getNumberOfUnreadFWLogs() {
+        return nGetNumberOfFwLogs(mHandle);
     }
 
     public boolean getFwLogPullingStatus() { return mFwLogPullingStatus; }
@@ -57,7 +57,7 @@ public class FwLogger extends Device {
 
     private native long nGetFwLog(long handle);
     private native long nGetFlashLog(long handle);
-    private native int nGetNumOfFwLogs(long handle);
+    private native long nGetNumberOfFwLogs(long handle);
     private static native boolean nInitParser(long handle, String xml_content);
     private static native long nParseFwLog(long handle, long fw_log_msg_handle);
 }

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogger.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/FwLogger.java
@@ -44,6 +44,10 @@ public class FwLogger extends Device {
         return new FwLogMsg(nGetFlashLog(mHandle));
     }
 
+    public int getNumOfFwLogsPolledFromDevice() {
+        return nGetNumOfFwLogs(mHandle);
+    }
+
     public boolean getFwLogPullingStatus() { return mFwLogPullingStatus; }
 
     public FwLogParsedMsg parseFwLog(FwLogMsg msg) {
@@ -53,6 +57,7 @@ public class FwLogger extends Device {
 
     private native long nGetFwLog(long handle);
     private native long nGetFlashLog(long handle);
+    private native int nGetNumOfFwLogs(long handle);
     private static native boolean nInitParser(long handle, String xml_content);
     private static native long nParseFwLog(long handle, long fw_log_msg_handle);
 }

--- a/wrappers/csharp/Intel.RealSense/Devices/FirmwareLogsDevice.cs
+++ b/wrappers/csharp/Intel.RealSense/Devices/FirmwareLogsDevice.cs
@@ -42,6 +42,12 @@ namespace Intel.RealSense
             return FwParsedLog.Create(NativeMethods.rs2_create_fw_log_parsed_message(Handle, out error));
         }
 
+        public int GetNumOfFwLogs()
+        {
+            object error;
+            return NativeMethods.rs2_get_num_of_fw_logs(Handle, out error);
+        }
+
         public bool GetFwLog(ref FwLog fwLog)
         {
             object error;

--- a/wrappers/csharp/Intel.RealSense/Devices/FirmwareLogsDevice.cs
+++ b/wrappers/csharp/Intel.RealSense/Devices/FirmwareLogsDevice.cs
@@ -42,10 +42,10 @@ namespace Intel.RealSense
             return FwParsedLog.Create(NativeMethods.rs2_create_fw_log_parsed_message(Handle, out error));
         }
 
-        public int GetNumOfFwLogs()
+        public uint GetNumberOfFwLogs()
         {
             object error;
-            return NativeMethods.rs2_get_num_of_fw_logs(Handle, out error);
+            return NativeMethods.rs2_get_number_of_fw_logs(Handle, out error);
         }
 
         public bool GetFwLog(ref FwLog fwLog)

--- a/wrappers/csharp/Intel.RealSense/NativeMethods.cs
+++ b/wrappers/csharp/Intel.RealSense/NativeMethods.cs
@@ -735,6 +735,9 @@ namespace Intel.RealSense
         internal static extern void rs2_delete_fw_log_message(IntPtr fw_log);
 
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int rs2_get_num_of_fw_logs(IntPtr device, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
+
+        [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int rs2_get_fw_log(IntPtr device, IntPtr fw_log_, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
 
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
@@ -781,6 +784,10 @@ namespace Intel.RealSense
 
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern uint rs2_get_fw_log_parsed_timestamp(IntPtr fw_parsed_log, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
+        
+        [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern uint rs2_get_fw_log_parsed_sequence(IntPtr fw_parsed_log, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
+
         #endregion
         #region terminal_parser
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]

--- a/wrappers/csharp/Intel.RealSense/NativeMethods.cs
+++ b/wrappers/csharp/Intel.RealSense/NativeMethods.cs
@@ -735,7 +735,7 @@ namespace Intel.RealSense
         internal static extern void rs2_delete_fw_log_message(IntPtr fw_log);
 
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int rs2_get_num_of_fw_logs(IntPtr device, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
+        internal static extern uint rs2_get_number_of_fw_logs(IntPtr device, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
 
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int rs2_get_fw_log(IntPtr device, IntPtr fw_log_, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
@@ -786,7 +786,7 @@ namespace Intel.RealSense
         internal static extern uint rs2_get_fw_log_parsed_timestamp(IntPtr fw_parsed_log, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
         
         [DllImport(dllName, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint rs2_get_fw_log_parsed_sequence(IntPtr fw_parsed_log, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
+        internal static extern uint rs2_get_fw_log_parsed_sequence_id(IntPtr fw_parsed_log, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ErrorMarshaler))] out object error);
 
         #endregion
         #region terminal_parser

--- a/wrappers/csharp/Intel.RealSense/Types/FwParsedLog.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/FwParsedLog.cs
@@ -57,10 +57,10 @@ namespace Intel.RealSense
             return NativeMethods.rs2_get_fw_log_parsed_timestamp(Handle, out error);
         }
 
-        public uint GetSequence()
+        public uint GetSequenceId()
         {
             object error;
-            return NativeMethods.rs2_get_fw_log_parsed_sequence(Handle, out error);
+            return NativeMethods.rs2_get_fw_log_parsed_sequence_id(Handle, out error);
         }
 
     }

--- a/wrappers/csharp/Intel.RealSense/Types/FwParsedLog.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/FwParsedLog.cs
@@ -57,6 +57,11 @@ namespace Intel.RealSense
             return NativeMethods.rs2_get_fw_log_parsed_timestamp(Handle, out error);
         }
 
+        public uint GetSequence()
+        {
+            object error;
+            return NativeMethods.rs2_get_fw_log_parsed_sequence(Handle, out error);
+        }
 
     }
 }

--- a/wrappers/python/pyrs_internal.cpp
+++ b/wrappers/python/pyrs_internal.cpp
@@ -168,13 +168,15 @@ void init_internal(py::module &m) {
         .def("get_thread_name", &rs2::firmware_log_parsed_message::thread_name, "Get thread name ")
         .def("get_severity", &rs2::firmware_log_parsed_message::severity, "Get severity ")
         .def("get_line", &rs2::firmware_log_parsed_message::line, "Get line ")
-        .def("get_timestamp", &rs2::firmware_log_parsed_message::timestamp, "Get timestamp ");
+        .def("get_timestamp", &rs2::firmware_log_parsed_message::timestamp, "Get timestamp ")
+        .def("get_sequence", &rs2::firmware_log_parsed_message::sequence, "Get sequence ");
 
     // rs2::firmware_logger
     py::class_<rs2::firmware_logger, rs2::device> firmware_logger(m, "firmware_logger");
     firmware_logger.def(py::init<rs2::device>(), "device"_a)
         .def("create_message", &rs2::firmware_logger::create_message, "Create FW Log")
         .def("create_parsed_message", &rs2::firmware_logger::create_parsed_message, "Create FW Parsed Log")
+        .def("get_num_of_fw_logs", &rs2::firmware_logger::get_num_of_fw_logs, "Get Num of Fw Logs Polled From Device")
         .def("get_firmware_log", &rs2::firmware_logger::get_firmware_log, "Get FW Log", "msg"_a)
         .def("get_flash_log", &rs2::firmware_logger::get_flash_log, "Get Flash Log", "msg"_a)
         .def("init_parser", &rs2::firmware_logger::init_parser, "Initialize Parser with content of xml file",

--- a/wrappers/python/pyrs_internal.cpp
+++ b/wrappers/python/pyrs_internal.cpp
@@ -169,7 +169,7 @@ void init_internal(py::module &m) {
         .def("get_severity", &rs2::firmware_log_parsed_message::severity, "Get severity ")
         .def("get_line", &rs2::firmware_log_parsed_message::line, "Get line ")
         .def("get_timestamp", &rs2::firmware_log_parsed_message::timestamp, "Get timestamp ")
-        .def("get_sequence_id", &rs2::firmware_log_parsed_message::sequence_id, "Get sequence ");
+        .def("get_sequence_id", &rs2::firmware_log_parsed_message::sequence_id, "Get sequence id");
 
     // rs2::firmware_logger
     py::class_<rs2::firmware_logger, rs2::device> firmware_logger(m, "firmware_logger");

--- a/wrappers/python/pyrs_internal.cpp
+++ b/wrappers/python/pyrs_internal.cpp
@@ -169,14 +169,14 @@ void init_internal(py::module &m) {
         .def("get_severity", &rs2::firmware_log_parsed_message::severity, "Get severity ")
         .def("get_line", &rs2::firmware_log_parsed_message::line, "Get line ")
         .def("get_timestamp", &rs2::firmware_log_parsed_message::timestamp, "Get timestamp ")
-        .def("get_sequence", &rs2::firmware_log_parsed_message::sequence, "Get sequence ");
+        .def("get_sequence_id", &rs2::firmware_log_parsed_message::sequence_id, "Get sequence ");
 
     // rs2::firmware_logger
     py::class_<rs2::firmware_logger, rs2::device> firmware_logger(m, "firmware_logger");
     firmware_logger.def(py::init<rs2::device>(), "device"_a)
         .def("create_message", &rs2::firmware_logger::create_message, "Create FW Log")
         .def("create_parsed_message", &rs2::firmware_logger::create_parsed_message, "Create FW Parsed Log")
-        .def("get_num_of_fw_logs", &rs2::firmware_logger::get_num_of_fw_logs, "Get Num of Fw Logs Polled From Device")
+        .def("get_number_of_fw_logs", &rs2::firmware_logger::get_number_of_fw_logs, "Get Number of Fw Logs Polled From Device")
         .def("get_firmware_log", &rs2::firmware_logger::get_firmware_log, "Get FW Log", "msg"_a)
         .def("get_flash_log", &rs2::firmware_logger::get_flash_log, "Get Flash Log", "msg"_a)
         .def("init_parser", &rs2::firmware_logger::init_parser, "Initialize Parser with content of xml file",


### PR DESCRIPTION
Adding a sleep between each fw log polling.
Default value is hardcoded in the tool's code.
This can be also input by the user using -s <sleep_in_ms>

Triggered by Jira DSO-15939