### PR TITLE
encapsulate linux test

### DIFF
--- a/unit-tests/internal/CMakeLists.txt
+++ b/unit-tests/internal/CMakeLists.txt
@@ -16,7 +16,7 @@ set (INTERNAL_TESTS_SOURCES
     ../approx.h
 )
 
-if(UNIX)
+if(UNIX AND NOT ANDROID)
 list(APPEND INTERNAL_TESTS_SOURCES internal-tests-linux.cpp)
 endif()
 

--- a/unit-tests/internal/CMakeLists.txt
+++ b/unit-tests/internal/CMakeLists.txt
@@ -12,10 +12,13 @@ set (INTERNAL_TESTS_SOURCES
     internal-tests-types.cpp
     internal-tests-uv-map.cpp
     internal-tests-class-logic.cpp
-    internal-tests-linux.cpp
     ../catch.h
     ../approx.h
 )
+
+if(UNIX)
+list(APPEND INTERNAL_TESTS_SOURCES internal-tests-linux.cpp)
+endif()
 
 add_executable(${PROJECT_NAME} ${INTERNAL_TESTS_SOURCES})
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)

--- a/unit-tests/internal/internal-tests-linux.cpp
+++ b/unit-tests/internal/internal-tests-linux.cpp
@@ -1,3 +1,5 @@
+#ifdef __linux__
+
 #include "catch/catch.hpp"
 #include <thread>
 #include <string>
@@ -188,3 +190,5 @@ TEST_CASE("named_mutex_processes", "[code]")
         REQUIRE(child_alive == actual_test);
     }
 }
+
+#endif // __linux__

--- a/unit-tests/internal/internal-tests-linux.cpp
+++ b/unit-tests/internal/internal-tests-linux.cpp
@@ -1,5 +1,3 @@
-#ifdef __linux__
-
 #include "catch/catch.hpp"
 #include <thread>
 #include <string>
@@ -191,4 +189,3 @@ TEST_CASE("named_mutex_processes", "[code]")
     }
 }
 
-#endif // __linux__


### PR DESCRIPTION
encapsulate the content of internal-tests-linux.cpp with #ifdef __linux__ .