### PR TITLE
Signed Firmware image check before updating 

### DIFF
--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -168,6 +168,8 @@ namespace librealsense
                 auto sn = get_serial_number();
                 if(_is_dfu_locked)
                     throw std::runtime_error("Device: " + sn  + " is locked for update.\nUse firmware version higher than: " + _highest_fw_version);
+                else if (state == RS2_DFU_STATE_DFU_ERROR)
+                    throw std::runtime_error("Device: " + sn + " failed to update firmware\nImage is unsupported for this device");
                 else
                     throw std::runtime_error("Device: " + sn + " failed to download firmware\nPlease verify that no other librealsense application is running");
             }


### PR DESCRIPTION
Throws a informative exception message when trying to update signed firmware image if its corrupted or not suited for the specific device.

Tracked on [DSO-16641](https://rsjira.intel.com/browse/DSO-16641)