### PR TITLE
Travis-ci : switch building all windows builds using VS2017 #8928

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ matrix:
         - |
           subst d: ../. 
         - cd d:/build
-        - cmake .. -G "Visual Studio 14 2015 Win64" -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DCHECK_FOR_UPDATES=true
+        # Currently build on VS2017, VS2015 is temporary unavailable (Microsoft issue)
+        #- cmake .. -G "Visual Studio 14 2015 Win64" -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DCHECK_FOR_UPDATES=true
+        - cmake .. -G "Visual Studio 15 2017 Win64" -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DCHECK_FOR_UPDATES=true
         - cmake --build . --config $LRS_BUILD_CONFIG -- -m
         - ls $LRS_BUILD_CONFIG
 
@@ -44,7 +46,9 @@ matrix:
         - |
           subst d: ../. 
         - cd d:/build
-        - cmake .. -G "Visual Studio 14 2015 Win64" -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_CSHARP_BINDINGS=true -DDOTNET_VERSION_LIBRARY="4.5" -DDOTNET_VERSION_EXAMPLES="4.5" -DCHECK_FOR_UPDATES=true
+        # Currently build on VS2017, VS2015 is temporary unavailable (Microsoft issue)
+        #- cmake .. -G "Visual Studio 14 2015 Win64" -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_CSHARP_BINDINGS=true -DDOTNET_VERSION_LIBRARY="4.5" -DDOTNET_VERSION_EXAMPLES="4.5" -DCHECK_FOR_UPDATES=true
+        - cmake .. -G "Visual Studio 15 2017 Win64" -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_CSHARP_BINDINGS=true -DDOTNET_VERSION_LIBRARY="4.5" -DDOTNET_VERSION_EXAMPLES="4.5" -DCHECK_FOR_UPDATES=true
         - cmake --build . --config $LRS_BUILD_CONFIG -- -m
         - ls $LRS_BUILD_CONFIG
 
@@ -151,11 +155,13 @@ install:
       sudo apt-get install libglfw3-dev libglfw3;
     fi
 
+# Currently build on VS2017, VS2015 is temporary unavailable (Microsoft issue)
+# This would go inside the following if:
+#    if [[ "$VS15" == "true" ]]; then
+#        choco install -y vcbuildtools --version 2015.4 --force;
+#    fi;
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
       choco install -y python3 --version 3.8.1;
-      if [[ "$VS15" == "true" ]]; then
-        choco install -y vcbuildtools --version 2015.4 --force;
-      fi;
     fi
 
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
Currently Microsoft has an issue with installing vcbuildtools 2015, temporary fix is to builds using 2017

