### PR TITLE
Memory leak test sensor option

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1165,6 +1165,7 @@ namespace librealsense
         }
         bool v4l_uvc_device::get_xu(const extension_unit& xu, uint8_t control, uint8_t* data, int size) const
         {
+            memset(data, 0, size);
             uvc_xu_control_query q = {static_cast<uint8_t>(xu.unit), control, UVC_GET_CUR,
                                       static_cast<uint16_t>(size), const_cast<uint8_t *>(data)};
             if(xioctl(_fd, UVCIOC_CTRL_QUERY, &q) < 0)

--- a/unit-tests/utilities/memory/test-sensor-option.cpp
+++ b/unit-tests/utilities/memory/test-sensor-option.cpp
@@ -1,0 +1,21 @@
+#include "../../test.h"
+#include "../../func/func-common.h"
+#include <iostream>
+
+
+TEST_CASE( "sensor get_option memory leak", "[live]" )
+{
+    // running this test with the following command:
+    // `valgrind --leak-check=yes --show-leak-kinds=all --track-origins=yes ./unit-tests/build/utilities/memory/test-sensor-option/test-utilities-memory-sensor-option 2>&1 | grep depends`
+    // should print nothing!
+
+    auto devices = find_devices_by_product_line_or_exit(RS2_PRODUCT_LINE_DEPTH);
+    if (devices.size() == 0) return;
+    auto dev = devices[0];
+
+    auto depth_sens = dev.first< rs2::depth_sensor >();
+    // float option_value(depth_sens.get_option(RS2_OPTION_EXPOSURE));
+    float option_value(depth_sens.get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE));
+
+    std::cout << "Declare: BOOL::" << option_value << std::endl;
+}

--- a/unit-tests/utilities/memory/test-sensor-option.cpp
+++ b/unit-tests/utilities/memory/test-sensor-option.cpp
@@ -6,7 +6,7 @@
 TEST_CASE( "sensor get_option memory leak", "[live]" )
 {
     // running this test with the following command:
-    // `valgrind --leak-check=yes --show-leak-kinds=all --track-origins=yes ./unit-tests/build/utilities/memory/test-sensor-option/test-utilities-memory-sensor-option 2>&1 | grep depends`
+    // `valgrind --leak-check=yes --show-leak-kinds=all --track-origins=yes ./unit-tests/build/utilities/memory/test-sensor-option/test-utilities-memory-sensor-option 2>&1 | grep 'depends\|No device'`
     // should print nothing!
 
     auto devices = find_devices_by_product_line_or_exit(RS2_PRODUCT_LINE_DEPTH);
@@ -17,5 +17,6 @@ TEST_CASE( "sensor get_option memory leak", "[live]" )
     // float option_value(depth_sens.get_option(RS2_OPTION_EXPOSURE));
     float option_value(depth_sens.get_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE));
 
-    std::cout << "Declare: BOOL::" << option_value << std::endl;
+    REQUIRE( (option_value) ); // Using the value of option_value, if memory error exist, causes valgrind to output: "Conditional jump or move depends on uninitialised value(s)"
 }
+


### PR DESCRIPTION
Add test for memory issue using valgrind and a fix.

To test the memory issue:
```
valgrind --leak-check=yes --show-leak-kinds=all --track-origins=yes ./unit-tests/build/utilities/memory/test-sensor-option/test-utilities-memory-sensor-option 2>&1 | grep depends
```
If everything is ok should print nothing.
Tracked in DSO-16885