### PR TITLE
Added Dockerfile for building Ubuntu based Docker images

### DIFF
--- a/scripts/Docker/Dockerfile
+++ b/scripts/Docker/Dockerfile
@@ -1,0 +1,73 @@
+ARG BASE_IMAGE=ubuntu:20.04 
+#################################
+#   Librealsense Builder Stage  #
+#################################
+FROM $BASE_IMAGE as librealsense-builder
+
+ARG LIBRS_VERSION
+# Make sure that we have a version number of librealsense as argument
+RUN test -n "$LIBRS_VERSION"
+
+# To avoid waiting for input during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Builder dependencies installation
+RUN apt-get update \
+    && apt-get install -qq -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    libssl-dev \
+    libusb-1.0-0-dev \
+    pkg-config \
+    libgtk-3-dev \
+    libglfw3-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \    
+    curl \
+    python3 \
+    python3-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download sources
+WORKDIR /usr/src
+RUN curl https://codeload.github.com/IntelRealSense/librealsense/tar.gz/refs/tags/v$LIBRS_VERSION -o librealsense.tar.gz 
+RUN tar -zxf librealsense.tar.gz \
+    && rm librealsense.tar.gz 
+RUN ln -s /usr/src/librealsense-$LIBRS_VERSION /usr/src/librealsense
+
+# Build and install
+RUN cd /usr/src/librealsense \
+    && mkdir build && cd build \
+    && cmake \
+    -DCMAKE_C_FLAGS_RELEASE="${CMAKE_C_FLAGS_RELEASE} -s" \
+    -DCMAKE_CXX_FLAGS_RELEASE="${CMAKE_CXX_FLAGS_RELEASE} -s" \
+    -DBUILD_NETWORK_DEVICE=ON \
+    -DCMAKE_INSTALL_PREFIX=/opt/librealsense \    
+    -DBUILD_GRAPHICAL_EXAMPLES=OFF \
+    -DBUILD_PYTHON_BINDINGS:bool=true \
+    -DCMAKE_BUILD_TYPE=Release ../ \
+    && make -j4 all \
+    && make install 
+
+######################################
+#   librealsense Base Image Stage    #
+######################################
+FROM ${BASE_IMAGE} as librealsense
+
+# Copy binaries from builder stage
+COPY --from=librealsense-builder /opt/librealsense /usr/local/
+COPY --from=librealsense-builder /usr/lib/python3/dist-packages/pyrealsense2 /usr/lib/python3/dist-packages/pyrealsense2
+COPY --from=librealsense-builder /usr/src/librealsense/config/99-realsense-libusb.rules /etc/udev/rules.d/
+ENV PYTHONPATH=$PYTHONPATH:/usr/local/lib
+
+# Install dep packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \	
+    libusb-1.0-0 \
+    udev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Shows a list of connected Realsense devices
+CMD [ "rs-enumerate-devices", "--compact" ]

--- a/scripts/Docker/build_image.sh
+++ b/scripts/Docker/build_image.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+# This script builds docker image of the latest librealsense github tag 
+# Get the latest git TAG version
+LIBRS_GIT_TAG=`git describe --abbrev=0 --tags`
+LIBRS_VERSION=${LIBRS_GIT_TAG#"v"}
+
+echo "Building images for librealsense version ${LIBRS_VERSION}"
+docker build \
+        --target librealsense \
+        --build-arg LIBRS_VERSION=$LIBRS_VERSION \
+        --tag librealsense \
+        --tag librealsense --tag librealsense:$LIBRS_GIT_TAG \
+        .

--- a/scripts/Docker/build_image_multi_platform.sh
+++ b/scripts/Docker/build_image_multi_platform.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+# This script builds librealsense for both the x86_64 and arm64 platforms. 
+# See: https://docs.docker.com/buildx/working-with-buildx/
+
+# Get the latest git TAG version
+LIBRS_GIT_TAG=`git describe --abbrev=0 --tags`
+LIBRS_VERSION=${LIBRS_GIT_TAG#"v"}
+
+echo "Building images for librealsense version ${LIBRS_VERSION}"
+
+# Build x86_64 image
+docker buildx \
+    build \
+    --platform linux/amd64 \
+    --target librealsense \
+    --build-arg LIBRS_VERSION=$LIBRS_VERSION \
+    --tag librealsense --tag librealsense:$LIBRS_GIT_TAG \
+    -o type=docker,dest=- . > librealsense-amd64.tar
+
+# Build arm64 image (slow!)
+docker buildx \
+    build \
+    --platform linux/arm64 \
+    --target librealsense \
+    --tag librealsense --tag librealsense:$LIBRS_GIT_TAG \
+    --build-arg LIBRS_VERSION=$LIBRS_VERSION \
+    -o type=docker,dest=- . > librealsense-arm64.tar

--- a/scripts/Docker/readme.md
+++ b/scripts/Docker/readme.md
@@ -1,0 +1,7 @@
+### Dockerfile for librealsense containers
+- Ubuntu base system (Ubuntu 20.04 by default)
+- **librealsense-builder** stage - builds the binaries and has all the build dependencies 
+- **librealsense** stage -  contain only the built binaries and the required runtime dependencies (~60MB)
+- Support for Python bindings (python not included) and networking
+- Binaries are stripped during build stage to minimize image size
+- Support scripts for building and running the image are also included

--- a/scripts/Docker/run_image.sh
+++ b/scripts/Docker/run_image.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+# By using --device-cgroup-rule flag we grant the docker continer permissions -
+# to the camera and usb endpoints of the machine.
+# It also mounts the /dev directory of the host platform on the contianer 
+docker run -it --rm \
+    -v /dev:/dev \
+    --device-cgroup-rule "c 81:* rmw" \
+    --device-cgroup-rule "c 189:* rmw" \
+    librealsense


### PR DESCRIPTION
### Dockerfile for librealsense containers
- Ubuntu base system (Ubuntu 20.04 by default)
- **librealsense-builder** stage - builds the binaries and has all the build dependencies 
- **librealsense** stage -  contain only the built binaries and the required runtime dependencies (~60MB)
- Support for Python bindings (python not included) and networking
- Binaries are stripped during build stage to minimize image size
- Support scripts for building and running the image are also included