### PR TITLE
improve unit-test-config.py to understand '#include <>' syntax

### DIFF
--- a/unit-tests/unit-test-config.py
+++ b/unit-tests/unit-test-config.py
@@ -68,7 +68,8 @@ if not os.path.isdir( dir ) or not os.path.isdir( builddir ):
     usage()
 
 # We have to stick to Unix conventions because CMake on Windows is fubar...
-src = repo.root.replace( '\\' , '/' ) + '/src'
+root = repo.root.replace( '\\' , '/' )
+src = root + '/src'
 
 def generate_cmake( builddir, testdir, testname, filelist ):
     makefile = builddir + '/' + testdir + '/CMakeLists.txt'


### PR DESCRIPTION
Up until now, only `#include "..."` syntax was understood.
Both now also search the "standard" include directories:
* `<librealsense>/include`
* `<librealsense>`

Added debug output.