### PR TITLE
T265 fix for race condition during pipeline stop.

### DIFF
--- a/src/tm2/tm-device.cpp
+++ b/src/tm2/tm-device.cpp
@@ -1326,8 +1326,8 @@ namespace librealsense
     void tm2_sensor::stop_interrupt()
     {
         if (_interrupt_request) {
+            _interrupt_callback->cancel();
             if (_device->cancel_request(_interrupt_request)) {
-                _interrupt_callback->cancel();
                 _interrupt_request.reset();
             }
         }
@@ -1387,8 +1387,8 @@ namespace librealsense
     void tm2_sensor::stop_stream()
     {
         if (_stream_request) {
+            _stream_callback->cancel();
             if (_device->cancel_request(_stream_request)) {
-                _stream_callback->cancel();
                 _stream_request.reset();
             }
         }


### PR DESCRIPTION
This PR is effectively the suggested fix in the GH issue below. Thank you @ankyur.
  
https://github.com/IntelRealSense/librealsense/issues/7276 

I've validated the fix works using the following code:

// Reproduces T265 Hand on Exit.
int main(int, char**)
{
	constexpr std::chrono::seconds timeout{ 1 };

	while (true)
	{
		// Start
		rs2::config config;
		rs2::pipeline pipeline;

		std::cout << "Entering pipeline.start()" << std::endl;
		pipeline.start();
		std::cout << "Exiting pipeline.start()" << std::endl;

		std::cout << "Sleeping for 1 second..." << std::endl;
		std::this_thread::sleep_for(timeout);
		
		std::cout << "Entering pipeline.stop()" << std::endl;
		pipeline.stop();
		std::cout << "Exiting pipeline.stop()" << std::endl;
	}

	return 0;
}

Suspect this fix potentially addresses the following open T265 issues as well:

https://github.com/IntelRealSense/librealsense/issues/7553
https://github.com/IntelRealSense/librealsense/issues/5807
https://github.com/IntelRealSense/librealsense/issues/6272
https://github.com/IntelRealSense/librealsense/issues/7555
https://github.com/IntelRealSense/librealsense/issues/7750