### PR TITLE
Fix syncer bug causing wrong frame order

### DIFF
--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -125,7 +125,7 @@ namespace librealsense
     {
         frame_interface* frame;
 
-        frame_interface* operator->()
+        frame_interface* operator->() const
         {
             return frame;
         }

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -184,7 +184,6 @@ namespace librealsense
 
         std::vector<stream_interface*> streams = { _depth_stream.get(), _ir_stream.get(), _confidence_stream.get() };
 
-        // TODO
         for (auto& s : streams)
         {
             depth_matchers.push_back(std::make_shared<identity_matcher>(s->get_unique_id(), s->get_stream_type()));

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -190,19 +190,12 @@ namespace librealsense
             depth_matchers.push_back(std::make_shared<identity_matcher>(s->get_unique_id(), s->get_stream_type()));
         }
         std::vector<std::shared_ptr<matcher>> matchers;
-        if (!frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
-        {
-            matchers.push_back(std::make_shared<timestamp_composite_matcher>(depth_matchers));
-        }
-        else
-        {
-            matchers.push_back(std::make_shared<timestamp_composite_matcher>(depth_matchers));
-        }
+        matchers.push_back(std::make_shared<timestamp_composite_matcher>(depth_matchers));
 
         return std::make_shared<timestamp_composite_matcher>(matchers);
     }
 
-   
+
 
 
     // If the user did not ask for IR, The open function will add it anyway. 

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -283,7 +283,7 @@ namespace librealsense
             [=]() {
                 auto z16rot = std::make_shared<rotation_transform>(RS2_FORMAT_Z16, RS2_STREAM_DEPTH, RS2_EXTENSION_DEPTH_FRAME);
                 auto y8rot = std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME);
-                auto sync = std::make_shared<syncer_process_unit>(); // is_zo_enabled_opt );
+                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // is_zo_enabled_opt );
 
                 auto cpb = std::make_shared<composite_processing_block>();
                 cpb->add(z16rot);
@@ -310,7 +310,7 @@ namespace librealsense
                 auto z16rot = std::make_shared<rotation_transform>(RS2_FORMAT_Z16, RS2_STREAM_DEPTH, RS2_EXTENSION_DEPTH_FRAME);
                 auto y8rot = std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME);
                 auto conf = std::make_shared<confidence_rotation_transform>();
-                auto sync = std::make_shared<syncer_process_unit>(); // is_zo_enabled_opt );
+                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // is_zo_enabled_opt );
 
                 auto cpb = std::make_shared<composite_processing_block>();
                 cpb->add(z16rot);

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -283,7 +283,7 @@ namespace librealsense
             [=]() {
                 auto z16rot = std::make_shared<rotation_transform>(RS2_FORMAT_Z16, RS2_STREAM_DEPTH, RS2_EXTENSION_DEPTH_FRAME);
                 auto y8rot = std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME);
-                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // is_zo_enabled_opt );
+                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // disable logging on this internal syncer
 
                 auto cpb = std::make_shared<composite_processing_block>();
                 cpb->add(z16rot);
@@ -310,7 +310,7 @@ namespace librealsense
                 auto z16rot = std::make_shared<rotation_transform>(RS2_FORMAT_Z16, RS2_STREAM_DEPTH, RS2_EXTENSION_DEPTH_FRAME);
                 auto y8rot = std::make_shared<rotation_transform>(RS2_FORMAT_Y8, RS2_STREAM_INFRARED, RS2_EXTENSION_VIDEO_FRAME);
                 auto conf = std::make_shared<confidence_rotation_transform>();
-                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // is_zo_enabled_opt );
+                auto sync = std::make_shared<syncer_process_unit>(nullptr, false); // disable logging on this internal syncer
 
                 auto cpb = std::make_shared<composite_processing_block>();
                 cpb->add(z16rot);

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -47,7 +47,11 @@ syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::pt
                     get_source().frame_ready(std::move(frame));
             }
             else
