### PR TITLE
DQT - wrong display of advanced controls for L515 + wrong UI setting when switching devices

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -1318,8 +1318,9 @@ namespace rs2
             << s->get_info(RS2_CAMERA_INFO_NAME);
 
         auto streaming_tooltip = [&]() {
-            if (streaming && ImGui::IsItemHovered())
-                ImGui::SetTooltip("Can't modify while streaming");
+            if( ( ! allow_change_resolution_while_streaming && streaming )
+                && ImGui::IsItemHovered() )
+                ImGui::SetTooltip( "Can't modify while streaming" );
         };
 
         //ImGui::Columns(2, label.c_str(), false);
@@ -1338,7 +1339,7 @@ namespace rs2
             label = to_string() << "##" << dev.get_info(RS2_CAMERA_INFO_NAME)
                 << s->get_info(RS2_CAMERA_INFO_NAME) << " resolution";
 
-            if (streaming)
+            if( ! allow_change_resolution_while_streaming && streaming )
             {
                 ImGui::Text("%s", res_chars[ui.selected_res_id]);
                 streaming_tooltip();
@@ -1413,7 +1414,7 @@ namespace rs2
                 label = to_string() << "##" << dev.get_info(RS2_CAMERA_INFO_NAME)
                     << s->get_info(RS2_CAMERA_INFO_NAME) << " fps";
 
-                if (streaming)
+                if( ! allow_change_fps_while_streaming && streaming )
                 {
                     ImGui::Text("%s", fps_chars[ui.selected_shared_fps_id]);
                     streaming_tooltip();

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -42,7 +42,7 @@ using namespace rs400;
 using namespace nlohmann;
 using namespace rs2::sw_update;
 
-static rs2_sensor_mode resolution_from_width_height(int width, int height)
+ rs2_sensor_mode rs2::resolution_from_width_height(int width, int height)
 {
     if ((width == 240 && height == 320) || (width == 320 && height == 240))
         return RS2_SENSOR_MODE_QVGA;

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -268,6 +268,8 @@ namespace rs2
 
     void imgui_easy_theming(ImFont*& font_14, ImFont*& font_18, ImFont*& monofont);
 
+    rs2_sensor_mode resolution_from_width_height(int width, int height);
+
     template<class T>
     void sort_together(std::vector<T>& vec, std::vector<std::string>& names)
     {

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -552,7 +552,7 @@ namespace rs2
             bool* options_invalidated,
             std::string& error_message);
 
-        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::shared_ptr< atomic_objects_in_frame > objects, std::string& error_message, viewer_model& viewer);
+        subdevice_model(device& dev, std::shared_ptr<sensor> s, std::shared_ptr< atomic_objects_in_frame > objects, std::string& error_message, viewer_model& viewer, bool new_device_connected = true);
         ~subdevice_model();
 
         bool is_there_common_fps() ;
@@ -754,7 +754,7 @@ namespace rs2
         typedef std::function<void(std::function<void()> load)> json_loading_func;
 
         void reset();
-        explicit device_model(device& dev, std::string& error_message, viewer_model& viewer, bool allow_remove=true);
+        explicit device_model(device& dev, std::string& error_message, viewer_model& viewer, bool new_device_connected = true, bool allow_remove=true);
         ~device_model();
         void start_recording(const std::string& path, std::string& error_message);
         void stop_recording(viewer_model& viewer);

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -648,7 +648,8 @@ namespace rs2
         int next_option = 0;
         std::vector<rs2_option> supported_options;
         bool streaming = false;
-
+        bool allow_change_resolution_while_streaming = false;
+        bool allow_change_fps_while_streaming = false;
         rect normalized_zoom{0, 0, 1, 1};
         rect roi_rect;
         bool auto_exposure_enabled = false;

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -927,6 +927,23 @@ namespace rs2
                 }
 
                 sub->algo_roi = _metrics_model.get_roi();
+
+                // We need to update the sensor mode and the resolution ID at the sub-model that draw the controls
+                sub->ui.selected_res_id = _depth_sensor_model->ui.selected_res_id;
+                if( sub->s->supports( RS2_OPTION_SENSOR_MODE ) &&  !sub->res_values.empty())
+                {
+                    try
+                    {
+                        sub->s->set_option(
+                            RS2_OPTION_SENSOR_MODE,
+                            static_cast< float >( rs2::resolution_from_width_height(
+                                sub->res_values[sub->ui.selected_res_id].first,
+                                sub->res_values[sub->ui.selected_res_id].second ) ) );
+                    }
+                    catch( ... )
+                    {
+                    }
+                }
             }
         }
 

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -838,10 +838,15 @@ namespace rs2
             bool save = false;
             subdevice_ui_selection prev_ui;
 
