### PR TITLE
Add Reflectivity option restrictions

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -76,25 +76,26 @@ static void width_height_from_resolution(rs2_sensor_mode mode, int &width, int &
     }
 }
 
-static int get_resolution_id_from_sensor_mode(int sensor_mode, const rs2::sensor &s, const std::vector<std::pair<int, int>> &res_values)
+static int get_resolution_id_from_sensor_mode( rs2_sensor_mode sensor_mode,
+                                    const rs2::sensor & s,
+                                    const std::vector< std::pair< int, int > > & res_values )
 {
     int width = 0, height = 0;
-    width_height_from_resolution(static_cast<rs2_sensor_mode>(sensor_mode), width, height);
-    auto iter = std::find_if(res_values.begin(),
-        res_values.end(),
-        [width, height](std::pair< int, int > res)
+    width_height_from_resolution( sensor_mode, width, height );
+    auto iter = std::find_if( res_values.begin(),
+                              res_values.end(),
+                              [width, height]( std::pair< int, int > res ) {
+                                  if( ( res.first == width ) && ( res.second == height )
+                                      || ( res.first == height ) && ( res.second == width ) )
+                                      return true;
+                                  return false;
+                              } );
+    if( iter != res_values.end() )
     {
-        if ((res.first == width) && (res.second == height) ||
-            (res.first == height) && (res.second == width))
-            return true;
-        return false;
-    });
-    if (iter != res_values.end())
-    {
-        return static_cast<int>(std::distance(res_values.begin(), iter));
+        return static_cast< int >( std::distance( res_values.begin(), iter ) );
     }
 
-    throw std::runtime_error("cannot convert sensor mode to resolution ID");
+    throw std::runtime_error( "cannot convert sensor mode to resolution ID" );
 }
 
 ImVec4 flip(const ImVec4& c)
@@ -1378,9 +1379,15 @@ namespace rs2
                             }
 
                             // Only update the cached value once set_option is done! That way, if it doesn't change anything...
-                            try 
+                            try
                             {
-                               ui.selected_res_id = get_resolution_id_from_sensor_mode(static_cast<int>(s->get_option(RS2_OPTION_SENSOR_MODE)), *s, res_values);
+                                int sensor_mode_val = static_cast<int>(s->get_option( RS2_OPTION_SENSOR_MODE ));
+                                {
+                                    ui.selected_res_id = get_resolution_id_from_sensor_mode(
+                                        static_cast< rs2_sensor_mode >( sensor_mode_val ),
+                                        *s,
+                                        res_values );
+                                }
                             }
                             catch (...) {}
                         }

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -330,6 +330,7 @@ namespace rs2
         bool is_all_integers() const;
         bool is_enum() const;
         bool is_checkbox() const;
+        bool allow_change(float val, std::string& error_message) const; 
     };
 
     class frame_queues
@@ -659,6 +660,7 @@ namespace rs2
 
         region_of_interest algo_roi;
         bool show_algo_roi = false;
+        float roi_percentage;
 
         std::shared_ptr<rs2::colorizer> depth_colorizer;
         std::shared_ptr<rs2::yuy_decoder> yuy2rgb;
@@ -712,6 +714,7 @@ namespace rs2
         fps_calc            fps, view_fps;
         int                 count = 0;
         rect                roi_display_rect{};
+        float               roi_percentage = 0.4f;
         frame_metadata      frame_md;
         bool                capturing_roi       = false;    // active modification of roi
         std::shared_ptr<subdevice_model> dev;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -309,7 +309,7 @@ namespace rs2
         void update_supported(std::string& error_message);
         void update_read_only_status(std::string& error_message);
         void update_all_fields(std::string& error_message, notifications_model& model);
-
+        void set_option(rs2_option opt, float value, std::string &error_message);
         bool draw_option(bool update_read_only_options, bool is_streaming,
             std::string& error_message, notifications_model& model);
 
@@ -551,7 +551,7 @@ namespace rs2
 
         bool is_there_common_fps() ;
         bool supports_on_chip_calib();
