### PR TITLE
2 small fixes to test running

### DIFF
--- a/unit-tests/py/test.py
+++ b/unit-tests/py/test.py
@@ -72,7 +72,10 @@ def print_stack():
     """
     Function for printing the current call stack. Used when an assertion fails
     """
+    test_py_path = "librealsense" + os.sep + "unit-tests" + os.sep + "py" + os.sep + "test.py"
     for line in traceback.format_stack():
+        if test_py_path in line: # avoid printing the lines of calling to this function
+            continue
         print(line)
 
 """

--- a/unit-tests/py/test.py
+++ b/unit-tests/py/test.py
@@ -72,7 +72,7 @@ def print_stack():
     """
     Function for printing the current call stack. Used when an assertion fails
     """
-    test_py_path = "librealsense" + os.sep + "unit-tests" + os.sep + "py" + os.sep + "test.py"
+    test_py_path = os.sep + "unit-tests" + os.sep + "py" + os.sep + "test.py"
     for line in traceback.format_stack():
         if test_py_path in line: # avoid printing the lines of calling to this function
             continue

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -160,7 +160,7 @@ if not target:
 if target:
     logdir = target + os.sep + 'unit-tests'
 else: # no test executables were found. We put the logs directly in build directory
-    logdir = librealsense + os.sep + 'build'
+    logdir = librealsense + os.sep + 'build' + os.sep + 'unit-tests'
 os.makedirs( logdir, exist_ok = True )
 n_tests = 0
 


### PR DESCRIPTION
Changed the default directory for test logs to build/unit-tests instead of build.
Removed from the printing of the call stack when check fails the printing of the calls to the functions inside test.py