### PR TITLE
Unit-test test:device acroname control (for py only)

### DIFF
--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -139,7 +139,7 @@ namespace librealsense
                     = utilities::time::l500::get_manufacture_work_week( optic_serial );
                 auto age
                     = utilities::time::get_work_weeks_since( manufacture );
-                command cmd( fw_cmd::SET_AGE, (uint8_t)age );
+                command cmd( fw_cmd::UNIT_AGE_SET, (uint8_t)age );
                 _hw_monitor->send( cmd );
             }
             catch( ... )

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -73,7 +73,7 @@ namespace librealsense
             RGB_EXTRINSIC_GET           = 0x82,
             FALL_DETECT_ENABLE          = 0x9D, // Enable (by default) free-fall sensor shutoff (0=disable; 1=enable)
             GET_SPECIAL_FRAME           = 0xA0, // Request auto-calibration (0) special frames (#)
-            SET_AGE                     = 0x5B  // Sets the age of the unit in weeks
+            UNIT_AGE_SET                = 0x5B  // Sets the age of the unit in weeks
         };
 
 #pragma pack(push, 1)

--- a/unit-tests/algo/d2rgb/test-bad-conditions.py
+++ b/unit-tests/algo/d2rgb/test-bad-conditions.py
@@ -3,12 +3,13 @@
 
 #test:device L500*
 
-import pyrealsense2 as rs
-from rspy import test, ac
-# We set the environment variables to suit this test
+from rspy import test
 test.set_env_vars({"RS2_AC_DISABLE_CONDITIONS":"0",
                    "RS2_AC_LOG_TO_STDOUT":"1"
                    })
+
+import pyrealsense2 as rs
+from rspy import ac
 
 # rs.log_to_file( rs.log_severity.debug, "rs.log" )
 
@@ -55,4 +56,10 @@ test.check_equal_lists(ac.status_list, [rs.calibration_status.bad_conditions])
 depth_sensor.set_option(rs.option.receiver_gain, old_receiver_gain)
 test.finish()
 #############################################################################################
+
+color_sensor.stop()
+color_sensor.close()
+depth_sensor.stop()
+depth_sensor.close()
+
 test.print_results_and_exit()

--- a/unit-tests/algo/d2rgb/test-bad-conditions.py
+++ b/unit-tests/algo/d2rgb/test-bad-conditions.py
@@ -1,3 +1,8 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#test:device L500*
+
 import pyrealsense2 as rs
 from rspy import test, ac
 # We set the environment variables to suit this test

--- a/unit-tests/algo/d2rgb/test-frame-drop.py
+++ b/unit-tests/algo/d2rgb/test-frame-drop.py
@@ -93,4 +93,10 @@ except:
 test.finish()
 
 #############################################################################################
+
+depth_sensor.stop()
+depth_sensor.close()
+color_sensor.stop()
+color_sensor.close()
+
 test.print_results_and_exit()

--- a/unit-tests/algo/d2rgb/test-frame-drop.py
+++ b/unit-tests/algo/d2rgb/test-frame-drop.py
@@ -1,3 +1,8 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#test:device L500*
+
 import pyrealsense2 as rs
 from rspy import test, ac
 

--- a/unit-tests/algo/d2rgb/test-triggers.py
+++ b/unit-tests/algo/d2rgb/test-triggers.py
@@ -3,16 +3,16 @@
 
 #test:device L500*
 
-import pyrealsense2 as rs, test
-from rspy import test, ac
-
-# We set the environment variables to suit this test
+from rspy import test
 test.set_env_vars({"RS2_AC_DISABLE_CONDITIONS":"1",
                    "RS2_AC_DISABLE_RETRIES":"1",
                    "RS2_AC_FORCE_BAD_RESULT":"1",
                    "RS2_AC_LOG_TO_STDOUT":"1"
                    #,"RS2_AC_IGNORE_LIMITERS":"1"
                    })
+
+import pyrealsense2 as rs
+from rspy import ac
 
 # rs.log_to_file( rs.log_severity.debug, "rs.log" )
 