-        bool draw_stream_selection();
+        bool draw_stream_selection(std::string& error_message);
         bool is_selected_combination_supported();
         std::vector<stream_profile> get_selected_profiles();
         std::vector<stream_profile> get_supported_profiles();

--- a/common/reflectivity/reflectivity.cpp
+++ b/common/reflectivity/reflectivity.cpp
@@ -18,8 +18,10 @@ static const float INDOOR_MAX_RANGE = 9.0f;
 static const float FOV_H = 0.610865f;
 static const float FOV_V = 0.479966f;
 
-static const int VGA_HALF_WIDTH = 320;
-static const int VGA_HALF_HEIGHT = 240;
+static const int VGA_WIDTH = 640;
+static const int VGA_HEIGHT = 480;
+static const int VGA_HALF_WIDTH = VGA_WIDTH / 2;
+static const int VGA_HALF_HEIGHT = VGA_HEIGHT / 2;
 
 static bool is_close_to_zero( float x )
 {
@@ -158,16 +160,19 @@ float reflectivity::get_reflectivity( float raw_noise_estimation,
 
 void reflectivity::add_depth_sample( float depth_val, int x_in_image, int y_in_image )
 {
-    auto dist_z = round( depth_val * 16000.f / MAX_RANGE_IN_UNIT );  // convert to mm units
-    float x_ang = FOV_H * std::abs( VGA_HALF_WIDTH - x_in_image ) / VGA_HALF_WIDTH;
-    float y_ang = FOV_V * std::abs( VGA_HALF_HEIGHT - y_in_image ) / VGA_HALF_HEIGHT;
-    auto dist_r = dist_z * std::sqrt( 1.0f + (std::pow( 2.0f * std::tan( x_ang ), 2.0f ) + std::pow( 2.0f * std::tan( y_ang ), 2.0f ) ) / 4.0f );
+    if( x_in_image >= 0 && x_in_image < VGA_WIDTH && y_in_image >= 0 && y_in_image < VGA_HEIGHT )
+    {
+        auto dist_z = round( depth_val * 16000.f / MAX_RANGE_IN_UNIT );  // convert to mm units
+        float x_ang = FOV_H * std::abs( VGA_HALF_WIDTH - x_in_image ) / VGA_HALF_WIDTH;
+        float y_ang = FOV_V * std::abs( VGA_HALF_HEIGHT - y_in_image ) / VGA_HALF_HEIGHT;
+        auto dist_r = dist_z * std::sqrt( 1.0f + (std::pow( 2.0f * std::tan( x_ang ), 2.0f ) + std::pow( 2.0f * std::tan( y_ang ), 2.0f ) ) / 4.0f );
 
-    if( _dist_queue.size() >= N_STD_FRAMES )  // Keep queue as N_STD_FRAMES size queue
-        _dist_queue.pop_front();
+        if( _dist_queue.size() >= N_STD_FRAMES )  // Keep queue as N_STD_FRAMES size queue
+            _dist_queue.pop_front();
 
-    _dist_queue.push_back( dist_r );
-    _is_empty = false;
+        _dist_queue.push_back( dist_r );
+        _is_empty = false;
+    }
 }
 
 void rs2::reflectivity::reset_history()

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -577,18 +577,6 @@ namespace librealsense
 
     }
 
-    rs2_sensor_mode get_resolution_from_width_height(int width, int height)
-    {
-        if ((width == 240 && height == 320) || (width == 320 && height == 240))
-            return RS2_SENSOR_MODE_QVGA;
-        else if ((width == 640 && height == 480) || (width == 480  && height == 640))
-            return RS2_SENSOR_MODE_VGA;
-        else if ((width == 1024 && height == 768) || (width == 768 && height == 1024))
-            return RS2_SENSOR_MODE_XGA;
-        else
-            throw std::runtime_error(to_string() << "Invalid resolution " << width << "x" << height);
-    }
-
     bool stream_profiles_correspond(stream_profile_interface* l, stream_profile_interface* r)
     {
         auto vl = dynamic_cast<video_stream_profile_interface*>(l);

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -210,11 +210,15 @@ namespace librealsense
 
         if( _fw_version >= firmware_version( "1.5.0.0" ) )
         {
-            auto enable_max_usable_range = std::make_shared<max_usable_range_option>(this);
-            depth_sensor.register_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE, enable_max_usable_range);
+            bool usb3mode = (_usb_mode >= platform::usb3_type || _usb_mode == platform::usb_undefined);
+            if (usb3mode)
+            {
+                auto enable_max_usable_range = std::make_shared<max_usable_range_option>(this);
+                depth_sensor.register_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE, enable_max_usable_range);
 
-            auto enable_ir_reflectivity = std::make_shared<ir_reflectivity_option>(this);
-            depth_sensor.register_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY, enable_ir_reflectivity);
+                auto enable_ir_reflectivity = std::make_shared<ir_reflectivity_option>(this);
+                depth_sensor.register_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY, enable_ir_reflectivity);
+            }
 
             // TODO may not need auto-cal if there's no color sensor, like on the rs500...
             _autocal = std::make_shared< ac_trigger >( *this, _hw_monitor );

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -25,7 +25,7 @@ namespace librealsense
             if( ds.supports_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
                 && ds.get_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY ).query() == 1.0f )
                 throw librealsense::wrong_api_call_sequence_exception(
-                    "Enabling Alternate IR while IR Reflectivity is enabled is prohibited" );
+                    "Alternate IR cannot be enabled with IR Reflectivity" );
         }
 
         _hw_monitor->send(command{ AMCSET, _type, (int)value });
