### PR TITLE
extrinsics depth to ir2 correction

### DIFF
--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -673,6 +673,7 @@ namespace librealsense
 
         environment::get_instance().get_extrinsics_graph().register_same_extrinsics(*_depth_stream, *_left_ir_stream);
         environment::get_instance().get_extrinsics_graph().register_extrinsics(*_depth_stream, *_right_ir_stream, _left_right_extrinsics);
+        environment::get_instance().get_extrinsics_graph().register_extrinsics(*_left_ir_stream, *_right_ir_stream, _left_right_extrinsics);
 
         register_stream_to_extrinsic_group(*_depth_stream, 0);
         register_stream_to_extrinsic_group(*_left_ir_stream, 0);


### PR DESCRIPTION
It is identity (rotation identity matrix and translation vector zero) without this correction.
Tracked by: DSO-16814
