### PR TITLE
Fix handling of hardware timestamps when they wrap around

### DIFF
--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -30,6 +30,14 @@ namespace librealsense
         double _y;
     };
 
+    class TimestampRectifier
+    {
+    public:
+        double get(double value);
+    private:
+        uint64_t _max_value = 0;
+    };
+
     class CLinearCoefficients
     {
     public:
@@ -37,7 +45,6 @@ namespace librealsense
         void reset();
         void add_value(CSample val);
         void add_const_y_coefs(double dy);
-        bool update_samples_base(double x);
         void update_last_sample_time(double x);
         double calc_value(double x) const;
         bool is_full() const;
@@ -54,6 +61,8 @@ namespace librealsense
         double _dest_a, _dest_b;    //Linear regression coeffitions - recently calculated.
         double _prev_time, _time_span_ms;
         double _last_request_time;
+
+        mutable TimestampRectifier _rectifier;
     };
 
     class global_time_interface;

--- a/unit-tests/internal/CMakeLists.txt
+++ b/unit-tests/internal/CMakeLists.txt
@@ -13,6 +13,7 @@ set (INTERNAL_TESTS_SOURCES
     internal-tests-uv-map.cpp
     internal-tests-class-logic.cpp
     internal-tests-linux.cpp
+    internal-tests-timestamps.cpp
     ../catch.h
     ../approx.h
 )

--- a/unit-tests/internal/internal-tests-timestamps.cpp
+++ b/unit-tests/internal/internal-tests-timestamps.cpp
@@ -32,8 +32,6 @@ static void testLinearCoefficients(const uint64_t ts_offset)
 
 
         // Feed sample for linear regression
-        coeffs.update_samples_base(hardware_ts);
-
         CSample sample(hardware_ts, system_ts);
         coeffs.add_value(sample);
     }
@@ -47,8 +45,6 @@ static void testLinearCoefficients(const uint64_t ts_offset)
         const double system_ts = ts * TIMESTAMP_USEC_TO_MSEC;
 
         // Query system time at the point of the sample
-        coeffs.update_samples_base(hardware_ts);
-
         coeffs.update_last_sample_time(hardware_ts);
         const double queried_ts = coeffs.calc_value(hardware_ts);
 

--- a/unit-tests/internal/internal-tests-timestamps.cpp
+++ b/unit-tests/internal/internal-tests-timestamps.cpp
@@ -1,0 +1,72 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 SLAMcore Ltd. All Rights Reserved.
+
+#include "catch.h"
+#include <global_timestamp_reader.h>
+#include <vector>
+
+#define PERIOD_USEC 20000 // 50 Hz
+#define TIMESTAMP_USEC_TO_MSEC 0.001
+
+using namespace librealsense;
+
+// When feeding inputs with zero latency to the linear regression
+// we don't expect the linear regression to have any effect
+static void testLinearCoefficients(const uint64_t ts_offset)
+{
+    CLinearCoefficients coeffs = CLinearCoefficients(15);
+
+    // Create a small set of timestamps at a regular interval
+    std::vector<uint64_t> timestamps;
+    for (size_t i = 0; i < 10; ++i)
+    {
+        timestamps.push_back(ts_offset + i * PERIOD_USEC);
+    }
+
+    // Feed zero-latency "ping" samples
+    for (const auto ts : timestamps)
+    {
+        // Create matching hardware and system timestamps
+        const double hardware_ts = (ts % UINT32_MAX) * TIMESTAMP_USEC_TO_MSEC;
+        const double system_ts = ts * TIMESTAMP_USEC_TO_MSEC;
+
+
+        // Feed sample for linear regression
+        coeffs.update_samples_base(hardware_ts);
+
+        CSample sample(hardware_ts, system_ts);
+        coeffs.add_value(sample);
+    }
+
+    // It should be possible to query timestamps in the past
+    // This is to account for a delay before a frame or packet is received
+    for (const auto ts : timestamps)
+    {
+        // Create matching hardware and system timestamps
+        const double hardware_ts = (ts % UINT32_MAX) * TIMESTAMP_USEC_TO_MSEC;
+        const double system_ts = ts * TIMESTAMP_USEC_TO_MSEC;
+
+        // Query system time at the point of the sample
+        coeffs.update_samples_base(hardware_ts);
+
+        coeffs.update_last_sample_time(hardware_ts);
+        const double queried_ts = coeffs.calc_value(hardware_ts);
+
+        // We fed matching timestamps so we expect the output to be equal
+        REQUIRE(queried_ts == system_ts);
+    }
+}
+
+TEST_CASE("linear_coefficients_simple", "")
+{
+    testLinearCoefficients(0);
+}
+
+TEST_CASE("linear_coefficients_timewrap", "")
+{
+    // Start a little bit before the hardware wrap-around time
+    const uint64_t ts_offset =
+      ((UINT32_MAX - 5 * PERIOD_USEC) / PERIOD_USEC) * PERIOD_USEC;
+
+    testLinearCoefficients(ts_offset);
+}


### PR DESCRIPTION
When hardware timestamp wrap around the global timestamps can go backwards.

Here is plot of what the frame timestamps look like when this happens.

![image (7)](https://user-images.githubusercontent.com/59742912/101222307-677f2900-3681-11eb-9021-d99ee7bbe11f.png)

Closes #7922