### PR TITLE
Auto Exposure : range value setting limitation

### DIFF
--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -977,8 +977,10 @@ namespace librealsense
         // Auto exposure and gain limit
         if (_fw_version >= firmware_version("5.12.10.11"))
         {
-            depth_sensor.register_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT, std::make_shared<auto_exposure_limit_option>(*_hw_monitor, &depth_sensor));
-            depth_sensor.register_option(RS2_OPTION_AUTO_GAIN_LIMIT, std::make_shared<auto_gain_limit_option>(*_hw_monitor, &depth_sensor));
+            auto exposure_range = depth_sensor.get_option(RS2_OPTION_EXPOSURE).get_range();
+            auto gain_range = depth_sensor.get_option(RS2_OPTION_GAIN).get_range();
+            depth_sensor.register_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT, std::make_shared<auto_exposure_limit_option>(*_hw_monitor, &depth_sensor, exposure_range));
+            depth_sensor.register_option(RS2_OPTION_AUTO_GAIN_LIMIT, std::make_shared<auto_gain_limit_option>(*_hw_monitor, &depth_sensor, gain_range));
         }
 
         // attributes of md_capture_timing

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -659,7 +659,7 @@ namespace librealsense
     }
 
     auto_exposure_limit_option::auto_exposure_limit_option(hw_monitor& hwm, sensor_base* ep)