@@ -342,7 +342,7 @@ namespace librealsense
                 return;
 
             throw wrong_api_call_sequence_exception(
-                to_string() << "Changing Visual Preset while Max Usable Range is enabled is prohibited");
+                to_string() << "Visual Preset cannot be changed while Max Usable Range is enabled");
         }
     }  
 

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -18,6 +18,16 @@ namespace librealsense
 
     void l500_hw_options::set(float value)
     {
+        // Block activating alternate IR when IR reflectivity is on [RS5-8358]
+        auto &ds = _l500_dev->get_depth_sensor();
+        if( ( alternate_ir == _type ) && ( 1.0f == value ) )
+        {
+            if( ds.supports_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
+                && ds.get_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY ).query() == 1.0f )
+                throw librealsense::wrong_api_call_sequence_exception(
+                    "Enabling Alternate IR while IR Reflectivity is enabled is prohibited" );
+        }
+
         _hw_monitor->send(command{ AMCSET, _type, (int)value });
     }
 
@@ -26,12 +36,15 @@ namespace librealsense
         return _range;
     }
 
-    l500_hw_options::l500_hw_options( hw_monitor * hw_monitor,
+    l500_hw_options::l500_hw_options( l500_device* l500_dev,
+                                      hw_monitor * hw_monitor,
                                       l500_control type,
                                       option * resolution,
                                       const std::string & description )
-        :_hw_monitor(hw_monitor),
-        _type(type), _resolution( resolution )
+        : _l500_dev( l500_dev )
+        , _hw_monitor( hw_monitor )
+        , _type( type )
+        , _resolution( resolution )
         , _description( description )
     {
         auto min = _hw_monitor->send(command{ AMCGET, _type, get_min });
@@ -102,7 +115,8 @@ namespace librealsense
 
             if( _fw_version >= firmware_version( "1.5.2.0" ) )
             {
-                auto alt_ir = std::make_shared< l500_hw_options >( _hw_monitor.get(),
+                auto alt_ir = std::make_shared< l500_hw_options >( this,
+                                                                   _hw_monitor.get(),
                                                                    alternate_ir,
                                                                    resolution_option.get(),
                                                                    "Enable/Disable alternate IR" );
@@ -111,22 +125,26 @@ namespace librealsense
             }
 
             _hw_options[RS2_OPTION_POST_PROCESSING_SHARPENING] = register_option< l500_hw_options,
+                                                                                  l500_device *,
                                                                                   hw_monitor *,
                                                                                   l500_control,
                                                                                   option *,
                                                                                   std::string >(
                 RS2_OPTION_POST_PROCESSING_SHARPENING,
+                this,
                 _hw_monitor.get(),
                 post_processing_sharpness,
                 resolution_option.get(),
                 "Changes the amount of sharpening in the post-processed image" );
 
             _hw_options[RS2_OPTION_PRE_PROCESSING_SHARPENING] = register_option< l500_hw_options,
+                                                                                 l500_device *,
                                                                                  hw_monitor *,
                                                                                  l500_control,
                                                                                  option *,
                                                                                  std::string >(
                 RS2_OPTION_PRE_PROCESSING_SHARPENING,
+                this,
                 _hw_monitor.get(),
                 pre_processing_sharpness,
                 resolution_option.get(),
@@ -134,43 +152,52 @@ namespace librealsense
 
             _hw_options[RS2_OPTION_NOISE_FILTERING]
                 = register_option< l500_hw_options,
+                                   l500_device *,
                                    hw_monitor *,
                                    l500_control,
                                    option *,
                                    std::string >( RS2_OPTION_NOISE_FILTERING,
+                                                  this,
                                                   _hw_monitor.get(),
                                                   noise_filtering,
                                                   resolution_option.get(),
                                                   "Control edges and background noise" );
 
             _hw_options[RS2_OPTION_AVALANCHE_PHOTO_DIODE] = register_option< l500_hw_options,
+                                                                             l500_device *,
                                                                              hw_monitor *,
                                                                              l500_control,
                                                                              option *,
                                                                              std::string >(
                 RS2_OPTION_AVALANCHE_PHOTO_DIODE,
+                this,
                 _hw_monitor.get(),
                 apd,
                 resolution_option.get(),
                 "Changes the exposure time of Avalanche Photo Diode in the receiver" );
 
-            _hw_options[RS2_OPTION_CONFIDENCE_THRESHOLD] = register_option< l500_hw_options,
-                                                                            hw_monitor *,
-                                                                            l500_control,
-                                                                            option *,
-                                                                            std::string >(
-                RS2_OPTION_CONFIDENCE_THRESHOLD,
-                _hw_monitor.get(),
-                confidence,
-                resolution_option.get(),
-                "The confidence level threshold to use to mark a pixel as valid by the depth algorithm" );
+            _hw_options[RS2_OPTION_CONFIDENCE_THRESHOLD]
+                = register_option< l500_hw_options,
+                                   l500_device *,
+                                   hw_monitor *,
+                                   l500_control,
+                                   option *,
+                                   std::string >( RS2_OPTION_CONFIDENCE_THRESHOLD,
+                                                  this,
+                                                  _hw_monitor.get(),
+                                                  confidence,
+                                                  resolution_option.get(),
+                                                  "The confidence level threshold to use to mark a "
+                                                  "pixel as valid by the depth algorithm" );
 
             _hw_options[RS2_OPTION_LASER_POWER] = register_option< l500_hw_options,
+                                                                   l500_device *,
                                                                    hw_monitor *,
                                                                    l500_control,
                                                                    option *,
                                                                    std::string >(
                 RS2_OPTION_LASER_POWER,
+                this,
                 _hw_monitor.get(),
                 laser_gain,
                 resolution_option.get(),
@@ -178,10 +205,12 @@ namespace librealsense
 
             _hw_options[RS2_OPTION_MIN_DISTANCE]
                 = register_option< l500_hw_options,
+                                   l500_device *,
                                    hw_monitor *,
                                    l500_control,
                                    option *,
                                    std::string >( RS2_OPTION_MIN_DISTANCE,
+                                                  this,
                                                   _hw_monitor.get(),
                                                   min_distance,
                                                   resolution_option.get(),
@@ -189,10 +218,12 @@ namespace librealsense
 
             _hw_options[RS2_OPTION_INVALIDATION_BYPASS]
                 = register_option< l500_hw_options,
+                                   l500_device *,
                                    hw_monitor *,
                                    l500_control,
                                    option *,
                                    std::string >( RS2_OPTION_INVALIDATION_BYPASS,
+                                                  this,
                                                   _hw_monitor.get(),
                                                   invalidation_bypass,
                                                   resolution_option.get(),
@@ -226,17 +257,19 @@ namespace librealsense
 
     void l500_options::on_set_option(rs2_option opt, float value)
     {
-        verify_max_usable_range_restrictions(value);
-       
         if (opt == RS2_OPTION_VISUAL_PRESET)
         {
+            verify_max_usable_range_restrictions( opt, value );
             change_preset(static_cast<rs2_l500_visual_preset>(int(value)));
         }
         else
         {
             auto advanced_controls = get_advanced_controls();
             if (std::find(advanced_controls.begin(), advanced_controls.end(), opt) != advanced_controls.end())
-                move_to_custom ();
+            {
+                verify_max_usable_range_restrictions( opt, value );
+                move_to_custom();
+            }
             else
                 throw  wrong_api_call_sequence_exception(to_string() << "on_set_option support advanced controls only "<< opt<<" injected");
         }
@@ -269,8 +302,8 @@ namespace librealsense
             break;
         case RS2_L500_VISUAL_PRESET_DEFAULT:
             LOG_ERROR("L515 Visual Preset option cannot be changed to Default");
-            throw  invalid_value_exception(to_string() << "The Default preset signifies that the controls have not been changed \n"
-                                                           "since initialization, the API does not support changing back to this state.\n"
+            throw  invalid_value_exception(to_string() << "The Default preset signifies that the controls have not been changed "
+                                                           "since initialization, the API does not support changing back to this state, "
                                                            "Please choose one of the other presets");
             break;
         default: break;
@@ -299,26 +332,33 @@ namespace librealsense
         _hw_options[RS2_OPTION_LASER_POWER]->set_with_no_signal(range.max);
     }
 
-    void l500_options::verify_max_usable_range_restrictions(float value) 
+    void l500_options::verify_max_usable_range_restrictions( rs2_option opt, float value )
     {
+        // Block changing visual preset while Max Usable Range is on [RS5-8358]
         if (get_depth_sensor().supports_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE)
-            && (get_depth_sensor().get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE).query() == 1.0) &&
-            (value != rs2_l500_visual_preset::RS2_L500_VISUAL_PRESET_MAX_RANGE))
-            throw  wrong_api_call_sequence_exception(to_string() << "Changing Visual Preset while Max Usable Range is enabled is prohibited");
+            && (get_depth_sensor().get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE).query() == 1.0))
+        {
+            if ((RS2_OPTION_VISUAL_PRESET == opt) && (value == RS2_L500_VISUAL_PRESET_MAX_RANGE))
+                return;
 
-    }
+            throw wrong_api_call_sequence_exception(
+                to_string() << "Changing Visual Preset while Max Usable Range is enabled is prohibited");
+        }
+    }  
 
     void max_usable_range_option::set(float value)
     {
+        // Restrictions for Max Usable Range option as required on [RS5-8358]
+        auto& ds = _l500_depth_dev->get_depth_sensor();
         if (value == 1.0f)
         {
-            auto &sensor_mode_option = _l500_depth_dev->get_depth_sensor().get_option(RS2_OPTION_SENSOR_MODE);
+            auto &sensor_mode_option = ds.get_option(RS2_OPTION_SENSOR_MODE);
             auto sensor_mode = sensor_mode_option.query();
             bool sensor_mode_is_vga = (sensor_mode == rs2_sensor_mode::RS2_SENSOR_MODE_VGA);
 
-            bool visual_preset_is_max_range = _l500_depth_dev->get_depth_sensor().is_max_range_preset();
+            bool visual_preset_is_max_range = ds.is_max_range_preset();
 
-            if (_l500_depth_dev->get_depth_sensor().is_streaming())
+            if (ds.is_streaming())
             {
                 if (!sensor_mode_is_vga || !visual_preset_is_max_range)
                     throw wrong_api_call_sequence_exception("Please set 'VGA' resolution and 'Max Range' preset before enabling Max Usable Range");
@@ -327,7 +367,7 @@ namespace librealsense
             {
                 if (!visual_preset_is_max_range)
                 {
-                    auto &visual_preset_option = _l500_depth_dev->get_depth_sensor().get_option(RS2_OPTION_VISUAL_PRESET);
+                    auto &visual_preset_option = ds.get_option(RS2_OPTION_VISUAL_PRESET);
                     visual_preset_option.set(rs2_l500_visual_preset::RS2_L500_VISUAL_PRESET_MAX_RANGE);
                     LOG_INFO("Visual Preset was changed to: " << visual_preset_option.get_value_description(rs2_l500_visual_preset::RS2_L500_VISUAL_PRESET_MAX_RANGE));
                 }
@@ -339,6 +379,14 @@ namespace librealsense
                 }
             }
         }
+        else
+        {
+            if (ds.supports_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY) && ds.get_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY).query() == 1.0f)
+            {
+                ds.get_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY).set(0.0f);
+                LOG_INFO("IR Reflectivity was on - turning it off");
+            }
+        }
 
         bool_option::set(value);
     }
