### PR TITLE
Rollback changes on dispatcher

### DIFF
--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -298,7 +298,6 @@ public:
 
     void stop()
     {
-        _is_alive = false;
         {
             std::unique_lock<std::mutex> lock(_was_stopped_mutex);
 
@@ -320,6 +319,7 @@ public:
     {
         stop();
         _queue.clear();
+        _is_alive = false;
 
         if (_thread.joinable())
         _thread.join();

--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -225,11 +225,6 @@ public:
             int timeout_ms = 5000;
             while (_is_alive)
             {
-                {
-                    std::unique_lock<std::mutex> lock(_was_flushed_mutex);
-                    _was_flushed = false;
-                }
-
                 std::function<void(cancellable_timer)> item;
 
                 if (_queue.dequeue(&item, timeout_ms))
@@ -308,6 +303,11 @@ public:
         }
 
         _queue.clear();
+
+        {
+            std::unique_lock<std::mutex> lock(_was_flushed_mutex);
+            _was_flushed = false;
+        }
 
         std::unique_lock<std::mutex> lock_was_flushed(_was_flushed_mutex);
         _was_flushed_cv.wait_for(lock_was_flushed, std::chrono::hours(999999), [&]() { return _was_flushed.load(); });


### PR DESCRIPTION
These changes (part of #8625) cause problems with polling (hw-errors unit-test) and dispatcher (no device-change notifications in RealCI). Rolling back until we have a fix.