### PR TITLE
make RSPointCloud.mapTo compatible with rs_processing.hpp map_to

### DIFF
--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -3013,7 +3013,7 @@ class RSPointCloud : public Nan::ObjectWrap, Options {
 
     CallNativeFunc(rs2_set_option, &me->error_,
         reinterpret_cast<rs2_options*>(me->processing_block_),
-        RS2_OPTION_STREAM_FORMAT_FILTER,
+        RS2_OPTION_STREAM_INDEX_FILTER,
         static_cast<float>(extrator.index_),
         &me->error_);
 

--- a/wrappers/nodejs/src/addon.cpp
+++ b/wrappers/nodejs/src/addon.cpp
@@ -3001,9 +3001,22 @@ class RSPointCloud : public Nan::ObjectWrap, Options {
     StreamProfileExtrator extrator(profile);
     CallNativeFunc(rs2_set_option, &me->error_,
         reinterpret_cast<rs2_options*>(me->processing_block_),
-        RS2_OPTION_TEXTURE_SOURCE,
-        static_cast<float>(extrator.unique_id_),
+        RS2_OPTION_STREAM_FILTER,
+        static_cast<float>(extrator.stream_),
         &me->error_);
+
+    CallNativeFunc(rs2_set_option, &me->error_,
+        reinterpret_cast<rs2_options*>(me->processing_block_),
+        RS2_OPTION_STREAM_FORMAT_FILTER,
+        static_cast<float>(extrator.format_),
+        &me->error_);
+
+    CallNativeFunc(rs2_set_option, &me->error_,
+        reinterpret_cast<rs2_options*>(me->processing_block_),
+        RS2_OPTION_STREAM_FORMAT_FILTER,
+        static_cast<float>(extrator.index_),
+        &me->error_);
+
     if (extrator.stream_ == RS2_STREAM_DEPTH) return;
 
     // rs2_process_frame will release the input frame, so we need to addref


### PR DESCRIPTION
Related to issues:
* https://github.com/IntelRealSense/librealsense/issues/5057
* https://github.com/IntelRealSense/librealsense/issues/6223

RSPointCloud.mapTo should repeat same behavior as rs_processing.hpp [map_to](https://github.com/IntelRealSense/librealsense/blob/master/include/librealsense2/hpp/rs_processing.hpp#L452) which was changed by [commit](https://github.com/IntelRealSense/librealsense/commit/6850677e0473bd01a2078ef6e0398a617539cf56#diff-0657358b7a274211507c5de54e211fe5915712beb08733d0c1dac831bbc32a5cL318)


