### PR TITLE
Use standard cast syntax to cast to float

### DIFF
--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -219,7 +219,7 @@ static void rs2_project_color_pixel_to_depth_pixel(float to_pixel[2],
         rs2_transform_point_to_point(transformed_point, depth_to_color, point);
         rs2_project_point_to_pixel(projected_pixel, color_intrin, transformed_point);
 
-        float new_dist = float(pow((projected_pixel[1] - from_pixel[1]), 2) + pow((projected_pixel[0] - from_pixel[0]), 2));
+        float new_dist = (float)(pow((projected_pixel[1] - from_pixel[1]), 2) + pow((projected_pixel[0] - from_pixel[0]), 2));
         if (new_dist < min_dist || min_dist < 0)
         {
             min_dist = new_dist;


### PR DESCRIPTION
This change was supposedly done to reduce / remove the number of warnings, but ended up breaking our Rust bindings to librealsense2 (bindgen is expecting an expression which isn't there). See [our realsense-rust fork](https://github.com/Tangram-Vision/realsense-rust) if you're looking for the specific error when building against the official 2.42 release.