### PR TITLE
Video profile eq

### DIFF
--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -244,6 +244,13 @@ namespace rs2
             return intr;
         }
 
+        bool operator==(const video_stream_profile& other) const
+        {
+            return (((stream_profile&)*this)==other && 
+                    width() == other.width() &&
+                    height() == other.height());
+        }
+
         using stream_profile::clone;
 
         /**

--- a/unit-tests/types/test-profile-eq.cpp
+++ b/unit-tests/types/test-profile-eq.cpp
@@ -9,16 +9,18 @@ using namespace rs2;
 
 TEST_CASE("test video_stream_profile operator==", "[live]")
 {
+    // Test that for 2 video_stream_profile objects, if width and height are different
+    // then, video_stream_profile.operator== returns false.
+
     auto devices = find_devices_by_product_line_or_exit(RS2_PRODUCT_LINE_ANY_INTEL);
     auto dev = devices[0];
 
     auto depth_sens = dev.first< rs2::depth_sensor >();
 
-    REQUIRE_NOTHROW(depth_sens.set_option(RS2_OPTION_EMITTER_ON_OFF, 1));
-
     stream_profile profile0, profile1;
     std::vector< stream_profile > stream_profiles;
     REQUIRE_NOTHROW(stream_profiles = depth_sens.get_stream_profiles());
+    REQUIRE_NOTHROW(stream_profiles.size() > 1);
     profile0 = stream_profiles[0];
     video_stream_profile vprofile0 = profile0.as<video_stream_profile>();
 
@@ -27,11 +29,13 @@ TEST_CASE("test video_stream_profile operator==", "[live]")
         if (profile == profile0)
         {
             video_stream_profile vprofile = profile.as<video_stream_profile>();
-            if (vprofile0.width() != vprofile.width() ||
-                vprofile0.height() != vprofile.height())
+            if (vprofile0.width() == vprofile.width() &&
+                vprofile0.height() == vprofile.height())
             {
-                //std::cout << "compare: " << vprofile0.stream_type() << "(" << vprofile0.stream_index() << "):" << vprofile0.width() << "x" << vprofile0.height() << " with:" <<
-                //    vprofile.stream_type() << "(" << vprofile.stream_index() << "):" << vprofile.width() << "x" << vprofile.height() << std::endl;
+                REQUIRE(vprofile0 == vprofile);
+            }
+            else
+            {
                 REQUIRE(!(vprofile0 == vprofile));
             }
         }

--- a/unit-tests/types/test-profile-eq.cpp
+++ b/unit-tests/types/test-profile-eq.cpp
@@ -12,7 +12,7 @@ TEST_CASE("test video_stream_profile operator==", "[live]")
     // Test that for 2 video_stream_profile objects, if width and height are different
     // then, video_stream_profile.operator== returns false.
 
-    auto devices = find_devices_by_product_line_or_exit(RS2_PRODUCT_LINE_ANY_INTEL);
+    auto devices = find_devices_by_product_line_or_exit(RS2_PRODUCT_LINE_DEPTH);
     if (devices.size() == 0) return;
     auto dev = devices[0];
 

--- a/unit-tests/types/test-profile-eq.cpp
+++ b/unit-tests/types/test-profile-eq.cpp
@@ -13,6 +13,7 @@ TEST_CASE("test video_stream_profile operator==", "[live]")
     // then, video_stream_profile.operator== returns false.
 
     auto devices = find_devices_by_product_line_or_exit(RS2_PRODUCT_LINE_ANY_INTEL);
+    if (devices.size() == 0) return;
     auto dev = devices[0];
 
     auto depth_sens = dev.first< rs2::depth_sensor >();
@@ -20,12 +21,19 @@ TEST_CASE("test video_stream_profile operator==", "[live]")
     stream_profile profile0, profile1;
     std::vector< stream_profile > stream_profiles;
     REQUIRE_NOTHROW(stream_profiles = depth_sens.get_stream_profiles());
-    REQUIRE_NOTHROW(stream_profiles.size() > 1);
-    profile0 = stream_profiles[0];
+    for (auto profile : stream_profiles)
+    {
+        if (profile.is<video_stream_profile>())
+        {
+            profile0 = profile;
+        }
+    }
+    if (!profile0) return;
     video_stream_profile vprofile0 = profile0.as<video_stream_profile>();
 
     for (auto profile : stream_profiles)
     {
+        if (!profile.is<video_stream_profile>()) continue;
         if (profile == profile0)
         {
             video_stream_profile vprofile = profile.as<video_stream_profile>();

--- a/unit-tests/types/test-profile-eq.cpp
+++ b/unit-tests/types/test-profile-eq.cpp
@@ -1,0 +1,39 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include "../func/func-common.h"
+#include "../../include/librealsense2/hpp/rs_frame.hpp"
+#include <iostream>
+
+using namespace rs2;
+
+TEST_CASE("test video_stream_profile operator==", "[live]")
+{
+    auto devices = find_devices_by_product_line_or_exit(RS2_PRODUCT_LINE_ANY_INTEL);
+    auto dev = devices[0];
+
+    auto depth_sens = dev.first< rs2::depth_sensor >();
+
+    REQUIRE_NOTHROW(depth_sens.set_option(RS2_OPTION_EMITTER_ON_OFF, 1));
+
+    stream_profile profile0, profile1;
+    std::vector< stream_profile > stream_profiles;
+    REQUIRE_NOTHROW(stream_profiles = depth_sens.get_stream_profiles());
+    profile0 = stream_profiles[0];
+    video_stream_profile vprofile0 = profile0.as<video_stream_profile>();
+
+    for (auto profile : stream_profiles)
+    {
+        if (profile == profile0)
+        {
+            video_stream_profile vprofile = profile.as<video_stream_profile>();
+            if (vprofile0.width() != vprofile.width() ||
+                vprofile0.height() != vprofile.height())
+            {
+                //std::cout << "compare: " << vprofile0.stream_type() << "(" << vprofile0.stream_index() << "):" << vprofile0.width() << "x" << vprofile0.height() << " with:" <<
+                //    vprofile.stream_type() << "(" << vprofile.stream_index() << "):" << vprofile.width() << "x" << vprofile.height() << std::endl;
+                REQUIRE(!(vprofile0 == vprofile));
+            }
+        }
+    }
+}


### PR DESCRIPTION
video_stream_profile class is missing operator==
This cause 2 video_stream_profile objects to use the stream_profile::operator== instead which gives false results.
PR includes a test to demonstrate the issue and the fix.

Relates to DSO-16565