-                _matcher->dispatch( std::move( frame ), { source, matches, log } );
+            {
+                auto env = syncronization_environment{ source, matches, log };
+                _matcher->dispatch(std::move(frame), env);
+            }
+                
         }
 
         frame_holder f;

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -16,7 +16,9 @@ syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::pt
     , _enable_opts( enable_opts.begin(), enable_opts.end() )
 {
     // This callback gets called by the previous processing block when it is done with a frame. We
-    // call the matchers the frame and eventually call the next callback in the list using frame_ready().
+    // call the matchers with the frame and eventually call the next callback in the list using frame_ready().
+    // This callback can get called from multiple threads, one thread per stream -- but always in the correct
+    // frame order per stream.
     auto f = [this, log]( frame_holder frame, synthetic_source_interface * source ) {
         // if the syncer is disabled passthrough the frame
         bool enabled = false;
@@ -110,7 +112,7 @@ bool syncer_process_unit::create_matcher( const frame_holder & frame )
     }
     catch( const std::bad_weak_ptr & )
     {
-        LOG_DEBUG("Device was destryed while trying get shared ptr of it, couldn't create matcher, the frame will passthrough ");
+        LOG_DEBUG("Device was destroyed while trying get shared ptr of it, couldn't create matcher, the frame will passthrough ");
         return false;
     }
 

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -10,63 +10,98 @@
 
 namespace librealsense
 {
-    syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::ptr > enable_opts )
-        : processing_block("syncer"), _matcher((new timestamp_composite_matcher({})))
-        , _enable_opts( enable_opts.begin(), enable_opts.end() )
+syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::ptr > enable_opts,
+                                          bool log )
+    : processing_block( "syncer" )
+    , _enable_opts( enable_opts.begin(), enable_opts.end() )
+{
+    auto f = [this, log]( frame_holder frame, synthetic_source_interface * source ) {
+        // if the syncer is disabled passthrough the frame
+        bool enabled = false;
+        size_t n_opts = 0;
+        for( auto & wopt : _enable_opts )
+        {
+            auto opt = wopt.lock();
+            if( opt )
+            {
+                ++n_opts;
+                if( opt->is_true() )
+                {
+                    enabled = true;
+                    break;
+                }
+            }
+        }
+        if( n_opts && ! enabled )
+        {
+            get_source().frame_ready( std::move( frame ) );
+            return;
+        }
+
+        {
+            std::lock_guard< std::mutex > lock( _mutex );
+
+            if( _matcher == nullptr )
+            {
+                create_matcher( frame, log );
+            }
+
+            _matcher->dispatch( std::move( frame ), { source, matches, log } );
+        }
+
+        frame_holder f;
+        {
+            std::lock_guard< std::mutex > lock(callback_mutex);
+
+            while( matches.try_dequeue( &f ) )
+            {
+                get_source().frame_ready( std::move( f ) );
+            }
+        }
+    };
+
+    set_processing_callback( std::shared_ptr< rs2_frame_processor_callback >(
+        new internal_frame_processor_callback< decltype( f ) >( f ) ) );
+}
+
+void syncer_process_unit::create_matcher( const frame_holder & frame, bool log )
+{
+    auto sensor = frame.frame->get_sensor().get();
+    const device_interface * dev = nullptr;
+    try
     {
-        _matcher->set_callback([this](frame_holder f, syncronization_environment env)
+        dev = sensor->get_device().shared_from_this().get();
+    }
+    catch( const std::bad_weak_ptr & )
+    {
+        LOG_WARNING( "Device destroyed" );
+    }
+    if( dev )
+    {
+        _matcher = dev->create_matcher( frame );
+    }
+    else
+    {
+        _matcher = std::shared_ptr< matcher >( new timestamp_composite_matcher( {} ) );
+    }
+
+    _matcher->set_callback( [this, log]( frame_holder f, syncronization_environment env ) {
+        if( log )
         {
             std::stringstream ss;
             ss << "SYNCED: ";
-            auto composite = dynamic_cast<composite_frame*>(f.frame);
-            for (int i = 0; i < composite->get_embedded_frames_count(); i++)
+            auto composite = dynamic_cast< composite_frame * >( f.frame );
+            for( int i = 0; i < composite->get_embedded_frames_count(); i++ )
             {
-                auto matched = composite->get_frame(i);
-                ss << matched->get_stream()->get_stream_type() << " " << matched->get_frame_number() << ", "<<std::fixed<< matched->get_frame_timestamp()<<" ";
+                auto matched = composite->get_frame( i );
+                ss << matched->get_stream()->get_stream_type() << " " << matched->get_frame_number()
+                   << ", " << std::fixed << matched->get_frame_timestamp() << " ";
             }
 
-            LOG_DEBUG(ss.str());
-            env.matches.enqueue(std::move(f));
-        });
+            LOG_DEBUG( ss.str() );
+        }
 
-        auto f = [&](frame_holder frame, synthetic_source_interface* source)
-        {
-            // if the syncer is disabled passthrough the frame
-            bool enabled = false;
-            size_t n_opts = 0;
-            for( auto& wopt : _enable_opts )
-            {
-                auto opt = wopt.lock();
-                if( opt )
-                {
-                    ++n_opts;
-                    if( opt->is_true() )
-                    {
-                        enabled = true;
-                        break;
-                    }
-                }
-            }
-            if( n_opts  &&  ! enabled )
-            {
-                get_source().frame_ready( std::move( frame ) );
-                return;
-            }
-
-            single_consumer_frame_queue<frame_holder> matches;
-
-            {
-                std::lock_guard<std::mutex> lock(_mutex);
-                _matcher->dispatch(std::move(frame), { source, matches });
-            }
-
-            frame_holder f;
-            while (matches.try_dequeue(&f))
-                get_source().frame_ready(std::move(f));
-
-        };
-
-        set_processing_callback(std::shared_ptr<rs2_frame_processor_callback>(
-            new internal_frame_processor_callback<decltype(f)>(f)));
-    }
+        env.matches.enqueue( std::move( f ) );
+    } );
 }
