### PR TITLE
fixed sdk v2.43-44 not connecting to D* net device with realsense-viewer

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -3817,7 +3817,7 @@ namespace rs2
             auto s = std::make_shared<sensor>(sub);
             auto objects = std::make_shared< atomic_objects_in_frame >();
             // checking if the sensor is color_sensor or is D405 (with integrated RGB in depth sensor)
-            if (s->is<color_sensor>() || !strcmp(dev.get_info(RS2_CAMERA_INFO_PRODUCT_ID), "0B5B"))
+            if (s->is<color_sensor>() || (dev.supports(RS2_CAMERA_INFO_PRODUCT_ID) && !strcmp(dev.get_info(RS2_CAMERA_INFO_PRODUCT_ID), "0B5B")))
                 objects = _detected_objects;
             auto model = std::make_shared<subdevice_model>(dev, std::make_shared<sensor>(sub), objects, error_message, viewer, new_device_connected);
             subdevices.push_back(model);


### PR DESCRIPTION
There was changes introduced in february 15th in model-views.cpp that breaks connections to network devices from realsense-viewer. This PR fixes this.