### PR TITLE
Fix pyrealsense2 crash when importing other pybind11 created modules

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory("${CMAKE_BINARY_DIR}/third-party/pybind11"
 set(PYBIND11_CPP_STANDARD -std=c++11)
 # Force Pybind11 not to share pyrealsense2 resources with other pybind modules.
 # With this definition we force the ABI version to be unique and not risk crashes on different modules.
+# (workaround for RS5-10582)
 add_definitions(-DPYBIND11_COMPILER_TYPE="_librs_abi")
 include_directories(${CMAKE_BINARY_DIR}/third-party/pybind11/include)
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory("${CMAKE_BINARY_DIR}/third-party/pybind11"
 set(PYBIND11_CPP_STANDARD -std=c++11)
 # Force Pybind11 not to share pyrealsense2 resources with other pybind modules.
 # With this definition we force the ABI version to be unique and not risk crashes on different modules.
-# (workaround for RS5-10582)
+# (workaround for RS5-10582; see also https://github.com/pybind/pybind11/issues/2898)
 add_definitions(-DPYBIND11_COMPILER_TYPE="_librs_abi")
 include_directories(${CMAKE_BINARY_DIR}/third-party/pybind11/include)
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -25,6 +25,9 @@ add_subdirectory("${CMAKE_BINARY_DIR}/third-party/pybind11"
 )
 
 set(PYBIND11_CPP_STANDARD -std=c++11)
+# Force Pybind11 not to share pyrealsense2 resources with other pybind modules.
+# With this definition we force the ABI version to be unique and not risk crashes on different modules.
+add_definitions(-DPYBIND11_COMPILER_TYPE="_librs_abi")
 include_directories(${CMAKE_BINARY_DIR}/third-party/pybind11/include)
 
 set(PYRS_CPP


### PR DESCRIPTION
Pybind's ABI is made up of compiler type among other things, but not compiler version -- so two modules with pybind compiled with VS 2019 and VS 2015 would generate the same ABI and pybind will try to share resources, crashing Python.
(see https://github.com/pybind/pybind11/issues/2898)

This forces a unique ABI version that won't be shared.

Tracked on [ RS5-10582 ]