### PR TITLE
Fix unpack from sr300 cuda implementation

### DIFF
--- a/src/proc/depth-formats-converter.cpp
+++ b/src/proc/depth-formats-converter.cpp
@@ -18,6 +18,7 @@ namespace librealsense
         auto out_ir = reinterpret_cast<uint8_t *>(dest[1]);
 #ifdef RS2_USE_CUDA
         rscuda::unpack_z16_y8_from_sr300_inzi_cuda(out_ir, in, count);
+        in += count;
 #else
         for (int i = 0; i < count; ++i) *out_ir++ = *in++ >> 2;
 #endif
@@ -31,6 +32,7 @@ namespace librealsense
         auto out_ir = reinterpret_cast<uint16_t*>(dest[1]);
 #ifdef RS2_USE_CUDA
         rscuda::unpack_z16_y16_from_sr300_inzi_cuda(out_ir, in, count);
+        in += count;
 #else
         for (int i = 0; i < count; ++i) *out_ir++ = *in++ << 6;
 #endif


### PR DESCRIPTION
This PR fixes a bug with incorrect depth image on the SR300 series cameras when librealsense is built with CUDA [/issues/8897]. 
The functions `unpack_z16_y8_from_sr300_inzi` and `unpack_z16_y16_from_sr300_inzi` use the source data pointer (`in`) - the first half of the data is bit-shifted and stored in `dest[1]`, the second half is directly copied to `dest[0]`. In the CPU version, the pointer is moved in a loop and after its execution it points to `in + count` - so the copying works as it should. In the CUDA version, the pointer is never moved, so bad data is copied to `dest[0]`, resulting in an incorrect depth image. Simply moving the pointer to the right place fixes the problem. 