### PR TITLE
Make intercam_sync option read-only while streaming

### DIFF
--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -197,7 +197,8 @@ namespace librealsense
         virtual void set(float value) override;
         virtual float query() const override;
         virtual option_range get_range() const override;
-        virtual bool is_enabled() const override { return _sensor && !_sensor->is_streaming(); }
+        virtual bool is_enabled() const override { return true; }
+        virtual bool is_read_only() const { return _sensor && _sensor->is_opened(); }
         const char* get_description() const override;
 
         void enable_recording(std::function<void(const option &)> record_action) override

--- a/src/ds5/ds5-options.h
+++ b/src/ds5/ds5-options.h
@@ -340,7 +340,8 @@ namespace librealsense
         virtual void set(float value) override;
         virtual float query() const override;
         virtual option_range get_range() const override;
-        virtual bool is_enabled() const override { return _sensor && !_sensor->is_streaming(); }
+        virtual bool is_enabled() const override { return true; }
+        virtual bool is_read_only() const { return _sensor && _sensor->is_opened(); }
         virtual const char* get_description() const override
         {
             return "Exposure limit is in microseconds. Default is 0 which means full exposure range. If the requested exposure limit is greater than frame time, it will be set to frame time at runtime. Setting will not take effect until next streaming session.";
@@ -362,7 +363,8 @@ namespace librealsense
         virtual void set(float value) override;
         virtual float query() const override;
         virtual option_range get_range() const override;
-        virtual bool is_enabled() const override { return _sensor && !_sensor->is_streaming(); }
+        virtual bool is_enabled() const override { return true; }
+        virtual bool is_read_only() const { return _sensor && _sensor->is_opened(); }
         virtual const char* get_description() const override
         {
             return "Gain limits ranges from 16 to 248. Default is 0 which means full gain. If the requested gain limit is less than 16, it will be set to 16. If the requested gain limit is greater than 248, it will be set to 248. Setting will not take effect until next streaming session.";


### PR DESCRIPTION
Tracked on: DSO-16833