### PR TITLE
FW update exception fix

### DIFF
--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -232,6 +232,10 @@ namespace rs2
             if (_is_signed)
             {
                 log("Requesting to switch to recovery mode");
+
+                // in order to update device to DFU state, it will be disconnected then switches to DFU state
+                // if querying devices is called while device still switching to DFU state, an exception will be thrown
+                // to prevent that, a blocking is added to make sure device is updated before continue to next step of querying device
                 upd.enter_update_state();
 
                 if (!check_for([this, serial, &dfu]() {

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -123,12 +123,26 @@ namespace librealsense
     {
         // Stop all data streaming/exchange pipes with HW
         stop_activity();
+        using namespace std;
+        using namespace std::chrono;
 
         try {
             LOG_INFO("entering to update state, device disconnect is expected");
             command cmd(ds::DFU);
             cmd.param1 = 1;
             _hw_monitor->send(cmd);
+            std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
+            for (auto i = 0; i < 10; i++)
+            {
+                _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::GVD);
+                this_thread::sleep_for(milliseconds(50));
+            }
+            throw std::runtime_error("Device still connected!");
+
+        }
+        catch (std::exception& e)
+        {
+            LOG_WARNING(e.what());
         }
         catch (...) {
             // The set command returns a failure because switching to DFU resets the device while the command is running.

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -132,7 +132,7 @@ namespace librealsense
             cmd.param1 = 1;
             _hw_monitor->send(cmd);
             std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
-            for (auto i = 0; i < 25; i++)
+            for (auto i = 0; i < 50; i++)
             {
                 _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::GVD);
                 this_thread::sleep_for(milliseconds(50));

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -132,7 +132,7 @@ namespace librealsense
             cmd.param1 = 1;
             _hw_monitor->send(cmd);
             std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
-            for (auto i = 0; i < 10; i++)
+            for (auto i = 0; i < 25; i++)
             {
                 _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::GVD);
                 this_thread::sleep_for(milliseconds(50));

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -326,11 +326,24 @@ namespace librealsense
     {
         // Stop all data streaming/exchange pipes with HW
         stop_activity();
+        using namespace std;
+        using namespace std::chrono;
 
         try {
             command cmd(ivcam::GoToDFU);
             cmd.param1 = 1;
             _hw_monitor->send(cmd);
+            std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
+            for (auto i = 0; i < 25; i++)
+            {
+                _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::GVD);
+                this_thread::sleep_for(milliseconds(50));
+            }
+            throw std::runtime_error("Device still connected!");
+        }
+        catch (std::exception& e)
+        {
+            LOG_WARNING(e.what());
         }
         catch (...) {
             // The set command returns a failure because switching to DFU resets the device while the command is running.

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -334,7 +334,7 @@ namespace librealsense
             cmd.param1 = 1;
             _hw_monitor->send(cmd);
             std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
-            for (auto i = 0; i < 25; i++)
+            for (auto i = 0; i < 50; i++)
             {
                 _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::GVD);
                 this_thread::sleep_for(milliseconds(50));

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -444,7 +444,7 @@ namespace librealsense
             cmd.param1 = 1;
             _hw_monitor->send(cmd);
             std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
-            for (auto i = 0; i < 25; i++)
+            for (auto i = 0; i < 50; i++)
             {
 
                 _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), GVD);

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -435,12 +435,26 @@ namespace librealsense
     {
         // Stop all data streaming/exchange pipes with HW
         stop_activity();
+        using namespace std;
+        using namespace std::chrono;
 
         try {
             LOG_INFO("entering to update state, device disconnect is expected");
             command cmd(ivcam2::DFU);
             cmd.param1 = 1;
             _hw_monitor->send(cmd);
+            std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
+            for (auto i = 0; i < 25; i++)
+            {
+
+                _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), GVD);
+                this_thread::sleep_for(milliseconds(50));
+            }
+            throw std::runtime_error("Device still connected!");
+
+        }
+        catch (std::exception& e) {
+            LOG_WARNING(e.what());
         }
         catch (...) {
             // The set command returns a failure because switching to DFU resets the device while the command is running.


### PR DESCRIPTION
When FW update runs, the device disconnects when it switches to DFU. 
Exception is thrown when FW update calls query devices while device still connected (not switch to DFU already).
In this fix, after sending the command of switching device to DFU, I checked when device is disconnected then continue to next step of querying devices.

Tracked on DSO-16069