### PR TITLE
Revert "Switch v4l to use memory-mapped files instead of userptr."

### DIFF
--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -349,7 +349,7 @@ namespace librealsense
         class v4l_uvc_meta_device : public v4l_uvc_device
         {
         public:
-            v4l_uvc_meta_device(const uvc_device_info& info, bool use_memory_map = true);
+            v4l_uvc_meta_device(const uvc_device_info& info, bool use_memory_map = false);
 
             ~v4l_uvc_meta_device();
 


### PR DESCRIPTION
Using mmap leads to sporadic segfault on stream close/frames release.
Revert to user-allocated buffers for v4l data exchange
Addresses #8154
Tracked on: DSO-16453

This reverts commit ac9f29dcd6b5c38fce9ed1f44598a0f0bf6cf913.