### PR TITLE
LibRS API to enable rolling log files

### DIFF
--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -82,6 +82,9 @@ void rs2_log_to_callback( rs2_log_severity min_severity, rs2_log_callback_ptr ca
 
 void rs2_reset_logger( rs2_error ** error);
 
+void rs2_enable_rolling_files(size_t max_size, rs2_error ** error);
+
+
 unsigned rs2_get_log_message_line_number( rs2_log_message const * msg, rs2_error** error );
 const char * rs2_get_log_message_filename( rs2_log_message const * msg, rs2_error** error );
 const char * rs2_get_raw_log_message( rs2_log_message const * msg, rs2_error** error );

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -36,6 +36,13 @@ namespace rs2
         rs2_reset_logger(&e);
         error::handle(e);
     }
+
+    inline void enable_rolling_files(std::size_t max_size )
+    {
+        rs2_error* e = nullptr;
+        rs2_enable_rolling_files(max_size,&e);
+        error::handle(e);
+    }
     /*
         Interface to the log message data we expose.
     */

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -34,6 +34,11 @@ void librealsense::reset_logger()
     logger.reset_logger();
 }
 
+void librealsense::enable_rolling_files(std::size_t max_size )
+{
+    logger.enable_rolling_files(max_size);
+}
+
 #else // BUILD_EASYLOGGINGPP
 
 void librealsense::log_to_console(rs2_log_severity min_severity)
@@ -50,6 +55,10 @@ void librealsense::log_to_callback(rs2_log_severity min_severity, log_callback_p
 }
 
 void librealsense::reset_logger()
+{
+}
+
+void librealsense::enable_rolling_files(std::size_t max_size )
 {
 }
 #endif // BUILD_EASYLOGGINGPP

--- a/src/log.h
+++ b/src/log.h
@@ -268,8 +268,8 @@ namespace librealsense
         {
             std::string file_str(filename);
             std::string old_file = file_str + ".old";
-            const char* old_filename = old_file.c_str();
 
+            const char* old_filename = old_file.c_str();
             std::ifstream exists(old_filename);
             if (exists.is_open()) {
                 exists.close();
@@ -280,8 +280,8 @@ namespace librealsense
         }
 
         //Since log file will be truncated upon reaching max_size, MaxLogFileSize is configured to be half of the original max_size
-        //another file will be created in rolloutHandler that contains previous half.
-        //file directory should have permissions of removing/renaming files. 
+        //another file that contains previous half will be created in rolloutHandler.
+        //log file directory should have permissions of removing/renaming files. 
         //@param max_size max file size in bytes
         void enable_rolling_files(std::size_t max_size)
         {

--- a/src/log.h
+++ b/src/log.h
@@ -263,21 +263,24 @@ namespace librealsense
 
         static void rolloutHandler(const char* filename, std::size_t size)
         {
-            char backup_name[256];
             std::string file_str(filename);
-            std::string file_name = file_str.substr(0, file_str.find_last_of('.'));
-            sprintf_s(backup_name, sizeof(backup_name), "%s-%s.log", file_name.c_str(), "backup");
-            std::string tmp = file_name + "_tmp.log";
-            rename(backup_name, tmp.c_str());
-            rename(filename, backup_name);
-            rename(tmp.c_str(), filename);
+            std::string old_file = file_str + ".old";
+            const char* old_filename = old_file.c_str();
+            std::ifstream exists(old_filename);
+            if (exists.is_open()) {
+                exists.close();
+                std::remove(old_filename);
+            }
+            rename(filename, old_filename);
         }
 
-        void enable_rolling_files(std::size_t max_size )
+        //enable rolling files upon reaching max_size
+        //@param max_size - in bytes.
+        void enable_rolling_files(std::size_t max_size)
         {
-            std::string size = std::to_string(max_size);
-            el::Loggers::addFlag( el::LoggingFlag::StrictLogFileSizeCheck );
-            el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, size.c_str());
+            std::string size = std::to_string(max_size/2);
+            el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
+            el::Loggers::reconfigureLogger(log_id, el::ConfigurationType::MaxLogFileSize, size.c_str());
             el::Helpers::installPreRollOutCallback(rolloutHandler);
         }
     };

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -148,7 +148,8 @@ EXPORTS
     rs2_log_to_callback
     rs2_log_to_callback_cpp
     rs2_reset_logger