+}  // namespace librealsense

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -52,7 +52,9 @@ syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::pt
 
         frame_holder f;
         {
-            std::lock_guard< std::mutex > lock(_callback_mutex);
+            std::unique_lock< std::mutex > lock(_callback_mutex, std::try_to_lock);
+            if (!lock.owns_lock())
+                return;
 
             while( matches.try_dequeue( &f ) )
             {

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -41,17 +41,18 @@ syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::pt
         {
             std::lock_guard< std::mutex > lock( _mutex );
 
-            if( _matcher == nullptr )
+            if( !_matcher )
             {
-                create_matcher( frame, log );
+                if(!create_matcher( frame, log ))
+                    get_source().frame_ready(std::move(frame));
             }
-
-            _matcher->dispatch( std::move( frame ), { source, matches, log } );
+            else
+                _matcher->dispatch( std::move( frame ), { source, matches, log } );
         }
 
         frame_holder f;
         {
-            std::lock_guard< std::mutex > lock(callback_mutex);
+            std::lock_guard< std::mutex > lock(_callback_mutex);
 
             while( matches.try_dequeue( &f ) )
             {
@@ -64,44 +65,55 @@ syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::pt
         new internal_frame_processor_callback< decltype( f ) >( f ) ) );
 }
 
-void syncer_process_unit::create_matcher( const frame_holder & frame, bool log )
+bool syncer_process_unit::create_matcher( const frame_holder & frame, bool log )
 {
-    auto sensor = frame.frame->get_sensor().get();
-    const device_interface * dev = nullptr;
     try
     {
+        auto sensor = frame.frame->get_sensor().get();
+        if (!sensor)
+        {
+            LOG_DEBUG("Sensor is not exist any more cannot create matcher the frame will passthrough ");
+            return false;
+        }
+
+        const device_interface * dev = nullptr;
         dev = sensor->get_device().shared_from_this().get();
+        if (dev)
+        {
+            _matcher = dev->create_matcher(frame);
+
+            _matcher->set_callback([this](frame_holder f, const syncronization_environment& env) {
+                if (env.log)
+                {
+                    std::stringstream ss;
+                    ss << "SYNCED: ";
+                    auto composite = dynamic_cast<composite_frame *>(f.frame);
+                    for (int i = 0; i < composite->get_embedded_frames_count(); i++)
+                    {
+                        auto matched = composite->get_frame(i);
+                        ss << matched->get_stream()->get_stream_type() << " " << matched->get_frame_number()
+                            << ", " << std::fixed << matched->get_frame_timestamp() << " ";
+                    }
+
+                    LOG_DEBUG(ss.str());
+                }
+
+                env.matches.enqueue(std::move(f));
+            });
+        }
+        else
+        {
+            LOG_DEBUG("Device is not exist any more cannot create matcher, the frame will passthrough ");
+            return false;
+        }
+
     }
     catch( const std::bad_weak_ptr & )
     {
         LOG_WARNING( "Device destroyed" );
     }
-    if( dev )
-    {
-        _matcher = dev->create_matcher( frame );
-    }
-    else
-    {
-        _matcher = std::shared_ptr< matcher >( new timestamp_composite_matcher( {} ) );
-    }
 
-    _matcher->set_callback( [this, log]( frame_holder f, syncronization_environment env ) {
-        if( log )
-        {
-            std::stringstream ss;
-            ss << "SYNCED: ";
-            auto composite = dynamic_cast< composite_frame * >( f.frame );
-            for( int i = 0; i < composite->get_embedded_frames_count(); i++ )
-            {
-                auto matched = composite->get_frame( i );
-                ss << matched->get_stream()->get_stream_type() << " " << matched->get_frame_number()
-                   << ", " << std::fixed << matched->get_frame_timestamp() << " ";
-            }
-
-            LOG_DEBUG( ss.str() );
-        }
-
-        env.matches.enqueue( std::move( f ) );
-    } );
+    return true;
+    
 }
 }  // namespace librealsense

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -45,16 +45,17 @@ syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::pt
         {
             std::lock_guard< std::mutex > lock( _mutex );
 
-            if( !_matcher )
+            if( ! _matcher )
             {
-                if(!create_matcher( frame ))
-                    get_source().frame_ready(std::move(frame));
+                if( ! create_matcher( frame ) )
+                {
+                    get_source().frame_ready( std::move( frame ) );
+                    return;
+                }
             }
-            else
-            {
-                auto env = syncronization_environment{ source, _matches, log };
-                _matcher->dispatch(std::move(frame), env);
-            }
+
+            auto env = syncronization_environment{ source, _matches, log };
+            _matcher->dispatch( std::move( frame ), env );
         }
 
         frame_holder f;
