### PR TITLE
Temporally disable recording of TL opton state

### DIFF
--- a/src/ds5/ds5-options.cpp
+++ b/src/ds5/ds5-options.cpp
@@ -782,4 +782,10 @@ namespace librealsense
             return "Thermal compensation is enabled";
         }
     }
+
+    //Work-around the control latency
+    void librealsense::thermal_compensation::create_snapshot(std::shared_ptr<option>& snapshot) const
+    {
+        snapshot = std::make_shared<const_value_option>(get_description(), 0.f);
+    }
 }

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -414,6 +414,7 @@ namespace librealsense
 
         const char* get_description() const override;
         const char* get_value_description(float value) const override;
+        void create_snapshot(std::shared_ptr<option>& snapshot) const override;
 
         void enable_recording(std::function<void(const option&)> record_action) override
         {


### PR DESCRIPTION
The Thermal Loop controls ToT exceed 30msec which makes recording not feasible.
Disabled till resolved in FW

Change-Id: I26daba025993ef415bc4469a64e515e17d23f365