### PR TITLE
Display error if invalid resolution picked in Viewer

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1391,6 +1391,11 @@ namespace rs2
                             }
                             catch (...) {}
                         }
+                        else
+                        {
+                            error_message = to_string() << "Resolution: " << width << " x " << height
+                                                        << " is not supported on this device";
+                        }
                     }
                     else
                     {

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1393,7 +1393,7 @@ namespace rs2
                         }
                         else
                         {
-                            error_message = to_string() << "Resolution: " << width << " x " << height
+                            error_message = to_string() << "Resolution " << width << "x" << height
                                                         << " is not supported on this device";
                         }
                     }


### PR DESCRIPTION
When selecting unsupported resolutions in the Viewer application, display a pop up with the appropriate error message.

![image](https://user-images.githubusercontent.com/64067618/98931277-7b05fc80-24e6-11eb-972e-3f40551eae91.png)



Tracked on [RS5-9523]