### PR TITLE
convert frame to frameset in post processing filters 

### DIFF
--- a/common/post-processing-filter.h
+++ b/common/post-processing-filter.h
@@ -27,7 +27,7 @@ protected:
     post_processing_filter( std::string const & name )
         : rs2::filter( [&]( rs2::frame f, rs2::frame_source & source ) {
                 // Process the frame, take the result and post it for the next post-processor
-        source.frame_ready(process_frameset(f));
+        source.frame_ready(process_frame(f));
             } )
         , _name( name )
         , _pb_enabled( true )
@@ -54,7 +54,7 @@ public:
 
 protected:
     // Main handler for each frameset we get
-    virtual rs2::frame process_frameset( rs2::frame fs ) = 0;
+    virtual rs2::frame process_frame( rs2::frame fs ) = 0;
 
 
     // Helper fn to get the frame context when logs are written, e.g.:

--- a/common/post-processing-filter.h
+++ b/common/post-processing-filter.h
@@ -54,7 +54,7 @@ public:
 
 protected:
     // Main handler for each frameset we get
-    virtual rs2::frameset process_frameset( rs2::frame fs ) = 0;
+    virtual rs2::frame process_frameset( rs2::frame fs ) = 0;
 
 
     // Helper fn to get the frame context when logs are written, e.g.:

--- a/common/post-processing-filter.h
+++ b/common/post-processing-filter.h
@@ -27,7 +27,7 @@ protected:
     post_processing_filter( std::string const & name )
         : rs2::filter( [&]( rs2::frame f, rs2::frame_source & source ) {
                 // Process the frame, take the result and post it for the next post-processor
-                source.frame_ready( process_frameset( f.as< rs2::frameset >() ) );
+        source.frame_ready(process_frameset(f));
             } )
         , _name( name )
         , _pb_enabled( true )
@@ -54,7 +54,7 @@ public:
 
 protected:
     // Main handler for each frameset we get
-    virtual rs2::frameset process_frameset( rs2::frameset fs ) = 0;
+    virtual rs2::frameset process_frameset( rs2::frame fs ) = 0;
 
 
     // Helper fn to get the frame context when logs are written, e.g.:

--- a/common/post-processing-worker-filter.h
+++ b/common/post-processing-worker-filter.h
@@ -66,7 +66,7 @@ public:
     }
 
 protected:
-    rs2::frame process_frameset(rs2::frame fs) override
+    rs2::frame process_frame(rs2::frame fs) override
     {
         _queue.enqueue(fs);
         return fs;

--- a/common/post-processing-worker-filter.h
+++ b/common/post-processing-worker-filter.h
@@ -66,29 +66,8 @@ public:
     }
 
 protected:
-    rs2::frameset process_frameset(rs2::frame fs) override
+    rs2::frame process_frameset(rs2::frame fs) override
     {
-        std::vector<rs2::frame> bundle;
-        rs2::processing_block bundler([&](rs2::frame f, rs2::frame_source& src) {
-            bundle.push_back(f);
-            if (bundle.size())
-            {
-                auto fs = src.allocate_composite_frame(bundle);
-                src.frame_ready(fs);
-                bundle.clear();
-            }
-            });
-
-        if (fs.as< rs2::frameset >().size() == 0)
-        {
-            rs2::frame_queue q;
-            bundler.start(q); // Results from the block will be enqueued into q
-            bundler.invoke(fs); // Invoke the lambda above
-            rs2::frameset output_frame = q.wait_for_frame(); // Fetch the result
-            _queue.enqueue(output_frame);
-            return output_frame;
-        }
-
         _queue.enqueue(fs);
         return fs;
     }


### PR DESCRIPTION
Track on: DSO-15250 
Allocating a frame to frameset in post_processing_filter c'tor returns NULL that passed to  process_frameset(..)
Because we want to work also with frames in post processing filters and not only framesets, the allocation is removed and the function signature changed to process_frame(..), its input and output changed from frameset to frame, and it solved the issue !