### PR TITLE
Viewer - No 3D image on playback

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -404,15 +404,16 @@ namespace rs2
             if (s.second.is_stream_visible() &&
                 s.second.profile.stream_type() == RS2_STREAM_DEPTH)
             {
+                auto stream_origin_iter = streams_origin.find(s.second.profile.unique_id());
                 if (selected_depth_source_uid == -1)
                 {
-                    if (streams_origin.find(s.second.profile.unique_id()) != streams_origin.end() &&
-                        streams.find(streams_origin[s.second.profile.unique_id()]) != streams.end())
+                    if ( stream_origin_iter != streams_origin.end() &&
+                        streams.find( stream_origin_iter->second ) != streams.end())
                     {
-                        selected_depth_source_uid = streams_origin[s.second.profile.unique_id()];
+                        selected_depth_source_uid = stream_origin_iter->second;
                     }   
                 }
-                if (streams_origin.find(s.second.profile.unique_id()) != streams_origin.end() && streams_origin[s.second.profile.unique_id()] == selected_depth_source_uid)
+                if ( stream_origin_iter != streams_origin.end() && stream_origin_iter->second == selected_depth_source_uid)
                 {
                     selected_depth_source = i;
                 }
@@ -443,21 +444,22 @@ namespace rs2
                  s.second.profile.stream_type() == RS2_STREAM_FISHEYE))
             {
                 auto profile_unique_id = s.second.profile.unique_id();
-                bool profile_found = streams_origin.find(profile_unique_id) != streams_origin.end();
+                auto stream_origin_iter = streams_origin.find(profile_unique_id);
+                auto profile_found = stream_origin_iter != streams_origin.end();
 
-                if (selected_tex_source_uid == -1 && selected_depth_source_uid != -1)
+                if( selected_tex_source_uid == -1 && selected_depth_source_uid != -1 )
                 {
-                    if (profile_found && streams.find(streams_origin[profile_unique_id]) != streams.end())
+                    if( profile_found && streams.find(stream_origin_iter->second ) != streams.end() )
                     {
                         selected_tex_source_uid = streams_origin[profile_unique_id];
                     }                         
                 }
-                if ((profile_found && streams_origin[profile_unique_id] == selected_tex_source_uid))
+                if( ( profile_found && stream_origin_iter->second == selected_tex_source_uid ) )
                 {
                     selected_tex_source = i;
                 }
 
-                if ( profile_found )
+                if( profile_found )
                 {
                     // The texture source shall always refer to the raw (original) streams
                     tex_sources.push_back(streams_origin[profile_unique_id]);
@@ -605,8 +607,10 @@ namespace rs2
                     {
                         if (selected)
                         {
-                            if( streams_origin.find( s.second.profile.unique_id() ) != streams_origin.end() )
-                                selected_depth_source_uid = streams_origin[s.second.profile.unique_id()];
+                            auto stream_origin_iter = streams_origin.find(s.second.profile.unique_id());
+
+                            if( stream_origin_iter != streams_origin.end() )
+                                selected_depth_source_uid = stream_origin_iter->second;
                         }
                     }
                     i++;
@@ -1349,17 +1353,24 @@ namespace rs2
             size_t index = 0;
             while (ppf.resulting_queue.poll_for_frame(&f) && ++index < ppf.resulting_queue_max_size)
             {
-                // Open the frameset and save the frames on last_frames 
+                // Open the frame-set and validate the incoming frame originated from one of the source streams
+                // and save the frames on last_frames 
                 // if one of the streams is missing we will use the last frame arrived
+                // point cloud is not a stream type yet it's a frame we want to display
                 if (f.is<rs2::frameset>())
                 {
                     for (auto frame : f.as<rs2::frameset>())
                     {
                         auto profile_id = frame.get_profile().unique_id();
 
-                        if( streams.find( profile_id ) != streams.end()
-                            || ( streams_origin.find( profile_id ) != streams_origin.end() && streams.find( streams_origin[ profile_id ] ) != streams.end() )
-                            || frame.is< points >() )  // point cloud is not a stream type yet it's a frame we want to display
+                        if (frame.is< points >() || streams.find(profile_id) != streams.end())
+                        {
+                            last_frames[profile_id] = frame;
+                            continue;
+                        }
+
+                        auto stream_origin_iter = streams_origin.find(profile_id);
+                        if( (stream_origin_iter != streams_origin.end() && streams.find( stream_origin_iter->second ) != streams.end() ))
                         {
                             last_frames[ profile_id ] = frame;
                         }
@@ -1369,9 +1380,14 @@ namespace rs2
                 {
                     auto profile_id = f.get_profile().unique_id();
 
-                    if( streams.find( f.get_profile().unique_id() ) != streams.end()
-                        || ( streams_origin.find( profile_id ) != streams_origin.end() && streams.find( streams_origin[profile_id] ) != streams.end() )
-                        || f.is< points >() )  // point cloud is not a stream type yet it's a frame we want to display
+                    if (f.is< points >() || streams.find(profile_id) != streams.end())
+                    {
+                        last_frames[profile_id] = f;
+                        continue;
+                    }
+
+                    auto stream_origin_iter = streams_origin.find(profile_id);
+                    if ((stream_origin_iter != streams_origin.end() && streams.find(stream_origin_iter->second) != streams.end()))
                     {
                         last_frames[profile_id] = f;
                     }
@@ -3330,8 +3346,9 @@ namespace rs2
         auto index = f.get_profile().unique_id();
 
         std::lock_guard<std::mutex> lock(streams_mutex);
-        if (streams_origin.find(index) != streams_origin.end() && streams.find(streams_origin[index]) != streams.end())
-            return streams[streams_origin[index]].upload_frame(std::move(f));
+        auto stream_origin_iter = streams_origin.find(index);
+        if ( stream_origin_iter != streams_origin.end() && streams.find( stream_origin_iter->second ) != streams.end())
+            return streams[stream_origin_iter->second].upload_frame(std::move(f));
         else return nullptr;
     }
 


### PR DESCRIPTION
point cloud image are ignored during playback / DQT 3D streaming
This fix allow pointcloud frames to be uploaded to the rendering window

Tracked on [RS5-11334]