### PR TITLE
IR Reflectivity - move setting

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -909,15 +909,7 @@ namespace rs2
 
     bool option_model::allow_change(float val, std::string& error_message) const
     {
-        // Deny enabling IR Reflectivity on ROI != 20% [RS5-8358]
-        if ((RS2_OPTION_ENABLE_IR_REFLECTIVITY == opt) && (1.0f == val))
-        {
-            if (0.2f != dev->roi_percentage)
-            {
-                error_message = "Please set 'VGA' resolution, 'Max Range' preset and 20% ROI before enabling IR Reflectivity";
-                return false;
-            }
-        }
+        // Place here option restrictions
         return true;
     }
 
@@ -2295,17 +2287,16 @@ namespace rs2
         }
         _stream_not_alive.reset();
         
-        try 
+        try
         {
-            if( ! viewer.is_option_skipped( RS2_OPTION_ENABLE_IR_REFLECTIVITY ) )
+            auto ds = d->dev.first< depth_sensor >();
+            if( viewer._support_ir_reflectivity
+                && ds.supports( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
+                && ds.supports( RS2_OPTION_ENABLE_MAX_USABLE_RANGE )
+                && ( ( p.stream_type() == RS2_STREAM_INFRARED )
+                     || ( p.stream_type() == RS2_STREAM_DEPTH ) ) )
             {
-                auto ds = d->dev.first< depth_sensor >();
-                if( ds.supports( RS2_OPTION_ENABLE_IR_REFLECTIVITY )
-                    && ds.supports( RS2_OPTION_ENABLE_MAX_USABLE_RANGE )
-                    && ( ( p.stream_type() == RS2_STREAM_INFRARED ) || ( p.stream_type() == RS2_STREAM_DEPTH ) ) )
-                {
-                    _reflectivity = std::unique_ptr< reflectivity >( new reflectivity() );
-                }
+                _reflectivity = std::unique_ptr< reflectivity >( new reflectivity() );
             }
         }
         catch(...) {};

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -939,12 +939,13 @@ namespace rs2
 
   
 
-    viewer_model::viewer_model(context &ctx_)
-            : ppf(*this),
-              ctx(ctx_),
-              frameset_alloc(this),
-              synchronization_enable(true),
-              zo_sensors(0)
+    viewer_model::viewer_model( context & ctx_ )
+        : ppf( *this )
+        , ctx( ctx_ )
+        , frameset_alloc( this )
+        , synchronization_enable( true )
+        , zo_sensors( 0 )
+        , _support_ir_reflectivity( false )
     {
 
         syncer = std::make_shared<syncer_model>();

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -192,6 +192,7 @@ namespace rs2
         std::shared_ptr<updates_model> updates;
 
         std::unordered_set<int> _hidden_options;
+        bool _support_ir_reflectivity;
     private:
 
         void check_permissions();


### PR DESCRIPTION
IR reflectivity option moved to configuration section at the DQT application

![image](https://user-images.githubusercontent.com/64067618/102901975-f27c6380-4476-11eb-96cd-ce4410fefd73.png)

Tracked on [RS5-9612] 