### PR TITLE
Add a CMake flag for disable AVX for OpenVINO

### DIFF
--- a/CMake/lrs_options.cmake
+++ b/CMake/lrs_options.cmake
@@ -35,6 +35,7 @@ option(FORCE_LIBUVC "Explicitly turn-on libuvc backend - deprecated, use FORCE_R
 option(FORCE_WINUSB_UVC "Explicitly turn-on winusb_uvc (for win7) backend - deprecated, use FORCE_RSUSB_BACKEND instead" OFF)
 option(ANDROID_USB_HOST_UVC "Build UVC backend for Android - deprecated, use FORCE_RSUSB_BACKEND instead" OFF)
 option(CHECK_FOR_UPDATES "Checks for versions updates" ON)
+option(BUILD_WITH_CPU_EXTENSIONS "Build with CPU extensions support" ON)
 #Performance improvement with Ubuntu 18/20
 if(UNIX AND (NOT ANDROID_NDK_TOOLCHAIN_INCLUDED))
     option(ENABLE_EASYLOGGINGPP_ASYNC "Switch Logger to Asynchronous Mode (set OFF for Synchronous Mode)"  ON)

--- a/CMake/lrs_options.cmake
+++ b/CMake/lrs_options.cmake
@@ -35,7 +35,7 @@ option(FORCE_LIBUVC "Explicitly turn-on libuvc backend - deprecated, use FORCE_R
 option(FORCE_WINUSB_UVC "Explicitly turn-on winusb_uvc (for win7) backend - deprecated, use FORCE_RSUSB_BACKEND instead" OFF)
 option(ANDROID_USB_HOST_UVC "Build UVC backend for Android - deprecated, use FORCE_RSUSB_BACKEND instead" OFF)
 option(CHECK_FOR_UPDATES "Checks for versions updates" ON)
-option(BUILD_WITH_CPU_EXTENSIONS "Build with CPU extensions support" ON)
+option(BUILD_WITH_CPU_EXTENSIONS "Enable compiler optimizations using CPU extensions (such as AVX)" ON)
 #Performance improvement with Ubuntu 18/20
 if(UNIX AND (NOT ANDROID_NDK_TOOLCHAIN_INCLUDED))
     option(ENABLE_EASYLOGGINGPP_ASYNC "Switch Logger to Asynchronous Mode (set OFF for Synchronous Mode)"  ON)

--- a/wrappers/openvino/CMakeLists.txt
+++ b/wrappers/openvino/CMakeLists.txt
@@ -11,7 +11,7 @@ if( NOT DEFINED INTEL_OPENVINO_DIR  OR  NOT IS_DIRECTORY ${INTEL_OPENVINO_DIR} )
 endif()
 
 if (NOT BUILD_WITH_CPU_EXTENSIONS)
-    message( STATUS "Disable CPU extensions for OpenVINO" )
+    message( STATUS "Disabling CPU extensions for OpenVINO" )
     set(ENABLE_AVX2    OFF)
     set(ENABLE_AVX512F OFF)
 endif()

--- a/wrappers/openvino/CMakeLists.txt
+++ b/wrappers/openvino/CMakeLists.txt
@@ -10,6 +10,12 @@ if( NOT DEFINED INTEL_OPENVINO_DIR  OR  NOT IS_DIRECTORY ${INTEL_OPENVINO_DIR} )
 	message( FATAL_ERROR "Invalid OpenVINO directory specified with INTEL_OPENVINO_DIR" )
 endif()
 
+if (NOT BUILD_WITH_CPU_EXTENSIONS)
+    message( STATUS "Disable CPU extensions for OpenVINO" )
+    set(ENABLE_AVX2    OFF)
+    set(ENABLE_AVX512F OFF)
+endif()
+           
 # Set dependencies, including a CPU extension
 set(IE_ROOT_DIR "${INTEL_OPENVINO_DIR}/inference_engine")
 include(${INTEL_OPENVINO_DIR}/inference_engine/share/InferenceEngineConfig.cmake)


### PR DESCRIPTION
* Add LRS CMake flag BUILD_WITH_CPU_EXTENSIONS default = ON (will affect LRS use of CPU extensions in the future)
* If BUILD_WITH_CPU_EXTENSIONS == OFF disable AVX support for OpenVINO