### PR TITLE
Increase updates windows stability on multiple updates

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -4933,104 +4933,44 @@ namespace rs2
                                 need_to_check_bundle = false;
                             }
                         }
-                        else
+                        else 
                         {
-                            if (sw_online_update_available)
+                            if (auto viewer_updates = updates_model_protected.lock())
                             {
-                                if (auto nm = notification_model_protected.lock())
+                                // Do not create pop ups if the viewer updates windows is on
+                                if (viewer_updates->has_updates())
                                 {
-                                    dev_updates_profile::version_info recommended_sw_update_info;
-                                    update_profile->get_sw_update(sw_update::RECOMMENDED, recommended_sw_update_info);
-                                    auto n = std::make_shared< sw_recommended_update_alert_model >(
-                                        RS2_API_FULL_VERSION_STR,
-                                        recommended_sw_update_info.ver,
-                                        recommended_sw_update_info.download_link);
-                                    auto name = get_device_name(dev);
-                                    n->delay_id = "update_alert." + name.second;
-                                    n->enable_complex_dismiss = true;  // allow advanced dismiss menu
-
-                                    if (!n->is_delayed())
-                                    {
-                                        nm->add_notification(n);
-                                        related_notifications.push_back(n);
-                                    }
+                                    need_to_check_bundle = false;
                                 }
-                            }
-                            if (fw_online_update_available)
-                            {
-                                if (auto nm = notification_model_protected.lock())
+                                else
                                 {
-                                    std::shared_ptr< firmware_update_manager > manager = nullptr;
-
-                                    std::vector< uint8_t > fw_data;
-                                    http::http_downloader downloader;
-
-                                    // Try to download the recommended FW binary file
-                                    int download_retries = 3;
-                                    dev_updates_profile::version_info recommended_fw_update_info;
-                                    update_profile->get_fw_update(sw_update::RECOMMENDED, recommended_fw_update_info);
-    
-                                    while (download_retries > 0)
+                                    if (sw_online_update_available)
                                     {
-                                        if (downloader.download_to_bytes_vector(
-                                            recommended_fw_update_info.download_link,
-                                            fw_data))
-                                            download_retries = 0;
-                                        else
-                                            --download_retries;
-                                    }
-
-                                    // If the download process finished successfully, pop up a
-                                    // notification for the FW update process
-                                    if (!fw_data.empty())
-                                    {
-                                        manager = std::make_shared< firmware_update_manager >(nm,
-                                            *this,
-                                            dev,
-                                            ctx,
-                                            fw_data,
-                                            true);
-
-                                        auto dev_name = get_device_name(dev);
-                                        std::stringstream msg;
-                                        msg << dev_name.first << " (S/N " << dev_name.second << ")\n"
-                                            << "Current Version: "
-                                            << std::string(update_profile->firmware_version) << "\n";
-
-                                        msg << "Recommended Version: "
-                                            << std::string(recommended_fw_update_info.ver);
-
-                                        auto n = std::make_shared< fw_update_notification_model >(
-                                            msg.str(),
-                                            manager,
-                                            false);
-                                        n->delay_id = "dfu." + dev_name.second;
-                                        n->enable_complex_dismiss = true;
-                                        if (!n->is_delayed())
+                                        if (auto nm = notification_model_protected.lock())
                                         {
-                                            nm->add_notification(n);
-                                            related_notifications.push_back(n);
-                                            need_to_check_bundle = false;
+                                            handle_online_sw_update( nm, update_profile );
                                         }
                                     }
-                                    else
-                                        nm->output.add_log(
-                                            RS2_LOG_SEVERITY_WARN,
-                                            __FILE__,
-                                            __LINE__,
-                                            to_string()
-                                            << "Error in downloading FW binary file: "
-                                            << recommended_fw_update_info.download_link);
+                                    if (fw_online_update_available)
+                                    {
+                                        if (auto nm = notification_model_protected.lock())
+                                        {
+                                            need_to_check_bundle = !handle_online_fw_update( ctx, nm, update_profile );
+                                        }
+                                    }
                                 }
                             }
-                            // For updating current device profile if exists (Could update firmware
-                            // version)
+                            // For updating current device profile if exists (Could update firmware version)
                             if (auto viewer_updates = updates_model_protected.lock())
                             {
                                 viewer_updates->update_profile(updates_profile_model);
                             }
                         }
                     }
