### PR TITLE
fix travis-ci path too long issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
       language: cpp
       env: VS15=false RS_CPP_TEST=true
       script:
+        # map librealsense folder to overcome windows path too long issue
+        - pwd
+        - |
+          subst d: ../. 
+        - cd d:/build
         - cmake .. -G "Visual Studio 15 2017 Win64" -DPYTHON_EXECUTABLE="C:/Python38/python.exe" -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.8 -DBUILD_UNIT_TESTS=true -DBUILD_EXAMPLES=false -DBUILD_GRAPHICAL_EXAMPLES=false -DBUILD_WITH_TM2=false -DFORCE_RSUSB_BACKEND=true -DCHECK_FOR_UPDATES=true
         - cmake --build . --config $LRS_RUN_CONFIG -- -m
         - cd $LRS_RUN_CONFIG
@@ -22,6 +27,11 @@ matrix:
       language: cpp
       env: VS15=true
       script:
+        # map librealsense folder to overcome windows path too long issue
+        - pwd
+        - |
+          subst d: ../. 
+        - cd d:/build
         - cmake .. -G "Visual Studio 14 2015 Win64" -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DCHECK_FOR_UPDATES=true
         - cmake --build . --config $LRS_BUILD_CONFIG -- -m
         - ls $LRS_BUILD_CONFIG
@@ -31,6 +41,11 @@ matrix:
       language: cpp
       env: VS15=true
       script:
+        # map librealsense folder to overcome windows path too long issue
+        - pwd
+        - |
+          subst d: ../. 
+        - cd d:/build
         - cmake .. -G "Visual Studio 14 2015 Win64" -DBUILD_EXAMPLES=false -DBUILD_CSHARP_BINDINGS=true -DDOTNET_VERSION_LIBRARY="4.5" -DDOTNET_VERSION_EXAMPLES="4.5" -DCHECK_FOR_UPDATES=true
         - cmake --build . --config $LRS_BUILD_CONFIG -- -m
         - ls $LRS_BUILD_CONFIG


### PR DESCRIPTION
### Fix Travis- CI windows build failure on path too long

**Explanation:**
Windows has a limitation on project/file full path length.

When we use long names/ folders hierarchy for the unit tests we get this error on travis-ci windows build:

C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\IDE\VC\VCTargets\Microsoft.CppBuild.targets(321,5): error MSB3491: Could not write lines to file <test path>. The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters. 

This PR map the libRealSense repo folder to drive 'd' and shorten the absolute path to the built files