### PR TITLE
Update pybind11 version to 2.6.2

### DIFF
--- a/third-party/pybind11/CMakeLists.txt
+++ b/third-party/pybind11/CMakeLists.txt
@@ -8,10 +8,9 @@ ExternalProject_Add(
         pybind11
         PREFIX .
         GIT_REPOSITORY "https://github.com/pybind/pybind11.git"
-        GIT_TAG "f1abf5d9159b805674197f6bc443592e631c9130" # v2.6.1
+        GIT_TAG "8de7772cc72daca8e947b79b83fea46214931604" # v2.6.2
         SOURCE_DIR "${CMAKE_BINARY_DIR}/third-party/pybind11"
         # Override default steps with no action, we just want the clone step.
-        UPDATE_COMMAND ""       
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""


### PR DESCRIPTION
Get some fixes for python 3.8 + 3.9 support, update to current latest version.

Sanity test pass on RealCI for L515 + D435