+                }
+                else if( auto nm = notification_model_protected.lock() )
+                {
+                    nm->add_log( "No online SW / FW updates available" );
                 }
 
                 // If no on-line updates notification, offer bundled FW update if needed
@@ -5654,6 +5594,93 @@ namespace rs2
                 }
             }
         }
+    }
+
+    void rs2::device_model::handle_online_sw_update(std::shared_ptr < notifications_model > nm , std::shared_ptr < dev_updates_profile::update_profile >update_profile )
+    {
+        dev_updates_profile::version_info recommended_sw_update_info;
+        update_profile->get_sw_update(sw_update::RECOMMENDED, recommended_sw_update_info);
+        auto n = std::make_shared< sw_recommended_update_alert_model >(
+            RS2_API_FULL_VERSION_STR,
+            recommended_sw_update_info.ver,
+            recommended_sw_update_info.download_link);
+        auto name = get_device_name(dev);
+        n->delay_id = "update_alert." + name.second;
+        n->enable_complex_dismiss = true;  // allow advanced dismiss menu
+
+        if (!n->is_delayed())
+        {
+            nm->add_notification(n);
+            related_notifications.push_back(n);
+        }
+    }
+
+    bool rs2::device_model::handle_online_fw_update( const context& ctx, std::shared_ptr < notifications_model >  nm, std::shared_ptr< dev_updates_profile::update_profile> update_profile )
+    {
+        bool fw_update_notification_raised = false;
+        std::shared_ptr< firmware_update_manager > manager = nullptr;
+
+        std::vector< uint8_t > fw_data;
+        http::http_downloader downloader;
+
+        // Try to download the recommended FW binary file
+        int download_retries = 3;
+        dev_updates_profile::version_info recommended_fw_update_info;
+        update_profile->get_fw_update(sw_update::RECOMMENDED, recommended_fw_update_info);
+
+        while (download_retries > 0)
+        {
+            if (downloader.download_to_bytes_vector(
+                recommended_fw_update_info.download_link,
+                fw_data))
+                download_retries = 0;
+            else
+                --download_retries;
+        }
+
+        // If the download process finished successfully, pop up a
+        // notification for the FW update process
+        if (!fw_data.empty())
+        {
+            manager = std::make_shared< firmware_update_manager >(nm,
+                *this,
+                dev,
+                ctx,
+                fw_data,
+                true);
+
+            auto dev_name = get_device_name(dev);
+            std::stringstream msg;
+            msg << dev_name.first << " (S/N " << dev_name.second << ")\n"
+                << "Current Version: "
+                << std::string(update_profile->firmware_version) << "\n";
+
+            msg << "Recommended Version: "
+                << std::string(recommended_fw_update_info.ver);
+
+            auto n = std::make_shared< fw_update_notification_model >(
+                msg.str(),
+                manager,
+                false);
+            n->delay_id = "dfu." + dev_name.second;
+            n->enable_complex_dismiss = true;
+            if (!n->is_delayed())
+            {
+                nm->add_notification(n);
+                related_notifications.push_back(n);
+                fw_update_notification_raised = true;
+            }
+        }
+        else
+            nm->output.add_log(
+                RS2_LOG_SEVERITY_WARN,
+                __FILE__,
+                __LINE__,
+                to_string()
+                << "Error in downloading FW binary file: "
+                << recommended_fw_update_info.download_link);
+
+        return fw_update_notification_raised;
     }
 
     // Load viewer configuration for stereo module (depth/infrared streams) only

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -851,7 +851,14 @@ namespace rs2
 
         void load_viewer_configurations(const std::string& json_str);
         void save_viewer_configurations(std::ofstream& outfile, nlohmann::json& j);
