### PR TITLE
Fixed some memory leaks

### DIFF
--- a/src/hdr-config.cpp
+++ b/src/hdr-config.cpp
@@ -262,8 +262,8 @@ namespace librealsense
                             // the following statement is needed in order to get/set the UVC exposure 
                             // instead of one of the hdr's configuration exposure
                             set_sequence_index(0.f);
-                            _pre_hdr_exposure = _sensor->get_option(RS2_OPTION_EXPOSURE).query();
-                            _sensor->get_option(RS2_OPTION_EXPOSURE).set(PRE_ENABLE_HDR_EXPOSURE);
+                            _pre_hdr_exposure = _sensor.lock()->get_option(RS2_OPTION_EXPOSURE).query();
+                            _sensor.lock()->get_option(RS2_OPTION_EXPOSURE).set(PRE_ENABLE_HDR_EXPOSURE);
                         } catch (...) {
                             LOG_WARNING("HDR: enforced exposure failed");
                         }
@@ -293,7 +293,7 @@ namespace librealsense
                         // the following statement is needed in order to get the UVC exposure 
                         // instead of one of the hdr's configuration exposure
                         set_sequence_index(0.f);
-                        _sensor->get_option(RS2_OPTION_EXPOSURE).set(_pre_hdr_exposure);
+                        _sensor.lock()->get_option(RS2_OPTION_EXPOSURE).set(_pre_hdr_exposure);
                     } catch (...) {
                         LOG_WARNING("HDR failed to restore manual exposure");
                     }
@@ -309,22 +309,22 @@ namespace librealsense
     void hdr_config::set_options_to_be_restored_after_disable()
     {
         // AUTO EXPOSURE
-        if (_sensor->supports_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE))
+        if (_sensor.lock()->supports_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE))
         {
-            if (_sensor->get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE).query())
+            if (_sensor.lock()->get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE).query())
             {
-                _sensor->get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE).set(0.f);
+                _sensor.lock()->get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE).set(0.f);
                 _auto_exposure_to_be_restored = true;
             }
         }
 
 
         // EMITTER ON OFF
-        if (_sensor->supports_option(RS2_OPTION_EMITTER_ON_OFF))
+        if (_sensor.lock()->supports_option(RS2_OPTION_EMITTER_ON_OFF))
         {
-            if (_sensor->get_option(RS2_OPTION_EMITTER_ON_OFF).query())
+            if (_sensor.lock()->get_option(RS2_OPTION_EMITTER_ON_OFF).query())
             {
-                _sensor->get_option(RS2_OPTION_EMITTER_ON_OFF).set(0.f);
+                _sensor.lock()->get_option(RS2_OPTION_EMITTER_ON_OFF).set(0.f);
                 _emitter_on_off_to_be_restored = true;
             }
         }
@@ -335,14 +335,14 @@ namespace librealsense
         // AUTO EXPOSURE
         if (_auto_exposure_to_be_restored)
         {
-            _sensor->get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE).set(1.f);
+            _sensor.lock()->get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE).set(1.f);
             _auto_exposure_to_be_restored = false;
         }
 
         // EMITTER ON OFF
         if (_emitter_on_off_to_be_restored)
         {
-            _sensor->get_option(RS2_OPTION_EMITTER_ON_OFF).set(1.f);
+            _sensor.lock()->get_option(RS2_OPTION_EMITTER_ON_OFF).set(1.f);
             _emitter_on_off_to_be_restored = false;
         }
     }

--- a/src/hdr-config.h
+++ b/src/hdr-config.h
@@ -83,7 +83,7 @@ namespace librealsense
         bool _auto_exposure_to_be_restored;
         bool _emitter_on_off_to_be_restored;
         hw_monitor& _hwm;
-        std::shared_ptr<sensor_base> _sensor;
+        std::weak_ptr<sensor_base> _sensor;
         option_range _exposure_range;
         option_range _gain_range;
         bool _use_workaround;

--- a/src/linux/backend-hid.cpp
+++ b/src/linux/backend-hid.cpp
@@ -666,7 +666,7 @@ namespace librealsense
 
             std::unique_ptr<int, std::function<void(int*)> > fd(
                         new int (_fd = open(iio_read_device_path.str().c_str(), O_RDONLY | O_NONBLOCK)),
-                        [&](int* d){ if (d && (*d)) { _fd = ::close(*d);}});
+                        [&](int* d){ if (d && (*d)) { _fd = ::close(*d); } delete d; });
 
             if (!(*fd > 0))
                 throw linux_backend_exception("open() failed with all retries!");

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -448,7 +448,7 @@ namespace librealsense
             // RAII to handle exceptions
             std::unique_ptr<int, std::function<void(int*)> > fd(
                         new int (open(dev_name.c_str(), O_RDWR | O_NONBLOCK, 0)),
-                        [](int* d){ if (d && (*d)) ::close(*d);});
+                        [](int* d){ if (d && (*d)) {::close(*d); } delete d; });
 
             if(*fd < 0)
                 throw linux_backend_exception(to_string() << __FUNCTION__ << ": Cannot open '" << dev_name);

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -170,11 +170,12 @@ namespace librealsense
         {
             stream_selector->set_description(float(s), "Process - " + std::string (rs2_stream_to_string((rs2_stream)s)));
         }
-        stream_selector->on_set([this, stream_selector](float val)
+        std::weak_ptr<ptr_option<int>> stream_selector_ref = stream_selector;
+        stream_selector->on_set([this, stream_selector_ref](float val)
         {
             std::lock_guard<std::mutex> lock(_mutex);
 
-            if (!stream_selector->is_valid(val))
+            if (!stream_selector_ref.lock()->is_valid(val))
                 throw invalid_value_exception(to_string()
                     << "Unsupported stream filter, " << val << " is out of range.");
 
@@ -186,11 +187,12 @@ namespace librealsense
         {
             format_selector->set_description(float(f), "Process - " + std::string(rs2_format_to_string((rs2_format)f)));
         }
-        format_selector->on_set([this, format_selector](float val)
+        std::weak_ptr<ptr_option<int>> format_selector_ref = format_selector;
+        format_selector->on_set([this, format_selector_ref](float val)
         {
             std::lock_guard<std::mutex> lock(_mutex);
 
-            if (!format_selector->is_valid(val))
+            if (!format_selector_ref.lock()->is_valid(val))
                 throw invalid_value_exception(to_string()
                     << "Unsupported stream format filter, " << val << " is out of range.");
 
@@ -198,11 +200,12 @@ namespace librealsense
         });
 
         auto index_selector = std::make_shared<ptr_option<int>>(-1, std::numeric_limits<int>::max(), 1, -1, &_stream_filter.index, "Stream index");
-        index_selector->on_set([this, index_selector](float val)
+        std::weak_ptr<ptr_option<int>> index_selector_ref = index_selector;
+        index_selector->on_set([this, index_selector_ref](float val)
         {
             std::lock_guard<std::mutex> lock(_mutex);
 
-            if (!index_selector->is_valid(val))
+            if (!index_selector_ref.lock()->is_valid(val))
                 throw invalid_value_exception(to_string()
                     << "Unsupported stream index filter, " << val << " is out of range.");
 


### PR DESCRIPTION
Fixes some memory leaks:

1) In the Linux backend, the deleter of a `std::unique_ptr` didn't call `delete`;
2) The `hdr_config` type and its sensor were holding mutual shared pointers to each other, causing them to not be deleted;
3) In `synthetic-stream.cpp`, the `on_set` method is called on a `ptr_option`, which stores the function passed to that method. However, the lambda passed captures the shared pointer, giving another shared pointer loop.