### PR TITLE
Fix FW update exception showed after entering update state

### DIFF
--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -257,10 +257,10 @@ namespace rs2
                             }
                         }
                         catch (std::exception &e) {
-                            _viewer.not_model->output.add_log(RS2_LOG_SEVERITY_WARN,
+                            _viewer.not_model->output.add_log( RS2_LOG_SEVERITY_WARN,
                                 __FILE__,
                                 __LINE__,
-                                to_string() << "Exception caught in FW Update process-flow: " << e.what() << " ; Retrying..");
+                                to_string() << "Exception caught in FW Update process-flow: " << e.what() << "; Retrying..." );
                         }
                         catch (...) {}
                     }

--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -233,6 +233,8 @@ namespace rs2
             {
                 log("Requesting to switch to recovery mode");
                 upd.enter_update_state();
+                // Allow time for the device to disconnect before calling "query_devices"
+                std::this_thread::sleep_for(std::chrono::seconds(2));
 
                 if (!check_for([this, serial, &dfu]() {
                     auto devs = _ctx.query_devices();
@@ -255,9 +257,10 @@ namespace rs2
                             }
                         }
                         catch (std::exception &e) {
-                            std::stringstream s;
-                            s << "Exception caught in FW Update process-flow: " << e.what();
-                            log(s.str().c_str());
+                            _viewer.not_model->output.add_log(RS2_LOG_SEVERITY_WARN,
+                                __FILE__,
+                                __LINE__,
+                                to_string() << "Exception caught in FW Update process-flow: " << e.what() << " ; Retrying..");
                         }
                         catch (...) {}
                     }


### PR DESCRIPTION
On FW update window we see a recoverable exception string during the FW update process

This PR fixes this behavior.
Actions taken:
1. Add delay between sending the device command to enter update state and query devices (if we do it too fast we still get the device before it was able to disconnect)
2. Replace FW update UI exception with log exception

Tracked on [RS5-7900]