### PR TITLE
Compatibility to both 2019/2020 versions of the openVINO was added

### DIFF
--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -82,6 +82,9 @@ if(DEFINED OpenCV_DIR  AND  IS_DIRECTORY ${OpenCV_DIR})
     )
 
 endif()
+
+include(../../wrappers/openvino/check_vino_version.cmake)
+
 if(DEFINED INTEL_OPENVINO_DIR  AND  IS_DIRECTORY ${INTEL_OPENVINO_DIR})
 
     message( STATUS "Enabling OpenVINO face-detection for realsense-viewer ..." )
@@ -89,12 +92,22 @@ if(DEFINED INTEL_OPENVINO_DIR  AND  IS_DIRECTORY ${INTEL_OPENVINO_DIR})
     include(${INTEL_OPENVINO_DIR}/inference_engine/share/InferenceEngineConfig.cmake)
 
     get_property(deps VARIABLE PROPERTY DEPENDENCIES)
-    set(DEPENDENCIES ${deps} ${InferenceEngine_LIBRARIES} ie_cpu_extension)
+
+    check_vino_version()
+    if(OPENVINO2019)
+        set(DEPENDENCIES ${deps} ${InferenceEngine_LIBRARIES} ie_cpu_extension)
+    else()
+        set(DEPENDENCIES ${deps} ${InferenceEngine_LIBRARIES})
+    endif()
+
     include_directories( ../../wrappers/openvino )
     include_directories( ../../wrappers/opencv )
     include_directories( ${InferenceEngine_INCLUDE_DIRS} )
+
+    if(OPENVINO2019)
     # We need additional access to ext_list.hpp, for CPU extension support:
-    include_directories( ${IE_ROOT_DIR}/src/extension )
+    include_directories( "${IE_ROOT_DIR}/src/extension" )
+    endif()
 
     set(OPENVINO_FILES
         ../../wrappers/openvino/rs-vino/base-detection.cpp
@@ -106,8 +119,11 @@ if(DEFINED INTEL_OPENVINO_DIR  AND  IS_DIRECTORY ${INTEL_OPENVINO_DIR})
         ../../wrappers/openvino/rs-vino/detected-object.cpp
         ../../wrappers/openvino/rs-vino/detected-object.h
         ../../wrappers/openvino/rs-vino/openvino-helpers.h
-        ${IE_ROOT_DIR}/src/extension/ext_list.hpp
         )
+
+    if(OPENVINO2019)
+        set(OPENVINO_FILES ${OPENVINO_FILES} "${IE_ROOT_DIR}/src/extension/ext_list.hpp")
+    endif()
 
     set(RS_VIEWER_CPP
         ${RS_VIEWER_CPP}
@@ -174,6 +190,10 @@ else()
         ${RS_VIEWER_CPP}
         ${ELPP_FILES}
     )
+endif()
+
+if(OPENVINO2019)
+    target_compile_definitions(realsense-viewer PRIVATE OPENVINO2019)
 endif()
 
 source_group("EasyLogging++" FILES ${ELPP_FILES})

--- a/wrappers/openvino/CMakeLists.txt
+++ b/wrappers/openvino/CMakeLists.txt
@@ -14,11 +14,23 @@ endif()
 set(IE_ROOT_DIR "${INTEL_OPENVINO_DIR}/inference_engine")
 include(${INTEL_OPENVINO_DIR}/inference_engine/share/InferenceEngineConfig.cmake)
 get_property(deps VARIABLE PROPERTY DEPENDENCIES)
-set(DEPENDENCIES ${deps} ${InferenceEngine_LIBRARIES} ie_cpu_extension)
+
+include(check_vino_version.cmake)
+check_vino_version()
+
+if(OPENVINO2019)
+	set(DEPENDENCIES ${deps} ${InferenceEngine_LIBRARIES} ie_cpu_extension)
+else()
+	set(DEPENDENCIES ${deps} ${InferenceEngine_LIBRARIES})
+endif()
+
 include_directories( . )
 include_directories( ${InferenceEngine_INCLUDE_DIRS} )
+
+if(OPENVINO2019)
 # We need additional access to ext_list.hpp, for CPU extension support:
-include_directories( ${IE_ROOT_DIR}/src/extension )
+	include_directories( "${IE_ROOT_DIR}/src/extension" )
+endif()
 
 # The rs-vino directory includes additional classes and helpers that need to be included
 set(OPENVINO_FILES
@@ -29,8 +41,12 @@ set(OPENVINO_FILES
 	../rs-vino/detected-object.cpp
 	../rs-vino/detected-object.h
 	../rs-vino/openvino-helpers.h
-	${IE_ROOT_DIR}/src/extension/ext_list.hpp
 )
+
+if(OPENVINO2019)
+	set(OPENVINO_FILES ${OPENVINO_FILES} "${IE_ROOT_DIR}/src/extension/ext_list.hpp")
+endif()
+
 # And they make use of ELPP (EasyLogging++):
 include_directories( ../../third-party/easyloggingpp/src )
 set( ELPP_FILES

--- a/wrappers/openvino/check_vino_version.cmake
+++ b/wrappers/openvino/check_vino_version.cmake
@@ -1,0 +1,10 @@
+
+# OPENVINO version 2019 an lower has its own API for working with the device extensions.
+# Here we checkout the OPENVINO version by existence of the specific file.
+set(OPENVINO2019 false)
+macro(check_vino_version)
+    if(EXISTS "${IE_ROOT_DIR}/src/extension/ext_list.hpp")
+    message("OPENVINO version has been found out to be 2019 or lower")
+	    set(OPENVINO2019 true)
+    endif()
+endmacro()

--- a/wrappers/openvino/dnn/CMakeLists.txt
+++ b/wrappers/openvino/dnn/CMakeLists.txt
@@ -21,6 +21,10 @@ add_executable(rs-dnn-vino
     ${ELPP_FILES}
 )
 
+if(OPENVINO2019)
+	target_compile_definitions(rs-dnn-vino PRIVATE OPENVINO2019)
+endif()
+
 source_group("OpenVINO" FILES ${OPENVINO_FILES})
 source_group("EasyLogging++" FILES ${ELPP_FILES})
 

--- a/wrappers/openvino/dnn/rs-dnn-vino.cpp
+++ b/wrappers/openvino/dnn/rs-dnn-vino.cpp
@@ -217,8 +217,11 @@ int main(int argc, char * argv[]) try
     openvino::Core engine;
     openvino_helpers::error_listener error_listener;
     engine.SetLogCallback( error_listener );
-    std::string const device_name { "CPU" };
-    engine.AddExtension( std::make_shared< openvino::Extensions::Cpu::CpuExtensions >(), device_name );
+    std::string const device_name { "ÑPU" };
+
+#ifdef OPENVINO2019
+	engine.AddExtension(std::make_shared< openvino::Extensions::Cpu::CpuExtensions >(), device_name);
+#endif
 
     std::vector< detector_and_labels > detectors;
     load_detectors_into( detectors, engine, device_name );

--- a/wrappers/openvino/dnn/rs-dnn-vino.cpp
+++ b/wrappers/openvino/dnn/rs-dnn-vino.cpp
@@ -217,7 +217,7 @@ int main(int argc, char * argv[]) try
     openvino::Core engine;
     openvino_helpers::error_listener error_listener;
     engine.SetLogCallback( error_listener );
-    std::string const device_name { "ÑPU" };
+    std::string const device_name { "CPU" };
 
 #ifdef OPENVINO2019
 	engine.AddExtension(std::make_shared< openvino::Extensions::Cpu::CpuExtensions >(), device_name);

--- a/wrappers/openvino/face/CMakeLists.txt
+++ b/wrappers/openvino/face/CMakeLists.txt
@@ -21,6 +21,10 @@ add_executable(rs-face-vino
     ${ELPP_FILES}
 )
 
+if(OPENVINO2019)
+	target_compile_definitions(rs-face-vino PRIVATE OPENVINO2019)
+endif()
+
 source_group("OpenVINO" FILES ${OPENVINO_FILES})
 source_group("EasyLogging++" FILES ${ELPP_FILES})
 

--- a/wrappers/openvino/face/rs-face-vino.cpp
+++ b/wrappers/openvino/face/rs-face-vino.cpp
@@ -40,7 +40,10 @@ int main(int argc, char * argv[]) try
     openvino_helpers::error_listener error_listener;
     engine.SetLogCallback( error_listener );
     std::string const device_name { "CPU" };
+
+#ifdef OPENVINO2019
     engine.AddExtension( std::make_shared< openvino::Extensions::Cpu::CpuExtensions >(), device_name );
+#endif
 
     openvino_helpers::object_detection faceDetector(
         "face-detection-adas-0001.xml",

--- a/wrappers/openvino/rs-vino/openvino-helpers.h
+++ b/wrappers/openvino/rs-vino/openvino-helpers.h
@@ -14,7 +14,9 @@
 #pragma warning(disable:4275)
 #   include <inference_engine.hpp>
 #   include <ie_iextension.h>
+#ifdef OPENVINO2019
 #   include <ext_list.hpp>              // Required for CPU extension usage
+#endif
 #pragma warning(pop)
 
 #include <opencv2/opencv.hpp>


### PR DESCRIPTION
Compatibility to both 2019 and 2020 versions of the openVINO for the openVINO wrapper examles and realsense-viewer has been added. See https://github.com/IntelRealSense/librealsense/issues/6127