+        void handle_online_sw_update(
+            std::shared_ptr < notifications_model > nm,
+            std::shared_ptr< sw_update::dev_updates_profile::update_profile > update_profile );
 
+        bool handle_online_fw_update(
+            const context & ctx,
+            std::shared_ptr< notifications_model > nm,
+            std::shared_ptr< sw_update::dev_updates_profile::update_profile > update_profile );
 
         std::shared_ptr<recorder> _recorder;
         std::vector<std::shared_ptr<subdevice_model>> live_subdevices;

--- a/common/sw-update/dev-updates-profile.cpp
+++ b/common/sw-update/dev-updates-profile.cpp
@@ -49,22 +49,31 @@ namespace rs2
                     version_info experimental_update;
                     if (try_parse_update(_versions_db, _update_profile.device_name, EXPERIMENTAL, comp, experimental_update))
                     {
-                        versions_vec[experimental_update.ver] = experimental_update;
-                        update_available = update_available || current_version < experimental_update.ver;
+                        if (current_version < experimental_update.ver)
+                        {
+                            versions_vec[experimental_update.ver] = experimental_update;
+                            update_available = true;
+                        }
                     }
 
                     version_info recommened_update;
                     if (try_parse_update(_versions_db, _update_profile.device_name, RECOMMENDED, comp, recommened_update))
                     {
-                        versions_vec[recommened_update.ver] = recommened_update;
-                        update_available = update_available || current_version < recommened_update.ver;
+                        if (current_version < recommened_update.ver)
+                        {
+                            versions_vec[recommened_update.ver] = recommened_update;
+                            update_available = true;
+                        }
                     }
 
                     version_info required_update;
                     if (try_parse_update(_versions_db, _update_profile.device_name, ESSENTIAL, comp, required_update))
                     {
-                        versions_vec[required_update.ver] = required_update;
-                        update_available = update_available || (current_version < required_update.ver);
+                        if (current_version < required_update.ver)
+                        {
+                            versions_vec[required_update.ver] = required_update;
+                            update_available = true;
+                        }
                     }
                 }
             }
