### PR TITLE
pybind linux - Fix missing debug symbols in RelWithDebug mode

### DIFF
--- a/wrappers/python/third_party/pybind11/tools/pybind11Tools.cmake
+++ b/wrappers/python/third_party/pybind11/tools/pybind11Tools.cmake
@@ -181,7 +181,7 @@ function(pybind11_add_module target_name)
 
   _pybind11_add_lto_flags(${target_name} ${ARG_THIN_LTO})
 
-  if (NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
+  if (NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
     # Strip unnecessary sections of the binary on Linux/Mac OS
     if(CMAKE_STRIP)
       if(APPLE)


### PR DESCRIPTION
### The output binary .so file of building pyrealsense2 on Linux and on configuration RelWithDebInfo does not contain symbols.

This is cause due to a known issue at pybind11 version 2.2.1 that is used in librealsense SDK.
The issue was fixed at [PR1892](https://github.com/pybind/pybind11/pull/1892/files) at pybind11 repo.

**This PR implement the same fix.**

Linux python 2.7 wheel size before this changes is : ~10 [MB]
Linux python 2.7 wheel size after this changes is : ~70 [MB]