@@ -346,8 +394,8 @@ namespace librealsense
 
     void sensor_mode_option::set(float value)
     {
+        // Restrictions for sensor mode option as required on [RS5-8358]
         auto &ds = _l500_depth_dev->get_depth_sensor();
-
         if (ds.supports_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY) && ds.get_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY).query() == 1.0f)
         {
             ds.get_option(RS2_OPTION_ENABLE_IR_REFLECTIVITY).set(0.0f);
@@ -358,7 +406,8 @@ namespace librealsense
             (ds.get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE).query() == 1.0) &&
             (value != rs2_sensor_mode::RS2_SENSOR_MODE_VGA))
         {
-            throw wrong_api_call_sequence_exception("Max Usable Range support VGA resolution only");
+            ds.get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE).set(0.0f);
+            LOG_INFO("Max Usable Range was on - turning it off");
         }
 
         float_option_with_description::set(value);
@@ -377,17 +426,15 @@ namespace librealsense
 
     void ir_reflectivity_option::set(float value)
     {
+        // Restrictions for IR Reflectivity option as required on [RS5-8358]
         auto &ds = _l500_depth_dev->get_depth_sensor();
-
         if (value == 1.0f)
         {
             // Verify option Alternate IR is off
-            if (ds.supports_option(RS2_OPTION_ALTERNATE_IR))
+            if( ds.supports_option( RS2_OPTION_ALTERNATE_IR )
+                && ds.get_option( RS2_OPTION_ALTERNATE_IR ).query() == 1.0f )
             {
-                auto alternate_ir_on = (ds.get_option(RS2_OPTION_ALTERNATE_IR).query() == 1.0f);
-
-                if (alternate_ir_on)
-                    throw wrong_api_call_sequence_exception("Cannot enable IR Reflectivity when Alternate IR option is on");
+                throw wrong_api_call_sequence_exception("Cannot enable IR Reflectivity when Alternate IR option is on");
             }
 
             auto &sensor_mode_option = ds.get_option(RS2_OPTION_SENSOR_MODE);
@@ -419,7 +466,7 @@ namespace librealsense
 
                 if( ( ! vga_sensor_mode ) || ! visual_preset_is_max_range )
                     throw wrong_api_call_sequence_exception(
-                        "Please set 'VGA' resolution and 'Max Range' preset before enabling IR Reflectivity" );
+                        "Please set 'VGA' resolution, 'Max Range' preset and 20% ROI before enabling IR Reflectivity" );
             }
             else
             {
@@ -449,11 +496,13 @@ namespace librealsense
         {
             if (_max_usable_range_forced_on)
             {
-                auto &max_usable_range_option = ds.get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE);
-
-                max_usable_range_option.set(0.0f);
                 _max_usable_range_forced_on = false;
+                bool_option::set( value );  // We set the value here to prevent a loop between Max Usable Range &
+                                            // Reflectivity options trying to turn off each other
+
+                ds.get_option(RS2_OPTION_ENABLE_MAX_USABLE_RANGE).set(0.0f);
                 LOG_INFO("Max Usable Range was on - turning it off");
+                return;
             }
         }
 
