### PR TITLE
Update repository server

### DIFF
--- a/CMake/connectivity_check.cmake
+++ b/CMake/connectivity_check.cmake
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 message(STATUS "Checking internet connection...")
-file(DOWNLOAD "http://realsense-hw-public.s3-eu-west-1.amazonaws.com/Releases/connectivity_check" "${CMAKE_CURRENT_SOURCE_DIR}/connectivity_check" SHOW_PROGRESS TIMEOUT 5 STATUS status)
+file(DOWNLOAD "http://librealsense.intel.com/Releases/connectivity_check" "${CMAKE_CURRENT_SOURCE_DIR}/connectivity_check" SHOW_PROGRESS TIMEOUT 5 STATUS status)
 list (FIND status "\"No error\"" _index)
 if (${_index} EQUAL -1)
     message(STATUS "Failed to identify Internet connection")

--- a/CMake/connectivity_check.cmake
+++ b/CMake/connectivity_check.cmake
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 message(STATUS "Checking internet connection...")
-file(DOWNLOAD "http://librealsense.intel.com/Releases/connectivity_check" "${CMAKE_CURRENT_SOURCE_DIR}/connectivity_check" SHOW_PROGRESS TIMEOUT 5 STATUS status)
+file(DOWNLOAD "https://librealsense.intel.com/Releases/connectivity_check" "${CMAKE_CURRENT_SOURCE_DIR}/connectivity_check" SHOW_PROGRESS TIMEOUT 5 STATUS status)
 list (FIND status "\"No error\"" _index)
 if (${_index} EQUAL -1)
     message(STATUS "Failed to identify Internet connection")

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -81,7 +81,7 @@ inline ImVec4 blend(const ImVec4& c, float a)
 
 namespace rs2
 {
-    constexpr const char* server_versions_db_url = "http://realsense-hw-public.s3-eu-west-1.amazonaws.com/Releases/rs_versions_db.json";
+    constexpr const char* server_versions_db_url = "http://librealsense.intel.com/Releases/rs_versions_db.json";
     
     void prepare_config_file();
 

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -81,7 +81,7 @@ inline ImVec4 blend(const ImVec4& c, float a)
 
 namespace rs2
 {
-    constexpr const char* server_versions_db_url = "http://librealsense.intel.com/Releases/rs_versions_db.json";
+    constexpr const char* server_versions_db_url = "http://realsense-hw-public.s3-eu-west-1.amazonaws.com/Releases/rs_versions_db.json";
     
     void prepare_config_file();
 

--- a/doc/distribution_linux.md
+++ b/doc/distribution_linux.md
@@ -21,11 +21,11 @@ In case the public key still cannot be retrieved, check and specify proxy settin
 
 - Add the server to the list of repositories:  
   Ubuntu 16 LTS:  
-`sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main" -u`  
+`sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo xenial main" -u`  
   Ubuntu 18 LTS:  
-`sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo bionic main" -u`  
+`sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo bionic main" -u`  
   Ubuntu 20 LTS:  
-`sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo focal main" -u`
+`sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo focal main" -u`
 
 - Install the libraries (see section below if upgrading packages):  
   `sudo apt-get install librealsense2-dkms`  

--- a/doc/distribution_linux.md
+++ b/doc/distribution_linux.md
@@ -21,11 +21,11 @@ In case the public key still cannot be retrieved, check and specify proxy settin
 
 - Add the server to the list of repositories:  
   Ubuntu 16 LTS:  
-`sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo xenial main" -u`  
+`sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo xenial main" -u`  
   Ubuntu 18 LTS:  
-`sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo bionic main" -u`  
+`sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo bionic main" -u`  
   Ubuntu 20 LTS:  
-`sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo focal main" -u`
+`sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo focal main" -u`
 
 - Install the libraries (see section below if upgrading packages):  
   `sudo apt-get install librealsense2-dkms`  

--- a/doc/installation_jetson.md
+++ b/doc/installation_jetson.md
@@ -54,12 +54,12 @@ Note that this method provides binary installation compiled using the `-DFORCE_R
 
   * Ubuntu 16:  
   ```
-  sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo xenial main" -u
+  sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo xenial main" -u
   ```
 
   * Ubuntu 18:
   ```
-  sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo bionic main" -u
+  sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo bionic main" -u
   ```
 
   3. Install the SDK:

--- a/doc/installation_jetson.md
+++ b/doc/installation_jetson.md
@@ -54,12 +54,12 @@ Note that this method provides binary installation compiled using the `-DFORCE_R
 
   * Ubuntu 16:  
   ```
-  sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo xenial main" -u
+  sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo xenial main" -u
   ```
 
   * Ubuntu 18:
   ```
-  sudo add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo bionic main" -u
+  sudo add-apt-repository "deb http://librealsense.intel.com/Debian/apt-repo bionic main" -u
   ```
 
   3. Install the SDK:

--- a/wrappers/tensorflow/README.md
+++ b/wrappers/tensorflow/README.md
@@ -211,7 +211,7 @@ When we upsample we get the lost information back (by the concatenation process)
 so we can see last-layer features in the perspective of the layer above them.
 		
 #### Training Dataset
-Download [part 1](https://librealsense.intel.com/rs-tests/ML/Depth_Learning/Dataset/part1_1_4000.zip) and [part 2](http://librealsense.intel.com/rs-tests/ML/Depth_Learning/Dataset/part2_4001_8375.zip) of the dataset. It contains 4 types of 848x480 images in uncompressed PNG format: 
+Download [part 1](https://librealsense.intel.com/rs-tests/ML/Depth_Learning/Dataset/part1_1_4000.zip) and [part 2](https://librealsense.intel.com/rs-tests/ML/Depth_Learning/Dataset/part2_4001_8375.zip) of the dataset. It contains 4 types of 848x480 images in uncompressed PNG format: 
 
 ###### 1. Simulated Left Infrared:
 - Synthetic view from left infrared sensor of the virtual camera, including infrared projection pattern

--- a/wrappers/tensorflow/README.md
+++ b/wrappers/tensorflow/README.md
@@ -211,7 +211,7 @@ When we upsample we get the lost information back (by the concatenation process)
 so we can see last-layer features in the perspective of the layer above them.
 		
 #### Training Dataset
-Download [part 1](https://librealsense.intel.com/rs-tests/ML/Depth_Learning/Dataset/part1_1_4000.zip) and [part 2](http://realsense-hw-public.s3.eu-west-1.amazonaws.com/rs-tests/ML/Depth_Learning/Dataset/part2_4001_8375.zip) of the dataset. It contains 4 types of 848x480 images in uncompressed PNG format: 
+Download [part 1](https://librealsense.intel.com/rs-tests/ML/Depth_Learning/Dataset/part1_1_4000.zip) and [part 2](http://librealsense.intel.com/rs-tests/ML/Depth_Learning/Dataset/part2_4001_8375.zip) of the dataset. It contains 4 types of 848x480 images in uncompressed PNG format: 
 
 ###### 1. Simulated Left Infrared:
 - Synthetic view from left infrared sensor of the virtual camera, including infrared projection pattern


### PR DESCRIPTION
replaced realsense-hw-public.s3.amazonaws.com and realsense-hw-publics3-eu-west-1.amazonaws.com addresses with librealsense.intel.com

Installation tested on Ubuntu 16.04, 18.04, 20.04
Tracked on: DSO-16482