### PR TITLE
Fixed playback Resuming on 3D viewer

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2074,7 +2074,7 @@ namespace rs2
 
     std::shared_ptr<texture_buffer> stream_model::upload_frame(frame&& f)
     {
-        if (dev && dev->is_paused() && !dev->dev.is<playback>()) return nullptr;
+        if (dev && dev->is_paused()) return nullptr;
 
         last_frame = std::chrono::high_resolution_clock::now();
 
@@ -4014,7 +4014,7 @@ namespace rs2
                         if (s->streaming)
                             s->resume();
                     }
-
+                    viewer.paused = false;
                     p.resume();
                 }
 


### PR DESCRIPTION
Fixed DSO-12584:
1. Resuming of playback  and Resuming 3D viewer are now coupled , when resuming playback - 3D automatically resumed.
2. stop uploading texture when playback is running and 3D viewer is resumed.