### PR TITLE
Work-around for libusb breaking changes in Master branch (v1.0.24)

### DIFF
--- a/CMake/external_libusb.cmake
+++ b/CMake/external_libusb.cmake
@@ -3,7 +3,9 @@ include(ExternalProject)
 ExternalProject_Add(
     libusb
 
-    GIT_REPOSITORY "https://github.com/libusb/libusb.git"
+    # Work-around for libusb master broken on Nov 26' 2020 with introduction of v1.0.24
+    # the issue has been reported in https://github.com/libusb/libusb/issues/812
+    GIT_REPOSITORY "https://github.com/ev-mp/libusb.git"
     GIT_TAG "2a7372db54094a406a755f0b8548b614ba8c78ec" # "v1.0.22" + Mac get_device_list hang fix
 
     UPDATE_COMMAND ${CMAKE_COMMAND} -E copy_if_different


### PR DESCRIPTION
Change-Id: I22d53022131041681759b89d62b1496700c07952