### PR TITLE
Fixed frame drops on pipeline + syncer usage when using streams with different FPS

### DIFF
--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -600,7 +600,7 @@ namespace rs2
         /**
         * Sync instance to align frames from different streams
         */
-        syncer(int queue_size = 1)
+        syncer(int queue_size = 10)
             :_results(queue_size)
         {
             _sync.start(_results);

--- a/src/pipeline/aggregator.cpp
+++ b/src/pipeline/aggregator.cpp
@@ -11,7 +11,7 @@ namespace librealsense
     {
         aggregator::aggregator(const std::vector<int>& streams_to_aggregate, const std::vector<int>& streams_to_sync) :
             processing_block("aggregator"),
-            _queue(new single_consumer_frame_queue<frame_holder>(1)),
+            _queue(new single_consumer_frame_queue<frame_holder>(10)),
             _streams_to_aggregate_ids(streams_to_aggregate),
             _streams_to_sync_ids(streams_to_sync),
             _accepting(true)

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -431,13 +431,12 @@ namespace librealsense
 
     unsigned int timestamp_composite_matcher::get_fps(const frame_holder & f)
     {
-        uint32_t fps = 0;
+        uint32_t fps = f.frame->get_stream()->get_framerate();
         if(f.frame->supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
         {
             fps = (uint32_t)f.frame->get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
         }
-        LOG_DEBUG("fps " <<fps<<" "<< frame_to_string(const_cast<frame_holder&>(f)));
-        return fps?fps:f.frame->get_stream()->get_framerate();
+        return fps;
     }
 
     void timestamp_composite_matcher::update_next_expected(const frame_holder & f)

--- a/unit-tests/func/frame-drops/test-frames-drops.py
+++ b/unit-tests/func/frame-drops/test-frames-drops.py
@@ -1,0 +1,164 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
+""" 
+The following tests check for frame drops when we use several streams with different frame rate (FPS).
+Each frame has it's own latency, the syncer and the pipeline should be able to handle all frames with no frame drops.
+"""
+
+import pyrealsense2 as rs
+from rspy import test
+from rspy.timer import Timer
+import time
+
+WAIT_FOR_FRAMES_TIME = 20 #[sec]
+
+dev = test.find_first_device_or_exit()
+
+depth_sensor = dev.first_depth_sensor()
+color_sensor = dev.first_color_sensor()
+
+previous_depth_frame_number = -1
+previous_color_frame_number = -1
+
+wait_frames_timer = Timer(WAIT_FOR_FRAMES_TIME)
+
+def check_depth_frame_drops(frame):
+    global previous_depth_frame_number
+    test.check_frame_drops(frame, previous_depth_frame_number, 0)
+    previous_depth_frame_number = frame.get_frame_number()
+
+def check_color_frame_drops(frame):
+    global previous_color_frame_number
+    test.check_frame_drops(frame, previous_color_frame_number, 0)
+    previous_color_frame_number = frame.get_frame_number()
+
+
+# Use a profiles with different FPS
+high_fps_depth_profile = next(p for p in
+                depth_sensor.profiles if p.fps() == 30
+                and p.stream_type() == rs.stream.depth
+                and p.format() == rs.format.z16)
+
+low_fps_color_profile = next(p for p in color_sensor.profiles if p.fps() == 6
+                and p.stream_type() == rs.stream.color
+                and p.format() == rs.format.rgb8)
+                
+#############################################################################################
+# Test #1
+
+test.start("Checking for frame drops when using sensor API")
+
+depth_sensor.open( high_fps_depth_profile )
+depth_sensor.start( check_depth_frame_drops )
+
+color_sensor.open( low_fps_color_profile )
+color_sensor.start( check_color_frame_drops )
+
+time.sleep(WAIT_FOR_FRAMES_TIME)
+
+# Check that we received frames
+test.check(previous_depth_frame_number > 0)
+test.check(previous_color_frame_number > 0)
+
+depth_sensor.stop()
+depth_sensor.close()
+
+color_sensor.stop()
+color_sensor.close()
+
+test.finish()
+
+#############################################################################################
+time.sleep(3) # allow some time for the sensor to closed before starting next test 
+#############################################################################################
+
+# Test #2
+
+test.start("Checking for frame drops when using sensor + syncer API")
+
+previous_depth_frame_number = -1
+previous_color_frame_number = -1
+
+syncer = rs.syncer()
+
+depth_sensor.open( high_fps_depth_profile )
+depth_sensor.start( syncer )
+
+color_sensor.open( low_fps_color_profile )
+color_sensor.start( syncer )
+
+frame = syncer.wait_for_frames()
+wait_frames_timer.start()
+
+while not wait_frames_timer.has_expired():
+    frame = syncer.wait_for_frames()
+    
+    depth_frame = frame.get_depth_frame()
+    color_frame = frame.get_color_frame()
+    
+    # The syncer can output only 1 frame (and not a frameset) if it wasn't synced
+    if depth_frame:
+        test.check_frame_drops(depth_frame, previous_depth_frame_number, 0, True)
+        previous_depth_frame_number = depth_frame.get_frame_number()
+
+    if color_frame:
+        test.check_frame_drops(color_frame, previous_color_frame_number, 0, True)
+        previous_color_frame_number = color_frame.get_frame_number()
+
+# Check that we received frames
+test.check(previous_depth_frame_number > 0)
+test.check(previous_color_frame_number > 0)
+
+depth_sensor.stop()
+depth_sensor.close()
+
+color_sensor.stop()
+color_sensor.close()
+
+test.finish()
+
+#############################################################################################
+time.sleep(3) # allow some time for the sensor to closed before starting next test 
+#############################################################################################
+
+# Test #3
+
+test.start("Checking for frame drops when using pipeline API")
+
+previous_depth_frame_number = -1
+previous_color_frame_number = -1
+
+pipeline = rs.pipeline()
+config = rs.config()
+
+config.enable_stream(rs.stream.depth, rs.format.z16, 30)
+config.enable_stream(rs.stream.color, rs.format.rgb8, 6)
+
+pipeline.start(config)
+
+frame = pipeline.wait_for_frames()
+
+wait_frames_timer.start()
+
+while not wait_frames_timer.has_expired():
+
+    frame = pipeline.wait_for_frames()
+    
+    # The pipeline always returns a frameset
+    test.check_frame_drops(frame.get_depth_frame(), previous_depth_frame_number, 0, True)
+    test.check_frame_drops(frame.get_color_frame(), previous_color_frame_number, 0, True)
+    
+    previous_depth_frame_number = frame.get_depth_frame().get_frame_number()
+    previous_color_frame_number = frame.get_color_frame().get_frame_number()
+
+# Check that we received frames
+test.check(previous_depth_frame_number > 0)
+test.check(previous_color_frame_number > 0)
+
+pipeline.stop()
+
+test.finish()
+#############################################################################################
+
+test.print_results_and_exit()

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -234,7 +234,7 @@ def check_exception(exception, expected_type, expected_msg = None, abort_if_fail
     reset_info()
     return True
 
-def check_frame_drops(frame, previous_frame_number, allowed_drops = 1):
+def check_frame_drops(frame, previous_frame_number, allowed_drops = 1, allowed_repeated = False):
     """
     Used for checking frame drops while streaming
     :param frame: Current frame being checked
@@ -252,7 +252,7 @@ def check_frame_drops(frame, previous_frame_number, allowed_drops = 1):
         if dropped_frames > allowed_drops:
             print( dropped_frames, "frame(s) starting from frame", previous_frame_number + 1, "were dropped" )
             failed = True
-        if dropped_frames < 0:
+        if dropped_frames < 0 and not allowed_repeated:
             print( "Frames repeated or out of order. Got frame", frame_number, "after frame",
                    previous_frame_number)
             failed = True

--- a/wrappers/python/pyrs_processing.cpp
+++ b/wrappers/python/pyrs_processing.cpp
@@ -100,7 +100,7 @@ void init_processing(py::module &m) {
     // rs2::asynchronous_syncer
 
     py::class_<rs2::syncer> syncer(m, "syncer", "Sync instance to align frames from different streams");
-    syncer.def(py::init<int>(), "queue_size"_a = 1)
+    syncer.def(py::init<int>(), "queue_size"_a = 10)
         .def("wait_for_frames", &rs2::syncer::wait_for_frames, "Wait until a coherent set "
              "of frames becomes available", "timeout_ms"_a = 5000, py::call_guard<py::gil_scoped_release>())
         .def("poll_for_frames", [](const rs2::syncer &self) {


### PR DESCRIPTION
When syncing streams with different frame rate the higher frame rate frames are dropped between each sync.

Here we increase the queue so the user will get all frames and can decide what to do with them on his side.

Changes:
1. Pipeline aggregator queue size increased to 10
2. Syncer processing block queue size increased to 10
3. Added unit tests for frame drops




Tracked on [RS5-8940]