@@ -468,6 +517,7 @@ namespace librealsense
         return "IR Reflectivity Tool calculates the percentage of IR light reflected by the "
                "object and returns to the camera for processing.\nFor example, a value of 60% means "
                "that 60% of the IR light projected by the camera is reflected by the object and returns "
-               "to the camera.";
+               "to the camera.\n\n"
+               "Note: only active on 2D view, Visual Preset:Max Range, Resolution:VGA, ROI:20%";
     }
 }  // namespace librealsense

--- a/src/l500/l500-options.h
+++ b/src/l500/l500-options.h
@@ -76,10 +76,20 @@ namespace librealsense
         l500_device *_l500_depth_dev;
     };
 
+    class sensor_mode_option : public float_option_with_description<rs2_sensor_mode>
+    {
+    public:
+        sensor_mode_option(l500_device *l500_depth_dev, option_range range, std::string description) : float_option_with_description<rs2_sensor_mode>(range, description), _l500_depth_dev(l500_depth_dev) {};
+        void set(float value) override;
+
+    private:
+        l500_device *_l500_depth_dev;
+    };
+
     class ir_reflectivity_option : public bool_option
     {
     public:
-        ir_reflectivity_option(l500_device *l500_depth_dev) : bool_option(false), _l500_depth_dev(l500_depth_dev) {};
+        ir_reflectivity_option(l500_device *l500_depth_dev) : bool_option(false), _l500_depth_dev(l500_depth_dev), _max_usable_range_forced_on(false){};
 
         void set(float value) override;
 
@@ -87,6 +97,7 @@ namespace librealsense
 
     private:
         l500_device *_l500_depth_dev;
+        bool _max_usable_range_forced_on;
     };
 
     class l500_options: public virtual l500_device
