### PR TITLE
Travis-CI - update OSX image  + decrease builds runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,11 @@ matrix:
         - |
           subst d: ../. 
         - cd d:/build
-        - cmake .. -G "Visual Studio 15 2017 Win64" -DPYTHON_EXECUTABLE="C:/Python38/python.exe" -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.8 -DBUILD_UNIT_TESTS=true -DBUILD_EXAMPLES=false -DBUILD_GRAPHICAL_EXAMPLES=false -DBUILD_WITH_TM2=false -DFORCE_RSUSB_BACKEND=true -DCHECK_FOR_UPDATES=true
+        - cmake .. -G "Visual Studio 15 2017 Win64" -DPYTHON_EXECUTABLE="C:/Python38/python.exe" -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.8 -DBUILD_UNIT_TESTS=true -DBUILD_EXAMPLES=false -DBUILD_GRAPHICAL_EXAMPLES=false -DBUILD_WITH_TM2=false -DFORCE_RSUSB_BACKEND=true
         - cmake --build . --config $LRS_RUN_CONFIG -- -m
         - cd $LRS_RUN_CONFIG
         - ls
         - ./live-test.exe -d yes -i [software-device]
-        - unset LRS_LOG_LEVEL
-        - C:/Python38/python.exe ../../unit-tests/run-unit-tests.py --verbose .
         
     - name: "Windows - cpp"
       os: windows
@@ -70,7 +68,7 @@ matrix:
       dist: xenial
       script:
         - cd ../scripts && ./pr_check.sh && cd ../build
-        - cmake .. -DBUILD_UNIT_TESTS=true -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5
+        - cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5
         - cmake --build . --config $LRS_BUILD_CONFIG -- -j4
         # python3 ../unit-tests/run-unit-tests.py --verbose .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ matrix:
       os: osx
       language: cpp
       sudo: required
-      osx_image: xcode7
+      osx_image: xcode12.2
       script:
         - export OPENSSL_ROOT_DIR=`brew --prefix openssl` # Used by libcurl for 'CHECK_FOR_UPDATES' capability
         - cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCHECK_FOR_UPDATES=true


### PR DESCRIPTION
Travis-CI build fails when using MacOs < 10.13.

1. Update xcode_image to 12.2 (latest)
2. Remove CHECK_FOR_UPDATE flag for windows build to shorten build time
3. Remove UT run on Windows first build
4. Remove building UT on Linux build

![image](https://user-images.githubusercontent.com/64067618/112965051-9306b180-9151-11eb-8a79-c18142f85f21.png)