@@ -107,12 +116,11 @@ namespace rs2
         bool dev_updates_profile::update_profile::get_sw_update( update_policy_type policy,
                                                                  version_info & info ) const
         {
-            auto found = std::find_if(
-                software_versions.begin(),
-                software_versions.end(),
-                [&]( const std::pair<  sw_update::version, version_info > & ver_info ) {
-                    return ver_info.second.policy == policy && software_version < ver_info.first;
-                } );
+            auto found = std::find_if( software_versions.begin(),
+                                       software_versions.end(),
+                                       [policy]( const version_to_info::value_type & ver_info ) {
+                                           return ver_info.second.policy == policy;
+                                       } );
             if( found != software_versions.end() )
             {
                 info = found->second;
@@ -124,12 +132,11 @@ namespace rs2
         bool dev_updates_profile::update_profile::get_fw_update( update_policy_type policy,
                                                                  version_info & info ) const
         {
-            auto found = std::find_if(
-                firmware_versions.begin(),
-                firmware_versions.end(),
-                [&](const std::pair<  sw_update::version, version_info >& ver_info) {
-                    return ver_info.second.policy == policy && firmware_version < ver_info.first;
-                } );
+            auto found = std::find_if( firmware_versions.begin(),
+                                       firmware_versions.end(),
+                                       [policy]( const version_to_info::value_type & ver_info ) {
+                                           return ver_info.second.policy == policy;
+                                       } );
             if( found != firmware_versions.end() )
             {
                 info = found->second;

--- a/common/sw-update/dev-updates-profile.h
+++ b/common/sw-update/dev-updates-profile.h
@@ -38,8 +38,9 @@ namespace rs2
                 sw_update::version software_version;
                 sw_update::version firmware_version;
 
-                std::map< sw_update::version, version_info > software_versions;
-                std::map< sw_update::version, version_info > firmware_versions;
+                typedef std::map< sw_update::version, version_info > version_to_info;
+                version_to_info software_versions;
+                version_to_info firmware_versions;
 
                 device dev;
                 bool dev_active;

--- a/common/updates-model.cpp
+++ b/common/updates-model.cpp
@@ -607,205 +607,215 @@ bool updates_model::draw_firmware_section(std::shared_ptr<notifications_model> n
     auto current_fw_ver_str = std::string(selected_profile.profile.firmware_version);
     ImGui::Text("%s", current_fw_ver_str.c_str());
 
-    if (_fw_update_state != fw_update_states::completed)
+    
+    
+    if (essential_fw_update_needed)
     {
-        if (essential_fw_update_needed)
-        {
-            ImGui::SameLine();
-            ImGui::PushStyleColor(ImGuiCol_Text, yellowish);
-            ImGui::Text("%s", " (Your version is older than the minimum version required for the proper functioning of your device)");
-            ImGui::PopStyleColor();
-        }
+        ImGui::SameLine();
+        ImGui::PushStyleColor(ImGuiCol_Text, yellowish);
+        ImGui::Text("%s", " (Your version is older than the minimum version required for the proper functioning of your device)");
+        ImGui::PopStyleColor();
+    }
 
-        if ( selected_firmware_update.ver )
-        {
-            fw_text_pos.y += 25;
-            ImGui::SetCursorScreenPos(fw_text_pos);
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
+    if ( selected_firmware_update.ver )
+    {
+        fw_text_pos.y += 25;
+        ImGui::SetCursorScreenPos(fw_text_pos);
+        ImGui::PushStyleColor(ImGuiCol_Text, white);
 
-            ImGui::Text("%s", (firmware_updates.size() >= 2) ?
-                "Versions available:" :
-                "Version to download:");
-            ImGui::SameLine();
-            ImGui::PopStyleColor();
-            // Combo box for multiple versions
-            if (firmware_updates.size() >= 2)
+        ImGui::Text("%s", (firmware_updates.size() >= 2) ?
+            "Versions available:" :
+            "Version to download:");
+        ImGui::SameLine();
+        ImGui::PopStyleColor();
+        // Combo box for multiple versions
+        if (firmware_updates.size() >= 2)
+        {
+            std::vector<const char*> fwu_labels;
+            for (auto&& fwu : firmware_updates)
             {
-                std::vector<const char*> fwu_labels;
-                for (auto&& fwu : firmware_updates)
-                {
-                    fwu_labels.push_back(fwu.name_for_display.c_str());
-                }
-
-                ImGui::PushStyleColor(ImGuiCol_BorderShadow, dark_grey);
-                ImGui::PushStyleColor(ImGuiCol_FrameBg, sensor_bg);
-
-                std::string combo_id = "##Firmware Update Version";
-                ImGui::PushItemWidth(200);
-                ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 3);
-                ImGui::Combo(combo_id.c_str(), &selected_firmware_update_index, fwu_labels.data(), static_cast<int>(fwu_labels.size()));
-                ImGui::PopItemWidth();
-                ImGui::PopStyleColor(2);
-                ImGui::SetWindowFontScale(1.);
+                fwu_labels.push_back(fwu.name_for_display.c_str());
             }
-            else
-            {   // Single version
-                ImGui::Text("%s", std::string(selected_firmware_update.ver).c_str());
-            }
-        }
 
-        if (selected_firmware_update.release_page != "")
-        {
-            fw_text_pos.y += 25;
-            ImGui::SetCursorScreenPos(fw_text_pos);
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::Text("%s", "Release Link:"); ImGui::SameLine();
-            ImGui::PopStyleColor();
-            ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
-            ImGui::Text("%s", selected_firmware_update.release_page.c_str());
+            ImGui::PushStyleColor(ImGuiCol_BorderShadow, dark_grey);
+            ImGui::PushStyleColor(ImGuiCol_FrameBg, sensor_bg);
 
-            ImGui::SameLine();
-            auto underline_start = ImVec2(ImGui::GetCursorScreenPos().x - (ImGui::CalcTextSize(selected_firmware_update.release_page.c_str()).x + 8), ImGui::GetCursorScreenPos().y + ImGui::GetFontSize());
-            auto underline_end = ImVec2(ImGui::GetCursorScreenPos().x - 8, ImGui::GetCursorScreenPos().y + ImGui::GetFontSize());
-            ImGui::GetWindowDrawList()->AddLine(underline_start, underline_end, ImColor(light_grey));
-
-
-            ImGui::PopStyleColor();
-            if (ImGui::IsItemHovered())
-                window.link_hovered();
-            if (ImGui::IsItemClicked())
-            {
-                try
-                {
-                    open_url(selected_firmware_update.release_page.c_str());
-                }
-                catch (...)
-                {
-                    LOG_ERROR("Error opening URL: " + selected_firmware_update.release_page);
-                }
-            }
-        }
-
-        if (selected_firmware_update.description != "")
-        {
-            fw_text_pos.y += 25;
-            ImGui::SetCursorScreenPos(fw_text_pos);
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::Text("%s", "Description:");
-            ImGui::PopStyleColor();
-
-            ImGui::PushTextWrapPos(pos.w - 150);
-            ImGui::PushStyleColor(ImGuiCol_Border, transparent);
-            ImGui::PushStyleColor(ImGuiCol_FrameBg, transparent);
-            ImGui::PushStyleColor(ImGuiCol_ScrollbarBg, transparent);
-            ImGui::PushStyleColor(ImGuiCol_ScrollbarGrab, transparent);
-            ImGui::PushStyleColor(ImGuiCol_ScrollbarGrabActive, transparent);
-            ImGui::PushStyleColor(ImGuiCol_ScrollbarGrabHovered, transparent);
-            ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, regular_blue);
-            auto msg = selected_firmware_update.description.c_str();
-            fw_text_pos.x -= 4;
-            fw_text_pos.y += 15;
-            ImGui::SetCursorScreenPos(fw_text_pos);
-            ImGui::InputTextMultiline("##Firmware Update Description", const_cast<char*>(msg),
-                strlen(msg) + 1, ImVec2(ImGui::GetContentRegionAvailWidth() - 150, 75),
-                ImGuiInputTextFlags_ReadOnly);
-            ImGui::PopStyleColor(7);
-            ImGui::PopTextWrapPos();
-        }
-
-
-        if ((_fw_update_state == fw_update_states::ready) &&
-            (essential_fw_update_needed || recommended_fw_update_needed))
-        {
-            ImGui::SetCursorScreenPos({ pos.orig_pos.x + pos.w - 150, pos.orig_pos.y + pos.h - 115 });
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::PushStyleColor(ImGuiCol_Button, sensor_bg);
-
-            if (ImGui::Button("Download &\n   Install", ImVec2(120, 40)) || _retry)
-            {
-                _retry = false;
-                auto link = selected_firmware_update.download_link;
-                std::thread download_thread([link, this]() {
-                    std::vector<uint8_t> vec;
-                    http_downloader client;
-
-                    if (!client.download_to_bytes_vector(link, vec,
-                        [this](uint64_t dl_current_bytes, uint64_t dl_total_bytes) -> callback_result {
-                        _fw_download_progress = static_cast<int>((dl_current_bytes * 100) / dl_total_bytes);
-                        return callback_result::CONTINUE_DOWNLOAD;
-                    }))
-                    {
-                        _fw_update_state = fw_update_states::failed_downloading;
-                        LOG_ERROR("Error in download firmware version from: " + link);
-                    }
-
-                    _fw_image = vec;
-
-                    _fw_download_progress = 100;
-                });
-                download_thread.detach();
-
-                _fw_update_state = fw_update_states::downloading;
-            }
-            if (ImGui::IsItemHovered())
-            {
-                ImGui::SetTooltip("This will download selected firmware and install it to the device");
-                window.link_hovered();
-            }
+            std::string combo_id = "##Firmware Update Version";
+            ImGui::PushItemWidth(200);
+            ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 3);
+            ImGui::Combo(combo_id.c_str(), &selected_firmware_update_index, fwu_labels.data(), static_cast<int>(fwu_labels.size()));
+            ImGui::PopItemWidth();
             ImGui::PopStyleColor(2);
+            ImGui::SetWindowFontScale(1.);
         }
-        else if (_fw_update_state == fw_update_states::downloading)
-        {
-            ImGui::SetCursorScreenPos({ pos.orig_pos.x + 150, pos.orig_pos.y + pos.h - 95 });
-            _progress.draw(window, static_cast<int>(pos.w) - 170, _fw_download_progress / 3);
-            if (_fw_download_progress == 100)
-            {
-                _fw_update_state = fw_update_states::started;
+        else
+        {   // Single version
+            ImGui::Text("%s", std::string(selected_firmware_update.ver).c_str());
+        }
+    }
 
-                _update_manager = std::make_shared<firmware_update_manager>(not_model,
-                    *selected_profile.dev_model, selected_profile.profile.dev, selected_profile.ctx, _fw_image, true
-                    );
-                auto invoke = [](std::function<void()> action) { action(); };
-                _update_manager->start(invoke);
-            }
-        }
-        else if (_fw_update_state == fw_update_states::started)
-        {
-            ImGui::SetCursorScreenPos({ pos.orig_pos.x + 150, pos.orig_pos.y + pos.h - 95 });
-            _progress.draw(window, static_cast<int>(pos.w) - 170, static_cast<int>(_update_manager->get_progress() * 0.66 + 33));
-            if (_update_manager->done()) {
-                _fw_update_state = fw_update_states::completed;
-                _fw_image.clear();
-            }
+    if (selected_firmware_update.release_page != "")
+    {
+        fw_text_pos.y += 25;
+        ImGui::SetCursorScreenPos(fw_text_pos);
+        ImGui::PushStyleColor(ImGuiCol_Text, white);
+        ImGui::Text("%s", "Release Link:"); ImGui::SameLine();
+        ImGui::PopStyleColor();
+        ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
+        ImGui::Text("%s", selected_firmware_update.release_page.c_str());
 
-            if (_update_manager->failed()) {
-                _fw_update_state = fw_update_states::failed_updating;
-                _fw_image.clear();
-                _fw_download_progress = 0;
-            }
-            // Verify an error window will not pop up. ImGui cannot handle 2 PopUpModals in parallel.
-            if (!error_message.empty())
-            {
-                LOG_ERROR("error caught during update process, details: " + error_message);
-                error_message.clear();
-            }
+        ImGui::SameLine();
+        auto underline_start = ImVec2(ImGui::GetCursorScreenPos().x - (ImGui::CalcTextSize(selected_firmware_update.release_page.c_str()).x + 8), ImGui::GetCursorScreenPos().y + ImGui::GetFontSize());
+        auto underline_end = ImVec2(ImGui::GetCursorScreenPos().x - 8, ImGui::GetCursorScreenPos().y + ImGui::GetFontSize());
+        ImGui::GetWindowDrawList()->AddLine(underline_start, underline_end, ImColor(light_grey));
 
-        }
-        else if (_fw_update_state == fw_update_states::failed_downloading ||
-            _fw_update_state == fw_update_states::failed_updating)
+
+        ImGui::PopStyleColor();
+        if (ImGui::IsItemHovered())
+            window.link_hovered();
+        if (ImGui::IsItemClicked())
         {
-            ImGui::SetCursorScreenPos({ pos.orig_pos.x + 150, pos.orig_pos.y + pos.h - 95 });
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            std::string text = _fw_update_state == fw_update_states::failed_downloading ?
-                "Firmware download failed, check connection and press to retry" :
-                "Firmware update process failed, press to retry";
-            if (ImGui::Button(text.c_str(), ImVec2(pos.w - 170, 25)))
+            try
             {
-                _fw_update_state = fw_update_states::ready;
-                _retry = true;
+                open_url(selected_firmware_update.release_page.c_str());
             }
-            ImGui::PopStyleColor();
+            catch (...)
+            {
+                LOG_ERROR("Error opening URL: " + selected_firmware_update.release_page);
+            }
         }
+    }
+
+    if (selected_firmware_update.description != "")
+    {
+        fw_text_pos.y += 25;
+        ImGui::SetCursorScreenPos(fw_text_pos);
+        ImGui::PushStyleColor(ImGuiCol_Text, white);
+        ImGui::Text("%s", "Description:");
+        ImGui::PopStyleColor();
+
+        ImGui::PushTextWrapPos(pos.w - 150);
+        ImGui::PushStyleColor(ImGuiCol_Border, transparent);
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, transparent);
+        ImGui::PushStyleColor(ImGuiCol_ScrollbarBg, transparent);
+        ImGui::PushStyleColor(ImGuiCol_ScrollbarGrab, transparent);
+        ImGui::PushStyleColor(ImGuiCol_ScrollbarGrabActive, transparent);
+        ImGui::PushStyleColor(ImGuiCol_ScrollbarGrabHovered, transparent);
+        ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, regular_blue);
+        auto msg = selected_firmware_update.description.c_str();
+        fw_text_pos.x -= 4;
+        fw_text_pos.y += 15;
+        ImGui::SetCursorScreenPos(fw_text_pos);
+        ImGui::InputTextMultiline("##Firmware Update Description", const_cast<char*>(msg),
+            strlen(msg) + 1, ImVec2(ImGui::GetContentRegionAvailWidth() - 150, 75),
+            ImGuiInputTextFlags_ReadOnly);
+        ImGui::PopStyleColor(7);
+        ImGui::PopTextWrapPos();
+    }
+
+
+    if( ( _fw_update_state == fw_update_states::ready || _fw_update_state == fw_update_states::completed )
+        && ( essential_fw_update_needed || recommended_fw_update_needed ) )
+    {
+        ImGui::SetCursorScreenPos({ pos.orig_pos.x + pos.w - 150, pos.orig_pos.y + pos.h - 115 });
+        ImGui::PushStyleColor(ImGuiCol_Text, white);
+        ImGui::PushStyleColor(ImGuiCol_Button, sensor_bg);
+
+        if (ImGui::Button("Download &\n   Install", ImVec2(120, 40)) || _retry)
+        {
+            _retry = false;
+            auto link = selected_firmware_update.download_link;
+            std::thread download_thread([link, this]() {
+                std::vector<uint8_t> vec;
+                http_downloader client;
+
+                if (!client.download_to_bytes_vector(link, vec,
+                    [this](uint64_t dl_current_bytes, uint64_t dl_total_bytes) -> callback_result {
+                    _fw_download_progress = static_cast<int>((dl_current_bytes * 100) / dl_total_bytes);
+                    return callback_result::CONTINUE_DOWNLOAD;
+                }))
+                {
+                    _fw_update_state = fw_update_states::failed_downloading;
+                    LOG_ERROR("Error in download firmware version from: " + link);
+                }
+
+                _fw_image = vec;
+
+                _fw_download_progress = 100;
+            });
+            download_thread.detach();
+
+            _fw_update_state = fw_update_states::downloading;
+        }
+        if (ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("This will download selected firmware and install it to the device");
+            window.link_hovered();
+        }
+        ImGui::PopStyleColor(2);
+    }
+    else if (_fw_update_state == fw_update_states::downloading)
+    {
+        ImGui::SetCursorScreenPos({ pos.orig_pos.x + 150, pos.orig_pos.y + pos.h - 95 });
+        _progress.draw(window, static_cast<int>(pos.w) - 170, _fw_download_progress / 3);
+        if (_fw_download_progress == 100 && !_fw_image.empty())
+        {
+            _fw_download_progress = 0;
+            _fw_update_state = fw_update_states::started;
+
+            _update_manager = std::make_shared<firmware_update_manager>(not_model,
+                *selected_profile.dev_model, selected_profile.profile.dev, selected_profile.ctx, _fw_image, true
+                );
+            auto invoke = [](std::function<void()> action) { action(); };
+            _update_manager->start(invoke);
+        }
+    }
+    else if (_fw_update_state == fw_update_states::started)
+    {
+        ImGui::SetCursorScreenPos({ pos.orig_pos.x + 150, pos.orig_pos.y + pos.h - 95 });
+        _progress.draw(window, static_cast<int>(pos.w) - 170, static_cast<int>(_update_manager->get_progress() * 0.66 + 33));
+        if (_update_manager->done()) {
+            _fw_update_state = fw_update_states::completed;
+            _fw_image.clear();
+        }
+
+        if (_update_manager->failed()) {
+            _fw_update_state = fw_update_states::failed_updating;
+            _fw_image.clear();
+            _fw_download_progress = 0;
+        }
+        // Verify an error window will not pop up. ImGui cannot handle 2 PopUpModals in parallel.
+        if (!error_message.empty())
+        {
+            LOG_ERROR("error caught during update process, details: " + error_message);
+            error_message.clear();
+        }
+
+    }
+    else if (_fw_update_state == fw_update_states::failed_downloading ||
+        _fw_update_state == fw_update_states::failed_updating)
+    {
+        ImGui::SetCursorScreenPos({ pos.orig_pos.x + 150, pos.orig_pos.y + pos.h - 95 });
+        ImGui::PushStyleColor(ImGuiCol_Text, white);
+        std::string text = _fw_update_state == fw_update_states::failed_downloading ?
+            "Firmware download failed, check connection and press to retry" :
+            "Firmware update process failed, press to retry";
+        if (ImGui::Button(text.c_str(), ImVec2(pos.w - 170, 25)))
+        {
+            _fw_update_state = fw_update_states::ready;
+            _update_manager.reset();
+            _fw_image.clear();
+            _retry = true;
+        }
+        ImGui::PopStyleColor();
+        _fw_download_progress = 0;
+    }
+    else if (_fw_update_state == fw_update_states::completed)
+    {
+        _fw_update_state = fw_update_states::ready;
+        _update_manager.reset();
+        _fw_image.clear();
+        _fw_download_progress = 0;
     }
 
     ImGui::PopStyleColor();

--- a/common/updates-model.h
+++ b/common/updates-model.h
@@ -75,6 +75,12 @@ namespace rs2
                 it->profile.dev_active = active;
         }
 
+        bool has_updates() const
+        {
+            std::lock_guard<std::mutex> lock(_lock);
+            return !_updates.empty();
+        }
+
         void draw(std::shared_ptr<notifications_model> not_model, ux_window& window, std::string& error_message);
     private:
         struct position_params
@@ -98,7 +104,7 @@ namespace rs2
         bool ignore = false;
         std::vector<update_profile_model> _updates;
         std::shared_ptr<texture_buffer> _icon = nullptr;
-        std::mutex _lock;
+        mutable std::mutex _lock;
         bool emphasize_dismiss_text = false;
 
         std::shared_ptr<firmware_update_manager> _fw_update = nullptr;


### PR DESCRIPTION
**Changes:**
- Fix Download & Install button missing on multiple update processes [DSO-16891]
- Use typedef to version to info map
- Inhibit updates popup when updates windows is on - even when only recommended available (Can occur after updating essential update)
- Break "check_for_updates" to several functions for simplicity