### PR TITLE
Fix DQT + Viewer crash when minimized when running on Debug

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -24,10 +24,15 @@
 #include "../common/utilities/string/trim-newlines.h"
 #include "../common/utilities/imgui/wrap.h"
 
-#define FORCE_NON_NEGATIVE(input) input < 0 ? 0 : input
 
 namespace rs2
 {
+    template <typename T>
+    T non_negative(const T& input)
+    {
+        return std::max(static_cast<T>(0), input);
+    }
+
     // Allocates a frameset from points and texture frames
     frameset_allocator::frameset_allocator(viewer_model* viewer) : owner(viewer),
         filter([this](frame f, frame_source& s)
@@ -1941,8 +1946,8 @@ namespace rs2
 
         auto bottom_y = win.framebuf_height() - viewer_rect.y - viewer_rect.h;
         
-        glViewport(static_cast<GLint>(FORCE_NON_NEGATIVE(viewer_rect.x)), static_cast<GLint>(FORCE_NON_NEGATIVE(bottom_y)),
-            static_cast<GLsizei>(FORCE_NON_NEGATIVE(viewer_rect.w)), static_cast<GLsizei>(FORCE_NON_NEGATIVE(viewer_rect.h - top_bar_height)));
+        glViewport(static_cast<GLint>(non_negative(viewer_rect.x)), static_cast<GLint>(non_negative(bottom_y)),
+            static_cast<GLsizei>(non_negative(viewer_rect.w)), static_cast<GLsizei>(non_negative(viewer_rect.h - top_bar_height)));
 
         glClearColor(0, 0, 0, 1);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1951,7 +1956,7 @@ namespace rs2
 
         glMatrixMode(GL_PROJECTION);
         glPushMatrix();
-        gluPerspective(45, FORCE_NON_NEGATIVE(viewer_rect.w / win.framebuf_height()), 0.001f, 100.0f);
+        gluPerspective(45, non_negative(viewer_rect.w / win.framebuf_height()), 0.001f, 100.0f);
         matrix4 perspective_mat;
         glGetFloatv(GL_PROJECTION_MATRIX, perspective_mat);
         glPopMatrix();

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -842,7 +842,28 @@ namespace rs2
                 if (dpt)
                     _metrics_model.begin_process_frame(dpt);
             }
-            catch (...){} // on device disconnect
+            catch( const error & e )
+            {
+                // Can occur on device disconnect
+                _viewer_model.not_model->output.add_log( RS2_LOG_SEVERITY_DEBUG,
+                                                         __FILE__,
+                                                         __LINE__,
+                                                         error_to_string( e ) );
+            }
+            catch( const std::exception & e )
+            {
+                _viewer_model.not_model->output.add_log( RS2_LOG_SEVERITY_ERROR,
+                                                         __FILE__,
+                                                         __LINE__,
+                                                         e.what() );
+            }
+            catch( ... )
+            {
+                _viewer_model.not_model->output.add_log( RS2_LOG_SEVERITY_ERROR,
+                                                         __FILE__,
+                                                         __LINE__,
+                                                         "Unknown error occurred" );
+            }
 
         }
 


### PR DESCRIPTION
When running on Debug configuration, minimizing the DQT / Viewer windows cause the application to crash.

On this PR I add protection against illegal inputs to open-gl functions
Tracked on [RS5-10796]