### PR TITLE
Make the http_proxy environment variable available.

### DIFF
--- a/doc/distribution_linux.md
+++ b/doc/distribution_linux.md
@@ -15,7 +15,7 @@ The steps are described in [Linux manual installation guide](./installation.md)
 
 ## Installing the packages:
 - Register the server's public key:  
-`sudo apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE`
+`curl -sSL "http://keys.gnupg.net/pks/lookup?op=get&search=0xC8B3A55A6F3EFCDE" | sudo apt-key add - || curl -sSL "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xC8B3A55A6F3EFCDE" | sudo apt-key add -`  
 In case the public key still cannot be retrieved, check and specify proxy settings: `export http_proxy="http://<proxy>:<port>"`  
 , and rerun the command. See additional methods in the following [link](https://unix.stackexchange.com/questions/361213/unable-to-add-gpg-key-with-apt-key-behind-a-proxy).  
 


### PR DESCRIPTION
Hello.
I am using this library in an environment where an HTTP proxy exists.
I was following https://github.com/IntelRealSense/librealsense/blob/master/doc/distribution_linux.md#installing-the-packages to do the installation, but It did not complete successfully.
According to https://unix.stackexchange.com/a/507581, it appears that apt-key no longer reads the http_proxy environment variable.

I have replaced it with the curl-based method. This seems to be working fine. I have changed the documentation. What do you think?