### PR TITLE
Replace GVD queries with device update notification to verify device removal during DFU

### DIFF
--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -257,8 +257,6 @@ namespace rs2
                 // if querying devices is called while device still switching to DFU state, an exception will be thrown
                 // to prevent that, a blocking is added to make sure device is updated before continue to next step of querying device
                 upd.enter_update_state();
-                // Allow time for the device to disconnect before calling "query_devices"
-                std::this_thread::sleep_for(std::chrono::seconds(2));
 
                 if (!check_for([this, serial, &dfu]() {
                     auto devs = _ctx.query_devices();

--- a/src/backend.h
+++ b/src/backend.h
@@ -31,6 +31,9 @@ const uint16_t MAX_RETRIES                = 100;
 const uint8_t  DEFAULT_V4L2_FRAME_BUFFERS = 4;
 const uint16_t DELAY_FOR_RETRIES          = 50;
 
+// We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
+const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = 6000 / DELAY_FOR_RETRIES;
+
 const uint8_t MAX_META_DATA_SIZE          = 0xff; // UVC Metadata total length
                                             // is limited by (UVC Bulk) design to 255 bytes
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -27,12 +27,10 @@
 #include <fstream>
 
 
-const uint16_t MAX_RETRIES                = 100;
-const uint8_t  DEFAULT_V4L2_FRAME_BUFFERS = 4;
-const uint16_t DELAY_FOR_RETRIES          = 50;
-
-// We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
-const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = 6000 / DELAY_FOR_RETRIES;
+const uint16_t MAX_RETRIES                 = 100;
+const uint8_t  DEFAULT_V4L2_FRAME_BUFFERS  = 4;
+const uint16_t DELAY_FOR_RETRIES           = 50;
+const int      POLLING_DEVICES_INTERVAL_MS = 5000;
 
 const uint8_t MAX_META_DATA_SIZE          = 0xff; // UVC Metadata total length
                                             // is limited by (UVC Bulk) design to 255 bytes

--- a/src/context.h
+++ b/src/context.h
@@ -43,7 +43,7 @@ namespace librealsense
     class device_info
     {
     public:
-        virtual std::shared_ptr<device_interface> create_device(bool register_device_notifications = false) const
+        virtual std::shared_ptr<device_interface> create_device(bool register_device_notifications = true) const
         {
             return create(_ctx, register_device_notifications);
         }

--- a/src/context.h
+++ b/src/context.h
@@ -43,9 +43,9 @@ namespace librealsense
     class device_info
     {
     public:
-        virtual std::shared_ptr<device_interface> create_device(bool register_device_notifications = true) const
+        virtual std::shared_ptr<device_interface> create_device() const
         {
-            return create(_ctx, register_device_notifications);
+            return create(_ctx, true);
         }
 
         virtual ~device_info() = default;
@@ -86,7 +86,7 @@ namespace librealsense
 
         }
 
-        std::shared_ptr<device_interface> create_device(bool) const override
+        std::shared_ptr<device_interface> create_device() const override
         {
             return _dev;
         }

--- a/src/device.h
+++ b/src/device.h
@@ -80,6 +80,8 @@ namespace librealsense
 
         virtual void stop_activity() const;
 
+        bool device_changed_notifications_on() const { return _device_changed_notifications; }
+
     protected:
         int add_sensor(const std::shared_ptr<sensor_interface>& sensor_base);
         int assign_sensor(const std::shared_ptr<sensor_interface>& sensor_base, uint8_t idx);

--- a/src/device.h
+++ b/src/device.h
@@ -88,7 +88,7 @@ namespace librealsense
 
         explicit device(std::shared_ptr<context> ctx,
                         const platform::backend_device_group group,
-                        bool device_changed_notifications = false);
+                        bool device_changed_notifications = true);
 
         std::map<int, std::pair<uint32_t, std::shared_ptr<const stream_interface>>> _extrinsics;
 

--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -40,11 +40,9 @@ namespace librealsense
         return result;
     }
 
-    device_hub::device_hub(std::shared_ptr<librealsense::context> ctx, int mask, int vid,
-                           bool register_device_notifications)
+    device_hub::device_hub(std::shared_ptr<librealsense::context> ctx, int mask, int vid)
         : _ctx(ctx), _vid(vid),
-          _device_changes_callback_id(0),
-          _register_device_notifications(register_device_notifications)
+          _device_changes_callback_id(0)
     {
         _device_list = filter_by_vid(_ctx->query_devices(mask), _vid);
 
@@ -82,7 +80,7 @@ namespace librealsense
             auto d = _device_list[ (_camera_index + i) % _device_list.size()];
             try
             {
-                auto dev = d->create_device(_register_device_notifications);
+                auto dev = d->create_device();
 
                 if(serial.size() > 0 )
                 {

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -15,7 +15,7 @@ namespace librealsense
     class device_hub
     {
     public:
-        explicit device_hub(std::shared_ptr<librealsense::context> ctx, int mask = RS2_PRODUCT_LINE_ANY, int vid = 0, bool register_device_notifications = true);
+        explicit device_hub(std::shared_ptr<librealsense::context> ctx, int mask = RS2_PRODUCT_LINE_ANY, int vid = 0);
 
         ~device_hub();
 
@@ -54,6 +54,5 @@ namespace librealsense
         int _camera_index = 0;
         int _vid = 0;
         uint64_t _device_changes_callback_id;
-        bool _register_device_notifications;
     };
 }

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -143,20 +143,19 @@ namespace librealsense
             command cmd( ds::DFU );
             cmd.param1 = 1;
             _hw_monitor->send( cmd );
-            std::vector< uint8_t > gvd_buff( HW_MONITOR_BUFFER_SIZE );
-            // 120 iterations = ~6 seconds, we allow 6 seconds because on Linux the removal status is
-            // updated at a 5 seconds rate.
-            for( auto i = 0; i < 120; i++ )
+            for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {
-                // If the device was detected as removed we assume the device is entering update
-                // mode
+                // If the device was detected as removed we assume the device is entering update mode
+                // Note: if no device status callback is registered we will wait the whole time and it is OK
                 if( ! is_valid() )
                     return;
 
-                this_thread::sleep_for( milliseconds( 50 ) );
+                this_thread::sleep_for( milliseconds( DELAY_FOR_RETRIES ) );
             }
 
-            LOG_WARNING( "Device still connected!" );
+
+            if (device_changed_notifications_on())
+                LOG_WARNING( "Timeout waiting for device disconnect after DFU command!" );
         }
         catch( std::exception & e )
         {
@@ -164,7 +163,7 @@ namespace librealsense
         }
         catch( ... )
         {
-            LOG_ERROR( " unknown error during entering DFU state" );
+            LOG_ERROR( "Unknown error during entering DFU state" );
         }
     }
 

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -143,6 +143,9 @@ namespace librealsense
             command cmd( ds::DFU );
             cmd.param1 = 1;
             _hw_monitor->send( cmd );
+
+            // We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
+            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = (POLLING_DEVICES_INTERVAL_MS + 1000) / DELAY_FOR_RETRIES;
             for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {
                 // If the device was detected as removed we assume the device is entering update mode

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -137,26 +137,34 @@ namespace librealsense
         using namespace std;
         using namespace std::chrono;
 
-        try {
-            LOG_INFO("entering to update state, device disconnect is expected");
-            command cmd(ds::DFU);
-            cmd.param1 = 1;
-            _hw_monitor->send(cmd);
-            std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
-            for (auto i = 0; i < 50; i++)
-            {
-                _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::GVD);
-                this_thread::sleep_for(milliseconds(50));
-            }
-            throw std::runtime_error("Device still connected!");
-
-        }
-        catch (std::exception& e)
+        try
         {
-            LOG_WARNING(e.what());
+            LOG_INFO( "entering to update state, device disconnect is expected" );
+            command cmd( ds::DFU );
+            cmd.param1 = 1;
+            _hw_monitor->send( cmd );
+            std::vector< uint8_t > gvd_buff( HW_MONITOR_BUFFER_SIZE );
+            // 120 iterations = ~6 seconds, we allow 6 seconds because on Linux the removal status is
+            // updated at a 5 seconds rate.
+            for( auto i = 0; i < 120; i++ )
+            {
+                // If the device was detected as removed we assume the device is entering update
+                // mode
+                if( ! is_valid() )
+                    return;
+
+                this_thread::sleep_for( milliseconds( 50 ) );
+            }
+
+            LOG_WARNING( "Device still connected!" );
         }
-        catch (...) {
-            // The set command returns a failure because switching to DFU resets the device while the command is running.
+        catch( std::exception & e )
+        {
+            LOG_WARNING( e.what() );
+        }
+        catch( ... )
+        {
+            LOG_ERROR( " unknown error during entering DFU state" );
         }
     }
 

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -339,24 +339,33 @@ namespace librealsense
         using namespace std;
         using namespace std::chrono;
 
-        try {
-            command cmd(ivcam::GoToDFU);
-            cmd.param1 = 1;
-            _hw_monitor->send(cmd);
-            std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
-            for (auto i = 0; i < 50; i++)
-            {
-                _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::GVD);
-                this_thread::sleep_for(milliseconds(50));
-            }
-            throw std::runtime_error("Device still connected!");
-        }
-        catch (std::exception& e)
+        try
         {
-            LOG_WARNING(e.what());
+            command cmd( ivcam::GoToDFU );
+            cmd.param1 = 1;
+            _hw_monitor->send( cmd );
+            std::vector< uint8_t > gvd_buff( HW_MONITOR_BUFFER_SIZE );
+            // 120 iterations = ~6 seconds, we allow 6 seconds because on Linux the removal status is
+            // updated at a 5 seconds rate.
+            for( auto i = 0; i < 120; i++ )
+            {
+                // If the device was detected as removed we assume the device is entering update
+                // mode
+                if( ! is_valid() )
+                    return;
+
+                this_thread::sleep_for( milliseconds( 50 ) );
+            }
+
+            LOG_WARNING( "Device still connected!" );
         }
-        catch (...) {
-            // The set command returns a failure because switching to DFU resets the device while the command is running.
+        catch( std::exception & e )
+        {
+            LOG_WARNING( e.what() );
+        }
+        catch( ... )
+        {
+            LOG_ERROR( " unknown error during entering DFU state" );
         }
     }
 

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -367,7 +367,7 @@ namespace librealsense
         }
         catch( ... )
         {
-            LOG_WARNING("Timeout waiting for device disconnect after DFU command!");
+            LOG_ERROR( "Unknown error during entering DFU state" );
         }
     }
 

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -344,6 +344,10 @@ namespace librealsense
             command cmd( ivcam::GoToDFU );
             cmd.param1 = 1;
             _hw_monitor->send( cmd );
