### PR TITLE
Fix unit-tests crash after hw-reset

### DIFF
--- a/unit-tests/func/reset-camera.h
+++ b/unit-tests/func/reset-camera.h
@@ -51,5 +51,6 @@ inline rs2::device reset_camera_and_wait_for_connection( rs2::device & dev)
     REQUIRE(cv.wait_for( lock, std::chrono::seconds( 50 ), [&]() { return disconnected; } ) );
     REQUIRE( cv.wait_for( lock, std::chrono::seconds( 50 ), [&]() { return connected; } ) );
     REQUIRE( result );
+    ctx.set_devices_changed_callback( []( rs2::event_information info ) {} );  // reset callback
     return result;
 }

--- a/unit-tests/unit-tests-common.h
+++ b/unit-tests/unit-tests-common.h
@@ -809,7 +809,7 @@ inline std::shared_ptr<rs2::device> do_with_waiting_for_camera_connection(rs2::c
     std::shared_ptr<rs2::device> result;
     std::condition_variable cv;
 
-    ctx.set_devices_changed_callback([&result, dev, &disconnected, &connected, &m, &cv, &serial](rs2::event_information info) mutable
+    ctx.set_devices_changed_callback([&](rs2::event_information info) mutable
         {
             if (info.was_removed(*dev))
             {
@@ -844,6 +844,8 @@ inline std::shared_ptr<rs2::device> do_with_waiting_for_camera_connection(rs2::c
         }, dev));
     REQUIRE(cv.wait_for(lock, std::chrono::seconds(20), [&]() { return connected; }));
     REQUIRE(result);
+    ctx.set_devices_changed_callback( []( rs2::event_information info ) {} );  // reset callback
+
     return result;
 }
 


### PR DESCRIPTION
**Issue:** UT register device callback function with a limited scope capture list.
The fix is to reset the callback before the captured data gets out of scope.