### PR TITLE
Fix `Resource deadlock avoided` exception on thread join

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -899,7 +899,11 @@ namespace librealsense
 
             if(val < 0)
             {
-                stop_data_capture();
+                _is_capturing = false;
+                _is_started = false;
+
+                // Notify kernel
+                streamoff();
             }
             else
             {


### PR DESCRIPTION
It's illegal to call **_thread->join();** in capture_loop().
Setting **_is_capturing = false** breaks to outer while loop, and the thread should be terminated.