-        : _hwm(hwm), _sensor(ep)
+        : option_base(option_range{ 0, 165000, 1, 0 }), _hwm(hwm), _sensor(ep)
     {
         _range = [this]()
         {
@@ -669,12 +669,9 @@ namespace librealsense
 
     void auto_exposure_limit_option::set(float value)
     {
-        if (value < get_range().min || value > get_range().max)
-        {
-            LOG_ERROR("Auto Exposure new value " << value << " is outside the range ["
-                << get_range().min << ", " << get_range().max << "].\n");
-            return;
-        }
+        if (!is_valid(value))
+            throw invalid_value_exception("set(enable_auto_exposure) failed! Invalid Auto-Exposure mode request " + std::to_string(value));
+
         command cmd_get(ds::AUTO_CALIB);
         cmd_get.param1 = 5;
         std::vector<uint8_t> ret = _hwm.send(cmd_get);

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -704,7 +704,7 @@ namespace librealsense
     }
 
     auto_gain_limit_option::auto_gain_limit_option(hw_monitor& hwm, sensor_base* ep)
-        : _hwm(hwm), _sensor(ep)
+        : option_base(option_range{ 0, 248, 1, 0 }), _hwm(hwm), _sensor(ep)
     {
         _range = [this]()
         {
@@ -714,6 +714,9 @@ namespace librealsense
 
     void auto_gain_limit_option::set(float value)
     {
+        if (!is_valid(value))
+            throw invalid_value_exception("set(enable_auto_exposure) failed! Invalid Auto-Exposure mode request " + std::to_string(value));
+
         command cmd_get(ds::AUTO_CALIB);
         cmd_get.param1 = 5;
         std::vector<uint8_t> ret = _hwm.send(cmd_get);

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -658,12 +658,12 @@ namespace librealsense
             return _uvc_option->is_enabled();
     }
 
-    auto_exposure_limit_option::auto_exposure_limit_option(hw_monitor& hwm, sensor_base* ep)
-        : option_base(option_range{ 0, 165000, 1, 0 }), _hwm(hwm), _sensor(ep)
+    auto_exposure_limit_option::auto_exposure_limit_option(hw_monitor& hwm, sensor_base* ep, option_range range)
+        : option_base(range), _hwm(hwm), _sensor(ep)
     {
-        _range = [this]()
+        _range = [this, range]()
         {
-            return option_range{ 0, 165000, 1, 0 };
+            return range;
         };
     }
 
@@ -703,12 +703,12 @@ namespace librealsense
         return *_range;
     }
 
-    auto_gain_limit_option::auto_gain_limit_option(hw_monitor& hwm, sensor_base* ep)
-        : option_base(option_range{ 0, 248, 1, 0 }), _hwm(hwm), _sensor(ep)
+    auto_gain_limit_option::auto_gain_limit_option(hw_monitor& hwm, sensor_base* ep, option_range range)
+        : option_base(range), _hwm(hwm), _sensor(ep)
     {
-        _range = [this]()
+        _range = [this, range]()
         {
-            return option_range{ 0, 248, 1, 0 };
+            return range;
         };
     }
 

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -661,7 +661,7 @@ namespace librealsense
     auto_exposure_limit_option::auto_exposure_limit_option(hw_monitor& hwm, sensor_base* ep, option_range range)
         : option_base(range), _hwm(hwm), _sensor(ep)
     {
-        _range = [this, range]()
+        _range = [range]()
         {
             return range;
         };
@@ -706,7 +706,7 @@ namespace librealsense
     auto_gain_limit_option::auto_gain_limit_option(hw_monitor& hwm, sensor_base* ep, option_range range)
         : option_base(range), _hwm(hwm), _sensor(ep)
     {
-        _range = [this, range]()
+        _range = [range]()
         {
             return range;
         };

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -715,7 +715,7 @@ namespace librealsense
     void auto_gain_limit_option::set(float value)
     {
         if (!is_valid(value))
-            throw invalid_value_exception("set(enable_auto_exposure) failed! Invalid Auto-Exposure mode request " + std::to_string(value));
+            throw invalid_value_exception("set(enable_auto_gain) failed! Invalid Auto-Gain mode request " + std::to_string(value));
 
         command cmd_get(ds::AUTO_CALIB);
         cmd_get.param1 = 5;

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -669,6 +669,12 @@ namespace librealsense
 
     void auto_exposure_limit_option::set(float value)
     {
+        if (value < get_range().min || value > get_range().max)
+        {
+            LOG_ERROR("Auto Exposure new value - " << value << " - is outside the limit : min = "
+                << get_range().min << ", max = " << get_range().max << ".\n");
+            return;
+        }
         command cmd_get(ds::AUTO_CALIB);
         cmd_get.param1 = 5;
         std::vector<uint8_t> ret = _hwm.send(cmd_get);

--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -671,8 +671,8 @@ namespace librealsense
     {
         if (value < get_range().min || value > get_range().max)
         {
-            LOG_ERROR("Auto Exposure new value - " << value << " - is outside the limit : min = "
-                << get_range().min << ", max = " << get_range().max << ".\n");
+            LOG_ERROR("Auto Exposure new value " << value << " is outside the range ["
+                << get_range().min << ", " << get_range().max << "].\n");
             return;
         }
         command cmd_get(ds::AUTO_CALIB);

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -357,7 +357,7 @@ namespace librealsense
     class auto_exposure_limit_option : public option_base
     {
     public:
-        auto_exposure_limit_option(hw_monitor& hwm, sensor_base* depth_ep);
+        auto_exposure_limit_option(hw_monitor& hwm, sensor_base* depth_ep, option_range range);
         virtual ~auto_exposure_limit_option() = default;
         virtual void set(float value) override;
         virtual float query() const override;
@@ -379,7 +379,7 @@ namespace librealsense
     class auto_gain_limit_option : public option_base
     {
     public:
-        auto_gain_limit_option(hw_monitor& hwm, sensor_base* depth_ep);
+        auto_gain_limit_option(hw_monitor& hwm, sensor_base* depth_ep, option_range range);
         virtual ~auto_gain_limit_option() = default;
         virtual void set(float value) override;
         virtual float query() const override;

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -376,7 +376,7 @@ namespace librealsense
         sensor_base* _sensor;
     };
 
-    class auto_gain_limit_option : public option
+    class auto_gain_limit_option : public option_base
     {
     public:
         auto_gain_limit_option(hw_monitor& hwm, sensor_base* depth_ep);

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -354,7 +354,7 @@ namespace librealsense
         std::shared_ptr<option> _hdr_option;
     };
 
-    class auto_exposure_limit_option : public option
+    class auto_exposure_limit_option : public option_base
     {
     public:
         auto_exposure_limit_option(hw_monitor& hwm, sensor_base* depth_ep);

--- a/unit-tests/internal/internal-tests-extrinsic.cpp
+++ b/unit-tests/internal/internal-tests-extrinsic.cpp
@@ -647,7 +647,7 @@ TEST_CASE("Controls limits validation", "[live]")
 
         for (auto&& device : list)
         {
-            if (std::string(device.get_info(RS2_CAMERA_INFO_PRODUCT_LINE))  != "D400")
+            if (std::string(device.get_info(RS2_CAMERA_INFO_PRODUCT_LINE)) != "D400")
                 continue;
             auto sensors = device.query_sensors();
             float ae_limit;
@@ -657,23 +657,21 @@ TEST_CASE("Controls limits validation", "[live]")
                 for (auto& s : sensors)
                 {
                     std::string val = s.get_info(RS2_CAMERA_INFO_NAME);
-                    if (!val.compare("Stereo Module")) {
                     if (!s.supports(control))
                         return;
-                        auto range = s.get_option_range(control);
-                        float set_value[3] = { range.min - 10, range.max + 10, std::floor((range.max + range.min) / 2) };
-                        for (auto& val : set_value)
+                    auto range = s.get_option_range(control);
+                    float set_value[3] = { range.min - 10, range.max + 10, std::floor((range.max + range.min) / 2) };
+                    for (auto& val : set_value)
+                    {
+                        CAPTURE(val);
+                        CAPTURE(range);
+                        if (val < range.min || val > range.max)
+                            REQUIRE_THROWS(s.set_option(control, val));
+                        else
                         {
-                            CAPTURE(val);
-                            CAPTURE(range);
-                            if (val < range.min || val > range.max)
-                                REQUIRE_THROWS(s.set_option(control, val));
-                            else
-                            {
-                                s.set_option(control, val);
-                                ae_limit = s.get_option(control);
-                                REQUIRE(ae_limit == val);
-                            }
+                            s.set_option(control, val);
+                            ae_limit = s.get_option(control);
+                            REQUIRE(ae_limit == val);
                         }
                     }
                 }

--- a/unit-tests/internal/internal-tests-extrinsic.cpp
+++ b/unit-tests/internal/internal-tests-extrinsic.cpp
@@ -650,7 +650,7 @@ TEST_CASE("Controls limits validation", "[live]")
             if (std::string(device.get_info(RS2_CAMERA_INFO_PRODUCT_LINE)) != "D400")
                 continue;
             auto sensors = device.query_sensors();
-            float ae_limit;
+            float limit;
             rs2_option controls[2] = { RS2_OPTION_AUTO_GAIN_LIMIT, RS2_OPTION_AUTO_EXPOSURE_LIMIT };
             for (auto& control : controls)
             {
@@ -658,7 +658,7 @@ TEST_CASE("Controls limits validation", "[live]")
                 {
                     std::string val = s.get_info(RS2_CAMERA_INFO_NAME);
                     if (!s.supports(control))
-                        return;
+                        break;
                     auto range = s.get_option_range(control);
                     float set_value[3] = { range.min - 10, range.max + 10, std::floor((range.max + range.min) / 2) };
                     for (auto& val : set_value)
@@ -670,8 +670,8 @@ TEST_CASE("Controls limits validation", "[live]")
                         else
                         {
                             s.set_option(control, val);
-                            ae_limit = s.get_option(control);
-                            REQUIRE(ae_limit == val);
+                            limit = s.get_option(control);
+                            REQUIRE(limit == val);
                         }
                     }
                 }

--- a/unit-tests/internal/internal-tests-extrinsic.cpp
+++ b/unit-tests/internal/internal-tests-extrinsic.cpp
@@ -645,10 +645,7 @@ TEST_CASE("Controls limits validation", "[live]")
         auto&& device = ctx.query_devices()[0];
         auto sensors = device.query_sensors();
         rs2::sensor depth_sensor;
-        float current_set_value;
         float ae_limit;
-        float prev_ae_limit;
-        //rs2::option_range range;
 
         for (auto& s : sensors)
         {
@@ -656,22 +653,18 @@ TEST_CASE("Controls limits validation", "[live]")
             if (!val.compare("Stereo Module")) {
                 depth_sensor = s;
                 auto range = s.get_option_range(RS2_OPTION_AUTO_EXPOSURE_LIMIT);
-                float set_value[3] = { range.min - 10, range.max + 10, (range.max - range.min) / 2 };
+                float set_value[3] = { range.min - 10, range.max + 10, (range.max + range.min) / 2 };
                 for (auto& val : set_value)
                 {
-                    try
+                    CAPTURE(val);
+                    CAPTURE(range);
+                    if (val < range.min || val > range.max)
+                        REQUIRE_THROWS(s.set_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT, val));
+                    else
                     {
-                        current_set_value = val;
-                        CAPTURE(val);
-                        CAPTURE(range);
                         s.set_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT, val);
-                        prev_ae_limit = ae_limit;
                         ae_limit = s.get_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT);
-                        REQUIRE_THROWS(ae_limit == val);
-                    }
-                    catch (const rs2::error& e)
-                    {
-                        REQUIRE_THROWS(ae_limit == prev_ae_limit);
+                        REQUIRE(ae_limit == val);
                     }
                 }
             }

--- a/unit-tests/internal/internal-tests-extrinsic.cpp
+++ b/unit-tests/internal/internal-tests-extrinsic.cpp
@@ -646,25 +646,28 @@ TEST_CASE("Controls limits validation", "[live]")
         auto sensors = device.query_sensors();
         rs2::sensor depth_sensor;
         float ae_limit;
-
-        for (auto& s : sensors)
+        rs2_option controls[2] = { RS2_OPTION_AUTO_GAIN_LIMIT, RS2_OPTION_AUTO_EXPOSURE_LIMIT };
+        for (auto& control : controls)
         {
-            std::string val = s.get_info(RS2_CAMERA_INFO_NAME);
-            if (!val.compare("Stereo Module")) {
-                depth_sensor = s;
-                auto range = s.get_option_range(RS2_OPTION_AUTO_EXPOSURE_LIMIT);
-                float set_value[3] = { range.min - 10, range.max + 10, (range.max + range.min) / 2 };
-                for (auto& val : set_value)
-                {
-                    CAPTURE(val);
-                    CAPTURE(range);
-                    if (val < range.min || val > range.max)
-                        REQUIRE_THROWS(s.set_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT, val));
-                    else
+            for (auto& s : sensors)
+            {
+                std::string val = s.get_info(RS2_CAMERA_INFO_NAME);
+                if (!val.compare("Stereo Module")) {
+                    depth_sensor = s;
+                    auto range = s.get_option_range(control);
+                    float set_value[3] = { range.min - 10, range.max + 10, std::floor((range.max + range.min) / 2) };
+                    for (auto& val : set_value)
                     {
-                        s.set_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT, val);
-                        ae_limit = s.get_option(RS2_OPTION_AUTO_EXPOSURE_LIMIT);
-                        REQUIRE(ae_limit == val);
+                        CAPTURE(val);
+                        CAPTURE(range);
+                        if (val < range.min || val > range.max)
+                            REQUIRE_THROWS(s.set_option(control, val));
+                        else
+                        {
+                            s.set_option(control, val);
+                            ae_limit = s.get_option(control);
+                            REQUIRE(ae_limit == val);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When setting Auto Exposure value outside the fixed limit, error will be printed to the log and AE value will remain as previous valid value.
Track on DSO-16596