### PR TITLE
fix rspy.unittest.ExeTest init w/ default TestConfig if source not found

### DIFF
--- a/unit-tests/py/rspy/unittest.py
+++ b/unit-tests/py/rspy/unittest.py
@@ -339,6 +339,8 @@ class ExeTest( Test ):
         relative_test_path = self.find_source_path()
         if relative_test_path:
             self._config = TestConfigFromCpp( unit_tests_dir + os.sep + relative_test_path )
+        else:
+            self._config = TestConfig()
 
     @property
     def command( self ):


### PR DESCRIPTION
If the source cannot be found, no TestConfig was created, causing failures in places that expected a config.