@@ -103,6 +114,7 @@ namespace librealsense
         void move_to_custom ();
         void reset_hw_controls();
         void set_max_laser();
+        void verify_max_usable_range_restrictions(float value);
 
         std::map<rs2_option, std::shared_ptr<cascade_option<l500_hw_options>>> _hw_options;
         std::shared_ptr< cascade_option<uvc_xu_option<int>>> _digital_gain;

--- a/src/l500/l500-options.h
+++ b/src/l500/l500-options.h
@@ -44,7 +44,8 @@ namespace librealsense
 
         void enable_recording(std::function<void(const option&)> recording_action) override;
 
-        l500_hw_options( hw_monitor * hw_monitor,
+        l500_hw_options( l500_device* l500_dev,
+                         hw_monitor* hw_monitor,
                          l500_control type,
                          option * resolution,
                          const std::string& description );
@@ -54,6 +55,7 @@ namespace librealsense
         float query(int width) const;
 
         l500_control _type;
+        l500_device* _l500_dev;
         hw_monitor* _hw_monitor;
         option_range _range;
         uint32_t _width;
@@ -114,7 +116,7 @@ namespace librealsense
         void move_to_custom ();
         void reset_hw_controls();
         void set_max_laser();
-        void verify_max_usable_range_restrictions(float value);
+        void verify_max_usable_range_restrictions(rs2_option opt, float value);
 
         std::map<rs2_option, std::shared_ptr<cascade_option<l500_hw_options>>> _hw_options;
         std::shared_ptr< cascade_option<uvc_xu_option<int>>> _digital_gain;

--- a/src/l500/l500-private.cpp
+++ b/src/l500/l500-private.cpp
@@ -204,5 +204,17 @@ namespace librealsense
             return temperature_data.nest_avg;
         }
 