@@ -67,6 +68,7 @@ syncer_process_unit::syncer_process_unit( std::initializer_list< bool_option::pt
 
             while( _matches.try_dequeue( &f ) )
             {
+                LOG_DEBUG("dequeue: " << frame_to_string(f));
                 get_source().frame_ready( std::move( f ) );
             }
         }

--- a/src/proc/syncer-processing-block.h
+++ b/src/proc/syncer-processing-block.h
@@ -41,6 +41,5 @@ namespace librealsense
 
         single_consumer_frame_queue<frame_holder> matches;
         std::mutex _callback_mutex;
-        bool _log;
     };
 }

--- a/src/proc/syncer-processing-block.h
+++ b/src/proc/syncer-processing-block.h
@@ -19,10 +19,10 @@ namespace librealsense
     class syncer_process_unit : public processing_block
     {
     public:
-        syncer_process_unit( std::initializer_list< bool_option::ptr > enable_opts );
+        syncer_process_unit(std::initializer_list< bool_option::ptr > enable_opts, bool log = true);
 
-        syncer_process_unit( bool_option::ptr is_enabled_opt = nullptr )
-            : syncer_process_unit( { is_enabled_opt } ) {}
+        syncer_process_unit( bool_option::ptr is_enabled_opt = nullptr, bool log = true)
+            : syncer_process_unit( { is_enabled_opt }, log) {}
 
         void add_enabling_option( bool_option::ptr is_enabled_opt )
         {
@@ -34,7 +34,13 @@ namespace librealsense
             _matcher.reset();
         }
     private:
-        std::unique_ptr<timestamp_composite_matcher> _matcher;
+        void create_matcher(const frame_holder& frame, bool log = true);
+
+        std::shared_ptr<matcher> _matcher;
         std::vector< std::weak_ptr<bool_option> > _enable_opts;
+
+        single_consumer_frame_queue<frame_holder> matches;
+        std::mutex callback_mutex;
+        bool _log;
     };
 }

--- a/src/proc/syncer-processing-block.h
+++ b/src/proc/syncer-processing-block.h
@@ -34,12 +34,12 @@ namespace librealsense
             _matcher.reset();
         }
     private:
-        bool create_matcher(const frame_holder& frame, bool log = true);
+        bool create_matcher(const frame_holder& frame);
 
         std::shared_ptr<matcher> _matcher;
         std::vector< std::weak_ptr<bool_option> > _enable_opts;
 
