### PR TITLE
IMU was temporarily switched off on Mac OS

### DIFF
--- a/examples/motion/rs-motion.cpp
+++ b/examples/motion/rs-motion.cpp
@@ -223,7 +223,7 @@ int main(int argc, char * argv[]) try
     // Before running the example, check that a device supporting IMU is connected
     if (!check_imu_is_supported())
     {
-        std::cerr << "Device supporting IMU (D435i) not found";
+        std::cerr << "Device supporting IMU not found";
         return EXIT_FAILURE;
     }
 

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -172,7 +172,7 @@ namespace librealsense
                                                                 const firmware_version& camera_fw_version)
     {
 #ifdef __APPLE__
-        std::cerr << "IMU is not avaliable on MAC OS in this version" << std::endl;
+        LOG_WARNING("IMU is not avaliable on MAC OS in this version");
         return nullptr;
 #endif
         if (all_hid_infos.empty())

--- a/src/ds5/ds5-motion.cpp
+++ b/src/ds5/ds5-motion.cpp
@@ -171,6 +171,10 @@ namespace librealsense
                                                                 const std::vector<platform::hid_device_info>& all_hid_infos,
                                                                 const firmware_version& camera_fw_version)
     {
+#ifdef __APPLE__
+        std::cerr << "IMU is not avaliable on MAC OS in this version" << std::endl;
+        return nullptr;
+#endif
         if (all_hid_infos.empty())
         {
             LOG_WARNING("No HID info provided, IMU is disabled");

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -96,7 +96,7 @@ namespace librealsense
     std::shared_ptr<synthetic_sensor> l500_motion::create_hid_device(std::shared_ptr<context> ctx, const std::vector<platform::hid_device_info>& all_hid_infos)
     {
 #ifdef __APPLE__
-        std::cerr << "IMU is not avaliable on MAC OS in this version" << std::endl;
+        LOG_WARNING("IMU is not avaliable on MAC OS in this version");
         return nullptr;
 #endif
         if (all_hid_infos.empty())

--- a/src/l500/l500-motion.cpp
+++ b/src/l500/l500-motion.cpp
@@ -95,6 +95,10 @@ namespace librealsense
 
     std::shared_ptr<synthetic_sensor> l500_motion::create_hid_device(std::shared_ptr<context> ctx, const std::vector<platform::hid_device_info>& all_hid_infos)
     {
+#ifdef __APPLE__
+        std::cerr << "IMU is not avaliable on MAC OS in this version" << std::endl;
+        return nullptr;
+#endif
         if (all_hid_infos.empty())
         {
             LOG_WARNING("No HID info provided, IMU is disabled");


### PR DESCRIPTION
Processing of IMU data was temporarily switched off in case of Mac OS usage to prevent the viewer and examples applications crash