### PR TITLE
Protect illegal access on types.h floats

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -6,7 +6,7 @@
 #define NOMINMAX
 #endif
 #endif
- 
+
 #include <regex>
 
 #include "viewer.h"

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -6,7 +6,7 @@
 #define NOMINMAX
 #endif
 #endif
-
+ 
 #include <regex>
 
 #include "viewer.h"

--- a/src/types.h
+++ b/src/types.h
@@ -578,11 +578,8 @@ namespace librealsense
         float x, y;
         float & operator[]( int i )
         {
-#ifdef _DEBUG
-
             assert( i >= 0 );
             assert( i < 2 );
-#endif
             return *( &x + i );
         }
     };
@@ -591,11 +588,8 @@ namespace librealsense
         float x, y, z;
         float & operator[]( int i )
         {
-#ifdef _DEBUG
-
             assert( i >= 0 );
             assert( i < 3 );
-#endif
             return ( *( &x + i ) );
         }
     };
@@ -604,11 +598,8 @@ namespace librealsense
         float x, y, z, w;
         float & operator[]( int i )
         {
-#ifdef _DEBUG
-
             assert( i >= 0 );
             assert( i < 4 );
-#endif
             return ( *( &x + i ) );
         }
     };
@@ -617,13 +608,10 @@ namespace librealsense
         float3 x, y, z;
         float & operator()( int i, int j )
         {
-#ifdef _DEBUG
-
             assert( i >= 0 );
             assert( i < 3 );
             assert( j >= 0 );
             assert( j < 3 );
-#endif
             return ( *( &x[0] + j * sizeof( float3 ) / sizeof( float ) + i ) );
         }
     };  // column-major

--- a/src/types.h
+++ b/src/types.h
@@ -567,13 +567,70 @@ namespace librealsense
     ////////////////////////////////////////////
     // World's tiniest linear algebra library //
     ////////////////////////////////////////////
-#pragma pack(push, 1)
-    struct int2 { int x, y; };
-    struct float2 { float x, y; float & operator [] (int i) { return (&x)[i]; } };
-    struct float3 { float x, y, z; float & operator [] (int i) { return (&x)[i]; } };
-    struct float4 { float x, y, z, w; float & operator [] (int i) { return (&x)[i]; } };
-    struct float3x3 { float3 x, y, z; float & operator () (int i, int j) { return (&x)[j][i]; } }; // column-major
-    struct pose { float3x3 orientation; float3 position; };
+#pragma pack( push, 1 )
+    struct int2
+    {
+        int x, y;
+    };
+    struct float2
+    {
+        float x, y;
+        float & operator[]( int i )
+        {
+#ifdef _DEBUG
+
+            assert( i >= 0 );
+            assert( i < 2 );
+#endif
+            return *( &x + i );
+        }
+    };
+    struct float3
+    {
+        float x, y, z;
+        float & operator[]( int i )
+        {
+#ifdef _DEBUG
+
+            assert( i >= 0 );
+            assert( i < 3 );
+#endif
+            return ( *( &x + i ) );
+        }
+    };
+    struct float4
+    {
+        float x, y, z, w;
+        float & operator[]( int i )
+        {
+#ifdef _DEBUG
+
+            assert( i >= 0 );
+            assert( i < 4 );
+#endif
+            return ( *( &x + i ) );
+        }
+    };
+    struct float3x3
+    {
+        float3 x, y, z;
+        float & operator()( int i, int j )
+        {
+#ifdef _DEBUG
+
+            assert( i >= 0 );
+            assert( i < 3 );
+            assert( j >= 0 );
+            assert( j < 3 );
+#endif
+            return ( *( &x[0] + j * sizeof( float3 ) / sizeof( float ) + i ) );
+        }
+    };  // column-major
+    struct pose
+    {
+        float3x3 orientation;
+        float3 position;
+    };
 #pragma pack(pop)
     inline bool operator == (const float3 & a, const float3 & b) { return a.x == b.x && a.y == b.y && a.z == b.z; }
     inline float3 operator + (const float3 & a, const float3 & b) { return{ a.x + b.x, a.y + b.y, a.z + b.z }; }

--- a/src/types.h
+++ b/src/types.h
@@ -395,8 +395,9 @@ namespace librealsense
         operator T () const
         {
             T le_value = 0;
-            for (unsigned int i = 0; i < sizeof(T); ++i) reinterpret_cast<char *>(&le_value)[i] = reinterpret_cast<const char *>(&be_value)[sizeof(T) - i - 1];
+            for (unsigned int i = 0; i < sizeof(T); ++i) *(reinterpret_cast<char*>(&le_value) + i) = *(reinterpret_cast<const char*>(&be_value) + sizeof(T) - i - 1);
             return le_value;
+
         }
     };
 #pragma pack(pop)


### PR DESCRIPTION
Fix CppCheck warning on types.h

i.e:
src\types.h:585:24: warning: The address of local variable 'x' might be accessed at non-zero index. [objectIndex]
            return (&x)[i];