### PR TITLE
Update python package descriptors for python 3.8 + 3.9

### DIFF
--- a/wrappers/python/readme.md
+++ b/wrappers/python/readme.md
@@ -20,7 +20,7 @@ Package is available at https://pypi.python.org/pypi/pyrealsense2
 To install the package, run:
 > `pip install pyrealsense2`
 
-Windows users can install the RealSense SDK 2.0 from the release tab to get pre-compiled binaries of the wrapper, for both x86 and x64 architectures. (Both Python 2.7 and Python 3 are supported).
+Windows users can install the RealSense SDK 2.0 from the release tab to get pre-compiled binaries of the wrapper, for both x86 and x64 architectures. (Both Python 2.7 and Python 3 (3.6, 3.7, 3.8, 3.9) are supported).
 
 
 ## Building From Source

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -63,6 +63,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Multimedia :: Video',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Human Machine Interfaces',

--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -59,8 +59,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Package classifiers updated to support python 3.8 + 3.9

[DSO-16485]
![image](https://user-images.githubusercontent.com/64067618/108625758-4bf01700-7455-11eb-8f65-3925e4a02399.png)
