### PR TITLE
Signed Firmware image check before updating

### DIFF
--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -169,7 +169,7 @@ namespace librealsense
                 if(_is_dfu_locked)
                     throw std::runtime_error("Device: " + sn  + " is locked for update.\nUse firmware version higher than: " + _highest_fw_version);
                 else if (state == RS2_DFU_STATE_DFU_ERROR)
-                    throw std::runtime_error("Device: " + sn + " failed to update firmware\nImage is unsupported for this device");
+                    throw std::runtime_error("Device: " + sn + " failed to update firmware\nImage is unsupported for this device or corrupted");
                 else
                     throw std::runtime_error("Device: " + sn + " failed to download firmware\nPlease verify that no other librealsense application is running");
             }

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -168,6 +168,8 @@ namespace librealsense
                 auto sn = get_serial_number();
                 if(_is_dfu_locked)
                     throw std::runtime_error("Device: " + sn  + " is locked for update.\nUse firmware version higher than: " + _highest_fw_version);
+                else if (state == RS2_DFU_STATE_DFU_ERROR)
+                    throw std::runtime_error("Device: " + sn + " failed to update firmware\nImage is unsupported for this device");
                 else
                     throw std::runtime_error("Device: " + sn + " failed to download firmware\nPlease verify that no other librealsense application is running");
             }


### PR DESCRIPTION
Throws a informative exception message when trying to update signed firmware image if its corrupted or unsupported by the specific device.

Tracked on DSO-16641