### PR TITLE
Adapting the Unity Wrapper for use in Unity 2018-2020

### DIFF
--- a/wrappers/unity/.gitignore
+++ b/wrappers/unity/.gitignore
@@ -3,7 +3,11 @@
 [Oo]bj/
 [Bb]uild/
 [Bb]uilds/
+[Ll]ogs/
 Assets/AssetStoreTools*
+Packages/
+UserSettings/
+UnityPackageManager/
 
 # Visual Studio 2015 cache directory
 /.vs/

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Materials/depthMat.mat
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Materials/depthMat.mat
@@ -4,9 +4,9 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: DepthMat
+  m_Name: depthMat
   m_Shader: {fileID: 4800000, guid: f8395e4599857704d889f76eb8a306b5, type: 3}
   m_ShaderKeywords: _COLORMAP_VIRIDIS
   m_LightmapFlags: 1

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/AlignmentSample.unity
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/AlignmentSample.unity
@@ -409,7 +409,6 @@ GameObject:
   m_Component:
   - component: {fileID: 413936642}
   - component: {fileID: 413936641}
-  - component: {fileID: 413936640}
   - component: {fileID: 413936639}
   - component: {fileID: 413936638}
   m_Layer: 0
@@ -427,13 +426,6 @@ AudioListener:
   m_GameObject: {fileID: 413936637}
   m_Enabled: 1
 --- !u!124 &413936639
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 413936637}
-  m_Enabled: 1
---- !u!92 &413936640
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/PointCloudDepthAndColor.unity
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/PointCloudDepthAndColor.unity
@@ -728,7 +728,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2133302831}
   - component: {fileID: 2133302830}
-  - component: {fileID: 2133302829}
   - component: {fileID: 2133302828}
   - component: {fileID: 2133302827}
   - component: {fileID: 2133302832}
@@ -747,13 +746,6 @@ AudioListener:
   m_GameObject: {fileID: 2133302826}
   m_Enabled: 1
 --- !u!124 &2133302828
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2133302826}
-  m_Enabled: 1
---- !u!92 &2133302829
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/PointCloudProcessingBlocks.unity
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/PointCloudProcessingBlocks.unity
@@ -9952,7 +9952,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2133302831}
   - component: {fileID: 2133302830}
-  - component: {fileID: 2133302829}
   - component: {fileID: 2133302828}
   - component: {fileID: 2133302827}
   - component: {fileID: 2133302832}
@@ -9971,13 +9970,6 @@ AudioListener:
   m_GameObject: {fileID: 2133302826}
   m_Enabled: 1
 --- !u!124 &2133302828
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2133302826}
-  m_Enabled: 1
---- !u!92 &2133302829
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/TexturesDepthAndColor.unity
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/TexturesDepthAndColor.unity
@@ -373,7 +373,6 @@ GameObject:
   m_Component:
   - component: {fileID: 413936642}
   - component: {fileID: 413936641}
-  - component: {fileID: 413936640}
   - component: {fileID: 413936639}
   - component: {fileID: 413936638}
   m_Layer: 0
@@ -391,13 +390,6 @@ AudioListener:
   m_GameObject: {fileID: 413936637}
   m_Enabled: 1
 --- !u!124 &413936639
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 413936637}
-  m_Enabled: 1
---- !u!92 &413936640
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/TexturesDepthAndInfrared.unity
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/Samples/TexturesDepthAndInfrared.unity
@@ -296,7 +296,6 @@ GameObject:
   m_Component:
   - component: {fileID: 413936642}
   - component: {fileID: 413936641}
-  - component: {fileID: 413936640}
   - component: {fileID: 413936639}
   - component: {fileID: 413936638}
   m_Layer: 0
@@ -314,13 +313,6 @@ AudioListener:
   m_GameObject: {fileID: 413936637}
   m_Enabled: 1
 --- !u!124 &413936639
-Behaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 413936637}
-  m_Enabled: 1
---- !u!92 &413936640
 Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/StartHere.unity
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scenes/StartHere.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -1966,6 +1966,7 @@ GameObject:
   m_Component:
   - component: {fileID: 633919694}
   - component: {fileID: 633919695}
+  - component: {fileID: 633919696}
   m_Layer: 5
   m_Name: AR
   m_TagString: Untagged
@@ -2003,6 +2004,17 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 633919693}
+--- !u!114 &633919696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 633919693}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1426f542ddac9f40a452d36579dc9ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &637844271
 GameObject:
   m_ObjectHideFlags: 0
@@ -5152,7 +5164,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 986175405}
   m_Direction: 2
   m_Value: 1
-  m_Size: 0.99999994
+  m_Size: 0.9999999
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsARBackgroundRenderer.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsARBackgroundRenderer.cs
@@ -11,7 +11,9 @@ public class RsARBackgroundRenderer : MonoBehaviour
     public RsFrameProvider Source;
     public Material material;
     private Camera cam;
