### PR TITLE
Make use of https link for resource downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ matrix:
         - cd ../wrappers/nodejs/
         - npm install
         - cd test
-        - wget http://realsense-hw-public.s3.amazonaws.com/rs-tests/nodejs_records.rec
+        - wget https://librealsense.intel.com/rs-tests/nodejs_records.rec
 
     - name: "Mac - cpp"
       os: osx
@@ -132,7 +132,7 @@ before_install:
   - mkdir build && cd build
   - if [[ "$RS_CPP_TEST" == "true" ]]; then
       export LRS_LOG_LEVEL="DEBUG";
-      url_records_path="http://realsense-hw-public.s3.amazonaws.com/rs-tests/lrs_2.8.3/";
+      url_records_path="https://librealsense.intel.com/rs-tests/lrs_2.8.3/";
       records_name="records_test.txt";
       url_records_list=$url_records_path$records_name;
       wget $url_records_path$records_name;

--- a/common/fw/CMakeLists.txt
+++ b/common/fw/CMakeLists.txt
@@ -8,7 +8,7 @@ file(READ "firmware-version.h" ver)
 
 message(STATUS "Fetching recommended firmwares:")
 
-set(REALSENSE_FIRMWARE_URL "http://realsense-hw-public.s3.amazonaws.com" CACHE STRING
+set(REALSENSE_FIRMWARE_URL "https://librealsense.intel.com" CACHE STRING
     "URL to download firmware binaries from")
 
 string(REGEX MATCH "D4XX_RECOMMENDED_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -164,7 +164,7 @@ endfunction()
 
 
 
-set(PP_TESTS_URL http://realsense-hw-public.s3.amazonaws.com/rs-tests/post_processing_tests_2018_ww18/)
+set(PP_TESTS_URL  https://librealsense.intel.com/rs-tests/post_processing_tests_2018_ww18/)
 message(STATUS "Preparing to download Post-processing tests dataset...\nRemote server: ${PP_TESTS_URL}\nTarget Location: ${Deployment_Location}\n")
 foreach(i ${PP_Tests_List})
   set(Test_Pattern ${i})
@@ -209,7 +209,7 @@ list(APPEND PP_Rosbag_Recordings_List
     single_depth_color_640x480.bag
     D435i_Depth_and_IMU.bag
 )
- set(PP_Rosbag_Recordings_URL http://realsense-hw-public.s3.amazonaws.com/rs-tests/Rosbag_unit_test_records/)
+ set(PP_Rosbag_Recordings_URL  https://librealsense.intel.com/rs-tests/Rosbag_unit_test_records/)
 foreach(i ${PP_Rosbag_Recordings_List})
     set (empty FALSE)
     is_file_empty(empty, ${Deployment_Location}${i} )


### PR DESCRIPTION
changed http -> https in:
build/CMakeCache.txt line 420
common/fw/CMakeLists.txt line 11
unit-tests/CMakeLists.txt line 167
unit-tests/CMakeLists.txt line 212
.travis.yml line 92
.travis.yml line 135

Triggered by DSO-16368