### PR TITLE
ImGui - clamp slider rounding operations to keep ranged values

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -6023,7 +6023,7 @@ namespace rs2
                                     model.add_log(to_string() << "Setting " << opt_model.opt << " to "
                                         << new_val << " (" << labels[selected] << ")");
 
-                                    opt_model.set_option(opt_model.opt, new_val, error_message);
+                                    opt_model.set_option(opt_model.opt, static_cast<float>(new_val), error_message);
 
                                     // Only apply preset to GUI if set_option was succesful
                                     selected_file_preset = "";

--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -156,7 +156,7 @@ void output_model::open(ux_window& win)
 {
     is_output_open = true;
     config_file::instance().set(configurations::viewer::output_open, true);
-    default_log_h = (int)((win.height() - 100) / 2);
+    default_log_h = static_cast<int>((win.height() - 100) / 2);
     new_log = true;
 }
 

--- a/common/realsense-ui-advanced-mode.h
+++ b/common/realsense-ui-advanced-mode.h
@@ -102,8 +102,17 @@ inline void slider_int(std::string& error_message, const char* id, T* val, S T::
             }
             else
             {
-                val->*field = static_cast<S>(new_value);
-                to_set = true;
+                if ((new_value > max) || (new_value < min))
+                {
+                    std::stringstream ss;
+                    ss << "New value " << new_value << " to be within [" << min << ", " << max << "] range";
+                    error_message = ss.str().c_str();
+                }
+                else
+                {
+                    val->*field = static_cast<S>(new_value);
+                    to_set = true;
+                }
             }
 
             *edit_mode = false;
@@ -158,8 +167,17 @@ inline void slider_float(std::string& error_message, const char* id, T* val, S T
             }
             else
             {
-                val->*field = static_cast<S>(new_value);
-                to_set = true;
+                if ((new_value > max) || (new_value<min))
+                {
+                    std::stringstream ss;
+                    ss << "New value " << new_value << " to be within [" << min << ", " << max << "] range";
+                    error_message = ss.str().c_str();
+                }
+                else
+                {
+                    val->*field = static_cast<S>(new_value);
+                    to_set = true;
+                }
             }
 
             *edit_mode = false;

--- a/common/realsense-ui-advanced-mode.h
+++ b/common/realsense-ui-advanced-mode.h
@@ -105,8 +105,8 @@ inline void slider_int(std::string& error_message, const char* id, T* val, S T::
                 if ((new_value > max) || (new_value < min))
                 {
                     std::stringstream ss;
-                    ss << "New value " << new_value << " to be within [" << min << ", " << max << "] range";
-                    error_message = ss.str().c_str();
+                    ss << "New value " << new_value << " must be within [" << min << ", " << max << "] range";
+                    error_message = ss.str();
                 }
                 else
                 {
@@ -170,8 +170,8 @@ inline void slider_float(std::string& error_message, const char* id, T* val, S T
                 if ((new_value > max) || (new_value<min))
                 {
                     std::stringstream ss;
-                    ss << "New value " << new_value << " to be within [" << min << ", " << max << "] range";
-                    error_message = ss.str().c_str();
+                    ss << "New value " << new_value << " must be within [" << min << ", " << max << "] range";
+                    error_message = ss.str();
                 }
                 else
                 {

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -274,7 +274,7 @@ namespace rs2
 
                         for (auto& option : curr_exporter->second.options)
                         {
-                            exporter->set_option(option.first, option.second);
+                            exporter->set_option(option.first, static_cast<float>(option.second));
                         }
 
                         export_frame(fname, std::move(exporter), *not_model, data);

--- a/src/gl/yuy2rgb-gl.cpp
+++ b/src/gl/yuy2rgb-gl.cpp
@@ -11,7 +11,7 @@
 
 #ifndef NOMINMAX
 #define NOMINMAX
-#endif
+#endif // NOMINMAX
 
 #include <glad/glad.h>
 

--- a/third-party/imgui/imgui.cpp
+++ b/third-party/imgui/imgui.cpp
@@ -6457,10 +6457,11 @@ bool ImGui::SliderBehavior(const ImRect& frame_bb, ImGuiID id, float* v, float v
 
             // Round past decimal precision, verify that it remains within min/max range
             new_value = RoundScalar(new_value, decimal_precision);
+            if (new_value > v_max)  new_value = v_max;
+            if (new_value < v_min)  new_value = v_min;
+
             if (*v != new_value)
             {
-                if (new_value >v_max )  new_value = v_max;
-                if (new_value < v_min)  new_value = v_min;
                 *v = new_value;
                 value_changed = true;
             }

--- a/third-party/imgui/imgui.cpp
+++ b/third-party/imgui/imgui.cpp
@@ -6455,10 +6455,12 @@ bool ImGui::SliderBehavior(const ImRect& frame_bb, ImGuiID id, float* v, float v
                 new_value = ImLerp(v_min, v_max, normalized_pos);
             }
 
-            // Round past decimal precision
+            // Round past decimal precision, verify that it remains within min/max range
             new_value = RoundScalar(new_value, decimal_precision);
             if (*v != new_value)
             {
+                if (new_value >v_max )  new_value = v_max;
+                if (new_value < v_min)  new_value = v_min;
                 *v = new_value;
                 value_changed = true;
             }

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -628,7 +628,7 @@ int main(int argc, const char** argv) try
 
         auto output_rect = rect{ viewer_model.panel_width,
             window.height() - viewer_model.get_output_height(),
-            window.width() - viewer_model.panel_width, viewer_model.get_output_height() };
+            window.width() - viewer_model.panel_width, float(viewer_model.get_output_height()) };
 
         viewer_model.not_model->output.draw(window, output_rect, *device_models);
 

--- a/unit-tests/LRS_windows_compile_pipeline.stats
+++ b/unit-tests/LRS_windows_compile_pipeline.stats
@@ -1,2 +1,2 @@
-warnings 342
+warnings 340
 


### PR DESCRIPTION
ImGUI floating point interpolations and rounding operations do not ensure min/max range on results
The PR fixes it to avoid overriding user-defined min/max slider boundaries.
Tracked on: DSO-15067