+#if !UNITY_2020_1_OR_NEWER
     private ARBackgroundRenderer bg;
+#endif
     private Intrinsics intrinsics;
     private RenderTexture rt;
 
@@ -28,12 +30,14 @@ public class RsARBackgroundRenderer : MonoBehaviour
 
         cam = GetComponent<Camera>();
 
+#if !UNITY_2020_1_OR_NEWER
         bg = new ARBackgroundRenderer()
         {
             backgroundMaterial = material,
             mode = ARRenderMode.MaterialAsBackground,
             backgroundTexture = material.mainTexture
         };
+#endif
 
         cam.depthTextureMode |= DepthTextureMode.Depth;
 
@@ -56,17 +60,21 @@ public class RsARBackgroundRenderer : MonoBehaviour
         light.AddCommandBuffer(LightEvent.AfterScreenspaceMask, copyScreenSpaceShadow);
     }
 
+#if !UNITY_2020_1_OR_NEWER
     void OnEnable()
     {
         if (bg != null)
             bg.mode = ARRenderMode.MaterialAsBackground;
     }
+#endif
 
+#if !UNITY_2020_1_OR_NEWER
     void OnDisable()
     {
         if (bg != null)
             bg.mode = ARRenderMode.StandardBackground;
     }
+#endif
 
     void Update()
     {

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsARBackgroundRestrictions.cs
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsARBackgroundRestrictions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RsARBackgroundRestrictions : MonoBehaviour {
+
+#if UNITY_2020_1_OR_NEWER
+    void Start ()
+    {
+        GameObject arPanel = GameObject.Find ("AR") as GameObject;
+        if (arPanel != null)
+            arPanel.SetActive(false);
+    }
+#endif
+
+}

--- a/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsARBackgroundRestrictions.cs.meta
+++ b/wrappers/unity/Assets/RealSenseSDK2.0/Scripts/RsARBackgroundRestrictions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1426f542ddac9f40a452d36579dc9ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/wrappers/unity/readme.md
+++ b/wrappers/unity/readme.md
@@ -1,6 +1,6 @@
 # Unity Wrapper for RealSense SDK 2.0
 
-<p align="center"><img src="http://realsense-hw-public.s3.amazonaws.com/rs-tests/unity_screenshot.PNG" height="400" /></p>
+<p align="center"><img src="http://realsense-hw-public.s3.amazonaws.com/rs-tests/unity_screenshot.PNG" height="400"/></p>
 
 > [Download **realsense.unitypackage**](https://github.com/IntelRealSense/librealsense/releases/download/v2.20.0/realsense.unitypackage) and go to `Assets > Scenes > Start Here` to see the home screen above
 
@@ -10,13 +10,14 @@ The Unity wrapper for RealSense SDK 2.0 allows Unity developers to add streams f
 We aim to provide an easy to use prefab which allows device configuration, and texture binding using the Unity Inspector, without having to code a single line of code.
 Using this wrapper, Unity developers can get a live stream of Color, Depth and Infrared textures. In addition we provide a simple way to align textures to one another (using Depth), and an example of background segmentation.
 
+> The Unity wrapper for RealSense SDK 2.0 examples have been designed and tested with Unity 2017-2020 versions no higher than 2020.1.8f1. Working with newer versions may require code changes.
 
 ### Table of content
 
 * [Getting Started](#getting-started)
 * [Prefabs](#prefabs)
-    * [RealSenseDevice](#realSenseDevice)
-    * [Images](#images)
+* [RealSenseDevice](#realSenseDevice)
+* [Images](#images)
 
 ## Getting Started
 
@@ -25,14 +26,20 @@ Using this wrapper, Unity developers can get a live stream of Color, Depth and I
 The Unity wrapper depends on the C# wrapper provided by the RealSense SDK 2.0.
 At the end of this step, the Unity project will be available in the CMake output folder:
 
-- Generate the VS solution using cmake (run from librealsense root dir):
-  - `mkdir build`
-  - `cd build`
-  - `cmake .. -DBUILD_CSHARP_BINDINGS=ON -DBUILD_UNITY_BINDINGS=ON -DBUILD_SHARED_LIBS=ON -DDOTNET_VERSION_LIBRARY=3.5 -DCMAKE_GENERATOR_PLATFORM=x64`
-- The file 'realsense2.sln' should be created in 'build' folder, open the file with Visual Studio, C# examples and library will be available in the solution under 'Wrappers/csharp'.
-- Build Intel.RealSense project, this step will build both the native library and the .NET wrapper and will copy both DLLs to the Unity project Plugins folder.
-- In case Unity is installed and activated, a Unity package should be created at build/\<configuration\>/realsense.unitypackage. This file can be imported by the Unity editor.
-  If Unity is not installed or activated a Unity project folder will still be avilable at 'build/wrappers/unity'.
+* Generate the VS solution using cmake (run from librealsense root dir):
+
+  ```bash
+  mkdir build
+  cd build
+  cmake .. -DBUILD_CSHARP_BINDINGS=ON -DBUILD_UNITY_BINDINGS=ON -DBUILD_SHARED_LIBS=ON \
+  -DDOTNET_VERSION_LIBRARY=3.5 -DCMAKE_GENERATOR_PLATFORM=x64 \
+  -DUNITY_PATH=<path_to_unityeditor>/Unity.exe
+  ```
+
+* The file 'realsense2.sln' should be created in 'build' folder, open the file with Visual Studio, C# examples and library will be available in the solution under 'Wrappers/csharp'.
+* Build Intel.RealSense project, this step will build both the native library and the .NET wrapper and will copy both DLLs to the Unity project Plugins folder.
+* In case Unity is installed and activated, a Unity package should be created at build/\<configuration\>/realsense.unitypackage. This file can be imported by the Unity editor.
+ If Unity is not installed or activated a Unity project folder will still be avilable at 'build/wrappers/unity'.
 
   > NOTE: Unity requires that manage assemblies (such as the C# wrapper) are targeted to .NET Framework 3.5 and lower. The .NET wrapper provides assemblies for multiple targets, one of which is .NET 3.5 (net35).
 
@@ -46,7 +53,7 @@ The Unity wrapper provides several example scenes to help you get started with R
 4. PointCloud Processing Blocks - 3D scene demonstrating both processing block usage and capabilities and binding a [PointCloud](#PointCloud) prefab to RealSense device depth stream.
 5. PointCloud Depth and Color - 3D scene demonstrating how to bind a [PointCloud](#PointCloud) prefab to RealSense device depth and color streams.
 6. Alignment - 2D scene demonstrating the usage of the alignment processing block.
-7. AR Background - 2D scene demonstrating augmented reality capabilities.
+7. AR Background - 2D scene demonstrating augmented reality capabilities (Not available in Unity 2020).
 
 ## Prefabs
 
@@ -56,7 +63,8 @@ The RealSenseDevice provides an encapsulation of a single device connected to th
 
 ![device_inspeector](https://user-images.githubusercontent.com/18511514/55072419-b9da0b00-5093-11e9-9f11-a40d263183a0.PNG)
 
-##### Process Mode
+#### Process Mode
+
 This option indicates which threading model the user expects to use.
 
 * Multithread - A separate thread will be used to raise device frames.
@@ -65,6 +73,7 @@ This option indicates which threading model the user expects to use.
 Note that this option affects all other scripts that do any sort of frame processing.
 
 ##### Configuration
+
 The device is configured the same way that a `Pipeline` is, i.e. with a `Config`. In order to make it available via Unity Inspector, a `Profiles` object is exposed for each RealSenseDevice. When Starting the scene, the device will try to start streaming the requested profiles (`Pipeline.Start(config)` is called).
 Upon starting the device, the device will begin raising frames via its `OnNewSample`public event. These frames are raised either from a separate thread or from the Unity thread, depending on the user's choice of Process Mode.
 
@@ -76,7 +85,6 @@ Setting the profile count to 0 will fall to the default configuration of the dev
 Once the device is streaming, Unity Inspector will show the device's sensors and allow controlling their options via the GUI under the RealSenseDeviceInspector script. Changing these options affect the sensor directly on runtime:
 
 ![image](https://user-images.githubusercontent.com/22654243/36370003-007a7bc2-1566-11e8-979f-e31617643e7a.png)
-
 
 ##### Texture Streams
 
@@ -99,15 +107,13 @@ A processing profile can be created as shown below:
 >Create a new processing profile
 >
 >![processingprofile](https://user-images.githubusercontent.com/18511514/47161646-1ffb7e80-d2fb-11e8-9793-4acf96191903.PNG)
-
 >Attach the processing profile to the RsProcessingPipe prefab
 >
 >![processingprofile2](https://user-images.githubusercontent.com/18511514/47161647-1ffb7e80-d2fb-11e8-948c-6ca57afe9375.PNG)
-
 >Add and configure processing blocks
-> 
+>
 >![processingprofile3](https://user-images.githubusercontent.com/18511514/47161650-20941500-d2fb-11e8-8994-f7b8452e254a.PNG)
- 
+
 An example for the usage of the processing blocks can be found in "PointCloudProcessingBlocks" scene and "AlignmentSample" scense.
 ![processingblocks](https://user-images.githubusercontent.com/18511514/47161644-1ffb7e80-d2fb-11e8-9dc2-80c897aa2544.PNG)
 


### PR DESCRIPTION
1. Deleted GUI Layer from some scenes
2. Added AR Background Resitrictions for  prevent using old classes in Unity 2020