### PR TITLE
Fix colorizer - Get depth units from depth_sensor API.

### DIFF
--- a/src/proc/colorizer.cpp
+++ b/src/proc/colorizer.cpp
@@ -245,6 +245,22 @@ namespace librealsense
             auto depth_sensor = As< librealsense::depth_sensor >( snr );
             if( depth_sensor )
                 _depth_units = depth_sensor->get_depth_scale();
+            else
+            {
+                // For playback sensors
+                auto extendable = As< librealsense::extendable_interface >( snr );
+                if( extendable
+                    && extendable->extend_to( TypeToExtension< librealsense::depth_sensor >::value,
+                                              (void **)( &depth_sensor ) ) )
+                {
+                    _depth_units = depth_sensor->get_depth_scale();
+                }
+                else
+                {
+                    LOG_ERROR( "Failed to query depth units from sensor." );
+                    throw std::runtime_error( "Failed to query depth units from sensor." );
+                }
+            }
 
             _d2d_convert_factor = info.d2d_convert_factor;
         }

--- a/src/proc/colorizer.cpp
+++ b/src/proc/colorizer.cpp
@@ -240,7 +240,6 @@ namespace librealsense
             _source_stream_profile = f.get_profile();
             _target_stream_profile = f.get_profile().clone(RS2_STREAM_DEPTH, f.get_profile().stream_index(), RS2_FORMAT_RGB8);
 
-            auto info = disparity_info::update_info_from_frame(f);
             auto snr = ( (frame_interface *)f.get() )->get_sensor().get();
             auto depth_sensor = As< librealsense::depth_sensor >( snr );
             if( depth_sensor )
@@ -261,7 +260,7 @@ namespace librealsense
                     throw std::runtime_error( "failed to query depth units from sensor" );
                 }
             }
-
+            auto info = disparity_info::update_info_from_frame( f );
             _d2d_convert_factor = info.d2d_convert_factor;
         }
 

--- a/src/proc/colorizer.cpp
+++ b/src/proc/colorizer.cpp
@@ -257,8 +257,8 @@ namespace librealsense
                 }
                 else
                 {
-                    LOG_ERROR( "Failed to query depth units from sensor." );
-                    throw std::runtime_error( "Failed to query depth units from sensor." );
+                    LOG_ERROR( "Failed to query depth units from sensor" );
+                    throw std::runtime_error( "failed to query depth units from sensor" );
                 }
             }
 

--- a/src/proc/colorizer.cpp
+++ b/src/proc/colorizer.cpp
@@ -241,7 +241,11 @@ namespace librealsense
             _target_stream_profile = f.get_profile().clone(RS2_STREAM_DEPTH, f.get_profile().stream_index(), RS2_FORMAT_RGB8);
 
             auto info = disparity_info::update_info_from_frame(f);
-            _depth_units = info.depth_units;
+            auto snr = ( (frame_interface *)f.get() )->get_sensor().get();
+            auto depth_sensor = As< librealsense::depth_sensor >( snr );
+            if( depth_sensor )
+                _depth_units = depth_sensor->get_depth_scale();
+
             _d2d_convert_factor = info.d2d_convert_factor;
         }
 


### PR DESCRIPTION
Get depth units from depth_sensor API instead of disparity_info to support also l500.
[#7089](https://github.com/IntelRealSense/librealsense/issues/7089)
Tracked on:RS5-8868 