-        single_consumer_frame_queue<frame_holder> matches;
+        single_consumer_frame_queue<frame_holder> _matches;
         std::mutex _callback_mutex;
     };
 }

--- a/src/proc/syncer-processing-block.h
+++ b/src/proc/syncer-processing-block.h
@@ -34,13 +34,13 @@ namespace librealsense
             _matcher.reset();
         }
     private:
-        void create_matcher(const frame_holder& frame, bool log = true);
+        bool create_matcher(const frame_holder& frame, bool log = true);
 
         std::shared_ptr<matcher> _matcher;
         std::vector< std::weak_ptr<bool_option> > _enable_opts;
 
         single_consumer_frame_queue<frame_holder> matches;
-        std::mutex callback_mutex;
+        std::mutex _callback_mutex;
         bool _log;
     };
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -9,29 +9,6 @@ namespace librealsense
 {
     const int MAX_GAP = 1000;
 
-    std::string frame_to_string(const frame_holder& f)
-    {
-        std::ostringstream s;
-        auto composite = dynamic_cast<composite_frame*>(f.frame);
-        if(composite)
-        {
-            for (int i = 0; i < composite->get_embedded_frames_count(); i++)
-            {
-                auto frame = composite->get_frame(i);
-                s << frame->get_stream()->get_stream_type()<<" "<<frame->get_frame_number()<<" "<<std::fixed << frame->get_frame_timestamp()<<" ";
-            }
-        }
-        else
-        {
-            s << f->get_stream()->get_stream_type();
-            s << " " << f->get_stream()->get_unique_id();
-            s << " " << f->get_frame_number();
-            s << " " << std::fixed << (double)f->get_frame_timestamp();
-            s << " ";
-        }
-        return s.str();
-    }
-
 #define LOG_IF_ENABLE( OSTREAM, ENV ) \
     while( ENV.log ) \
     { \
@@ -168,12 +145,8 @@ namespace librealsense
 
     std::shared_ptr<matcher> composite_matcher::find_matcher(const frame_holder& frame)
     {
-        std::shared_ptr<matcher> matcher;
         auto stream_id = frame.frame->get_stream()->get_unique_id();
-        auto stream_type = frame.frame->get_stream()->get_stream_type();
-
-        auto dev_exist = false;
-        matcher = _matchers[stream_id];
+        auto matcher = _matchers[stream_id];
 
         if (!matcher->get_active())
         {
@@ -559,5 +532,29 @@ namespace librealsense
     {
         LOG_DEBUG("by_pass_composite_matcher: " << _name << " " << frame_to_string(f));
         _callback(std::move(f), env);
+    }
+    std::string frame_to_string(const frame_holder & f)
+    {
+        {
+            std::ostringstream s;
+            auto composite = dynamic_cast<composite_frame*>(f.frame);
+            if (composite)
+            {
+                for (int i = 0; i < composite->get_embedded_frames_count(); i++)
+                {
+                    auto frame = composite->get_frame(i);
+                    s << frame->get_stream()->get_stream_type() << " " << frame->get_frame_number() << " " << std::fixed << frame->get_frame_timestamp() << " ";
+                }
+            }
+            else
+            {
+                s << f->get_stream()->get_stream_type();
+                s << " " << f->get_stream()->get_unique_id();
+                s << " " << f->get_frame_number();
+                s << " " << std::fixed << (double)f->get_frame_timestamp();
+                s << " ";
+            }
+            return s.str();
+        }
     }
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -533,28 +533,28 @@ namespace librealsense
         LOG_DEBUG("by_pass_composite_matcher: " << _name << " " << frame_to_string(f));
         _callback(std::move(f), env);
     }
-    std::string frame_to_string(const frame_holder & f)
+
+    std::string frame_to_string( const frame_holder & f )
     {
+        std::ostringstream s;
+        auto composite = dynamic_cast< composite_frame * >( f.frame );
+        if( composite )
         {
-            std::ostringstream s;
-            auto composite = dynamic_cast<composite_frame*>(f.frame);
-            if (composite)
+            for( int i = 0; i < composite->get_embedded_frames_count(); i++ )
             {
-                for (int i = 0; i < composite->get_embedded_frames_count(); i++)
-                {
-                    auto frame = composite->get_frame(i);
-                    s << frame->get_stream()->get_stream_type() << " " << frame->get_frame_number() << " " << std::fixed << frame->get_frame_timestamp() << " ";
-                }
+                auto frame = composite->get_frame( i );
+                s << frame->get_stream()->get_stream_type() << " " << frame->get_frame_number()
+                  << " " << std::fixed << frame->get_frame_timestamp() << " ";
             }
-            else
-            {
-                s << f->get_stream()->get_stream_type();
-                s << " " << f->get_stream()->get_unique_id();
-                s << " " << f->get_frame_number();
-                s << " " << std::fixed << (double)f->get_frame_timestamp();
-                s << " ";
-            }
-            return s.str();
         }
+        else
+        {
+            s << f->get_stream()->get_stream_type();
+            s << " " << f->get_stream()->get_unique_id();
+            s << " " << f->get_frame_number();
+            s << " " << std::fixed << (double)f->get_frame_timestamp();
+            s << " ";
+        }
+        return s.str();
     }
-}
+}  // namespace librealsense

--- a/src/sync.h
+++ b/src/sync.h
@@ -59,6 +59,7 @@ namespace librealsense
         synthetic_source_interface* source;
         //sync_lock& lock_ref;
         single_consumer_frame_queue<frame_holder>& matches;
+        bool log;
     };
 
     typedef int stream_id;