-            if (_depth_sensor_model)
+            auto dev = _pipe.get_active_profile().get_device();
+
+            if (_device_model && _depth_sensor_model)
             {
-                prev_ui = _depth_sensor_model->last_valid_ui;
-                save = true;
+                if( ! _first_frame )
+                {
+                    prev_ui = _depth_sensor_model->last_valid_ui;
+                    save = true;
+                }
 
                 // Clean-up the models for new configuration
                 for (auto&& s : _device_model->subdevices)
@@ -851,21 +856,30 @@ namespace rs2
                 _viewer_model.selected_depth_source_uid = -1;
                 _viewer_model.selected_tex_source_uid = -1;
             }
-
-            auto dev = _pipe.get_active_profile().get_device();
-            auto dpt_sensor = std::make_shared<sensor>(dev.first<depth_sensor>());
-            _device_model = std::shared_ptr<rs2::device_model>(new device_model(dev, _error_message, _viewer_model,false));
+            // Create a new device model - reset all UI the new device
+            _device_model = std::shared_ptr<rs2::device_model>(new device_model(dev, _error_message, _viewer_model, false));
+            
+            // Get device depth sensor model
+            for (auto&& sub : _device_model->subdevices)
+            {
+                if (sub->s->is<depth_sensor>())
+                {
+                    _depth_sensor_model = sub;
+                    break;
+                }
+            }
+        
             _device_model->show_depth_only = true;
             _device_model->show_stream_selection = false;
-            std::shared_ptr< atomic_objects_in_frame > no_detected_objects;
-            _depth_sensor_model = std::make_shared<rs2::subdevice_model>(dev, dpt_sensor, no_detected_objects, _error_message, _viewer_model);
 
             _depth_sensor_model->draw_streams_selector = false;
             _depth_sensor_model->draw_fps_selector = true;
+            _depth_sensor_model->allow_change_resolution_while_streaming = true;
+            _depth_sensor_model->allow_change_fps_while_streaming = true;
 
             // Retrieve stereo baseline for supported devices
             auto baseline_mm = -1.f;
-            auto profiles = dpt_sensor->get_stream_profiles();
+            auto profiles = _depth_sensor_model->s->get_stream_profiles();
             auto right_sensor = std::find_if(profiles.begin(), profiles.end(), [](rs2::stream_profile& p)
             { return (p.stream_index() == 2) && (p.stream_type() == RS2_STREAM_INFRARED); });
 
@@ -890,6 +904,47 @@ namespace rs2
             if (save)
             {
                 _depth_sensor_model->ui = _depth_sensor_model->last_valid_ui = prev_ui;
+
+                // Set the sensor mode according to the selected resolution (it was reseted to
+                // default upon creation of new device model)
+                if( _depth_sensor_model->s->supports( RS2_OPTION_SENSOR_MODE )
+                    && ! _depth_sensor_model->res_values.empty() )
+                {
+                    try
+                    {
+                        if (_depth_sensor_model->ui.selected_res_id < _depth_sensor_model->res_values.size())
+                        {
+                            _depth_sensor_model->s->set_option(
+                                RS2_OPTION_SENSOR_MODE,
+                                static_cast< float >( resolution_from_width_height(
+                                    _depth_sensor_model
+                                    ->res_values[_depth_sensor_model->ui.selected_res_id]
+                                    .first,
+                                    _depth_sensor_model
+                                    ->res_values[_depth_sensor_model->ui.selected_res_id]
+                                    .second ) ) );
+                        }
+                        else
+                        {
+                            _viewer_model.not_model->output.add_log(
+                                RS2_LOG_SEVERITY_ERROR,
+                                __FILE__,
+                                __LINE__,
+                                to_string()
+                                    << "resolution id:" << _depth_sensor_model->ui.selected_res_id
+                                    << " not supported" );
+                        }
+                    }
+                    catch( const error &e )
+                    {
+                        _viewer_model.not_model->output.add_log(
+                            RS2_LOG_SEVERITY_ERROR,
+                            __FILE__,
+                            __LINE__,
+                            to_string()
+                            << "error setting sensor mode; selected resolution id:"  << _depth_sensor_model->ui.selected_res_id << " is out of bound");
+                    }
+                }
             }
 
             // Connect the device_model to the viewer_model