@@ -88,6 +88,8 @@ except Exception as e:
     test.check_exception(e, RuntimeError, "tried to stop sensor without starting it")
 else:
     test.unexpected_exception()
+depth_sensor.stop()
+depth_sensor.close()
 test.finish()
 
 #############################################################################################
@@ -133,6 +135,8 @@ try:
     test.check_equal_lists(ac.status_list, successful_calibration_status_list)
 except:
     test.unexpected_exception()
+color_sensor.stop()
+color_sensor.close()
 test.finish()
 
 #############################################################################################

--- a/unit-tests/algo/d2rgb/test-triggers.py
+++ b/unit-tests/algo/d2rgb/test-triggers.py
@@ -1,3 +1,8 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#test:device L500*
+
 import pyrealsense2 as rs, test
 from rspy import test, ac
 
@@ -54,7 +59,7 @@ irrelevant_statuses = [rs.calibration_status.retry,
 test.start("Depth sensor is off, should get an error")
 try:
     d2r.trigger_device_calibration( rs.calibration_type.manual_depth_to_rgb )
-    ac.wait_for_calibration() 
+    ac.wait_for_calibration()
 except Exception as e:
     test.check_exception(e, RuntimeError, "not streaming")
 else:
@@ -76,9 +81,9 @@ try:
 except Exception:
     test.unexpected_exception()
 try:
-    # Since the sensor was closed before calibration started, it should have been returned to a 
+    # Since the sensor was closed before calibration started, it should have been returned to a
     # closed state
-    color_sensor.stop() 
+    color_sensor.stop()
 except Exception as e:
     test.check_exception(e, RuntimeError, "tried to stop sensor without starting it")
 else:
@@ -102,7 +107,7 @@ except:
     test.unexpected_exception()
 try:
     # This time the color sensor was on before calibration so it should remain on at the end
-    color_sensor.stop() 
+    color_sensor.stop()
 except:
     test.unexpected_exception()
 test.finish()

--- a/unit-tests/algo/d2rgb/test-triggers.py
+++ b/unit-tests/algo/d2rgb/test-triggers.py
@@ -88,8 +88,7 @@ except Exception as e:
     test.check_exception(e, RuntimeError, "tried to stop sensor without starting it")
 else:
     test.unexpected_exception()
-depth_sensor.stop()
-depth_sensor.close()
+# Leave the depth sensor open for the next test
 test.finish()
 
 #############################################################################################
@@ -112,6 +111,7 @@ try:
     color_sensor.stop()
 except:
     test.unexpected_exception()
+# Leave the depth sensor open for the next test
 test.finish()
 
 #############################################################################################
@@ -137,6 +137,8 @@ except:
     test.unexpected_exception()
 color_sensor.stop()
 color_sensor.close()
+depth_sensor.stop()
+depth_sensor.close()
 test.finish()
 
 #############################################################################################

--- a/unit-tests/func/fg/test-fg.py
+++ b/unit-tests/func/fg/test-fg.py
@@ -1,6 +1,8 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+#test:device L500*
+
 import pyrealsense2 as rs
 from rspy import test,ac
 

--- a/unit-tests/func/serializable-device/test-l500-json-load.py
+++ b/unit-tests/func/serializable-device/test-l500-json-load.py
@@ -1,6 +1,8 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+#test:device L500*
+
 import pyrealsense2 as rs
 from rspy import test
 

--- a/unit-tests/func/test-set-option.py
+++ b/unit-tests/func/test-set-option.py
@@ -1,6 +1,8 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+#test:device L500*
+
 import platform
 import pyrealsense2 as rs
 from rspy import test

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -1,5 +1,11 @@
-from rspy import acroname
+try:
+    from rspy import acroname
+except ModuleNotFoundError:
+    # Error should have already been printed
+    # We assume there's no brainstem library, meaning no acroname either
+    acroname = None
 import pyrealsense2 as rs
+import time
 
 _device_by_sn = None
 _context = None
@@ -12,19 +18,42 @@ def query():
     #
     # Before we can start a context and query devices, we need to enable all the ports
     # on the acroname, if any:
-    acroname.connect()  # MAY THROW!
-    acroname.enable_ports()
+    if acroname:
+        acroname.connect()  # MAY THROW!
+        acroname.enable_ports()
     #
     # Get all devices, and store by serial-number
     global _device_by_sn, _context, _port_to_sn
     _context = rs.context()
-    _device_by_sn = {}
+    _context.set_devices_changed_callback( _device_change_callback )
+    _device_by_sn = dict()
     for dev in _context.query_devices():
         if dev.is_update_device():
             sn = dev.get_info( rs.camera_info.firmware_update_id )
         else:
             sn = dev.get_info( rs.camera_info.serial_number )
         _device_by_sn[sn] = dev
+
+
+def _device_change_callback( info ):
+    """
+    Called when librealsense detects a device change (see query())
+    """
+    global _device_by_sn
+    new_device_by_sn = dict()
+    for sn, dev in _device_by_sn.items():
+        if info.was_removed( dev ):
+            print( '-D-', 'device removed:', sn )
+        else:
+            new_device_by_sn[sn] = dev
+    for dev in info.get_new_devices():
+        if dev.is_update_device():
+            sn = dev.get_info( rs.camera_info.firmware_update_id )
+        else:
+            sn = dev.get_info( rs.camera_info.serial_number )
+        print( '-D-', 'device added:', dev )
+        new_device_by_sn[sn] = dev
+    _device_by_sn = new_device_by_sn
 
 
 def all():
@@ -40,11 +69,11 @@ def by_product_line( product_line ):
     :param product_line: The product line we're interested in, as a string ("L500", etc.)
     :return: A list of device serial-numbers
     """
-    sns = []
+    sns = set()
     global _device_by_sn
     for sn, dev in _device_by_sn.items():
         if dev.supports( rs.camera_info.product_line ) and dev.get_info( rs.camera_info.product_line ) == product_line:
-            sns.append( sn )
+            sns.add( sn )
     return sns
 
 
@@ -53,11 +82,43 @@ def by_name( name ):
     :param name: Part of the product name to search for ("L515" would match "Intel RealSense L515")
     :return: A list of device serial-numbers
     """
-    sns = []
+    sns = set()
     global _device_by_sn
     for sn, dev in _device_by_sn.items():
         if dev.supports( rs.camera_info.name ) and dev.get_info( rs.camera_info.name ).find( name ) >= 0:
-            sns.append( sn )
+            sns.add( sn )
+    return sns
+
+
+def by_configuration( config ):
+    """
+    :param config: A test:device line collection of arguments (e.g., [L515 D400*])
+    :return: A set of device serial-numbers matching
+
+    If no device matches the configuration devices specified, a RuntimeError will be
+    raised!
+    """
+    sns = set()
+    for spec in config:
+        old_len = len(sns)
+        if spec.endswith( '*' ):
+            # By product line
+            for sn in by_product_line( spec[:-1] ):
+                if sn not in sns:
+                    sns.add( sn )
+                    break
+        else:
+            # By name
+            for sn in by_name( spec ):
+                if sn not in sns:
+                    sns.add( sn )
+                    break
+        new_len = len(sns)
+        if new_len == old_len:
+            if len(spec):
+                raise RuntimeError( 'no device matches configuration "' + spec + '" (after already matching ' + str(sns) + ')' )
+            else:
+                raise RuntimeError( 'no device matches configuration "' + spec + '"' )
     return sns
 
 
@@ -78,19 +139,124 @@ def get_port( sn ):
     return _get_port_by_dev( get( sn ))
 
 
-def enable_only( serial_numbers ):
+def enable_only( serial_numbers, recycle = False, timeout = 5 ):
     """
+    Enable only the devices corresponding to the given serial-numbers. This can work either
+    with or without Acroname: without, the devices will simply be HW-reset, but other devices
+    will still be present.
+
     :param serial_numbers: A collection of serial-numbers to enable - all others' ports are
                            disabled and will no longer be usable!
+    :param recycle: If False, the devices will not be reset if they were already enabled. If
+                    True, the devices will be recycled by disabling the port, waiting, then
+                    re-enabling
+    :param timeout: The maximum seconds to wait to make sure the devices are indeed online
     """
-    ports = [ get_port( sn ) for sn in serial_numbers ]
-    acroname.enable_ports( ports )
+    if acroname:
+        #
+        ports = [ get_port( sn ) for sn in serial_numbers ]
+        #
+        if recycle:
+            #
+            print( '-D-', 'Recycling ports via acroname:', ports )
+            #
+            acroname.disable_ports( acroname.ports() )
+            _wait_until_removed( serial_numbers, timeout = timeout )
+            #
+            acroname.enable_ports( ports )
+            #
+        else:
+            #
+            acroname.enable_ports( ports, disable_other_ports = True )
+        #
+        _wait_for( serial_numbers, timeout = timeout )
+        #
+    elif recycle:
+        #
+        hw_reset( serial_numbers )
+        #
+    else:
+        print( '-D-', 'No acroname; ports left as-is' )
 
 
 def enable_all():
     """
     """
-    enable_only( all() )
+    if acroname:
+        acroname.enable_ports()
+
+
+def _wait_until_removed( serial_numbers, timeout = 5 ):
+    """
+    Wait until the given serial numbers are all offline
+
+    :param timeout: Number of seconds of maximum wait time
+    :return: True if all have come offline; False if timeout was reached
+    """
+    while True:
+        have_devices = False
+        for sn in serial_numbers:
+            if sn in _device_by_sn:
+                have_devices = True
+                break
+        if not have_devices:
+            return True
+        #
+        if timeout <= 0:
+            return False
+        timeout -= 1
+        time.sleep( 1 )
+
+
+def _wait_for( serial_numbers, timeout = 5, wait_for_recycle = False ):
+    """
+    Wait until the given serial numbers are all online
+
+    :param timeout: Number of seconds of maximum wait time
+    :param wait_for_recycle: If True, will wait until all devices are first removed
+    :return: True if all have come online; False if timeout was reached
+    """
+    did_some_waiting = False
+    while True:
+        #
+        have_all_devices = True
+        for sn in serial_numbers:
+            if sn not in _device_by_sn:
+                have_all_devices = False
+                break
+        #
+        if have_all_devices:
+            if did_some_waiting:
+                # Wait an extra second, just in case -- let the devices properly power up
+                print( '-D-', 'All devices powered up' )
+                time.sleep( 1 )
+            return True
+        #
+        if timeout <= 0:
+            return False
+        timeout -= 1
+        time.sleep( 1 )
+        did_some_waiting = True
+
+
+def hw_reset( serial_numbers, timeout = 5 ):
+    """
+    Recycles the given devices manually, using a hardware-reset (rather than any acroname port
+    reset). The devices are sent a HW-reset command and then we'll wait until they come back
+    online.
+
+    :param serial_numbers: A collection of serial-numbers to reset
+    :param timeout: Maximum # of seconds to wait for the devices to come back online
+    :return: True if all devices have come back online before timeout
+    """
+    for sn in serial_numbers:
+        dev = get( sn )
+        dev.hardware_reset()
+    #
+    _wait_until_removed( serial_numbers )
+    #
+    return _wait_for( serial_numbers, timeout = timeout )
+
 
 ###############################################################################################
 import platform

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -1,3 +1,6 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
 try:
     from rspy import acroname
 except ModuleNotFoundError:
@@ -116,7 +119,7 @@ def by_configuration( config ):
                     break
         new_len = len(sns)
         if new_len == old_len:
-            if len(spec):
+            if old_len:
                 raise RuntimeError( 'no device matches configuration "' + spec + '" (after already matching ' + str(sns) + ')' )
             else:
                 raise RuntimeError( 'no device matches configuration "' + spec + '"' )
@@ -194,6 +197,7 @@ def _wait_until_removed( serial_numbers, timeout = 5 ):
     :param timeout: Number of seconds of maximum wait time
     :return: True if all have come offline; False if timeout was reached
     """
+    global _device_by_sn
     while True:
         have_devices = False
         for sn in serial_numbers:
@@ -217,6 +221,7 @@ def _wait_for( serial_numbers, timeout = 5, wait_for_recycle = False ):
     :param wait_for_recycle: If True, will wait until all devices are first removed
     :return: True if all have come online; False if timeout was reached
     """
+    global _device_by_sn
     did_some_waiting = False
     while True:
         #

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -6,6 +6,7 @@ except ModuleNotFoundError:
     acroname = None
 import pyrealsense2 as rs
 import time
+from rspy import log
 
 _device_by_sn = None
 _context = None
@@ -43,7 +44,7 @@ def _device_change_callback( info ):
     new_device_by_sn = dict()
     for sn, dev in _device_by_sn.items():
         if info.was_removed( dev ):
-            print( '-D-', 'device removed:', sn )
+            log.d( 'device removed:', sn )
         else:
             new_device_by_sn[sn] = dev
     for dev in info.get_new_devices():
@@ -51,7 +52,7 @@ def _device_change_callback( info ):
             sn = dev.get_info( rs.camera_info.firmware_update_id )
         else:
             sn = dev.get_info( rs.camera_info.serial_number )
-        print( '-D-', 'device added:', dev )
+        log.d( 'device added:', dev )
         new_device_by_sn[sn] = dev
     _device_by_sn = new_device_by_sn
 
@@ -158,7 +159,7 @@ def enable_only( serial_numbers, recycle = False, timeout = 5 ):
         #
         if recycle:
             #
-            print( '-D-', 'Recycling ports via acroname:', ports )
+            log.d( 'recycling ports via acroname:', ports )
             #
             acroname.disable_ports( acroname.ports() )
             _wait_until_removed( serial_numbers, timeout = timeout )
@@ -176,7 +177,7 @@ def enable_only( serial_numbers, recycle = False, timeout = 5 ):
         hw_reset( serial_numbers )
         #
     else:
-        print( '-D-', 'No acroname; ports left as-is' )
+        log.d( 'no acroname; ports left as-is' )
 
 
 def enable_all():
@@ -228,7 +229,7 @@ def _wait_for( serial_numbers, timeout = 5, wait_for_recycle = False ):
         if have_all_devices:
             if did_some_waiting:
                 # Wait an extra second, just in case -- let the devices properly power up
-                print( '-D-', 'All devices powered up' )
+                log.d( 'all devices powered up' )
                 time.sleep( 1 )
             return True
         #

--- a/unit-tests/py/rspy/log.py
+++ b/unit-tests/py/rspy/log.py
@@ -50,13 +50,18 @@ def quiet_on():
         pass
 
 
+_verbose_on = False
 def v(*args):
     pass
 def verbose_on():
-    global v
+    global v, _verbose_on
     def v(*args):
         global gray, reset
         out( gray + '-V-', *args, reset )
+    _verbose_on = True
+def is_verbose_on():
+    global _verbose_on
+    return _verbose_on
 
 
 _debug_on = False

--- a/unit-tests/py/rspy/log.py
+++ b/unit-tests/py/rspy/log.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 import sys
 
@@ -59,13 +59,18 @@ def verbose_on():
         out( gray + '-V-', *args, reset )
 
 
+_debug_on = False
 def d(*args):
     pass
 def debug_on():
-    global d
+    global d, _debug_on
     def d(*args):
         global gray, reset
         out( gray + '-D-', *args, reset )
+    _debug_on = True
+def is_debug_on():
+    global _debug_on
+    return _debug_on
 
 
 def i(*args):

--- a/unit-tests/py/rspy/log.py
+++ b/unit-tests/py/rspy/log.py
@@ -1,0 +1,90 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+import sys
+
+
+# Set up the default output system; if not a terminal, disable colors!
+def _stream_has_color( stream ):
+    if not hasattr(stream, "isatty"):
+        return False
+    if not stream.isatty():
+        return False # auto color only on TTYs
+    try:
+        import curses
+        curses.setupterm()
+        return curses.tigetnum( "colors" ) > 2
+    except:
+        # guess false in case of error
+        return False
+
+if _stream_has_color( sys.stdout ):
+    red = '\033[91m'
+    gray = '\033[90m'
+    reset = '\033[0m'
+    cr = '\033[G'
+    clear_eos = '\033[J'
+    clear_eol = '\033[K'
+    _progress = ''
+    def out(*args):
+        print( *args, end = clear_eol + '\n' )
+        global _progress
+        if len(_progress):
+            progress( *_progress )
+    def progress(*args):
+        print( *args, end = clear_eol + '\r' )
+        global _progress
+        _progress = args
+else:
+    red = gray = reset = cr = clear_eos = ''
+    def out(*args):
+        print( *args )
+    def progress(*args):
+        print( *args )
+
+
+def quiet_on():
+    print( "QUIET ON" )
+    global out
+    def out(*args):
+        pass
+
+
+def v(*args):
+    pass
+def verbose_on():
+    global v
+    def v(*args):
+        global gray, reset
+        out( gray + '-V-', *args, reset )
+
+
+def d(*args):
+    pass
+def debug_on():
+    global d
+    def d(*args):
+        global gray, reset
+        out( gray + '-D-', *args, reset )
+
+
+def i(*args):
+    out( '-I-', *args)
+
+
+# We track the number of errors
+_n_errors = 0
+def e(*args):
+    global red, reset
+    out( red + '-E-' + reset, *args )
+    global _n_errors
+    _n_errors = _n_errors + 1
+
+def n_errors():
+    global _n_errors
+    return _n_errors
+
+def reset_errors():
+    global _n_errors
+    _n_errors = 0
+

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -36,10 +36,7 @@ def set_env_vars(env_vars):
         for env_var, val in env_vars.items():
             os.environ[env_var] = val
         sys.argv.append("rerun")
-        if platform.system() == 'Linux' and "microsoft" not in platform.uname()[3].lower():
-            cmd = ["python3"]
-        else:
-            cmd = ["py", "-3"]
+        cmd = [sys.executable]
         if sys.flags.verbose:
             cmd += ["-v"]
         cmd += sys.argv

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -431,7 +431,7 @@ def devices_by_test_config( test ):
         try:
             serial_numbers = devices.by_configuration( configuration )
         except RuntimeError as e:
-            log.e( log.red + self.name + log.reset + ': ' + str(e) )
+            log.e( log.red + test.name + log.reset + ': ' + str(e) )
             continue
         yield configuration, serial_numbers
 

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -202,7 +202,6 @@ def check_log_for_fails( path_to_log, testname, exe ):
     #      assertions: 9 | 6 passed | 3 failed"
     if path_to_log is None:
         return False
-    global verbose
     for ctx in grep( r'^test cases:\s*(\d+) \|\s*(\d+) (passed|failed)', path_to_log ):
         m = ctx['match']
         total = int(m.group(1))
@@ -216,7 +215,7 @@ def check_log_for_fails( path_to_log, testname, exe ):
             else:
                 desc = str(total - passed) + ' of ' + str(total) + ' failed'
 
-            if verbose:
+            if log.is_verbose_on():
                 log.e( log.red + testname + log.reset + ': ' + desc )
                 log.i( 'Executable:', exe )
                 log.i( 'Log: >>>' )


### PR DESCRIPTION
Separated log functionality into `rspy.log` module
Use `devices` module from run-unit-tests.py
Changed python subprocess invocation to `sys.executable`
HWM cmd `SET_AGE` -> `UNIT_AGE_SET`, to fit XML