@@ -117,7 +118,7 @@ namespace librealsense
 
         virtual bool are_equivalent(frame_holder& a, frame_holder& b) = 0;
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) = 0;
-        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) = 0;
+        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) = 0;
         virtual void clean_inactive_streams(frame_holder& f) = 0;
         virtual void update_last_arrived(frame_holder& f, matcher* m) = 0;
 
@@ -144,7 +145,7 @@ namespace librealsense
         void sync(frame_holder f, syncronization_environment env) override;
         virtual bool are_equivalent(frame_holder& a, frame_holder& b) override { return false; }
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) override { return false; }
-        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) override { return false; }
+        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) override { return false; }
         virtual void clean_inactive_streams(frame_holder& f) override {}
         virtual void update_last_arrived(frame_holder& f, matcher* m) override {}
 
@@ -159,7 +160,7 @@ namespace librealsense
         virtual void update_last_arrived(frame_holder& f, matcher* m) override;
         bool are_equivalent(frame_holder& a, frame_holder& b) override;
         bool is_smaller_than(frame_holder& a, frame_holder& b) override;
-        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) override;
+        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) override;
         void clean_inactive_streams(frame_holder& f) override;
         void update_next_expected(const frame_holder& f) override;
 
@@ -175,7 +176,7 @@ namespace librealsense
         bool is_smaller_than(frame_holder& a, frame_holder& b) override;
         virtual void update_last_arrived(frame_holder& f, matcher* m) override;
         void clean_inactive_streams(frame_holder& f) override;
-        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing) override;
+        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) override;
         void update_next_expected(const frame_holder & f) override;
 
     private:

--- a/src/sync.h
+++ b/src/sync.h
@@ -16,6 +16,8 @@ namespace librealsense
 
     typedef int stream_id;
 
+    std::string frame_to_string(const frame_holder& f);
+
     class sync_lock
     {
     public:

--- a/src/sync.h
+++ b/src/sync.h
@@ -59,17 +59,17 @@ namespace librealsense
         synthetic_source_interface* source;
         //sync_lock& lock_ref;
         single_consumer_frame_queue<frame_holder>& matches;
-        bool log;
+        bool log = true;
     };
 
     typedef int stream_id;
