### PR TITLE
Set distortion model of color on L515 to RS2_DISTORTION_BROWN_CONRADY

### DIFF
--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -96,6 +96,15 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
         x = ux;
         y = uy;
     }
+    if (intrin->model == RS2_DISTORTION_BROWN_CONRADY)
+    {
+        float r2 = x * x + y * y;
+        auto icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
+        auto delta_x = 2 * intrin->coeffs[2] * x*y + intrin->coeffs[3] * (r2 + 2 * x*x);
+        auto delta_y = 2 * intrin->coeffs[3] * x*y + intrin->coeffs[2] * (r2 + 2 * y*y);
+        x = (x - delta_x)*icdist;
+        y = (y - delta_y)*icdist;
+    }
     if (intrin->model == RS2_DISTORTION_KANNALA_BRANDT4)
     {
         float rd = sqrtf(x*x + y*y);

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -95,7 +95,7 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
     {
         // need to loop until convergence 
         // 10 iterations determined empirically
-        for (auto i = 0; i < 10; i++)
+        for (int i = 0; i < 10; i++)
         {
             float r2 = x * x + y * y;
             float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
@@ -111,7 +111,7 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
     {
         // need to loop until convergence 
         // 10 iterations determined empirically
-        for (auto i = 0; i < 10; i++)
+        for (int i = 0; i < 10; i++)
         {
             float r2 = x * x + y * y;
             float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -88,11 +88,11 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
     float x = (pixel[0] - intrin->ppx) / intrin->fx;
     float y = (pixel[1] - intrin->ppy) / intrin->fy;
 
+    auto xo = x;
+    auto yo = y;
+
     if(intrin->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY)
     {
-        auto xo = x;
-        auto yo = y;
-
         // need to loop until convergence 
         // 10 iterations determined empirically
         for (auto i = 0; i < 10; i++)
@@ -109,9 +109,6 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
     }
     if (intrin->model == RS2_DISTORTION_BROWN_CONRADY)
     {
-        auto xo = x;
-        auto yo = y;
-
         // need to loop until convergence 
         // 10 iterations determined empirically
         for (auto i = 0; i < 10; i++)

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -88,8 +88,8 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
     float x = (pixel[0] - intrin->ppx) / intrin->fx;
     float y = (pixel[1] - intrin->ppy) / intrin->fy;
 
-    auto xo = x;
-    auto yo = y;
+    float xo = x;
+    float yo = y;
 
     if(intrin->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY)
     {

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -99,8 +99,8 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
         {
             float r2 = x * x + y * y;
             float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
-            auto xq = x / icdist;
-            auto yq = y / icdist;
+            float xq = x / icdist;
+            float yq = y / icdist;
             float delta_x = 2 * intrin->coeffs[2] * xq*yq + intrin->coeffs[3] * (r2 + 2 * xq*xq);
             float delta_y = 2 * intrin->coeffs[3] * xq*yq + intrin->coeffs[2] * (r2 + 2 * yq*yq);
             x = (xo - delta_x)*icdist;

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -99,9 +99,9 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
     if (intrin->model == RS2_DISTORTION_BROWN_CONRADY)
     {
         float r2 = x * x + y * y;
-        auto icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
-        auto delta_x = 2 * intrin->coeffs[2] * x*y + intrin->coeffs[3] * (r2 + 2 * x*x);
-        auto delta_y = 2 * intrin->coeffs[3] * x*y + intrin->coeffs[2] * (r2 + 2 * y*y);
+        float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
+        float delta_x = 2 * intrin->coeffs[2] * x*y + intrin->coeffs[3] * (r2 + 2 * x*x);
+        float delta_y = 2 * intrin->coeffs[3] * x*y + intrin->coeffs[2] * (r2 + 2 * y*y);
         x = (x - delta_x)*icdist;
         y = (y - delta_y)*icdist;
     }

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -90,8 +90,8 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
 
     if(intrin->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY)
     {
-        auto x_0 = x;
-        auto y_0 = y;
+        auto xo = x;
+        auto yo = y;
 
         // need to loop until convergence 
         // 10 iterations determined empirically
@@ -103,8 +103,8 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
             auto yq = y / icdist;
             float delta_x = 2 * intrin->coeffs[2] * xq*yq + intrin->coeffs[3] * (r2 + 2 * xq*xq);
             float delta_y = 2 * intrin->coeffs[3] * xq*yq + intrin->coeffs[2] * (r2 + 2 * yq*yq);
-            x = (x_0 - delta_x)*icdist;
-            y = (y_0 - delta_y)*icdist;
+            x = (xo - delta_x)*icdist;
+            y = (yo - delta_y)*icdist;
         }
     }
     if (intrin->model == RS2_DISTORTION_BROWN_CONRADY)

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -87,23 +87,43 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
 
     float x = (pixel[0] - intrin->ppx) / intrin->fx;
     float y = (pixel[1] - intrin->ppy) / intrin->fy;
+
     if(intrin->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY)
     {
-        float r2  = x*x + y*y;
-        float f = 1 + intrin->coeffs[0]*r2 + intrin->coeffs[1]*r2*r2 + intrin->coeffs[4]*r2*r2*r2;
-        float ux = x*f + 2*intrin->coeffs[2]*x*y + intrin->coeffs[3]*(r2 + 2*x*x);
-        float uy = y*f + 2*intrin->coeffs[3]*x*y + intrin->coeffs[2]*(r2 + 2*y*y);
-        x = ux;
-        y = uy;
+        auto x_0 = x;
+        auto y_0 = y;
+
+        // need to loop until convergence 
+        // 10 iterations determined empirically
+        for (auto i = 0; i < 10; i++)
+        {
+            float r2 = x * x + y * y;
+            float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
+            auto xq = x / icdist;
+            auto yq = y / icdist;
+            float delta_x = 2 * intrin->coeffs[2] * xq*yq + intrin->coeffs[3] * (r2 + 2 * xq*xq);
+            float delta_y = 2 * intrin->coeffs[3] * xq*yq + intrin->coeffs[2] * (r2 + 2 * yq*yq);
+            x = (x_0 - delta_x)*icdist;
+            y = (y_0 - delta_y)*icdist;
+        }
     }
     if (intrin->model == RS2_DISTORTION_BROWN_CONRADY)
     {
-        float r2 = x * x + y * y;
-        float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
-        float delta_x = 2 * intrin->coeffs[2] * x*y + intrin->coeffs[3] * (r2 + 2 * x*x);
-        float delta_y = 2 * intrin->coeffs[3] * x*y + intrin->coeffs[2] * (r2 + 2 * y*y);
-        x = (x - delta_x)*icdist;
-        y = (y - delta_y)*icdist;
+        auto x_0 = x;
+        auto y_0 = y;
+
+        // need to loop until convergence 
+        // 10 iterations determined empirically
+        for (auto i = 0; i < 10; i++)
+        {
+            float r2 = x * x + y * y;
+            float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
+            float delta_x = 2 * intrin->coeffs[2] * x*y + intrin->coeffs[3] * (r2 + 2 * x*x);
+            float delta_y = 2 * intrin->coeffs[3] * x*y + intrin->coeffs[2] * (r2 + 2 * y*y);
+            x = (x_0 - delta_x)*icdist;
+            y = (y_0 - delta_y)*icdist;
+        }
+        
     }
     if (intrin->model == RS2_DISTORTION_KANNALA_BRANDT4)
     {

--- a/include/librealsense2/rsutil.h
+++ b/include/librealsense2/rsutil.h
@@ -109,8 +109,8 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
     }
     if (intrin->model == RS2_DISTORTION_BROWN_CONRADY)
     {
-        auto x_0 = x;
-        auto y_0 = y;
+        auto xo = x;
+        auto yo = y;
 
         // need to loop until convergence 
         // 10 iterations determined empirically
@@ -120,8 +120,8 @@ static void rs2_deproject_pixel_to_point(float point[3], const struct rs2_intrin
             float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
             float delta_x = 2 * intrin->coeffs[2] * x*y + intrin->coeffs[3] * (r2 + 2 * x*x);
             float delta_y = 2 * intrin->coeffs[3] * x*y + intrin->coeffs[2] * (r2 + 2 * y*y);
-            x = (x_0 - delta_x)*icdist;
-            y = (y_0 - delta_y)*icdist;
+            x = (xo - delta_x)*icdist;
+            y = (yo - delta_y)*icdist;
         }
         
     }

--- a/src/cuda/cuda-pointcloud.cu
+++ b/src/cuda/cuda-pointcloud.cu
@@ -17,15 +17,40 @@ void deproject_pixel_to_point_cuda(float points[3], const struct rs2_intrinsics 
     //assert(intrin->model != RS2_DISTORTION_BROWN_CONRADY); // Cannot deproject to an brown conrady model
     float x = (pixel[0] - intrin->ppx) / intrin->fx;
     float y = (pixel[1] - intrin->ppy) / intrin->fy;    
-    if(intrin->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY)
+
+    float xo = x;
+    float yo = y;
+
+    if (intrin->model == RS2_DISTORTION_INVERSE_BROWN_CONRADY)
     {
-        float r2  = x*x + y*y;
-        float f = 1 + intrin->coeffs[0]*r2 + intrin->coeffs[1]*r2*r2 + intrin->coeffs[4]*r2*r2*r2;
-        float ux = x*f + 2*intrin->coeffs[2]*x*y + intrin->coeffs[3]*(r2 + 2*x*x);
-        float uy = y*f + 2*intrin->coeffs[3]*x*y + intrin->coeffs[2]*(r2 + 2*y*y);
-        x = ux;
-        y = uy;
-    } 
+        // need to loop until convergence 
+        // 10 iterations determined empirically
+        for (int i = 0; i < 10; i++)
+        {
+            float r2 = x * x + y * y;
+            float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
+            float xq = x / icdist;
+            float yq = y / icdist;
+            float delta_x = 2 * intrin->coeffs[2] * xq*yq + intrin->coeffs[3] * (r2 + 2 * xq*xq);
+            float delta_y = 2 * intrin->coeffs[3] * xq*yq + intrin->coeffs[2] * (r2 + 2 * yq*yq);
+            x = (xo - delta_x)*icdist;
+            y = (yo - delta_y)*icdist;
+        }
+    }
+    if (intrin->model == RS2_DISTORTION_BROWN_CONRADY)
+    {
+        // need to loop until convergence 
+        // 10 iterations determined empirically
+        for (int i = 0; i < 10; i++)
+        {
+            float r2 = x * x + y * y;
+            float icdist = (float)1 / (float)(1 + ((intrin->coeffs[4] * r2 + intrin->coeffs[1])*r2 + intrin->coeffs[0])*r2);
+            float delta_x = 2 * intrin->coeffs[2] * x*y + intrin->coeffs[3] * (r2 + 2 * x*x);
+            float delta_y = 2 * intrin->coeffs[3] * x*y + intrin->coeffs[2] * (r2 + 2 * y*y);
+            x = (xo - delta_x)*icdist;
+            y = (yo - delta_y)*icdist;
+        }
+    }
     points[0] = depth * x;
     points[1] = depth * y;
     points[2] = depth;

--- a/src/depth-to-rgb-calibration.cpp
+++ b/src/depth-to-rgb-calibration.cpp
@@ -184,8 +184,12 @@ rs2_calibration_status depth_to_rgb_calibration::optimize(
 
         AC_LOG( DEBUG, "Optimization successful!" );
         _thermal_intr = _algo.get_calibration().get_intrinsics();
-        _thermal_intr.model = RS2_DISTORTION_INVERSE_BROWN_CONRADY;  // restore LRS model
 
+#ifdef __SSSE3__
+        _thermal_intr.model = RS2_DISTORTION_INVERSE_BROWN_CONRADY;  // restore LRS model
+#else
+        _thermal_intr.model = RS2_DISTORTION_BROWN_CONRADY;  // restore LRS model
+#endif
         // Override everything in the raw intrinsics except the focal length (fx and fy)
         // TODO: AC is not "supposed" to change focal length, but we shouldn't assume this! The
         // proper way to do the following is not by restoring the original, but rather by DEscaling

--- a/src/depth-to-rgb-calibration.cpp
+++ b/src/depth-to-rgb-calibration.cpp
@@ -185,11 +185,8 @@ rs2_calibration_status depth_to_rgb_calibration::optimize(
         AC_LOG( DEBUG, "Optimization successful!" );
         _thermal_intr = _algo.get_calibration().get_intrinsics();
 
-#ifdef __SSSE3__
-        _thermal_intr.model = RS2_DISTORTION_INVERSE_BROWN_CONRADY;  // restore LRS model
-#else
-        _thermal_intr.model = RS2_DISTORTION_BROWN_CONRADY;  // restore LRS model
-#endif
+        _thermal_intr.model = l500_distortion;  // restore LRS model
+
         // Override everything in the raw intrinsics except the focal length (fx and fy)
         // TODO: AC is not "supposed" to change focal length, but we shouldn't assume this! The
         // proper way to do the following is not by restoring the original, but rather by DEscaling

--- a/src/gl/pointcloud-gl.cpp
+++ b/src/gl/pointcloud-gl.cpp
@@ -248,7 +248,7 @@ public:
     {
         rs2::float2 focal{ intr.fx, intr.fy };
         rs2::float2 principal{ intr.ppx, intr.ppy };
-        float is_bc = (intr.model == RS2_DISTORTION_INVERSE_BROWN_CONRADY ? 1.f : 0.f);
+        float is_bc = (intr.model == RS2_DISTORTION_INVERSE_BROWN_CONRADY || intr.model == RS2_DISTORTION_BROWN_CONRADY ? 1.f : 0.f);
         _shader->load_uniform(_focal_location[idx], focal);
         _shader->load_uniform(_principal_location[idx], principal);
         _shader->load_uniform(_is_bc_location[idx], is_bc);

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -19,13 +19,6 @@ namespace librealsense
 {
     using namespace ivcam2;
 
-// brown conrady distortion model doesn't implemented yet on sse code
-#ifdef __SSSE3__
-    const rs2_distortion l500_distortion = RS2_DISTORTION_INVERSE_BROWN_CONRADY;
-#else
-    const rs2_distortion l500_distortion = RS2_DISTORTION_BROWN_CONRADY;
-#endif
-
     std::map<uint32_t, rs2_format> l500_color_fourcc_to_rs2_format = {
         {rs_fourcc('Y','U','Y','2'), RS2_FORMAT_YUYV},
         {rs_fourcc('Y','U','Y','V'), RS2_FORMAT_YUYV},

--- a/src/l500/l500-color.cpp
+++ b/src/l500/l500-color.cpp
@@ -258,7 +258,11 @@ namespace librealsense
                     intrinsics.coeffs[3] = model.distort.tangential_p2;
                     intrinsics.coeffs[4] = model.distort.radial_k3;
 
+#ifdef __SSSE3__
                     intrinsics.model = RS2_DISTORTION_INVERSE_BROWN_CONRADY;
+#else
+                    intrinsics.model = RS2_DISTORTION_BROWN_CONRADY;
+#endif
                 }
 
                 return intrinsics;
@@ -345,9 +349,12 @@ namespace librealsense
         // The distortion model is not part of the table. The FW assumes it is brown,
         // but in LRS we (mistakenly) use INVERSE brown. We therefore make sure the user
         // has not tried to change anything from the intrinsics reported:
-        if( intr.model != RS2_DISTORTION_INVERSE_BROWN_CONRADY )
-            throw invalid_value_exception( "invalid intrinsics distortion model" );
-
+#ifdef __SSSE3__
+        if( intr.model != RS2_DISTORTION_INVERSE_BROWN_CONRADY)
+#else
+        if (intr.model != RS2_DISTORTION_BROWN_CONRADY)
+#endif
+            throw invalid_value_exception("invalid intrinsics distortion model");
         rgb_calibration_table table;
         AC_LOG( DEBUG, "Reading RGB calibration table 0x" << std::hex << table.table_id );
         ivcam2::read_fw_table( *_owner->_hw_monitor, table.table_id, &table );

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -15,11 +15,8 @@
 
 namespace librealsense
 {
-#ifdef RS2_USE_CUDA
+
     const rs2_distortion l500_distortion = RS2_DISTORTION_BROWN_CONRADY;
-#else
-    const rs2_distortion l500_distortion = RS2_DISTORTION_INVERSE_BROWN_CONRADY;
-#endif
 
     class l500_color
         : public virtual l500_device

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -15,7 +15,7 @@
 
 namespace librealsense
 {
-    // brown conrady distortion model doesn't implemented yet on sse code
+    // brown conrady distortion model isn't yet implemented on sse code
 #ifdef __SSSE3__
     const rs2_distortion l500_distortion = RS2_DISTORTION_INVERSE_BROWN_CONRADY;
 #else

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -15,6 +15,12 @@
 
 namespace librealsense
 {
+    // brown conrady distortion model doesn't implemented yet on sse code
+#ifdef __SSSE3__
+    const rs2_distortion l500_distortion = RS2_DISTORTION_INVERSE_BROWN_CONRADY;
+#else
+    const rs2_distortion l500_distortion = RS2_DISTORTION_BROWN_CONRADY;
+#endif
 
     class l500_color
         : public virtual l500_device

--- a/src/l500/l500-color.h
+++ b/src/l500/l500-color.h
@@ -15,11 +15,10 @@
 
 namespace librealsense
 {
-    // brown conrady distortion model isn't yet implemented on sse code
-#ifdef __SSSE3__
-    const rs2_distortion l500_distortion = RS2_DISTORTION_INVERSE_BROWN_CONRADY;
-#else
+#ifdef RS2_USE_CUDA
     const rs2_distortion l500_distortion = RS2_DISTORTION_BROWN_CONRADY;
+#else
+    const rs2_distortion l500_distortion = RS2_DISTORTION_INVERSE_BROWN_CONRADY;
 #endif
 
     class l500_color

--- a/src/proc/sse/sse-pointcloud.h
+++ b/src/proc/sse/sse-pointcloud.h
@@ -10,6 +10,15 @@ namespace librealsense
     {
     public:
         pointcloud_sse();
+
+        void get_texture_map_sse(float2 * texture_map,
+            const float3 * points,
+            const unsigned int width,
+            const unsigned int height,
+            const rs2_intrinsics & other_intrinsics,
+            const rs2_extrinsics & extr,
+            float2 * pixels_ptr);
+
     private:
         void preprocess() override;
         const float3 * depth_to_points(

--- a/unit-tests/algo/projection/test-distortion.cpp
+++ b/unit-tests/algo/projection/test-distortion.cpp
@@ -1,0 +1,57 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+
+#include "../algo-common.h"
+#include "../../../include/librealsense2/rsutil.h"
+
+void compare(float pixel1[2], float pixel2[2])
+{
+    for (auto i = 0; i < 3; i++)
+    {
+        REQUIRE(std::abs(pixel1[0] - pixel2[0]) < 0.0001);
+    }
+}
+
+TEST_CASE( "inverse_brown_conrady_deproject" )
+{
+    float point[3] = { 0 };
+
+    rs2_intrinsics intrin
+        = { 1280,
+            720,
+            643.720581,
+            357.821259,
+            904.170471,
+            905.155090,
+            RS2_DISTORTION_INVERSE_BROWN_CONRADY,
+            { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
+    float pixel1[2] = { 1, 1 };
+    float pixel2[2] = { 0, 0 };
+    float depth = 10.5;
+    rs2_deproject_pixel_to_point( point, &intrin, pixel1, depth );
+    rs2_project_point_to_pixel( pixel2, &intrin, point );
+
+    compare(pixel1, pixel2);
+}
+
+TEST_CASE( "brown_conrady_deproject" )
+{
+    float point[3] = { 0 };
+
+    rs2_intrinsics intrin
+        = { 1280,
+            720,
+            643.720581,
+            357.821259,
+            904.170471,
+            905.155090,
+            RS2_DISTORTION_BROWN_CONRADY,
+            { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
+    float pixel1[2] = { 1, 1 };
+    float pixel2[2] = { 0, 0 };
+    float depth = 10.5;
+    rs2_deproject_pixel_to_point( point, &intrin, pixel1, depth );
+    rs2_project_point_to_pixel( pixel2, &intrin, point );
+
+    compare(pixel1, pixel2);
+}

--- a/unit-tests/algo/projection/test-distortion.cpp
+++ b/unit-tests/algo/projection/test-distortion.cpp
@@ -1,8 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 #include "../algo-common.h"
-#include "../../../include/librealsense2/rsutil.h"
+#include <librealsense2/rsutil.h>
 
 void compare(float pixel1[2], float pixel2[2])
 {

--- a/unit-tests/algo/projection/test-distortion.cpp
+++ b/unit-tests/algo/projection/test-distortion.cpp
@@ -1,14 +1,18 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
+//#cmake:add-file ../../../src/proc/sse/sse-pointcloud.cpp
+
 #include "../algo-common.h"
 #include <librealsense2/rsutil.h>
+#include "../src/proc/sse/sse-pointcloud.h"
+#include "../src/types.h"
 
-void compare(float pixel1[2], float pixel2[2])
+void compare(librealsense::float2 pixel1, librealsense::float2 pixel2)
 {
-    for (auto i = 0; i < 3; i++)
+    for (auto i = 0; i < 2; i++)
     {
-        REQUIRE(std::abs(pixel1[0] - pixel2[0]) < 0.0001);
+        REQUIRE(std::abs(pixel1[i] - pixel2[i]) < 0.0001);
     }
 }
 
@@ -25,11 +29,11 @@ TEST_CASE( "inverse_brown_conrady_deproject" )
             905.155090,
             RS2_DISTORTION_INVERSE_BROWN_CONRADY,
             { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
-    float pixel1[2] = { 1, 1 };
-    float pixel2[2] = { 0, 0 };
+    librealsense::float2 pixel1 = { 1, 1 };
+    librealsense::float2 pixel2 = { 0, 0 };
     float depth = 10.5;
-    rs2_deproject_pixel_to_point( point, &intrin, pixel1, depth );
-    rs2_project_point_to_pixel( pixel2, &intrin, point );
+    rs2_deproject_pixel_to_point( point, &intrin, (float*)&pixel1, depth );
+    rs2_project_point_to_pixel((float*)&pixel2, &intrin, point );
 
     compare(pixel1, pixel2);
 }
@@ -47,11 +51,49 @@ TEST_CASE( "brown_conrady_deproject" )
             905.155090,
             RS2_DISTORTION_BROWN_CONRADY,
             { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
-    float pixel1[2] = { 1, 1 };
-    float pixel2[2] = { 0, 0 };
+    librealsense::float2 pixel1 = { 1, 1 };
+    librealsense::float2 pixel2 = { 0, 0 };
     float depth = 10.5;
-    rs2_deproject_pixel_to_point( point, &intrin, pixel1, depth );
-    rs2_project_point_to_pixel( pixel2, &intrin, point );
+    rs2_deproject_pixel_to_point( point, &intrin, (float*)&pixel1, depth );
+    rs2_project_point_to_pixel((float*)&pixel2, &intrin, point );
 
     compare(pixel1, pixel2);
+}
+
+TEST_CASE("inverse_brown_conrady_sse_deproject")
+{
+    std::shared_ptr<librealsense::pointcloud_sse> pc_sse = std::make_shared<librealsense::pointcloud_sse >();
+
+    rs2_intrinsics intrin
+        = { 1280,
+            720,
+            643.720581,
+            357.821259,
+            904.170471,
+            905.155090,
+            RS2_DISTORTION_INVERSE_BROWN_CONRADY,
+            { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
+
+    librealsense::float2 pixel[4] = { {1, 1}, {0,2},{1,3},{1,4} };
+    float depth = 10.5;
+    librealsense::float3 points[4] = {};
+
+    // deproject with native code because sse deprojection doesn't implement distortion
+    for (auto i = 0; i < 4; i++)
+    {
+        rs2_deproject_pixel_to_point((float*)&points[i], &intrin, (float*)&pixel[i], depth);
+    }
+   
+    std::vector<librealsense::float2> res(4, { 0,0 });
+    std::vector<librealsense::float2> unnormalized_res(4, { 0,0 });
+    rs2_extrinsics extrin = { {1,0,0,
+        0,1,0,
+        0,0,1},{0,0,0} };
+
+    pc_sse->get_texture_map_sse((librealsense::float2*)res.data(), points, 4, 1, intrin, extrin, (librealsense::float2*)unnormalized_res.data());
+
+    for (auto i = 0; i < 4; i++)
+    {
+        compare(unnormalized_res[i], pixel[i]);
+    }
 }

--- a/unit-tests/algo/projection/test-distortion.cpp
+++ b/unit-tests/algo/projection/test-distortion.cpp
@@ -6,13 +6,15 @@
 #include "../algo-common.h"
 #include <librealsense2/rsutil.h>
 #include "../src/proc/sse/sse-pointcloud.h"
+#include "../src/cuda/cuda-pointcloud.cuh"
 #include "../src/types.h"
 
 void compare(librealsense::float2 pixel1, librealsense::float2 pixel2)
 {
     for (auto i = 0; i < 2; i++)
     {
-        REQUIRE(std::abs(pixel1[i] - pixel2[i]) < 0.0001);
+        CAPTURE(i);
+        REQUIRE(std::abs(pixel1[i] - pixel2[i]) <= 0.001);
     }
 }
 
@@ -97,3 +99,101 @@ TEST_CASE("inverse_brown_conrady_sse_deproject")
         compare(unnormalized_res[i], pixel[i]);
     }
 }
+
+TEST_CASE("brown_conrady_sse_deproject")
+{
+    std::shared_ptr<librealsense::pointcloud_sse> pc_sse = std::make_shared<librealsense::pointcloud_sse >();
+
+    rs2_intrinsics intrin
+        = { 1280,
+            720,
+            643.720581,
+            357.821259,
+            904.170471,
+            905.155090,
+            RS2_DISTORTION_BROWN_CONRADY,
+            { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
+
+    librealsense::float2 pixel[4] = { {1, 1}, {0,2},{1,3},{1,4} };
+    float depth = 10.5;
+    librealsense::float3 points[4] = {};
+
+    // deproject with native code because sse deprojection doesn't implement distortion
+    for (auto i = 0; i < 4; i++)
+    {
+        rs2_deproject_pixel_to_point((float*)&points[i], &intrin, (float*)&pixel[i], depth);
+    }
+
+    std::vector<librealsense::float2> res(4, { 0,0 });
+    std::vector<librealsense::float2> unnormalized_res(4, { 0,0 });
+    rs2_extrinsics extrin = { {1,0,0,
+        0,1,0,
+        0,0,1},{0,0,0} };
+
+    pc_sse->get_texture_map_sse((librealsense::float2*)res.data(), points, 4, 1, intrin, extrin, (librealsense::float2*)unnormalized_res.data());
+
+    for (auto i = 0; i < 4; i++)
+    {
+        compare(unnormalized_res[i], pixel[i]);
+    }
+}
+
+#ifdef RS2_USE_CUDA
+TEST_CASE("inverse_brown_conrady_cuda_deproject")
+{
+    std::vector<float3> point(1280 * 720, { 0,0,0 });
+
+    rs2_intrinsics intrin
+        = { 1280,
+            720,
+            643.720581,
+            357.821259,
+            904.170471,
+            905.155090,
+            RS2_DISTORTION_INVERSE_BROWN_CONRADY,
+            { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
+
+    librealsense::float2 pixel = { 0, 0 };
+
+    std::vector<uint16_t> depth(1280 * 720, 1000);
+    rscuda::deproject_depth_cuda((float*)point.data(), intrin, depth.data(), 1);
+    for (auto i = 0; i < 720; i++)
+    {
+        for (auto j = 0; j < 1280; j++)
+        {
+            CAPTURE(i, j);
+            rs2_project_point_to_pixel((float*)&pixel, &intrin, (float*)&point[i* 1280 +j]);
+            compare({ (float)j,(float)i }, pixel);
+        }
+    }
+}
+
+TEST_CASE("brown_conrady_cuda_deproject")
+{
+    std::vector<float3> point(1280 * 720, { 0,0,0 });
+
+    rs2_intrinsics intrin
+        = { 1280,
+            720,
+            643.720581,
+            357.821259,
+            904.170471,
+            905.155090,
+            RS2_DISTORTION_BROWN_CONRADY,
+            { 0.180086836, -0.534179211, -0.00139013783, 0.000118769123, 0.470662683 } };
+
+    librealsense::float2 pixel = { 0, 0 };
+
+    std::vector<uint16_t> depth(1280 * 720, 1000);
+    rscuda::deproject_depth_cuda((float*)point.data(), intrin, depth.data(), 1);
+    for (auto i = 0; i < 720; i++)
+    {
+        for (auto j = 0; j < 1280; j++)
+        {
+            CAPTURE(i, j);
+            rs2_project_point_to_pixel((float*)&pixel, &intrin, (float*)&point[i * 1280 + j]);
+            compare({ (float)j,(float)i }, pixel);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
1. Set l500 distortion modal to RS2_DISTORTION_BROWN_CONRADY instead of  RS2_DISTORTION_INVERSE_BROWN_CONRADY
2. Implementation of Brown-Conrady transformation on rs2_deproject_pixel_to_point().
2. Fix of Inverse-Brown-Conrady transformation on rs2_deproject_pixel_to_point().
3. Implementation of Brown-Conrady transformation on deproject_pixel_to_point_cuda().
4. Fix of Inverse-Brown-Conrady transformation  on deproject_pixel_to_point_cuda().
5. Implementation of Brown-Conrady transformation on get_texture_map_sse().
6. Added unit tests for native code (Inverse-Brown and Brown).
7. Added unit tests for sse code (Inverse-Brown and Brown).
8. Added unit tests for cuda code (Inverse-Brown and Brown).