### PR TITLE
Viewer - Depth color map ruler show wrong values

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2108,12 +2108,12 @@ namespace rs2
                     }
                 }
 
-                if (next_option == RS2_OPTION_DEPTH_UNITS)
+                if (next == RS2_OPTION_DEPTH_UNITS)
                 {
                     opt_md.dev->depth_units = opt_md.value;
                 }
 
-                if (next_option == RS2_OPTION_STEREO_BASELINE)
+                if (next == RS2_OPTION_STEREO_BASELINE)
                     opt_md.dev->stereo_baseline = opt_md.value;
             }
 


### PR DESCRIPTION
Fix Viewer depth units ruler. range of numbers on the right side

**Before fix:**
![image](https://user-images.githubusercontent.com/64067618/110775132-3eb19580-8267-11eb-89ac-03213e17c704.png)

**After fix:**
![image](https://user-images.githubusercontent.com/64067618/110774020-065d8780-8266-11eb-8de3-a6646001018f.png)

Tracked on [10658]