-    typedef std::function<void(frame_holder, syncronization_environment)> sync_callback;
+    typedef std::function<void(frame_holder, const syncronization_environment&)> sync_callback;
 
     class matcher_interface
     {
     public:
-        virtual void dispatch(frame_holder f, syncronization_environment env) = 0;
-        virtual void sync(frame_holder f, syncronization_environment env) = 0;
+        virtual void dispatch(frame_holder f, const syncronization_environment& env) = 0;
+        virtual void sync(frame_holder f, const syncronization_environment& env) = 0;
         virtual void set_callback(sync_callback f) = 0;
         virtual const std::vector<stream_id>& get_streams() const = 0;
         virtual const std::vector<rs2_stream>& get_streams_types() const = 0;
@@ -80,7 +80,7 @@ namespace librealsense
     {
     public:
         matcher(std::vector<stream_id> streams_id = {});
-        virtual void sync(frame_holder f, syncronization_environment env) override;
+        virtual void sync(frame_holder f, const syncronization_environment& env) override;
         virtual void set_callback(sync_callback f) override;
         const std::vector<stream_id>& get_streams() const override;
         const std::vector<rs2_stream>& get_streams_types() const override;
@@ -106,7 +106,7 @@ namespace librealsense
     public:
         identity_matcher(stream_id stream, rs2_stream streams_type);
 
-        void dispatch(frame_holder f, syncronization_environment env) override;
+        void dispatch(frame_holder f, const syncronization_environment& env) override;
 
     };
 
@@ -118,13 +118,13 @@ namespace librealsense
 
         virtual bool are_equivalent(frame_holder& a, frame_holder& b) = 0;
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) = 0;
-        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) = 0;
+        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, const syncronization_environment& env) = 0;
         virtual void clean_inactive_streams(frame_holder& f) = 0;
         virtual void update_last_arrived(frame_holder& f, matcher* m) = 0;
 
-        void dispatch(frame_holder f, syncronization_environment env) override;
+        void dispatch(frame_holder f, const syncronization_environment& env) override;
         std::string frames_to_string(std::vector<librealsense::matcher*> matchers);
-        void sync(frame_holder f, syncronization_environment env) override;
+        void sync(frame_holder f, const syncronization_environment& env) override;
         std::shared_ptr<matcher> find_matcher(const frame_holder& f);
 
     protected:
@@ -142,10 +142,10 @@ namespace librealsense
     public:
         composite_identity_matcher(std::vector<std::shared_ptr<matcher>> matchers);
 
-        void sync(frame_holder f, syncronization_environment env) override;
+        void sync(frame_holder f, const syncronization_environment& env) override;
         virtual bool are_equivalent(frame_holder& a, frame_holder& b) override { return false; }
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) override { return false; }
-        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) override { return false; }
+        virtual bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, const syncronization_environment& env) override { return false; }
         virtual void clean_inactive_streams(frame_holder& f) override {}
         virtual void update_last_arrived(frame_holder& f, matcher* m) override {}
 
@@ -160,7 +160,7 @@ namespace librealsense
         virtual void update_last_arrived(frame_holder& f, matcher* m) override;
         bool are_equivalent(frame_holder& a, frame_holder& b) override;
         bool is_smaller_than(frame_holder& a, frame_holder& b) override;
-        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) override;
+        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, const syncronization_environment& env) override;
         void clean_inactive_streams(frame_holder& f) override;
         void update_next_expected(const frame_holder& f) override;
 
@@ -176,7 +176,7 @@ namespace librealsense
         bool is_smaller_than(frame_holder& a, frame_holder& b) override;
         virtual void update_last_arrived(frame_holder& f, matcher* m) override;
         void clean_inactive_streams(frame_holder& f) override;
-        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, syncronization_environment env) override;
+        bool skip_missing_stream(std::vector<matcher*> synced, matcher* missing, const syncronization_environment& env) override;
         void update_next_expected(const frame_holder & f) override;
 
     private:

--- a/src/sync.h
+++ b/src/sync.h
@@ -56,9 +56,17 @@ namespace librealsense
 
     struct syncronization_environment
     {
-        synthetic_source_interface* source;
-        //sync_lock& lock_ref;
-        single_consumer_frame_queue<frame_holder>& matches;
+        syncronization_environment( synthetic_source_interface * source,
+                                    single_consumer_frame_queue< frame_holder >& matches,
+                                    bool log )
+            : source( source )
+            , matches( matches )
+            , log( log )
+        {
+        }
+        synthetic_source_interface * source;
+        // sync_lock& lock_ref;
+        single_consumer_frame_queue< frame_holder > & matches;
         bool log = true;
     };
 


### PR DESCRIPTION
1. fixed l500 matcher hierarchy (remove timestamp_composite_matcher as root above device-generated matcher)
2.  Added mutex to protect try_dequeue and calling to callback
3. added log parameter to syncer

Tracked on: RS5-10200