+
+            // We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
+            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = (POLLING_DEVICES_INTERVAL_MS + 1000) / DELAY_FOR_RETRIES;
+
             for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {
                 // If the device was detected as removed we assume the device is entering update mode

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -462,7 +462,9 @@ namespace librealsense
             command cmd( ivcam2::DFU );
             cmd.param1 = 1;
             _hw_monitor->send( cmd );
-            
+
+            // We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
+            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = (POLLING_DEVICES_INTERVAL_MS + 1000) / DELAY_FOR_RETRIES;
             for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {
                 // If the device was detected as removed we assume the device is entering update mode

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -456,26 +456,33 @@ namespace librealsense
         using namespace std;
         using namespace std::chrono;
 
-        try {
-            LOG_INFO("entering to update state, device disconnect is expected");
-            command cmd(ivcam2::DFU);
+        try
+        {
+            LOG_INFO( "entering to update state, device disconnect is expected" );
+            command cmd( ivcam2::DFU );
             cmd.param1 = 1;
-            _hw_monitor->send(cmd);
-            std::vector<uint8_t> gvd_buff(HW_MONITOR_BUFFER_SIZE);
-            for (auto i = 0; i < 50; i++)
+            _hw_monitor->send( cmd );
+            // 120 iterations = ~6 seconds, we allow 6 seconds because on Linux the removal status is
+            // updated at a 5 seconds rate.
+            for( auto i = 0; i < 120; i++ )
             {
+                // If the device was detected as removed we assume the device is entering update
+                // mode
+                if( ! is_valid() )
+                    return;
 
-                _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), GVD);
-                this_thread::sleep_for(milliseconds(50));
+                this_thread::sleep_for( milliseconds( 50 ) );
             }
-            throw std::runtime_error("Device still connected!");
 
+            LOG_WARNING( "Device still connected!" );
         }
-        catch (std::exception& e) {
-            LOG_WARNING(e.what());
+        catch( std::exception & e )
+        {
+            LOG_ERROR( e.what() );
         }
-        catch (...) {
-            // The set command returns a failure because switching to DFU resets the device while the command is running.
+        catch( ... )
+        {
+            LOG_ERROR( " unknown error during entering DFU state" );
         }
     }
 

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -462,19 +462,19 @@ namespace librealsense
             command cmd( ivcam2::DFU );
             cmd.param1 = 1;
             _hw_monitor->send( cmd );
-            // 120 iterations = ~6 seconds, we allow 6 seconds because on Linux the removal status is
-            // updated at a 5 seconds rate.
-            for( auto i = 0; i < 120; i++ )
+            
+            for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {
-                // If the device was detected as removed we assume the device is entering update
-                // mode
+                // If the device was detected as removed we assume the device is entering update mode
+                // Note: if no device status callback is registered we will wait the whole time and it is OK
                 if( ! is_valid() )
                     return;
 
-                this_thread::sleep_for( milliseconds( 50 ) );
+                this_thread::sleep_for( milliseconds(DELAY_FOR_RETRIES) );
             }
 
-            LOG_WARNING( "Device still connected!" );
+            if (device_changed_notifications_on())
+                LOG_WARNING("Timeout waiting for device disconnect after DFU command!");
         }
         catch( std::exception & e )
         {
@@ -482,7 +482,7 @@ namespace librealsense
         }
         catch( ... )
         {
-            LOG_ERROR( " unknown error during entering DFU state" );
+            LOG_ERROR( "Unknown error during entering DFU state" );
         }
     }
 

