### PR TITLE
LibRS API to enable rolling log files

### DIFF
--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -83,8 +83,10 @@ void rs2_log_to_callback( rs2_log_severity min_severity, rs2_log_callback_ptr ca
 void rs2_reset_logger( rs2_error ** error);
 
 /**
-* Enable rolling log file upon reaching max size.
-* Must have permissions of removing/renaming files in log file directory.
+* Enable rolling log file when used with rs2_log_to_file:
+* Upon reaching (max_size/2) bytes, the log will be renamed with an ".old" suffix and a new log created. Any
+* previous .old file will be erased.
+* Must have permissions to remove/rename files in log file directory.
 * \param[in] max_size   max file size in bytes
 * \param[out] error   if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -82,7 +82,13 @@ void rs2_log_to_callback( rs2_log_severity min_severity, rs2_log_callback_ptr ca
 
 void rs2_reset_logger( rs2_error ** error);
 
-void rs2_enable_rolling_files(size_t max_size, rs2_error ** error);
+/**
+* Enable rolling log file upon reaching max size.
+* Must have permissions of removing/renaming files in log file directory.
+* \param[in] max_size   max file size in bytes
+* \param[out] error   if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+void rs2_enable_rolling_log_file(size_t max_size, rs2_error ** error);
 
 
 unsigned rs2_get_log_message_line_number( rs2_log_message const * msg, rs2_error** error );

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -87,7 +87,7 @@ void rs2_reset_logger( rs2_error ** error);
 * Upon reaching (max_size/2) bytes, the log will be renamed with an ".old" suffix and a new log created. Any
 * previous .old file will be erased.
 * Must have permissions to remove/rename files in log file directory.
-* \param[in] max_size   max file size in bytes
+* \param[in] max_size   max file size in megabytes
 * \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
 void rs2_enable_rolling_log_file( unsigned max_size, rs2_error ** error );

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -88,9 +88,9 @@ void rs2_reset_logger( rs2_error ** error);
 * previous .old file will be erased.
 * Must have permissions to remove/rename files in log file directory.
 * \param[in] max_size   max file size in bytes
-* \param[out] error   if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+* \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
 */
-void rs2_enable_rolling_log_file(size_t max_size, rs2_error ** error);
+void rs2_enable_rolling_log_file( unsigned max_size, rs2_error ** error );
 
 
 unsigned rs2_get_log_message_line_number( rs2_log_message const * msg, rs2_error** error );

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -82,6 +82,9 @@ void rs2_log_to_callback( rs2_log_severity min_severity, rs2_log_callback_ptr ca
 
 void rs2_reset_logger( rs2_error ** error);
 
+void rs2_enable_rolling_files(size_t max_size, rs2_error ** error);
+
+
 unsigned rs2_get_log_message_line_number( rs2_log_message const * msg, rs2_error** error );
 const char * rs2_get_log_message_filename( rs2_log_message const * msg, rs2_error** error );
 const char * rs2_get_raw_log_message( rs2_log_message const * msg, rs2_error** error );

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -42,7 +42,7 @@ namespace rs2
     // previous .old file will be erased.
     // Must have permissions to remove/rename files in log file directory.
     //
-    // @param max_size max file size in bytes
+    // @param max_size max file size in megabytes
     //
     inline void enable_rolling_log_file( unsigned max_size )
     {

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -36,6 +36,13 @@ namespace rs2
         rs2_reset_logger(&e);
         error::handle(e);
     }
+
+    inline void enable_rolling_files(std::size_t max_size )
+    {
+        rs2_error* e = nullptr;
+        rs2_enable_rolling_files(max_size,&e);
+        error::handle(e);
+    }
     /*
         Interface to the log message data we expose.
     */

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -44,11 +44,11 @@ namespace rs2
     //
     // @param max_size max file size in bytes
     //
-    inline void enable_rolling_log_file(std::size_t max_size )
+    inline void enable_rolling_log_file( unsigned max_size )
     {
-        rs2_error* e = nullptr;
-        rs2_enable_rolling_log_file(max_size,&e);
-        error::handle(e);
+        rs2_error * e = nullptr;
+        rs2_enable_rolling_log_file( max_size, &e );
+        error::handle( e );
     }
     
     /*

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -37,10 +37,12 @@ namespace rs2
         error::handle(e);
     }
 
-    inline void enable_rolling_files(std::size_t max_size )
+    //Enable rolling log file upon reaching max size.
+    //@param max_size max file size in bytes
+    inline void enable_rolling_log_file(std::size_t max_size )
     {
         rs2_error* e = nullptr;
-        rs2_enable_rolling_files(max_size,&e);
+        rs2_enable_rolling_log_file(max_size,&e);
         error::handle(e);
     }
     /*

--- a/include/librealsense2/rs.hpp
+++ b/include/librealsense2/rs.hpp
@@ -37,14 +37,20 @@ namespace rs2
         error::handle(e);
     }
 
-    //Enable rolling log file upon reaching max size.
-    //@param max_size max file size in bytes
+    // Enable rolling log file when used with rs2_log_to_file:
+    // Upon reaching (max_size/2) bytes, the log will be renamed with an ".old" suffix and a new log created. Any
+    // previous .old file will be erased.
+    // Must have permissions to remove/rename files in log file directory.
+    //
+    // @param max_size max file size in bytes
+    //
     inline void enable_rolling_log_file(std::size_t max_size )
     {
         rs2_error* e = nullptr;
         rs2_enable_rolling_log_file(max_size,&e);
         error::handle(e);
     }
+    
     /*
         Interface to the log message data we expose.
     */

--- a/src/api.h
+++ b/src/api.h
@@ -398,6 +398,7 @@ return __p.invoke(func);\
 #define NOEXCEPT_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); rs2_error* e; librealsense::translate_exception(__FUNCTION__, ss.str(), &e); LOG_WARNING(rs2_get_error_message(e)); rs2_free_error(e); return R; }
 #define HANDLE_EXCEPTIONS_AND_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); librealsense::translate_exception(__FUNCTION__, ss.str(), error); return R; }
 #define NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(R) catch(...) { librealsense::translate_exception(__FUNCTION__, "", error); return R; }
+#define NOARGS_HANDLE_EXCEPTIONS_AND_RETURN_VOID() catch(...) { librealsense::translate_exception(__FUNCTION__, "", error); }
 
 #endif
 

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -60,11 +60,11 @@ namespace librealsense
         new_vertices.reserve(get_vertex_count());
         new_tex.reserve(get_vertex_count());
         assert(get_vertex_count());
-        for (size_t i = 0; i < get_vertex_count(); ++i)
+        for (int i = 0; i < get_vertex_count(); ++i)
             if (fabs(vertices[i].x) >= MIN_DISTANCE || fabs(vertices[i].y) >= MIN_DISTANCE ||
                 fabs(vertices[i].z) >= MIN_DISTANCE)
             {
-                index2reducedIndex[i] = new_vertices.size();
+                index2reducedIndex[i] = (int)new_vertices.size();
                 new_vertices.push_back({ vertices[i].x,  -1*vertices[i].y, -1*vertices[i].z });
                 if (texture)
                 {
@@ -76,8 +76,10 @@ namespace librealsense
         const auto threshold = 0.05f;
         auto width = video_stream_profile->get_width();
         std::vector<std::tuple<int, int, int>> faces;
-        for (int x = 0; x < width - 1; ++x) {
-            for (int y = 0; y < video_stream_profile->get_height() - 1; ++y) {
+        for( uint32_t x = 0; x < width - 1; ++x )
+        {
+            for( uint32_t y = 0; y < video_stream_profile->get_height() - 1; ++y )
+            {
                 auto a = y * width + x, b = y * width + x + 1, c = (y + 1)*width + x, d = (y + 1)*width + x + 1;
                 if (vertices[a].z && vertices[b].z && vertices[c].z && vertices[d].z
                     && abs(vertices[a].z - vertices[b].z) < threshold && abs(vertices[a].z - vertices[c].z) < threshold
@@ -242,7 +244,7 @@ namespace librealsense
 
     int frame::get_frame_data_size() const
     {
-        return data.size();
+        return (int)data.size();
     }
 
     const byte* frame::get_frame_data() const

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -198,11 +198,11 @@ namespace librealsense
 
         sector_count += first_sector;
 
-        for (int sector_index = first_sector; sector_index < sector_count; sector_index++)
+        for (auto sector_index = first_sector; sector_index < sector_count; sector_index++)
         {
             command cmdFES(ds::FES);
             cmdFES.require_response = false;
-            cmdFES.param1 = sector_index;
+            cmdFES.param1 = (int)sector_index;
             cmdFES.param2 = 1;
             auto res = hwm->send(cmdFES);
 
@@ -214,7 +214,7 @@ namespace librealsense
                 int packet_size = std::min((int)(HW_MONITOR_COMMAND_SIZE - (i % HW_MONITOR_COMMAND_SIZE)), (int)(ds::FLASH_SECTOR_SIZE - i));
                 command cmdFWB(ds::FWB);
                 cmdFWB.require_response = false;
-                cmdFWB.param1 = index;
+                cmdFWB.param1 = (int)index;
                 cmdFWB.param2 = packet_size;
                 cmdFWB.data.assign(image.data() + index, image.data() + index + packet_size);
                 res = hwm->send(cmdFWB);

--- a/src/firmware_logger_device.cpp
+++ b/src/firmware_logger_device.cpp
@@ -40,7 +40,7 @@ namespace librealsense
 
     unsigned int firmware_logger_device::get_number_of_fw_logs() const
     {
-        return _fw_logs.size();
+        return (unsigned int)_fw_logs.size();
     }
 
     void firmware_logger_device::get_fw_logs_from_hw_monitor()

--- a/src/fw-logs/fw-log-data.cpp
+++ b/src/fw-logs/fw-log-data.cpp
@@ -66,7 +66,7 @@ namespace librealsense
 
         uint32_t fw_log_data::get_timestamp() const
         {
-            return _timestamp;
+            return (uint32_t)_timestamp;
         }
 
         uint32_t fw_log_data::get_sequence_id() const

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -143,7 +143,7 @@ namespace librealsense
         const size_t transfer_size = 1024;
 
         size_t remaining_bytes = fw_image_size;
-        uint16_t blocks_count = fw_image_size / transfer_size;
+        uint16_t blocks_count = uint16_t( fw_image_size / transfer_size );
         uint16_t block_number = 0;
 
         size_t offset = 0;
@@ -155,7 +155,7 @@ namespace librealsense
             size_t chunk_size = std::min(transfer_size, remaining_bytes);
 
             auto curr_block = ((uint8_t*)fw_image + offset);
-            auto sts = messenger->control_transfer(0x21 /*DFU_DOWNLOAD_PACKET*/, RS2_DFU_DOWNLOAD, block_number, 0, curr_block, chunk_size, transferred, 5000);
+            auto sts = messenger->control_transfer(0x21 /*DFU_DOWNLOAD_PACKET*/, RS2_DFU_DOWNLOAD, block_number, 0, curr_block, uint32_t(chunk_size), transferred, 5000);
             if (sts != platform::RS2_USB_STATUS_SUCCESS || !wait_for_state(messenger, RS2_DFU_STATE_DFU_DOWNLOAD_IDLE, 1000))
             {
                 auto state = get_dfu_state(messenger);

--- a/src/hdr-config.cpp
+++ b/src/hdr-config.cpp
@@ -101,13 +101,15 @@ namespace librealsense
         if (current_subpreset[offset] != CONTROL_ID_EXPOSURE)
             return false;
         offset += size_of_control_id;
-        float exposure_0 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float exposure_0
+            = (float)*reinterpret_cast< const uint32_t * >( &( current_subpreset[offset] ) );
         offset += size_of_control_value;
 
         if (current_subpreset[offset] != CONTROL_ID_GAIN)
             return false;
         offset += size_of_control_id;
-        float gain_0 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float gain_0
+            = (float)*reinterpret_cast< const uint32_t * >( &( current_subpreset[offset] ) );
         offset += size_of_control_value;
 
         offset += size_of_subpreset_item_header;
@@ -115,13 +117,15 @@ namespace librealsense
         if (current_subpreset[offset] != CONTROL_ID_EXPOSURE)
             return false;
         offset += size_of_control_id;
-        float exposure_1 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float exposure_1
+            = (float)*reinterpret_cast< const uint32_t * >( &( current_subpreset[offset] ) );
         offset += size_of_control_value;
 
         if (current_subpreset[offset] != CONTROL_ID_GAIN)
             return false;
         offset += size_of_control_id;
-        float gain_1 = *reinterpret_cast<const uint32_t*>(&(current_subpreset[offset]));
+        float gain_1
+            = (float)*reinterpret_cast< const uint32_t * >( &( current_subpreset[offset] ) );
         offset += size_of_control_value;
 
         _hdr_sequence_params[0]._exposure = exposure_0;
@@ -482,7 +486,7 @@ namespace librealsense
 
         if (new_index <= _hdr_sequence_params.size())
         {
-            _current_hdr_sequence_index = new_index - 1;
+            _current_hdr_sequence_index = (int)new_index - 1;
         }
         else
             throw invalid_value_exception(to_string() << "hdr_config::set_sequence_index(...) failed! Index above sequence size.");

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -61,7 +61,7 @@ void librealsense::reset_logger()
     throw std::runtime_error("reset_logger is not supported without BUILD_EASYLOGGINGPP");
 }
 
-void librealsense::enable_rolling_log_file(std::size_t max_size )
+void librealsense::enable_rolling_log_file( unsigned max_size )
 {
     throw std::runtime_error("enable_rolling_log_file is not supported without BUILD_EASYLOGGINGPP");
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -34,9 +34,9 @@ void librealsense::reset_logger()
     logger.reset_logger();
 }
 
-void librealsense::enable_rolling_log_file(std::size_t max_size )
+void librealsense::enable_rolling_log_file( unsigned max_size )
 {
-    logger.enable_rolling_log_file(max_size);
+    logger.enable_rolling_log_file( max_size );
 }
 
 #else // BUILD_EASYLOGGINGPP

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -34,19 +34,21 @@ void librealsense::reset_logger()
     logger.reset_logger();
 }
 
-void librealsense::enable_rolling_files(std::size_t max_size )
+void librealsense::enable_rolling_log_file(std::size_t max_size )
 {
-    logger.enable_rolling_files(max_size);
+    logger.enable_rolling_log_file(max_size);
 }
 
 #else // BUILD_EASYLOGGINGPP
 
 void librealsense::log_to_console(rs2_log_severity min_severity)
 {
+    throw std::runtime_error("log_to_console is not supported without BUILD_EASYLOGGINGPP");
 }
 
 void librealsense::log_to_file(rs2_log_severity min_severity, const char * file_path)
 {
+    throw std::runtime_error("log_to_file is not supported without BUILD_EASYLOGGINGPP");
 }
 
 void librealsense::log_to_callback(rs2_log_severity min_severity, log_callback_ptr callback)
@@ -56,10 +58,12 @@ void librealsense::log_to_callback(rs2_log_severity min_severity, log_callback_p
 
 void librealsense::reset_logger()
 {
+    throw std::runtime_error("reset_logger is not supported without BUILD_EASYLOGGINGPP");
 }
 
-void librealsense::enable_rolling_files(std::size_t max_size )
+void librealsense::enable_rolling_log_file(std::size_t max_size )
 {
+    throw std::runtime_error("enable_rolling_log_file is not supported without BUILD_EASYLOGGINGPP");
 }
 #endif // BUILD_EASYLOGGINGPP
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -34,6 +34,11 @@ void librealsense::reset_logger()
     logger.reset_logger();
 }
 
+void librealsense::enable_rolling_files(std::size_t max_size )
+{
+    logger.enable_rolling_files(max_size);
+}
+
 #else // BUILD_EASYLOGGINGPP
 
 void librealsense::log_to_console(rs2_log_severity min_severity)
@@ -50,6 +55,10 @@ void librealsense::log_to_callback(rs2_log_severity min_severity, log_callback_p
 }
 
 void librealsense::reset_logger()
+{
+}
+
+void librealsense::enable_rolling_files(std::size_t max_size )
 {
 }
 #endif // BUILD_EASYLOGGINGPP

--- a/src/log.h
+++ b/src/log.h
@@ -249,13 +249,8 @@ namespace librealsense
         {
             el::Loggers::reconfigureLogger(log_id, el::ConfigurationType::ToFile, "false");
             el::Loggers::reconfigureLogger(log_id, el::ConfigurationType::ToStandardOutput, "false");
+            el::Loggers::reconfigureLogger(log_id, el::ConfigurationType::MaxLogFileSize, "0");
             remove_callbacks();
-
-            if(el::Loggers::hasFlag(el::LoggingFlag::StrictLogFileSizeCheck))
-            {
-                el::Loggers::removeFlag(el::LoggingFlag::StrictLogFileSizeCheck);
-                el::Loggers::reconfigureLogger(log_id, el::ConfigurationType::MaxLogFileSize, "0");
-            }
 
             minimum_log_severity = RS2_LOG_SEVERITY_NONE;
             minimum_console_severity = RS2_LOG_SEVERITY_NONE;
@@ -276,17 +271,21 @@ namespace librealsense
                 std::remove(old_filename);
             }
 
-            rename(filename, old_filename);
+            std::rename(filename, old_filename);
         }
 
         //Since log file will be truncated upon reaching max_size, MaxLogFileSize is configured to be half of the original max_size
         //another file that contains previous half will be created in rolloutHandler.
         //log file directory should have permissions of removing/renaming files. 
         //@param max_size max file size in bytes
-        void enable_rolling_files(std::size_t max_size)
+        void enable_rolling_log_file(std::size_t max_size)
         {
             std::string size = std::to_string( max_size/2 );
-            el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
+
+            //Rollout checking happens when Easylogging++ flushes the log file,
+            //or, if you have added the flag el::LoggingFlags::StrictLogFileSizeCheck, at each log output.
+            //el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
+
             el::Loggers::reconfigureLogger(log_id, el::ConfigurationType::MaxLogFileSize, size.c_str());
             el::Helpers::installPreRollOutCallback(rolloutHandler);
         }

--- a/src/log.h
+++ b/src/log.h
@@ -268,8 +268,8 @@ namespace librealsense
         {
             std::string file_str(filename);
             std::string old_file = file_str + ".old";
-            const char* old_filename = old_file.c_str();
 
+            const char* old_filename = old_file.c_str();
             std::ifstream exists(old_filename);
             if (exists.is_open()) {
                 exists.close();
@@ -280,8 +280,8 @@ namespace librealsense
         }
 
         //Since log file will be truncated upon reaching max_size, MaxLogFileSize is configured to be half of the original max_size
-        //another file will be created in rolloutHandler that contains previous half.
-        //file directory should have permissions of removing/renaming files. 
+        //another file that contains previous half will be created in rolloutHandler.
+        //log file directory should have permissions of removing/renaming files. 
         //@param max_size max file size in bytes
         void enable_rolling_files(std::size_t max_size)
         {

--- a/src/log.h
+++ b/src/log.h
@@ -263,21 +263,24 @@ namespace librealsense
 
         static void rolloutHandler(const char* filename, std::size_t size)
         {
-            char backup_name[256];
             std::string file_str(filename);
-            std::string file_name = file_str.substr(0, file_str.find_last_of('.'));
-            sprintf_s(backup_name, sizeof(backup_name), "%s-%s.log", file_name.c_str(), "backup");
-            std::string tmp = file_name + "_tmp.log";
-            rename(backup_name, tmp.c_str());
-            rename(filename, backup_name);
-            rename(tmp.c_str(), filename);
+            std::string old_file = file_str + ".old";
+            const char* old_filename = old_file.c_str();
+            std::ifstream exists(old_filename);
+            if (exists.is_open()) {
+                exists.close();
+                std::remove(old_filename);
+            }
+            rename(filename, old_filename);
         }
 
-        void enable_rolling_files(std::size_t max_size )
+        //enable rolling files upon reaching max_size
+        //@param max_size - in bytes.
+        void enable_rolling_files(std::size_t max_size)
         {
-            std::string size = std::to_string(max_size);
-            el::Loggers::addFlag( el::LoggingFlag::StrictLogFileSizeCheck );
-            el::Loggers::reconfigureLogger( log_id, el::ConfigurationType::MaxLogFileSize, size.c_str());
+            std::string size = std::to_string(max_size/2);
+            el::Loggers::addFlag(el::LoggingFlag::StrictLogFileSizeCheck);
+            el::Loggers::reconfigureLogger(log_id, el::ConfigurationType::MaxLogFileSize, size.c_str());
             el::Helpers::installPreRollOutCallback(rolloutHandler);
         }
     };

--- a/src/log.h
+++ b/src/log.h
@@ -284,7 +284,7 @@ namespace librealsense
         //
         // @param max_size max file size in bytes
         //
-        void enable_rolling_log_file( std::size_t max_size )
+        void enable_rolling_log_file( unsigned max_size )
         {
             std::string size = std::to_string( max_size/2 );
 

--- a/src/log.h
+++ b/src/log.h
@@ -282,11 +282,12 @@ namespace librealsense
         // previous .old file will be erased.
         // Must have permissions to remove/rename files in log file directory.
         //
-        // @param max_size max file size in bytes
+        // @param max_size max file size in megabytes
         //
         void enable_rolling_log_file( unsigned max_size )
         {
-            std::string size = std::to_string( max_size/2 );
+            auto max_size_in_bytes = max_size * 1024 * 1024;
+            std::string size = std::to_string(max_size_in_bytes / 2 );
 
             // Rollout checking happens when Easylogging++ flushes the log file!
             // Or, with the flag el::LoggingFlags::StrictLogFileSizeCheck, at each log output...

--- a/src/proc/hdr-merge.cpp
+++ b/src/proc/hdr-merge.cpp
@@ -84,7 +84,7 @@ namespace librealsense
         // with frame n as basis
         if (_framesets.size() == depth_seq_id)
         {
-            _framesets[depth_seq_id] = fs;
+            _framesets[(int)depth_seq_id] = fs;
         }
 
         // discard merged frame if not relevant

--- a/src/proc/sequence-id-filter.cpp
+++ b/src/proc/sequence-id-filter.cpp
@@ -30,7 +30,7 @@ namespace librealsense
             return false;
         if (!frame.supports_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID))
             return false;
-        int seq_size = frame.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_SIZE);
+        int seq_size = (int)frame.get_frame_metadata( RS2_FRAME_METADATA_SEQUENCE_SIZE );
         if (seq_size == 0)
             return false;
         return true;
@@ -43,7 +43,7 @@ namespace librealsense
         // if not as the option selected id, return last frame with the selected id
         // else return current frame
 
-        int seq_id = f.get_frame_metadata(RS2_FRAME_METADATA_SEQUENCE_ID);
+        int seq_id = (int)f.get_frame_metadata( RS2_FRAME_METADATA_SEQUENCE_ID );
         auto unique_id = f.get_profile().unique_id();
         auto current_key = std::make_pair(seq_id, unique_id);
 

--- a/src/proc/units-transform.cpp
+++ b/src/proc/units-transform.cpp
@@ -51,8 +51,13 @@ namespace librealsense
     {
         update_configuration(f);
 
-        auto new_f = source.allocate_video_frame(_target_stream_profile, f,
-            _bpp, _width, _height, _stride, RS2_EXTENSION_DEPTH_FRAME);
+        auto new_f = source.allocate_video_frame( _target_stream_profile,
+                                                  f,
+                                                  (int)_bpp,
+                                                  (int)_width,
+                                                  (int)_height,
+                                                  (int)_stride,
+                                                  RS2_EXTENSION_DEPTH_FRAME );
 
         if (new_f && _depth_units)
         {

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -148,7 +148,8 @@ EXPORTS
     rs2_log_to_callback
     rs2_log_to_callback_cpp
     rs2_reset_logger
-    
+    rs2_enable_rolling_files
+
     rs2_get_log_message_line_number
     rs2_get_log_message_filename
     rs2_get_raw_log_message

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -148,7 +148,7 @@ EXPORTS
     rs2_log_to_callback
     rs2_log_to_callback_cpp
     rs2_reset_logger
-    rs2_enable_rolling_files
+    rs2_enable_rolling_log_file
 
     rs2_get_log_message_line_number
     rs2_get_log_message_filename

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1310,6 +1310,12 @@ void rs2_reset_logger( rs2_error** error) BEGIN_API_CALL
 }
 NOARGS_HANDLE_EXCEPTIONS_AND_RETURN()
 
+void rs2_enable_rolling_files(std::size_t max_size, rs2_error** error) BEGIN_API_CALL
+{
+    librealsense::enable_rolling_files(max_size);
+}
+HANDLE_EXCEPTIONS_AND_RETURN(, max_size)
+
 // librealsense wrapper around a C function
 class on_log_callback : public rs2_log_callback
 {

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1308,11 +1308,11 @@ void rs2_reset_logger( rs2_error** error) BEGIN_API_CALL
 {
     librealsense::reset_logger();
 }
-NOARGS_HANDLE_EXCEPTIONS_AND_RETURN()
+NOARGS_HANDLE_EXCEPTIONS_AND_RETURN_VOID()
 
-void rs2_enable_rolling_log_file(std::size_t max_size, rs2_error** error) BEGIN_API_CALL
+void rs2_enable_rolling_log_file( unsigned max_size, rs2_error ** error ) BEGIN_API_CALL
 {
-    librealsense::enable_rolling_log_file(max_size);
+    librealsense::enable_rolling_log_file( max_size );
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, max_size)
 
@@ -3220,7 +3220,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(nullptr, msg)
 int rs2_fw_log_message_size(rs2_firmware_log_message* msg, rs2_error** error)BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(msg);
-    return msg->firmware_log_binary_data->logs_buffer.size();
+    return (int)msg->firmware_log_binary_data->logs_buffer.size();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, msg)
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1310,9 +1310,9 @@ void rs2_reset_logger( rs2_error** error) BEGIN_API_CALL
 }
 NOARGS_HANDLE_EXCEPTIONS_AND_RETURN()
 
-void rs2_enable_rolling_files(std::size_t max_size, rs2_error** error) BEGIN_API_CALL
+void rs2_enable_rolling_log_file(std::size_t max_size, rs2_error** error) BEGIN_API_CALL
 {
-    librealsense::enable_rolling_files(max_size);
+    librealsense::enable_rolling_log_file(max_size);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, max_size)
 

--- a/src/types.h
+++ b/src/types.h
@@ -205,6 +205,7 @@ namespace librealsense
     void log_to_file( rs2_log_severity min_severity, const char* file_path );
     void log_to_callback( rs2_log_severity min_severity, log_callback_ptr callback );
     void reset_logger();
+    void enable_rolling_files(std::size_t max_size);
 
 #if BUILD_EASYLOGGINGPP
 

--- a/src/types.h
+++ b/src/types.h
@@ -205,7 +205,7 @@ namespace librealsense
     void log_to_file( rs2_log_severity min_severity, const char* file_path );
     void log_to_callback( rs2_log_severity min_severity, log_callback_ptr callback );
     void reset_logger();
-    void enable_rolling_files(std::size_t max_size);
+    void enable_rolling_log_file(std::size_t max_size);
 
 #if BUILD_EASYLOGGINGPP
 

--- a/src/types.h
+++ b/src/types.h
@@ -205,7 +205,7 @@ namespace librealsense
     void log_to_file( rs2_log_severity min_severity, const char* file_path );
     void log_to_callback( rs2_log_severity min_severity, log_callback_ptr callback );
     void reset_logger();
-    void enable_rolling_log_file(std::size_t max_size);
+    void enable_rolling_log_file( unsigned max_size );
 
 #if BUILD_EASYLOGGINGPP
 

--- a/unit-tests/log/test-cpp-enable-rolling.cpp
+++ b/unit-tests/log/test-cpp-enable-rolling.cpp
@@ -3,31 +3,36 @@
 
 //#cmake:add-file log-common.h
 #include "log-common.h"
-#include<fstream>
+#include <fstream>
 
 TEST_CASE("ROLLING C++ LOGGER", "[log]") {
 
     std::string log_filename = "rolling-log.log";
     rs2::log_to_file(RS2_LOG_SEVERITY_INFO, log_filename.c_str());
 
-    int max_size = 1024;
+    int max_size = 1;
     rs2::enable_rolling_log_file(max_size);
 
-    for (int i = 0; i < 100; ++i)
-        log_all();
+    for (int i = 0; i < 15000; ++i)
+    {
+        const std::string msg("debug message ");
+        REQUIRE_NOTHROW(rs2::log(RS2_LOG_SEVERITY_INFO, (msg + std::to_string(i)).c_str()));
+    }
 
     rs2::reset_logger();
 
-    std::ifstream log_file(log_filename.c_str(), std::ios::binary);
+    std::ifstream log_file(log_filename.c_str(), std::ios::binary | std::ios::in);
+    REQUIRE(log_file.good());
     log_file.seekg(0, std::ios::end);
     auto log_size = log_file.tellg();
 
     std::string old_filename = log_filename + ".old";
-    std::ifstream old_file(old_filename.c_str(), std::ios::binary);
+    std::ifstream old_file(old_filename.c_str(), std::ios::binary | std::ios::in);
+    REQUIRE(old_file.good());
     old_file.seekg(0, std::ios::end);
     auto old_size = old_file.tellg();
-
+    auto max_size_in_bytes = max_size * 1024 * 1024;
     auto size = log_size + old_size;
-    REQUIRE(size <= 2*max_size);
+    REQUIRE(size <= 2 * max_size_in_bytes);
 
 }

--- a/unit-tests/log/test-cpp-enable-rolling.cpp
+++ b/unit-tests/log/test-cpp-enable-rolling.cpp
@@ -5,7 +5,7 @@
 #include "log-common.h"
 #include<fstream>
 
-TEST_CASE("ENABLE ROLLING C++ LOGGER", "[log]") {
+TEST_CASE("ROLLING C++ LOGGER", "[log]") {
 
     std::string log_filename = "rolling-log.log";
     rs2::log_to_file(RS2_LOG_SEVERITY_INFO, log_filename.c_str());

--- a/unit-tests/log/test-cpp-enable-rolling.cpp
+++ b/unit-tests/log/test-cpp-enable-rolling.cpp
@@ -20,14 +20,14 @@ TEST_CASE("ROLLING C++ LOGGER", "[log]") {
 
     std::ifstream log_file(log_filename.c_str(), std::ios::binary);
     log_file.seekg(0, std::ios::end);
-    int log_size = log_file.tellg();
+    auto log_size = log_file.tellg();
 
     std::string old_filename = log_filename + ".old";
     std::ifstream old_file(old_filename.c_str(), std::ios::binary);
     old_file.seekg(0, std::ios::end);
-    int old_size = old_file.tellg();
+    auto old_size = old_file.tellg();
 
-    int size = log_size + old_size;
+    auto size = log_size + old_size;
     REQUIRE(size <= 2*max_size);
 
 }

--- a/unit-tests/log/test-cpp-enable-rolling.cpp
+++ b/unit-tests/log/test-cpp-enable-rolling.cpp
@@ -11,10 +11,12 @@ TEST_CASE("ROLLING C++ LOGGER", "[log]") {
     rs2::log_to_file(RS2_LOG_SEVERITY_INFO, log_filename.c_str());
 
     int max_size = 1024;
-    rs2::enable_rolling_files(max_size);
+    rs2::enable_rolling_log_file(max_size);
 
     for (int i = 0; i < 100; ++i)
         log_all();
+
+    rs2::reset_logger();
 
     std::ifstream log_file(log_filename.c_str(), std::ios::binary);
     log_file.seekg(0, std::ios::end);
@@ -26,6 +28,6 @@ TEST_CASE("ROLLING C++ LOGGER", "[log]") {
     int old_size = old_file.tellg();
 
     int size = log_size + old_size;
-    REQUIRE(size <= max_size);
+    REQUIRE(size <= 2*max_size);
 
 }

--- a/unit-tests/log/test-cpp-enable-rolling.cpp
+++ b/unit-tests/log/test-cpp-enable-rolling.cpp
@@ -1,0 +1,28 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+//#cmake:add-file log-common.h
+#include "log-common.h"
+
+
+TEST_CASE("ENABLE ROLLING C++ LOGGER", "[log]") {
+    size_t n_callbacks = 0;
+    auto callback = [&](rs2_log_severity severity, rs2::log_message const& msg)
+    {
+        ++n_callbacks;
+
+
+        TRACE(severity << ' ' << msg.filename() << '+' << msg.line_number() << ": " << msg.raw());
+    };
+
+    rs2::log_to_callback(RS2_LOG_SEVERITY_INFO, callback);
+    REQUIRE(!n_callbacks);
+    rs2::log_to_file(RS2_LOG_SEVERITY_INFO, "C:/Users/aegbaria/Documents/max-size.log");
+
+    rs2::enable_rolling_files( 1024 );
+
+    for (int i = 0; i < 100; ++i)
+        log_all();
+
+    n_callbacks = 2;
+}

--- a/unit-tests/log/test-env-log-level-on.cpp
+++ b/unit-tests/log/test-env-log-level-on.cpp
@@ -12,7 +12,12 @@
 TEST_CASE( "With LRS_LOG_LEVEL", "[log]" ) {
 
     REQUIRE( ! getenv( "LRS_LOG_LEVEL" ));
-    _putenv( "LRS_LOG_LEVEL=WARN" );
+#ifdef _WINDOWS
+    _putenv
+#else
+    putenv
+#endif
+        ( "LRS_LOG_LEVEL=WARN" );
     REQUIRE( getenv( "LRS_LOG_LEVEL" ));
     TRACE( "LRS_LOG_LEVEL=" << getenv( "LRS_LOG_LEVEL" ));
 

--- a/unit-tests/log/test-env-log-level-on.cpp
+++ b/unit-tests/log/test-env-log-level-on.cpp
@@ -12,7 +12,7 @@
 TEST_CASE( "With LRS_LOG_LEVEL", "[log]" ) {
 
     REQUIRE( ! getenv( "LRS_LOG_LEVEL" ));
-    putenv( "LRS_LOG_LEVEL=WARN" );
+    _putenv( "LRS_LOG_LEVEL=WARN" );
     REQUIRE( getenv( "LRS_LOG_LEVEL" ));
     TRACE( "LRS_LOG_LEVEL=" << getenv( "LRS_LOG_LEVEL" ));
 

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -42,7 +42,7 @@ PYBIND11_MODULE(NAME, m) {
     m.def("log_to_console", &rs2::log_to_console, "min_severity"_a);
     m.def("log_to_file", &rs2::log_to_file, "min_severity"_a, "file_path"_a);
     m.def("reset_logger", &rs2::reset_logger);
-    m.def("enable_rolling_files", &rs2::enable_rolling_files, "max_size"_a);
+    m.def("enable_rolling_log_file", &rs2::enable_rolling_log_file, "max_size"_a);
 
     // Access to log_message is only from a callback (see log_to_callback below) and so already
     // should have the GIL acquired

--- a/wrappers/python/python.cpp
+++ b/wrappers/python/python.cpp
@@ -42,6 +42,7 @@ PYBIND11_MODULE(NAME, m) {
     m.def("log_to_console", &rs2::log_to_console, "min_severity"_a);
     m.def("log_to_file", &rs2::log_to_file, "min_severity"_a, "file_path"_a);
     m.def("reset_logger", &rs2::reset_logger);
+    m.def("enable_rolling_files", &rs2::enable_rolling_files, "max_size"_a);
 
     // Access to log_message is only from a callback (see log_to_callback below) and so already
     // should have the GIL acquired


### PR DESCRIPTION
Continues the work of @aseelegbaria (#8212)

Log files can have a max size. upon reaching max size new file will be created and current file will be truncated.
Tracked on [RS5-9271]