### PR TITLE
mem leak (false alarm) test fix 

### DIFF
--- a/unit-tests/internal/internal-tests-extrinsic.cpp
+++ b/unit-tests/internal/internal-tests-extrinsic.cpp
@@ -29,7 +29,7 @@ constexpr int SPIKE_THRESHOLD = 2; //[stdev]
 // Output:  - vector of line fitting data according to least squares algorithm 
 //          - slope of the fitted line
 // reference: https://en.wikipedia.org/wiki/Least_squares
-double line_fitting(const std::vector<double>& y_vec, std::vector<double>& y_fit = std::vector<double>())
+double line_fitting(const std::vector<double>& y_vec, std::vector<double>y_fit = std::vector<double>())
 {
     double ysum = std::accumulate(y_vec.begin(), y_vec.end(), 0.0);  //calculate sigma(yi)
     double xsum = 0;
@@ -369,7 +369,7 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
             {
                 CAPTURE(extrinsics_table_size);
                 // 1. extrinsics table preserve its size over iterations
-                CHECK(std::adjacent_find(extrinsics_table_size.begin(), extrinsics_table_size.end(), std::not_equal_to<>()) == extrinsics_table_size.end());
+                CHECK(std::adjacent_find(extrinsics_table_size.begin(), extrinsics_table_size.end(), std::not_equal_to<size_t>()) == extrinsics_table_size.end());
             }
             // 2.  no delay increment over iterations 
             // filter spikes : calc stdev for each half and filter out samples that are not close 

--- a/unit-tests/internal/internal-tests-extrinsic.cpp
+++ b/unit-tests/internal/internal-tests-extrinsic.cpp
@@ -19,7 +19,7 @@
 using namespace librealsense;
 using namespace librealsense::platform;
 
-constexpr int ITERATIONS_PER_CONFIG = 40;
+constexpr int ITERATIONS_PER_CONFIG = 100;
 constexpr int INNER_ITERATIONS_PER_CONFIG = 10;
 constexpr int DELAY_INCREMENT_THRESHOLD = 3; //[%]
 constexpr int DELAY_INCREMENT_THRESHOLD_IMU = 8; //[%]
@@ -208,7 +208,6 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
             std::vector<size_t> extrinsics_table_size;
             std::map<std::string, std::vector<double>> streams_delay; // map to vector to collect all data
             std::map<std::string, std::vector<std::map<unsigned long long, size_t >>> unique_streams_delay;
-            //std::map<std::string, std::vector<unsigned long long>> frame_number;
             std::map<std::string, size_t> new_frame;
             std::map<std::string, size_t> extrinsic_graph_at_sensor;
 
@@ -271,16 +270,12 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
                     auto frame_num = f.get_frame_number();
                     auto time_of_arrival = f.get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL);
 
-                    //if (std::find(frame_number[stream_type].begin(), frame_number[stream_type].end(), frame_num) == frame_number[stream_type].end())
-                    //{
-                        if (!new_frame[stream_type])
-                        {
-                            //frame_number[stream_type].push_back(frame_num);
-                            streams_delay[stream_type].push_back(time_of_arrival - start_time_milli);
-                            new_frame[stream_type] = true;
-                        }
-                        new_frame[stream_type] += 1;
-                    //}
+                    if (!new_frame[stream_type])
+                    {
+                        streams_delay[stream_type].push_back(time_of_arrival - start_time_milli);
+                        new_frame[stream_type] = true;
+                    }
+                    new_frame[stream_type] += 1;
                 };
                 auto frame_callback = [&](const rs2::frame& f)
                 {

--- a/unit-tests/internal/internal-tests-extrinsic.cpp
+++ b/unit-tests/internal/internal-tests-extrinsic.cpp
@@ -19,7 +19,7 @@
 using namespace librealsense;
 using namespace librealsense::platform;
 
-constexpr int ITERATIONS_PER_CONFIG = 100;
+constexpr int ITERATIONS_PER_CONFIG = 40;
 constexpr int INNER_ITERATIONS_PER_CONFIG = 10;
 constexpr int DELAY_INCREMENT_THRESHOLD = 3; //[%]
 constexpr int DELAY_INCREMENT_THRESHOLD_IMU = 8; //[%]
@@ -208,7 +208,7 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
             std::vector<size_t> extrinsics_table_size;
             std::map<std::string, std::vector<double>> streams_delay; // map to vector to collect all data
             std::map<std::string, std::vector<std::map<unsigned long long, size_t >>> unique_streams_delay;
-            std::map<std::string, std::vector<unsigned long long>> frame_number;
+            //std::map<std::string, std::vector<unsigned long long>> frame_number;
             std::map<std::string, size_t> new_frame;
             std::map<std::string, size_t> extrinsic_graph_at_sensor;
 
@@ -271,16 +271,16 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
                     auto frame_num = f.get_frame_number();
                     auto time_of_arrival = f.get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL);
 
-                    if (std::find(frame_number[stream_type].begin(), frame_number[stream_type].end(), frame_num) == frame_number[stream_type].end())
-                    {
+                    //if (std::find(frame_number[stream_type].begin(), frame_number[stream_type].end(), frame_num) == frame_number[stream_type].end())
+                    //{
                         if (!new_frame[stream_type])
                         {
-                            frame_number[stream_type].push_back(frame_num);
+                            //frame_number[stream_type].push_back(frame_num);
                             streams_delay[stream_type].push_back(time_of_arrival - start_time_milli);
                             new_frame[stream_type] = true;
                         }
                         new_frame[stream_type] += 1;
-                    }
+                    //}
                 };
                 auto frame_callback = [&](const rs2::frame& f)
                 {

--- a/unit-tests/internal/internal-tests-types.cpp
+++ b/unit-tests/internal/internal-tests-types.cpp
@@ -22,7 +22,7 @@ TEST_CASE("copy_array", "[code]")
     float src_float[]   = { 1.1f, 2.2f, 3.3f, -5.5f, 0.f, 123534.f };
     double src_double[] = { 0.00000000000000000001, -2222222222222222222222222.222222, 334529087543.30875246784, -5.51234533524532345254645234256, 5888985940.4535, -0.0000000000001 };
 
-    constexpr size_t src_size = arr_size(src_float);
+    const size_t src_size = 6;
 
     float       tgt_float[src_size]     = { 0 };
     double      tgt_double[src_size]    = { 0 };
@@ -64,7 +64,7 @@ TEST_CASE("copy_2darray", "[code]")
     double src_double[2][6] = { { -254354352341.1, 765732052.21124, 3.4432007654764633233554, -524432.5432650645, 0.0000000000000000112, 123534.4234254673 },
                                 { 764.07654343263, -242675463465342.243, -9876322453.6342453, -42315432545.2153542, 0.1345521543251324, -0.0000123413242329 } };
 
-    constexpr size_t src_size = arr_size(src_float);
+    const size_t src_size = arr_size(src_float);
 
     // Get the internal dimension sizes
     auto h = std::extent<decltype(src_float),0>::value;


### PR DESCRIPTION
Fixed internal unit test : "Extrinsic memory leak detection"
Fix: accepting first arrived frame in each iteration regardless of its frame number 
Track on DSO-16625