--- a/src/pipeline/config.cpp
+++ b/src/pipeline/config.cpp
@@ -199,7 +199,7 @@ namespace librealsense
             {
                 try
                 {
-                    auto dev = dev_info->create_device(true);
+                    auto dev = dev_info->create_device();
                     _resolved_profile = resolve(dev);
                     return _resolved_profile;
                 }
@@ -256,7 +256,7 @@ namespace librealsense
                 }
             }
 
-            return ctx->add_device(file)->create_device(false);
+            return ctx->add_device(file)->create_device();
         }
 
         std::shared_ptr<device_interface> config::resolve_device_requests(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout)

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1522,7 +1522,7 @@ rs2_device* rs2_context_add_device(rs2_context* ctx, const char* file, rs2_error
     VALIDATE_NOT_NULL(file);
 
     auto dev_info = ctx->ctx->add_device(file);
-    return new rs2_device{ ctx->ctx, dev_info, dev_info->create_device(false) };
+    return new rs2_device{ ctx->ctx, dev_info, dev_info->create_device() };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, ctx, file)
 

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -7,7 +7,7 @@
 namespace librealsense
 {
     software_device::software_device()
-        : device(std::make_shared<context>(backend_type::standard), {}),
+        : device(std::make_shared<context>(backend_type::standard), {}, false),
         _user_destruction_callback()
     {
         register_info(RS2_CAMERA_INFO_NAME, "Software-Device");

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -52,7 +52,7 @@ namespace librealsense
         {
         }
         
-        std::shared_ptr<device_interface> create_device(bool) const override
+        std::shared_ptr<device_interface> create_device() const override
         {
             return _dev.lock();
         }

--- a/src/types.h
+++ b/src/types.h
@@ -1600,7 +1600,7 @@ namespace librealsense
 
         void polling(dispatcher::cancellable_timer cancellable_timer)
         {
-            if(cancellable_timer.try_sleep(5000))
+            if(cancellable_timer.try_sleep(POLLING_DEVICES_INTERVAL_MS))
             {
                 platform::backend_device_group curr(_backend->query_uvc_devices(), _backend->query_usb_devices(), _backend->query_hid_devices());
                 if(list_changed(_devices_data.uvc_devices, curr.uvc_devices ) ||


### PR DESCRIPTION
We add a ~6 seconds maximum loop to verify the device is disconnected after the DFU command (replacing HWM calls)

This partly reverts PR #8018 which caused freezes after DFUs.

Tracked on [RS5-11058]