### PR TITLE
SW update - support 3 fields version

### DIFF
--- a/common/sw-update/versions-db-manager.h
+++ b/common/sw-update/versions-db-manager.h
@@ -44,7 +44,7 @@ namespace rs2
             {
                 constexpr int MINIMAL_MATCH_SECTIONS = 4;
                 constexpr int MATCH_SECTIONS_INC_BUILD_NUM = 5;
-                std::regex rgx("^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,5})?$");
+                std::regex rgx("^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})(\\.\\d{1,5})?$");
                 std::smatch match;
 
                 if (std::regex_search(str.begin(), str.end(), match, rgx) && match.size() >= MINIMAL_MATCH_SECTIONS)


### PR DESCRIPTION
DB file parsing will now support 3 fields version (as release versions are represented).

i.e
"version": "1.5.4"

before the fix the regex supported 3 fields only with an ending period.
i.e 
"version": "1.5.4."
