### PR TITLE
RS5-8371 fixed Spelling mistake on LDD Temperature option.

### DIFF
--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -70,7 +70,7 @@ extern "C" {
         RS2_OPTION_EMITTER_ON_OFF, /**< When supported, this option make the camera to switch the emitter state every frame. 0 for disabled, 1 for enabled */
         RS2_OPTION_ZERO_ORDER_POINT_X, /**< Zero order point x*/
         RS2_OPTION_ZERO_ORDER_POINT_Y, /**< Zero order point y*/
-        RS2_OPTION_LLD_TEMPERATURE, /**< LLD temperature*/
+        RS2_OPTION_LLD_TEMPERATURE, /**< LDD temperature*/
         RS2_OPTION_MC_TEMPERATURE, /**< MC temperature*/
         RS2_OPTION_MA_TEMPERATURE, /**< MA temperature*/
         RS2_OPTION_HARDWARE_PRESET, /**< Hardware stream configuration */

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -412,8 +412,7 @@ namespace librealsense
             CASE(EMITTER_ON_OFF)
             CASE(ZERO_ORDER_POINT_X)
             CASE(ZERO_ORDER_POINT_Y)
-            case RS2_OPTION_LLD_TEMPERATURE:
-            return "LDD temperature";
+            case RS2_OPTION_LLD_TEMPERATURE:       return "LDD temperature";
             CASE(MC_TEMPERATURE)
             CASE(MA_TEMPERATURE)
             CASE(APD_TEMPERATURE)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -412,7 +412,8 @@ namespace librealsense
             CASE(EMITTER_ON_OFF)
             CASE(ZERO_ORDER_POINT_X)
             CASE(ZERO_ORDER_POINT_Y)
-            CASE(LLD_TEMPERATURE)
+            case RS2_OPTION_LLD_TEMPERATURE:
+            return "Ldd temperture";
             CASE(MC_TEMPERATURE)
             CASE(MA_TEMPERATURE)
             CASE(APD_TEMPERATURE)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -413,7 +413,7 @@ namespace librealsense
             CASE(ZERO_ORDER_POINT_X)
             CASE(ZERO_ORDER_POINT_Y)
             case RS2_OPTION_LLD_TEMPERATURE:
-            return "Ldd temperture";
+            return "LDD temperature";
             CASE(MC_TEMPERATURE)
             CASE(MA_TEMPERATURE)
             CASE(APD_TEMPERATURE)


### PR DESCRIPTION
Fixed spelling mistake of LDD Temperature option on get_string(), 
We cant change the enum value because of backward compatibility.  