### PR TITLE
update python examples to python 3

### DIFF
--- a/wrappers/python/examples/depth_auto_calibration_example.py
+++ b/wrappers/python/examples/depth_auto_calibration_example.py
@@ -49,31 +49,31 @@ def main(argv):
 
     while True:
         try:
-            input = raw_input("Please select what the operation you want to do\nc - on chip calibration\nt - tare calibration\ng - get the active calibration\nw - write new calibration\ne - exit\n")
+            operation = input("Please select what the operation you want to do\nc - on chip calibration\nt - tare calibration\ng - get the active calibration\nw - write new calibration\ne - exit\n")
 
-            if input == 'c':
+            if operation == 'c':
                 print("Starting on chip calibration")
                 new_calib, health = calib_dev.run_on_chip_calibration(file_cnt, on_chip_calib_cb, 5000)
                 print("Calibration completed")
                 print("health factor = ", health)
 
-            if input == 't':
+            if operation == 't':
                 print("Starting tare calibration")
-                ground_truth = float(raw_input("Please enter ground truth in mm\n"))
+                ground_truth = float(input("Please enter ground truth in mm\n"))
                 new_calib, health = calib_dev.run_tare_calibration(ground_truth, file_cnt, on_chip_calib_cb, 5000)
                 print("Calibration completed")
                 print("health factor = ", health)
 
-            if input == 'g':
+            if operation == 'g':
                 calib = calib_dev.get_calibration_table()
                 print("Calibration", calib)
 
-            if input == 'w':
+            if operation == 'w':
                 print("Writing the new calibration")
                 calib_dev.set_calibration_table(new_calib)
                 calib_dev.write_calibration()
 
-            if input == 'e':
+            if operation == 'e':
                 pipeline.stop()
                 return
 

--- a/wrappers/python/examples/pyglet_pointcloud_viewer.py
+++ b/wrappers/python/examples/pyglet_pointcloud_viewer.py
@@ -153,7 +153,7 @@ if state.color:
 image_data = pyglet.image.ImageData(image_w, image_h, convert_fmt(
 other_profile.format()), (gl.GLubyte * (image_w * image_h * 3))())
 
-if (pyglet.version.startswith('1.') and not pyglet.version.startswith('1.4')):
+if (pyglet.version <  '1.4' ):
     # pyglet.clock.ClockDisplay has be removed in 1.4
     fps_display = pyglet.clock.ClockDisplay()
 else:

--- a/wrappers/python/examples/read_bag_example.py
+++ b/wrappers/python/examples/read_bag_example.py
@@ -52,7 +52,7 @@ try:
     cv2.namedWindow("Depth Stream", cv2.WINDOW_AUTOSIZE)
     
     # Create colorizer object
-    colorizer = rs.colorizer();
+    colorizer = rs.colorizer()
 
     # Streaming loop
     while True:


### PR DESCRIPTION
tests now work using python 3 (does not include: box_dimensioner_multicam, ethernet_client_server, t265_wheel_odometry).
Tracked on: RS5-10433