### PR TITLE
fix build with network option and other workaround

### DIFF
--- a/src/ethernet/ip_device.cpp
+++ b/src/ethernet/ip_device.cpp
@@ -361,6 +361,11 @@ void ip_device::inject_frames_loop(std::shared_ptr<rs_rtp_stream> rtp_stream)
         rtp_stream.get()->is_enabled = true;
 
         rtp_stream.get()->frame_data_buff.frame_number = 0;
+
+        /// FIXME: bbp and stride should be filled by m_rs_stream. but There are something wrong in m_rs_stream.
+        rtp_stream->frame_data_buff.bpp = librealsense::get_image_bpp(rtp_stream.get()->get_stream_profile().format()) / 8;
+        rtp_stream->frame_data_buff.stride = rtp_stream->frame_data_buff.bpp * rtp_stream->m_rs_stream.width;
+
         int uid = rtp_stream.get()->m_rs_stream.uid;
         rs2_stream type = rtp_stream.get()->m_rs_stream.type;
         int sensor_id = stream_type_to_sensor_id(type);

--- a/tools/rs-server/CMakeLists.txt
+++ b/tools/rs-server/CMakeLists.txt
@@ -38,6 +38,7 @@ else()
 
   include_directories(
     ../../common
+    ../../src
     ../../src/ipDeviceCommon
     ../../include/librealsense2
     ../../third-party/tclap/include

--- a/tools/rs-server/RsRTSPServer.cpp
+++ b/tools/rs-server/RsRTSPServer.cpp
@@ -18,15 +18,15 @@
 
 RsRTSPServer* RsRTSPServer::createNew(UsageEnvironment& t_env, std::shared_ptr<RsDevice> t_device, Port t_ourPort, UserAuthenticationDatabase* t_authDatabase, unsigned t_reclamationSeconds)
 {
-    int ourSocket = setUpOurSocket(t_env, t_ourPort);
-    if(ourSocket == -1)
-        return NULL;
+    int ourSocketIPv4 = setUpOurSocket(t_env, t_ourPort, AF_INET);
+    int ourSocketIPv6 = setUpOurSocket(t_env, t_ourPort, AF_INET6);
+    if (ourSocketIPv4 < 0 && ourSocketIPv6 < 0) return NULL;
 
-    return new RsRTSPServer(t_env, t_device, ourSocket, t_ourPort, t_authDatabase, t_reclamationSeconds);
+    return new RsRTSPServer(t_env, t_device, ourSocketIPv4, ourSocketIPv6, t_ourPort, t_authDatabase, t_reclamationSeconds);
 }
 
-RsRTSPServer::RsRTSPServer(UsageEnvironment& t_env, std::shared_ptr<RsDevice> t_device, int t_ourSocket, Port t_ourPort, UserAuthenticationDatabase* t_authDatabase, unsigned t_reclamationSeconds)
-    : RTSPServer(t_env, t_ourSocket, t_ourPort, t_authDatabase, t_reclamationSeconds)
+RsRTSPServer::RsRTSPServer(UsageEnvironment& t_env, std::shared_ptr<RsDevice> t_device, int t_ourSocketIPv4, int t_ourSocketIPv6, Port t_ourPort, UserAuthenticationDatabase* t_authDatabase, unsigned t_reclamationSeconds)
+    : RTSPServer(t_env, t_ourSocketIPv4, t_ourSocketIPv6, t_ourPort, t_authDatabase, t_reclamationSeconds)
     , m_device(t_device)
 {}
 

--- a/tools/rs-server/RsRTSPServer.hh
+++ b/tools/rs-server/RsRTSPServer.hh
@@ -15,7 +15,7 @@ public:
     void setSupportedOptions(std::string t_key, std::vector<RsOption> t_supportedOptions);
 
 protected:
-    RsRTSPServer(UsageEnvironment& t_env, std::shared_ptr<RsDevice> t_device, int t_ourSocket, Port t_ourPort, UserAuthenticationDatabase* t_authDatabase, unsigned t_reclamationSeconds);
+    RsRTSPServer(UsageEnvironment& t_env, std::shared_ptr<RsDevice> t_device, int t_ourSocketIPv4, int t_ourSocketIPv6, Port t_ourPort, UserAuthenticationDatabase* t_authDatabase, unsigned t_reclamationSeconds);
     virtual ~RsRTSPServer();
     char const* allowedCommandNames();
 

--- a/tools/rs-server/RsSensor.cpp
+++ b/tools/rs-server/RsSensor.cpp
@@ -182,6 +182,11 @@ std::vector<RsOption> RsSensor::getSupportedOptions()
             RsOption option;
             option.m_opt = opt;
             option.m_range = m_sensor.get_option_range(opt);
+
+            /// FIXME: the default value for some option is invalid
+            if (option.m_range.def < option.m_range.min) option.m_range.def = option.m_range.min;
+            if (option.m_range.def > option.m_range.max) option.m_range.def = option.m_range.max;
+
             returnedVector.push_back(option);
         }
     }

--- a/wrappers/python/pyrs_net.cpp
+++ b/wrappers/python/pyrs_net.cpp
@@ -20,5 +20,8 @@ PYBIND11_MODULE(NAME, m) {
     m.doc() = "Wrapper for the librealsense ethernet device extension module";
 
     py::class_<rs2::net_device> net_device(m, "net_device", device);
-    net_device.def(py::init<std::string>(), "address"_a);
+    net_device.def(py::init<std::string>(), "address"_a)
+        .def("add_to", &rs2::net_device::add_to, "Add net device to existing context.\n"
+             "Any future queries on the context will return this device.\n"
+             "This operation cannot be undone (except for destroying the context)", "ctx"_a);
 }


### PR DESCRIPTION
1. third-party library liveMedia update
   liveMedia has been upgraded by live555 in 2021-jan-21.
   and only one archive on the server.
2. A workaround for wrong default value about RS2_OPTION_POWER_LINE_FREQUENCY.
3. A workaround for bad parameter when create frame object in Y8 format with network mode.
4. add 'add_to' method for net_device in python wrapper.