### PR TITLE
Fixed frameset handling on viewer

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1371,7 +1371,6 @@ namespace rs2
             {
                 auto f = frame.second;
 
-
                 if( f.is< points >()
                     && ! paused )  // find and store the 3d points frame for later use
                 {
@@ -1395,11 +1394,6 @@ namespace rs2
                     || ( f.get_profile().format() != RS2_FORMAT_ANY && is_3d_texture_source( f ) ) )
                 {
                     texture_frame = texture;
-                }
-
-                if( ! p )
-                {
-                    upload_frame( std::move( f ) );
                 }
             }
         }

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1345,49 +1345,61 @@ namespace rs2
             size_t index = 0;
             while (ppf.resulting_queue.poll_for_frame(&f) && ++index < ppf.resulting_queue_max_size)
             {
-                if (streams.find(f.get_profile().unique_id()) != streams.end() ||
-                    streams.find(streams_origin[f.get_profile().unique_id()]) != streams.end())
-                    last_frames[f.get_profile().unique_id()] = f;
+                // Open the frameset and save the frames on last_frames 
+                // if one of the streams is missing we will use the last frame arrived
+                if (f.is<rs2::frameset>())
+                {
+                    for (auto frame : f.as<rs2::frameset>())
+                    {
+                        if (streams.find(frame.get_profile().unique_id()) != streams.end() ||
+                            streams.find(streams_origin[frame.get_profile().unique_id()]) != streams.end())
+                            last_frames[frame.get_profile().unique_id()] = frame;
+                    }
+                }
+                else
+                {
+                    if (streams.find(f.get_profile().unique_id()) != streams.end() ||
+                        streams.find(streams_origin[f.get_profile().unique_id()]) != streams.end())
+                        last_frames[f.get_profile().unique_id()] = f;
+                }
             }
 
             for(auto&& f : last_frames)
                 not_model->output.update_dashboards(f.second);
 
-            for(auto&& frame : last_frames)
+            for( auto && frame : last_frames )
             {
                 auto f = frame.second;
-                frameset frames;
-                if ((frames = f.as<frameset>()))
+
+
+                if( f.is< points >()
+                    && ! paused )  // find and store the 3d points frame for later use
                 {
-                    for (auto&& frame : frames)
+                    p = f.as< points >();
+                    continue;
+                }
+
+                if( f.is< pose_frame >() )  // Aggregate the trajectory in pause mode to make the
+                                            // path consistent
+                {
+                    auto dev = streams[f.get_profile().unique_id()].dev;
+                    if( dev )
                     {
-                        if (frame.is<points>() && !paused)  // find and store the 3d points frame for later use
-                        {
-                            p = frame.as<points>();
-                            continue;
-                        }
-
-                        if (frame.is<pose_frame>())  // Aggregate the trajectory in pause mode to make the path consistent
-                        {
-                            auto dev = streams[frame.get_profile().unique_id()].dev;
-                            if (dev)
-                            {
-                                dev->tm2.update_model_trajectory(frame.as<pose_frame>(), !paused);
-                            }
-                        }
-
-                        auto texture = upload_frame(std::move(frame));
-
-                        if ((selected_tex_source_uid == -1 && frame.get_profile().format() == RS2_FORMAT_Z16) ||
-                            (frame.get_profile().format() != RS2_FORMAT_ANY && is_3d_texture_source(frame)))
-                        {
-                            texture_frame = texture;
-                        }
+                        dev->tm2.update_model_trajectory( f.as< pose_frame >(), ! paused );
                     }
                 }
-                else if (!p)
+
+                auto texture = upload_frame( std::move( f ) );
+
+                if( ( selected_tex_source_uid == -1 && f.get_profile().format() == RS2_FORMAT_Z16 )
+                    || ( f.get_profile().format() != RS2_FORMAT_ANY && is_3d_texture_source( f ) ) )
                 {
-                    upload_frame(std::move(f));
+                    texture_frame = texture;
+                }
+
+                if( ! p )
+                {
+                    upload_frame( std::move( f ) );
                 }
             }
         }


### PR DESCRIPTION
Open the frameset on viewer_model::handle_ready_frames and save the frames on last_frames,
so if one of the frames missing we will take the last frame saved.
[tracked on DSO-16419] 