### PR TITLE
Fixed test-fg - remove 1280x720 resolution

### DIFF
--- a/unit-tests/func/fg/test-fg.py
+++ b/unit-tests/func/fg/test-fg.py
@@ -44,26 +44,5 @@ finally:
 test.finish()
 
 #############################################################################################
-test.start("streaming FG 1280x720")
-
-dp = next(p for p in debug_profiles if p.fps() == 30
-                        and p.stream_type() == rs.stream.depth
-                        and p.format() == rs.format.fg
-                        and p.as_video_stream_profile().width() == 1280
-                        and p.as_video_stream_profile().height() == 720)
-depth_sensor.open( dp )
-lrs_queue = rs.frame_queue(capacity=10, keep_frames=False)
-depth_sensor.start( lrs_queue )
-
-try:
-    lrs_frame = lrs_queue.wait_for_frame(5000)
-    test.check_equal(lrs_frame.profile.format(), rs.format.fg)
-except:
-    test.unexpected_exception()
-finally:
-    debug_sensor.stop()
-    debug_sensor.close()
-test.finish()
-#############################################################################################
 
 test.print_results_and_exit()


### PR DESCRIPTION
Remove test "streaming FG 1280x720"
(FW support only 800x600 resolution on FG)

Tracked on: RS5-9894