### PR TITLE
Add log creation to unity build command

### DIFF
--- a/wrappers/csharp/Intel.RealSense/CMakeLists.txt
+++ b/wrappers/csharp/Intel.RealSense/CMakeLists.txt
@@ -51,7 +51,7 @@ if(BUILD_UNITY_BINDINGS)
         string(REPLACE "/" "\\" UNITY_WIN_PATH ${UNITY_PATH})
         add_custom_command(TARGET ${PROJECT_NAME}
                    POST_BUILD
-                   COMMAND ${UNITY_WIN_PATH} -quit -batchmode -projectPath "${CMAKE_BINARY_WIN_DIR}\\wrappers\\unity" -exportPackage "Assets" "$(OutDir)realsense.unitypackage" || EXIT 0
+                   COMMAND ${UNITY_WIN_PATH} -quit -batchmode -logFile "$(OutDir)Unity.log" -projectPath "${CMAKE_BINARY_WIN_DIR}\\wrappers\\unity" -exportPackage "Assets" "$(OutDir)realsense.unitypackage" || EXIT 0
                    COMMENT "Try to generate a Unity package")
     else()
         message(WARNING "Couldn't locate Unity.exe")


### PR DESCRIPTION
Add a -logFile parameter to unity export package command for investigation failures.