@@ -927,23 +982,6 @@ namespace rs2
                 }
 
                 sub->algo_roi = _metrics_model.get_roi();
-
-                // We need to update the sensor mode and the resolution ID at the sub-model that draw the controls
-                sub->ui.selected_res_id = _depth_sensor_model->ui.selected_res_id;
-                if( sub->s->supports( RS2_OPTION_SENSOR_MODE ) &&  !sub->res_values.empty())
-                {
-                    try
-                    {
-                        sub->s->set_option(
-                            RS2_OPTION_SENSOR_MODE,
-                            static_cast< float >( rs2::resolution_from_width_height(
-                                sub->res_values[sub->ui.selected_res_id].first,
-                                sub->res_values[sub->ui.selected_res_id].second ) ) );
-                    }
-                    catch( ... )
-                    {
-                    }
-                }
             }
         }
 

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -857,7 +857,7 @@ namespace rs2
                 _viewer_model.selected_tex_source_uid = -1;
             }
             // Create a new device model - reset all UI the new device
-            _device_model = std::shared_ptr<rs2::device_model>(new device_model(dev, _error_message, _viewer_model, false));
+            _device_model = std::shared_ptr<rs2::device_model>(new device_model(dev, _error_message, _viewer_model, _first_frame, false));
             
             // Get device depth sensor model
             for (auto&& sub : _device_model->subdevices)
@@ -904,47 +904,6 @@ namespace rs2
             if (save)
             {
                 _depth_sensor_model->ui = _depth_sensor_model->last_valid_ui = prev_ui;
-
-                // Set the sensor mode according to the selected resolution (it was reseted to
-                // default upon creation of new device model)
-                if( _depth_sensor_model->s->supports( RS2_OPTION_SENSOR_MODE )
-                    && ! _depth_sensor_model->res_values.empty() )
-                {
-                    try
-                    {
-                        if (_depth_sensor_model->ui.selected_res_id < _depth_sensor_model->res_values.size())
-                        {
-                            _depth_sensor_model->s->set_option(
-                                RS2_OPTION_SENSOR_MODE,
-                                static_cast< float >( resolution_from_width_height(
-                                    _depth_sensor_model
-                                    ->res_values[_depth_sensor_model->ui.selected_res_id]
-                                    .first,
-                                    _depth_sensor_model
-                                    ->res_values[_depth_sensor_model->ui.selected_res_id]
-                                    .second ) ) );
-                        }
-                        else
-                        {
-                            _viewer_model.not_model->output.add_log(
-                                RS2_LOG_SEVERITY_ERROR,
-                                __FILE__,
-                                __LINE__,
-                                to_string()
-                                    << "resolution id:" << _depth_sensor_model->ui.selected_res_id
-                                    << " not supported" );
-                        }
-                    }
-                    catch( const error &e )
-                    {
-                        _viewer_model.not_model->output.add_log(
-                            RS2_LOG_SEVERITY_ERROR,
-                            __FILE__,
-                            __LINE__,
-                            to_string()
-                            << "error setting sensor mode; selected resolution id:"  << _depth_sensor_model->ui.selected_res_id << " is out of bound");
-                    }
-                }
             }
 
             // Connect the device_model to the viewer_model


### PR DESCRIPTION
DQT:
- Fix querying advanced controls with the wrong sensor mode.
- Fix restoring UI controls from different device

Tracked on [RS5-9466]