-    
+    rs2_enable_rolling_files
+
     rs2_get_log_message_line_number
     rs2_get_log_message_filename
     rs2_get_raw_log_message

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1310,6 +1310,12 @@ void rs2_reset_logger( rs2_error** error) BEGIN_API_CALL
 }
 NOARGS_HANDLE_EXCEPTIONS_AND_RETURN()
 
+void rs2_enable_rolling_files(std::size_t max_size, rs2_error** error) BEGIN_API_CALL
+{
+    librealsense::enable_rolling_files(max_size);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, max_size)
+
 // librealsense wrapper around a C function
 class on_log_callback : public rs2_log_callback
 {

--- a/src/types.h
+++ b/src/types.h
@@ -205,6 +205,7 @@ namespace librealsense
     void log_to_file( rs2_log_severity min_severity, const char* file_path );
     void log_to_callback( rs2_log_severity min_severity, log_callback_ptr callback );
     void reset_logger();
+    void enable_rolling_files(std::size_t max_size);
 
 #if BUILD_EASYLOGGINGPP
 

--- a/unit-tests/log/test-cpp-enable-rolling.cpp
+++ b/unit-tests/log/test-cpp-enable-rolling.cpp
@@ -5,7 +5,7 @@
 #include "log-common.h"
 #include<fstream>
 
-TEST_CASE("ENABLE ROLLING C++ LOGGER", "[log]") {
+TEST_CASE("ROLLING C++ LOGGER", "[log]") {
 
     std::string log_filename = "rolling-log.log";
     rs2::log_to_file(RS2_LOG_SEVERITY_INFO, log_filename.c_str());

--- a/unit-tests/log/test-cpp-enable-rolling.cpp
+++ b/unit-tests/log/test-cpp-enable-rolling.cpp
@@ -1,0 +1,28 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+//#cmake:add-file log-common.h
+#include "log-common.h"
+
+
+TEST_CASE("ENABLE ROLLING C++ LOGGER", "[log]") {
+    size_t n_callbacks = 0;
+    auto callback = [&](rs2_log_severity severity, rs2::log_message const& msg)
+    {
+        ++n_callbacks;
+
+
+        TRACE(severity << ' ' << msg.filename() << '+' << msg.line_number() << ": " << msg.raw());
+    };
+
+    rs2::log_to_callback(RS2_LOG_SEVERITY_INFO, callback);
+    REQUIRE(!n_callbacks);
+    rs2::log_to_file(RS2_LOG_SEVERITY_INFO, "C:/Users/aegbaria/Documents/max-size.log");
+
+    rs2::enable_rolling_files( 1024 );
+
+    for (int i = 0; i < 100; ++i)
+        log_all();
+
+    n_callbacks = 2;
+}

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -42,6 +42,7 @@ PYBIND11_MODULE(NAME, m) {
     m.def("log_to_console", &rs2::log_to_console, "min_severity"_a);
     m.def("log_to_file", &rs2::log_to_file, "min_severity"_a, "file_path"_a);
     m.def("reset_logger", &rs2::reset_logger);
+    m.def("enable_rolling_files", &rs2::enable_rolling_files, "max_size"_a);
 
     // Access to log_message is only from a callback (see log_to_callback below) and so already
     // should have the GIL acquired


### PR DESCRIPTION
Log files can have a max size. upon reaching max size new file will be created and current file will be truncated.
Tracked on [RS5-9271]