### PR TITLE
correct link to GIF in hdr_demo's readme 

### DIFF
--- a/examples/hdr/readme.md
+++ b/examples/hdr/readme.md
@@ -11,7 +11,7 @@ It walks through the sensor configuration phase and visualizes the algorithm inp
 
 
 ## Expected Output
- ![](https://github.com/IntelRealSense/librealsense/blob/development/examples/hdr/hdr_demo.gif)
+ ![](https://github.com/IntelRealSense/librealsense/blob/master/examples/hdr/hdr_demo.gif)
  
 ## Code Overview 
 

--- a/examples/hdr/readme.md
+++ b/examples/hdr/readme.md
@@ -11,7 +11,7 @@ It walks through the sensor configuration phase and visualizes the algorithm inp
 
 
 ## Expected Output
- ![](https://github.com/Tomertech/librealsense/blob/hdr_demo/examples/hdr/hdr_demo.gif)
+ ![](https://github.com/IntelRealSense/librealsense/blob/development/examples/hdr/hdr_demo.gif)
  
 ## Code Overview 
 


### PR DESCRIPTION
changed Gif address to the Gif in the development branch instead of the previous (private github link)