+        rs2_sensor_mode get_resolution_from_width_height(int width, int height)
+        {
+            if ((width == 240 && height == 320) || (width == 320 && height == 240))
+                return RS2_SENSOR_MODE_QVGA;
+            else if ((width == 640 && height == 480) || (width == 480 && height == 640))
+                return RS2_SENSOR_MODE_VGA;
+            else if ((width == 1024 && height == 768) || (width == 768 && height == 1024))
+                return RS2_SENSOR_MODE_XGA;
+            else
+                throw std::runtime_error(to_string() << "Invalid resolution " << width << "x" << height);
+        }
+
 } // librealsense::ivcam2
 } // namespace librealsense

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -580,6 +580,8 @@ namespace librealsense
             std::shared_ptr< freefall_option > _freefall_opt;
         };
 
+        rs2_sensor_mode get_resolution_from_width_height(int width, int height);
+
         class ac_trigger;
     } // librealsense::ivcam2
 } // namespace librealsense

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -554,7 +554,7 @@ namespace rs2
                         ImGui::PopStyleVar();
                         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, { 2, 2 });
 
-                        if (_depth_sensor_model->draw_stream_selection())
+                        if (_depth_sensor_model->draw_stream_selection(_error_message))
                         {
                             if (_depth_sensor_model->is_selected_combination_supported())
                             {

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -622,12 +622,12 @@ namespace rs2
                             {
                                 if (_depth_sensor_model)
                                 {
-                                    auto& ds = _depth_sensor_model->dev.first<depth_sensor>();
+                                    auto && ds = _depth_sensor_model->dev.first<depth_sensor>();
                                     if( ds.supports( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
                                         && ( ds.get_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY ) == 1.0f ) )
                                     {
                                         allow_changing_roi = false;
-                                        _error_message = "Changing ROI while IR Reflectivity is enabled is prohibited!";
+                                        _error_message = "ROI cannot be changed while IR Reflectivity is enabled";
                                     }
                                 }
                             }

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -614,13 +614,34 @@ namespace rs2
                         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, { 1,1,1,1 });
 
                         static std::vector<std::string> items{ "80%", "60%", "40%", "20%" };
-                        if (draw_combo_box("##ROI Percent", items, _roi_combo_index))
+                        int tmp_roi_combo_box = _roi_combo_index;
+                        if (draw_combo_box("##ROI Percent", items, tmp_roi_combo_box))
                         {
-                            if (_roi_combo_index == 0) _roi_percent = 0.8f;
-                            else if (_roi_combo_index == 1) _roi_percent = 0.6f;
-                            else if (_roi_combo_index == 2) _roi_percent = 0.4f;
-                            else if (_roi_combo_index == 3) _roi_percent = 0.2f;
-                            update_configuration();
+                            bool allow_changing_roi = true;
+                            try
+                            {
+                                if (_depth_sensor_model)
+                                {
+                                    auto& ds = _depth_sensor_model->dev.first<depth_sensor>();
+                                    if( ds.supports( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
+                                        && ( ds.get_option( RS2_OPTION_ENABLE_IR_REFLECTIVITY ) == 1.0f ) )
+                                    {
+                                        allow_changing_roi = false;
+                                        _error_message = "Changing ROI while IR Reflectivity is enabled is prohibited!";
+                                    }
+                                }
+                            }
+                            catch (...) {}
+
+                            if (allow_changing_roi)
+                            {
+                                _roi_combo_index = tmp_roi_combo_box;
+                                if (_roi_combo_index == 0) _roi_percent = 0.8f;
+                                else if (_roi_combo_index == 1) _roi_percent = 0.6f;
+                                else if (_roi_combo_index == 2) _roi_percent = 0.4f;
+                                else if (_roi_combo_index == 3) _roi_percent = 0.2f;
+                                update_configuration();
+                            }
                         }
 
                         ImGui::PopStyleColor();
@@ -837,6 +858,7 @@ namespace rs2
                 if (!sub->s->is<depth_sensor>()) continue;
 
                 sub->show_algo_roi = true;
+                sub->roi_percentage = _roi_percent;
                 auto profiles = _pipe.get_active_profile().get_streams();
                 sub->streaming = true;      // The streaming activated externally to the device_model
                 sub->depth_colorizer->set_option(RS2_OPTION_HISTOGRAM_EQUALIZATION_ENABLED, 0.f);


### PR DESCRIPTION
Implement IR Reflectivity option restrictions according to [RS5-8358]

**Note:**

- When changing resolution (sensor mode) during streaming and Enable IR Reflectivity on , IR reflectivity will be disabled (With no error pop up window)
- ROI restriction is not addressed on this PR 