### PR TITLE
L515 - Keep USB power on when multiple HWM calls made

### DIFF
--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -485,13 +485,15 @@ namespace librealsense
                 }
 
                 try {
-                    // endpoint 5 - 32KB
-                    command cmdTprocGranEp5(ivcam2::TPROC_USB_GRAN_SET, 5, usb_trb);
-                    _owner->_hw_monitor->send(cmdTprocGranEp5);
+                    // Keep the USB power on while triggering multiple calls on it.
+                    _owner->get_raw_depth_sensor().invoke_powered([&](platform::uvc_device& dev) {
+                        // endpoint 5 - 32KB
+                        command cmdTprocGranEp5(ivcam2::TPROC_USB_GRAN_SET, 5, usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp5);
 
-                    command cmdTprocThresholdEp5(ivcam2::TPROC_TRB_THRSLD_SET, 5, 1);
-                    _owner->_hw_monitor->send(cmdTprocThresholdEp5);
-
+                        command cmdTprocThresholdEp5(ivcam2::TPROC_TRB_THRSLD_SET, 5, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp5);
+                        });
                     LOG_DEBUG("Color usb tproc granularity and TRB threshold updated.");
                 } catch (...)
                 {

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -486,7 +486,7 @@ namespace librealsense
 
                 try {
                     // Keep the USB power on while triggering multiple calls on it.
-                    _owner->get_raw_depth_sensor().invoke_powered([&](platform::uvc_device& dev) {
+                    ivcam2::group_multiple_fw_calls(*this, [&]() {
                         // endpoint 5 - 32KB
                         command cmdTprocGranEp5(ivcam2::TPROC_USB_GRAN_SET, 5, usb_trb);
                         _owner->_hw_monitor->send(cmdTprocGranEp5);

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -516,7 +516,7 @@ namespace librealsense
 
                 try {
                     // Keep the USB power on while triggering multiple calls on it.
-                    _owner->get_raw_depth_sensor().invoke_powered([&](platform::uvc_device& dev) {
+                    ivcam2::group_multiple_fw_calls(*this, [&]() {
                         // endpoint 2 (depth)
                         command cmdTprocGranEp2(ivcam2::TPROC_USB_GRAN_SET, 2, ep2_usb_trb);
                         _owner->_hw_monitor->send(cmdTprocGranEp2);

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -515,27 +515,29 @@ namespace librealsense
                 }
 
                 try {
-                    // endpoint 2 (depth)
-                    command cmdTprocGranEp2(ivcam2::TPROC_USB_GRAN_SET, 2, ep2_usb_trb);
-                    _owner->_hw_monitor->send(cmdTprocGranEp2);
+                    // Keep the USB power on while triggering multiple calls on it.
+                    _owner->get_raw_depth_sensor().invoke_powered([&](platform::uvc_device& dev) {
+                        // endpoint 2 (depth)
+                        command cmdTprocGranEp2(ivcam2::TPROC_USB_GRAN_SET, 2, ep2_usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp2);
 
-                    command cmdTprocThresholdEp2(ivcam2::TPROC_TRB_THRSLD_SET, 2, 1);
-                    _owner->_hw_monitor->send(cmdTprocThresholdEp2);
+                        command cmdTprocThresholdEp2(ivcam2::TPROC_TRB_THRSLD_SET, 2, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp2);
 
-                    // endpoint 3 (IR)
-                    command cmdTprocGranEp3(ivcam2::TPROC_USB_GRAN_SET, 3, ep3_usb_trb);
-                    _owner->_hw_monitor->send(cmdTprocGranEp3);
+                        // endpoint 3 (IR)
+                        command cmdTprocGranEp3(ivcam2::TPROC_USB_GRAN_SET, 3, ep3_usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp3);
 
-                    command cmdTprocThresholdEp3(ivcam2::TPROC_TRB_THRSLD_SET, 3, 1);
-                    _owner->_hw_monitor->send(cmdTprocThresholdEp3);
+                        command cmdTprocThresholdEp3(ivcam2::TPROC_TRB_THRSLD_SET, 3, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp3);
 
-                    // endpoint 4 (confidence)
-                    command cmdTprocGranEp4(ivcam2::TPROC_USB_GRAN_SET, 4, ep4_usb_trb);
-                    _owner->_hw_monitor->send(cmdTprocGranEp4);
+                        // endpoint 4 (confidence)
+                        command cmdTprocGranEp4(ivcam2::TPROC_USB_GRAN_SET, 4, ep4_usb_trb);
+                        _owner->_hw_monitor->send(cmdTprocGranEp4);
 
-                    command cmdTprocThresholdEp4(ivcam2::TPROC_TRB_THRSLD_SET, 4, 1);
-                    _owner->_hw_monitor->send(cmdTprocThresholdEp4);
-
+                        command cmdTprocThresholdEp4(ivcam2::TPROC_TRB_THRSLD_SET, 4, 1);
+                        _owner->_hw_monitor->send(cmdTprocThresholdEp4);
+                        });
                     LOG_DEBUG("Depth and IR usb tproc granularity and TRB threshold updated.");
                 } catch (...)
                 {

--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -524,7 +524,7 @@ namespace librealsense
         // Block changing visual preset while Max Usable Range is on [RS5-8358]
         if( _owner->get_depth_sensor().supports_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE )
             && ( _owner->get_depth_sensor().get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE ).query()
-                 == 1.0 ) )
+                 == 1.0f ) )
         {
             if( ( RS2_OPTION_VISUAL_PRESET == opt )
                 && ( value == RS2_L500_VISUAL_PRESET_MAX_RANGE ) )
@@ -792,7 +792,7 @@ namespace librealsense
         }
 
         if( ds.supports_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE )
-            && ( ds.get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE ).query() == 1.0 )
+            && ( ds.get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE ).query() == 1.0f )
             && ( value != rs2_sensor_mode::RS2_SENSOR_MODE_VGA ) )
         {
             ds.get_option( RS2_OPTION_ENABLE_MAX_USABLE_RANGE ).set( 0.0f );

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -603,6 +603,18 @@ namespace librealsense
 
         rs2_sensor_mode get_resolution_from_width_height(int width, int height);
 
+        // Helper function that should be used when multiple FW calls needs to be made.
+        // This function change the USB power to D0 (Operational) using the invoke_power function
+        // activate the received function and power down the state to D3 (Idle)
+        template<class T>
+        auto group_multiple_fw_calls(synthetic_sensor &s, T action)
+            -> decltype(action())
+        {
+            auto &us =  dynamic_cast<uvc_sensor&>(*s.get_raw_sensor());
+            
+            return us.invoke_powered([&](platform::uvc_device& dev) { return action(); });
+        }
+
         class ac_trigger;
     } // librealsense::ivcam2
 } // namespace librealsense

--- a/src/l500/l500-serializable.cpp
+++ b/src/l500/l500-serializable.cpp
@@ -18,14 +18,8 @@ namespace librealsense
 
     std::vector<uint8_t> l500_serializable::serialize_json() const
     {
-        auto l500_uvc_sensor
-            = std::dynamic_pointer_cast< uvc_sensor >( _depth_sensor.get_raw_sensor() );
-        if( ! l500_uvc_sensor )
-            throw invalid_value_exception(
-                to_string() << "Failed to get raw depth sensor from serializable device" );
+        return ivcam2::group_multiple_fw_calls( _depth_sensor, [&]() {
 
-
-        return l500_uvc_sensor->invoke_powered( [&]( platform::uvc_device & dev ) {
             json j;
             auto options = _depth_sensor.get_supported_options();
 
@@ -44,14 +38,7 @@ namespace librealsense
 
     void l500_serializable::load_json( const std::string & json_content )
     {
-        auto l500_uvc_sensor
-            = std::dynamic_pointer_cast< uvc_sensor >( _depth_sensor.get_raw_sensor() );
-        if( ! l500_uvc_sensor )
-            throw invalid_value_exception(
-                to_string() << "Failed to get raw depth sensor from serializable device" );
-
-
-        l500_uvc_sensor->invoke_powered( [&]( platform::uvc_device & dev ) {
+        return ivcam2::group_multiple_fw_calls(_depth_sensor, [&]() {
             json j = json::parse( json_content );
 
             // Set of options that should not be set in the loop

--- a/src/l500/l500-serializable.cpp
+++ b/src/l500/l500-serializable.cpp
@@ -18,27 +18,27 @@ namespace librealsense
 
     std::vector<uint8_t> l500_serializable::serialize_json() const
     {
-        auto l500_uvc_sensor = std::dynamic_pointer_cast<uvc_sensor>(_depth_sensor.get_raw_sensor());
-        if (!l500_uvc_sensor)
+        auto l500_uvc_sensor
+            = std::dynamic_pointer_cast< uvc_sensor >( _depth_sensor.get_raw_sensor() );
+        if( ! l500_uvc_sensor )
             throw invalid_value_exception(
                 to_string() << "Failed to get raw depth sensor from serializable device" );
 
-        
-            return l500_uvc_sensor->invoke_powered([&](platform::uvc_device& dev) {
 
-                json j;
-                auto options = _depth_sensor.get_supported_options();
+        return l500_uvc_sensor->invoke_powered( [&]( platform::uvc_device & dev ) {
+            json j;
+            auto options = _depth_sensor.get_supported_options();
 
-                for (auto o : options)
-                {
-                    auto&& opt = _depth_sensor.get_option(o);
-                    auto val = opt.query();
-                    j[get_string(o)] = val;
-                }
+            for( auto o : options )
+            {
+                auto && opt = _depth_sensor.get_option( o );
+                auto val = opt.query();
+                j[get_string( o )] = val;
+            }
 
-                auto str = j.dump(4);
-                return std::vector<uint8_t>(str.begin(), str.end());
-                });
+            auto str = j.dump( 4 );
+            return std::vector< uint8_t >( str.begin(), str.end() );
+        } );
         
     }
 

--- a/src/l500/l500-serializable.cpp
+++ b/src/l500/l500-serializable.cpp
@@ -18,93 +18,112 @@ namespace librealsense
 
     std::vector<uint8_t> l500_serializable::serialize_json() const
     {
-        json j;
-        auto options = _depth_sensor.get_supported_options();
+        auto l500_uvc_sensor = std::dynamic_pointer_cast<uvc_sensor>(_depth_sensor.get_raw_sensor());
+        if (!l500_uvc_sensor)
+            throw invalid_value_exception(
+                to_string() << "Failed to get raw depth sensor from serializable device" );
 
-        for (auto o : options)
-        {
-            auto&& opt = _depth_sensor.get_option(o);
-            auto val = opt.query();
-            j[get_string(o)] = val;
-        }
+        
+            return l500_uvc_sensor->invoke_powered([&](platform::uvc_device& dev) {
 
-        auto str = j.dump(4);
-        return std::vector<uint8_t>(str.begin(), str.end());
-    }
+                json j;
+                auto options = _depth_sensor.get_supported_options();
 
-    void l500_serializable::load_json(const std::string& json_content)
-    {
-        json j = json::parse(json_content);
-
-        // Set of options that should not be set in the loop
-        std::set< rs2_option > options_to_ignore{ RS2_OPTION_SENSOR_MODE,
-                                                  RS2_OPTION_TRIGGER_CAMERA_ACCURACY_HEALTH,
-                                                  RS2_OPTION_RESET_CAMERA_ACCURACY_HEALTH };
-
-        // We have to set the sensor mode (resolution) first
-        auto & sensor_mode = _depth_sensor.get_option( RS2_OPTION_SENSOR_MODE );
-        auto found_sensor_mode = j.find( get_string( RS2_OPTION_SENSOR_MODE ) );
-        if( found_sensor_mode != j.end() )
-        {
-            float sensor_mode_val = found_sensor_mode.value();
-            sensor_mode.set( sensor_mode_val );
-        }
-
-        // If a non custom preset is used, we should ignore all the settings that are automatically
-        // set by the preset
-        auto found_iterator = j.find( get_string( RS2_OPTION_VISUAL_PRESET ) );
-        if( found_iterator != j.end() )
-        {
-            auto found_preset = rs2_l500_visual_preset( int( found_iterator.value() ));
-            if( found_preset != RS2_L500_VISUAL_PRESET_CUSTOM
-                && found_preset != RS2_L500_VISUAL_PRESET_DEFAULT ) 
-            {
-                options_to_ignore.insert( RS2_OPTION_POST_PROCESSING_SHARPENING );
-                options_to_ignore.insert( RS2_OPTION_PRE_PROCESSING_SHARPENING );
-                options_to_ignore.insert( RS2_OPTION_NOISE_FILTERING );
-                options_to_ignore.insert( RS2_OPTION_AVALANCHE_PHOTO_DIODE );
-                options_to_ignore.insert( RS2_OPTION_CONFIDENCE_THRESHOLD );
-                options_to_ignore.insert( RS2_OPTION_LASER_POWER );
-                options_to_ignore.insert( RS2_OPTION_MIN_DISTANCE );
-                options_to_ignore.insert( RS2_OPTION_INVALIDATION_BYPASS );
-                options_to_ignore.insert( RS2_OPTION_DIGITAL_GAIN );
-            }
-        }
-
-        auto opts = _depth_sensor.get_supported_options();
-
-        auto default_preset = false;
-        for (auto o: opts)
-        {
-            auto& opt = _depth_sensor.get_option(o);
-            if (opt.is_read_only()) 
-                continue;
-            if (options_to_ignore.find(o) != options_to_ignore.end()) 
-                continue;
-
-            auto key = get_string(o);
-            auto it = j.find(key);
-            if (it != j.end())
-            {
-                float val = it.value();
-                if (o == RS2_OPTION_VISUAL_PRESET
-                    && (int)val == (int)RS2_L500_VISUAL_PRESET_DEFAULT)
+                for (auto o : options)
                 {
-                    default_preset = true;
-                    continue;
+                    auto&& opt = _depth_sensor.get_option(o);
+                    auto val = opt.query();
+                    j[get_string(o)] = val;
                 }
-                    
-                opt.set(val);
-            }
-        }
-        if (default_preset)
-        {
-            auto options = dynamic_cast< l500_options * >( this );
-            if( options )
-            {
-                auto preset = options->calc_preset_from_controls();
-                options->set_preset_value( preset );
-            }
-        }
+
+                auto str = j.dump(4);
+                return std::vector<uint8_t>(str.begin(), str.end());
+                });
+        
     }
-} // namespace librealsense
+
+    void l500_serializable::load_json( const std::string & json_content )
+    {
+        auto l500_uvc_sensor
+            = std::dynamic_pointer_cast< uvc_sensor >( _depth_sensor.get_raw_sensor() );
+        if( ! l500_uvc_sensor )
+            throw invalid_value_exception(
+                to_string() << "Failed to get raw depth sensor from serializable device" );
+
+
+        l500_uvc_sensor->invoke_powered( [&]( platform::uvc_device & dev ) {
+            json j = json::parse( json_content );
+
+            // Set of options that should not be set in the loop
+            std::set< rs2_option > options_to_ignore{ RS2_OPTION_SENSOR_MODE,
+                                                      RS2_OPTION_TRIGGER_CAMERA_ACCURACY_HEALTH,
+                                                      RS2_OPTION_RESET_CAMERA_ACCURACY_HEALTH };
+
+            // We have to set the sensor mode (resolution) first
+            auto & sensor_mode = _depth_sensor.get_option( RS2_OPTION_SENSOR_MODE );
+            auto found_sensor_mode = j.find( get_string( RS2_OPTION_SENSOR_MODE ) );
+            if( found_sensor_mode != j.end() )
+            {
+                float sensor_mode_val = found_sensor_mode.value();
+                sensor_mode.set( sensor_mode_val );
+            }
+
+            // If a non custom preset is used, we should ignore all the settings that are
+            // automatically set by the preset
+            auto found_iterator = j.find( get_string( RS2_OPTION_VISUAL_PRESET ) );
+            if( found_iterator != j.end() )
+            {
+                auto found_preset = rs2_l500_visual_preset( int( found_iterator.value() ) );
+                if( found_preset != RS2_L500_VISUAL_PRESET_CUSTOM
+                    && found_preset != RS2_L500_VISUAL_PRESET_DEFAULT )
+                {
+                    options_to_ignore.insert( RS2_OPTION_POST_PROCESSING_SHARPENING );
+                    options_to_ignore.insert( RS2_OPTION_PRE_PROCESSING_SHARPENING );
+                    options_to_ignore.insert( RS2_OPTION_NOISE_FILTERING );
+                    options_to_ignore.insert( RS2_OPTION_AVALANCHE_PHOTO_DIODE );
+                    options_to_ignore.insert( RS2_OPTION_CONFIDENCE_THRESHOLD );
+                    options_to_ignore.insert( RS2_OPTION_LASER_POWER );
+                    options_to_ignore.insert( RS2_OPTION_MIN_DISTANCE );
+                    options_to_ignore.insert( RS2_OPTION_INVALIDATION_BYPASS );
+                    options_to_ignore.insert( RS2_OPTION_DIGITAL_GAIN );
+                }
+            }
+
+            auto opts = _depth_sensor.get_supported_options();
+
+            auto default_preset = false;
+            for( auto o : opts )
+            {
+                auto & opt = _depth_sensor.get_option( o );
+                if( opt.is_read_only() )
+                    continue;
+                if( options_to_ignore.find( o ) != options_to_ignore.end() )
+                    continue;
+
+                auto key = get_string( o );
+                auto it = j.find( key );
+                if( it != j.end() )
+                {
+                    float val = it.value();
+                    if( o == RS2_OPTION_VISUAL_PRESET
+                        && (int)val == (int)RS2_L500_VISUAL_PRESET_DEFAULT )
+                    {
+                        default_preset = true;
+                        continue;
+                    }
+
+                    opt.set( val );
+                }
+            }
+            if( default_preset )
+            {
+                auto options = dynamic_cast< l500_options * >( this );
+                if( options )
+                {
+                    auto preset = options->calc_preset_from_controls();
+                    options->set_preset_value( preset );
+                }
+            }
+        } );
+    }
+    } // namespace librealsense

--- a/unit-tests/func/frames/test_first_frame_delay.py
+++ b/unit-tests/func/frames/test_first_frame_delay.py
@@ -1,0 +1,68 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
+# test:device L500*
+# test:device D400*
+
+import pyrealsense2 as rs
+from rspy.stopwatch import Stopwatch
+from rspy import test
+import time
+import platform
+
+# Start depth + color streams and measure the time from stream opened until first frame arrived.
+# Verify that the time do not exceeds the maximum time allowed
+MAX_TIME_TO_WAIT_FOR_FIRST_FRAME = 2.5  # [sec]
+open_call_stopwatch = Stopwatch()
+first_frame_time = None
+
+
+def time_to_first_frame(sensor, profile):
+    global first_frame_time
+    first_frame_time = MAX_TIME_TO_WAIT_FOR_FIRST_FRAME
+
+    def frame_cb(frame):
+        global first_frame_time
+        if first_frame_time == MAX_TIME_TO_WAIT_FOR_FIRST_FRAME:
+            global open_call_stopwatch
+            first_frame_time = open_call_stopwatch.get_elapsed()
+
+    open_call_stopwatch.reset()
+    sensor.open(profile)
+    sensor.start(frame_cb)
+
+    while first_frame_time == MAX_TIME_TO_WAIT_FOR_FIRST_FRAME and open_call_stopwatch.get_elapsed() < MAX_TIME_TO_WAIT_FOR_FIRST_FRAME:
+        time.sleep(0.05)
+
+    sensor.stop()
+    sensor.close()
+
+    return first_frame_time
+
+
+dev = test.find_first_device_or_exit()
+
+ds = dev.first_depth_sensor()
+cs = dev.first_color_sensor()
+
+dp = next(p for p in
+          ds.profiles if p.fps() == 30
+          and p.stream_type() == rs.stream.depth
+          and p.format() == rs.format.z16)
+
+cp = next(p for p in
+          cs.profiles if p.fps() == 30
+          and p.stream_type() == rs.stream.color
+          and p.format() == rs.format.rgb8)
+
+test.start("Testing first depth frame delay on " + platform.system())
+first_depth_frame_delay = time_to_first_frame(ds, dp)
+print("Time until first depth frame is: {:.3f} [sec]".format(first_depth_frame_delay))
+test.check(first_depth_frame_delay < MAX_TIME_TO_WAIT_FOR_FIRST_FRAME)
+test.finish()
+
+test.start("Testing first color frame delay on " + platform.system())
+first_color_frame_delay = time_to_first_frame(cs, cp)
+print("Time until first color frame is: {:.3f} [sec]".format(first_color_frame_delay))
+test.check(first_color_frame_delay < MAX_TIME_TO_WAIT_FOR_FIRST_FRAME)
+test.finish()

--- a/unit-tests/func/frames/test_first_frame_delay.py
+++ b/unit-tests/func/frames/test_first_frame_delay.py
@@ -52,10 +52,10 @@ if dev.supports(rs.camera_info.product_line):
     product_line = dev.get_info(rs.camera_info.product_line)
     if product_line == "D400":
         max_delay_for_depth_frame = 1.5
-        max_delay_for_color_frame = 1.0
+        max_delay_for_color_frame = 1.5
     elif product_line == "L500":
         max_delay_for_depth_frame = 2.5 # depth frame has a 1.5 seconds built in delay at the FW side + 1.0 second for LRS
-        max_delay_for_color_frame = 1.0
+        max_delay_for_color_frame = 1.5
 
 ds = dev.first_depth_sensor()
 cs = dev.first_color_sensor()

--- a/unit-tests/func/frames/test_first_frame_delay.py
+++ b/unit-tests/func/frames/test_first_frame_delay.py
@@ -12,6 +12,7 @@ import platform
 
 # Start depth + color streams and measure the time from stream opened until first frame arrived.
 # Verify that the time do not exceeds the maximum time allowed
+# Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
 open_call_stopwatch = Stopwatch()
 
 # Function will wait for the first frame for 'max_delay_allowed' + 1 extra second
@@ -43,7 +44,7 @@ def time_to_first_frame(sensor, profile, max_delay_allowed):
 
 
 dev = test.find_first_device_or_exit()
-
+time.sleep(3) # The device starts at D0 (Operational) state, allow time for it to get into idle state
 max_delay_for_depth_frame = 5
 max_delay_for_color_frame = 5
 

--- a/unit-tests/func/frames/test_pipeline_first_frame_delay.py
+++ b/unit-tests/func/frames/test_pipeline_first_frame_delay.py
@@ -17,23 +17,11 @@ import platform
 # Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
 
 
-def time_to_first_frame(config):
-    pipe = rs.pipeline()
-    start_call_stopwatch = Stopwatch()
-    pipe.start(config)
-    pipe.wait_for_frames()
-    delay = start_call_stopwatch.get_elapsed()
-    pipe.stop()
-    return delay
-
-
-time.sleep(3)  # The device starts at D0 (Operational) state, allow time for it to get into idle state
-
-max_delay_for_depth_frame = 5
-max_delay_for_color_frame = 5
-
 # Set maximum delay for first frame according to product line
 dev = test.find_first_device_or_exit()
+
+# The device starts at D0 (Operational) state, allow time for it to get into idle state
+time.sleep( 3 )
 
 product_line = dev.get_info(rs.camera_info.product_line)
 if product_line == "D400":
@@ -45,6 +33,18 @@ elif product_line == "L500":
 else:
     log.f("This test support only D400 + L515 devices")
 
+
+def time_to_first_frame(config):
+    pipe = rs.pipeline()
+    start_call_stopwatch = Stopwatch()
+    pipe.start(config)
+    pipe.wait_for_frames()
+    delay = start_call_stopwatch.get_elapsed()
+    pipe.stop()
+    return delay
+
+
+################################################################################################
 test.start("Testing pipeline first depth frame delay on " + product_line + " device - " + platform.system() + " OS")
 depth_cfg = rs.config()
 depth_cfg.enable_stream(rs.stream.depth, rs.format.z16, 30)
@@ -53,6 +53,8 @@ print("Delay from pipeline.start() until first depth frame is: {:.3f} [sec] max 
 test.check(frame_delay < max_delay_for_depth_frame)
 test.finish()
 
+
+################################################################################################
 test.start("Testing pipeline first color frame delay on " + product_line + " device - " + platform.system() + " OS")
 color_cfg = rs.config()
 color_cfg.enable_stream(rs.stream.color, rs.format.rgb8, 30)
@@ -60,3 +62,7 @@ frame_delay = time_to_first_frame(color_cfg)
 print("Delay from pipeline.start() until first color frame is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".format(frame_delay, max_delay_for_color_frame))
 test.check(frame_delay < max_delay_for_color_frame)
 test.finish()
+
+
+################################################################################################
+test.print_results_and_exit()

--- a/unit-tests/func/frames/test_pipeline_first_frame_delay.py
+++ b/unit-tests/func/frames/test_pipeline_first_frame_delay.py
@@ -6,7 +6,8 @@
 
 import pyrealsense2 as rs
 from rspy.stopwatch import Stopwatch
-from rspy import test
+import sys
+from rspy import test, log
 import time
 import platform
 
@@ -42,8 +43,7 @@ elif product_line == "L500":
     max_delay_for_depth_frame = 3  # Includes L515 depth frame FW delay of 1.5 [sec]
     max_delay_for_color_frame = 1.5
 else:
-    print("This test support only D400 + L515 devices")
-    exit (0)
+    log.f("This test support only D400 + L515 devices")
 
 test.start("Testing pipeline first depth frame delay on " + product_line + " device - " + platform.system() + " OS")
 depth_cfg = rs.config()

--- a/unit-tests/func/frames/test_pipeline_first_frame_delay.py
+++ b/unit-tests/func/frames/test_pipeline_first_frame_delay.py
@@ -34,15 +34,16 @@ max_delay_for_color_frame = 5
 # Set maximum delay for first frame according to product line
 dev = test.find_first_device_or_exit()
 
-product_line = "Unknown"
-if dev.supports(rs.camera_info.product_line):
-    product_line = dev.get_info(rs.camera_info.product_line)
-    if product_line == "D400":
-        max_delay_for_depth_frame = 2
-        max_delay_for_color_frame = 2
-    elif product_line == "L500":
-        max_delay_for_depth_frame = 3  # L515 depth frame has a 1.5 seconds built in delay at the FW side + 1.0 second for LRS
-        max_delay_for_color_frame = 1.5
+product_line = dev.get_info(rs.camera_info.product_line)
+if product_line == "D400":
+    max_delay_for_depth_frame = 2
+    max_delay_for_color_frame = 2
+elif product_line == "L500":
+    max_delay_for_depth_frame = 3  # Includes L515 depth frame FW delay of 1.5 [sec]
+    max_delay_for_color_frame = 1.5
+else:
+    print("This test support only D400 + L515 devices")
+    exit (0)
 
 test.start("Testing pipeline first depth frame delay on " + product_line + " device - " + platform.system() + " OS")
 depth_cfg = rs.config()

--- a/unit-tests/func/frames/test_pipeline_first_frame_delay.py
+++ b/unit-tests/func/frames/test_pipeline_first_frame_delay.py
@@ -6,7 +6,6 @@
 
 import pyrealsense2 as rs
 from rspy.stopwatch import Stopwatch
-import sys
 from rspy import test, log
 import time
 import platform

--- a/unit-tests/func/frames/test_pipeline_first_frame_delay.py
+++ b/unit-tests/func/frames/test_pipeline_first_frame_delay.py
@@ -1,0 +1,61 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
+# test:device L500*
+# test:device D400*
+
+import pyrealsense2 as rs
+from rspy.stopwatch import Stopwatch
+from rspy import test
+import time
+import platform
+
+
+# Start depth + color streams and measure the time from stream opened until first frame arrived using pipeline API.
+# Verify that the time do not exceeds the maximum time allowed
+# Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
+
+
+def time_to_first_frame(config):
+    pipe = rs.pipeline()
+    start_call_stopwatch = Stopwatch()
+    pipe.start(config)
+    pipe.wait_for_frames()
+    delay = start_call_stopwatch.get_elapsed()
+    pipe.stop()
+    return delay
+
+
+time.sleep(3)  # The device starts at D0 (Operational) state, allow time for it to get into idle state
+
+max_delay_for_depth_frame = 5
+max_delay_for_color_frame = 5
+
+# Set maximum delay for first frame according to product line
+dev = test.find_first_device_or_exit()
+
+product_line = "Unknown"
+if dev.supports(rs.camera_info.product_line):
+    product_line = dev.get_info(rs.camera_info.product_line)
+    if product_line == "D400":
+        max_delay_for_depth_frame = 2
+        max_delay_for_color_frame = 2
+    elif product_line == "L500":
+        max_delay_for_depth_frame = 3  # L515 depth frame has a 1.5 seconds built in delay at the FW side + 1.0 second for LRS
+        max_delay_for_color_frame = 1.5
+
+test.start("Testing pipeline first depth frame delay on " + product_line + " device - " + platform.system() + " OS")
+depth_cfg = rs.config()
+depth_cfg.enable_stream(rs.stream.depth, rs.format.z16, 30)
+frame_delay = time_to_first_frame(depth_cfg)
+print("Delay from pipeline.start() until first depth frame is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".format(frame_delay, max_delay_for_depth_frame))
+test.check(frame_delay < max_delay_for_depth_frame)
+test.finish()
+
+test.start("Testing pipeline first color frame delay on " + product_line + " device - " + platform.system() + " OS")
+color_cfg = rs.config()
+color_cfg.enable_stream(rs.stream.color, rs.format.rgb8, 30)
+frame_delay = time_to_first_frame(color_cfg)
+print("Delay from pipeline.start() until first color frame is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".format(frame_delay, max_delay_for_color_frame))
+test.check(frame_delay < max_delay_for_color_frame)
+test.finish()

--- a/unit-tests/func/frames/test_sensor_first_frame_delay.py
+++ b/unit-tests/func/frames/test_sensor_first_frame_delay.py
@@ -10,7 +10,7 @@ from rspy import test
 import time
 import platform
 
-# Start depth + color streams and measure the time from stream opened until first frame arrived.
+# Start depth + color streams and measure the time from stream opened until first frame arrived using sensor API.
 # Verify that the time do not exceeds the maximum time allowed
 # Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
 open_call_stopwatch = Stopwatch()
@@ -48,6 +48,7 @@ time.sleep(3) # The device starts at D0 (Operational) state, allow time for it t
 max_delay_for_depth_frame = 5
 max_delay_for_color_frame = 5
 
+product_line = "Unknown"
 # Set maximum delay for first frame according to product line
 if dev.supports(rs.camera_info.product_line):
     product_line = dev.get_info(rs.camera_info.product_line)
@@ -55,7 +56,7 @@ if dev.supports(rs.camera_info.product_line):
         max_delay_for_depth_frame = 1.5
         max_delay_for_color_frame = 1.5
     elif product_line == "L500":
-        max_delay_for_depth_frame = 2.5 # depth frame has a 1.5 seconds built in delay at the FW side + 1.0 second for LRS
+        max_delay_for_depth_frame = 2.5 # L515 depth frame has a 1.5 seconds built in delay at the FW side + 1.0 second for LRS
         max_delay_for_color_frame = 1.5
 
 ds = dev.first_depth_sensor()
@@ -71,13 +72,13 @@ cp = next(p for p in
           and p.stream_type() == rs.stream.color
           and p.format() == rs.format.rgb8)
 
-test.start("Testing first depth frame delay on " + platform.system())
+test.start("Testing first depth frame delay on " + product_line + " device - "+ platform.system() + " OS")
 first_depth_frame_delay = time_to_first_frame(ds, dp, max_delay_for_depth_frame)
 print("Time until first depth frame is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".format(first_depth_frame_delay, max_delay_for_depth_frame))
 test.check(first_depth_frame_delay < max_delay_for_depth_frame)
 test.finish()
 
-test.start("Testing first color frame delay on " + platform.system())
+test.start("Testing first color frame delay on " + product_line + " device - "+ platform.system() + " OS")
 first_color_frame_delay = time_to_first_frame(cs, cp, max_delay_for_color_frame)
 print("Time until first color frame is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".format(first_color_frame_delay, max_delay_for_color_frame))
 test.check(first_color_frame_delay < max_delay_for_color_frame)

--- a/unit-tests/func/frames/test_sensor_first_frame_delay.py
+++ b/unit-tests/func/frames/test_sensor_first_frame_delay.py
@@ -6,7 +6,7 @@
 
 import pyrealsense2 as rs
 from rspy.stopwatch import Stopwatch
-from rspy import test
+from rspy import test, log
 import time
 import platform
 

--- a/unit-tests/func/frames/test_sensor_first_frame_delay.py
+++ b/unit-tests/func/frames/test_sensor_first_frame_delay.py
@@ -15,6 +15,7 @@ import platform
 # Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
 open_call_stopwatch = Stopwatch()
 
+
 # Function will wait for the first frame for 'max_delay_allowed' + 1 extra second
 # If the frame arrive it will return the time it took since open() call
 # If no frame it will return 'max_delay_allowed'
@@ -42,11 +43,20 @@ def time_to_first_frame(sensor, profile, max_delay_allowed):
 
     return first_frame_time
 
-
-dev = test.find_first_device_or_exit()
 time.sleep(3) # The device starts at D0 (Operational) state, allow time for it to get into idle state
+
+max_time_for_device_creation = 1.5
 max_delay_for_depth_frame = 5
 max_delay_for_color_frame = 5
+
+test.start("Testing device creation time on " + platform.system() + " OS")
+device_creation_stopwatch = Stopwatch()
+dev = test.find_first_device_or_exit()
+device_creation_time = device_creation_stopwatch.get_elapsed()
+print("Device creation time is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".format(device_creation_time, max_time_for_device_creation))
+test.check(device_creation_time < max_time_for_device_creation)
+test.finish()
+
 
 product_line = "Unknown"
 # Set maximum delay for first frame according to product line


### PR DESCRIPTION
Reduce L515 device creation and sensor open/start calls time by keeping the USB power on when multiple access are made

Tracked on [RS5-8208]