### PR TITLE
Bug fix in unittest.py, log.d instead of error

### DIFF
--- a/unit-tests/py/rspy/unittest.py
+++ b/unit-tests/py/rspy/unittest.py
@@ -332,7 +332,7 @@ class ExeTest( Test ):
         """
         global unit_tests_dir
         if not os.path.isfile( exe ):
-            raise RuntimeError( "Tried to create exe test with invalid exe file: " + exe )
+            log.d( "Tried to create exe test with invalid exe file: " + exe )
         Test.__init__( self, testname )
         self.exe = exe
 


### PR DESCRIPTION
If .cpp unit-test was configured by never compiled, an ExeTest was created and errored out because the .exe wasn't there...