### PR TITLE
Avoid an unnecessary copy of the frame data

### DIFF
--- a/src/sensor.h
+++ b/src/sensor.h
@@ -94,7 +94,7 @@ namespace librealsense
         void assign_stream(const std::shared_ptr<stream_interface>& stream,
                            std::shared_ptr<stream_profile_interface> target) const;
 
-        std::shared_ptr<frame> generate_frame_from_data(const platform::frame_object& fo,
+        std::shared_ptr<frame> generate_empty_frame_from_data(const platform::frame_object& fo,
             frame_timestamp_reader* timestamp_reader,
             const rs2_time_t& last_timestamp,
             const unsigned long long& last_frame_number,


### PR DESCRIPTION
The callback that handles sensor data, which starts here:
https://github.com/IntelRealSense/librealsense/blob/fc007cef1b9bb4f68dfdb540fcbea70aac46ebaa/src/sensor.cpp#L318
... calls `generate_frame_from_data()` on its `platform::frame_object` parameter. This function makes a copy of the frame data here:
https://github.com/IntelRealSense/librealsense/blob/fc007cef1b9bb4f68dfdb540fcbea70aac46ebaa/src/sensor.cpp#L249
As far as I can tell, the only place where this copy of the frame data is subsequently used is to make another copy of the frame data, here:
https://github.com/IntelRealSense/librealsense/blob/fc007cef1b9bb4f68dfdb540fcbea70aac46ebaa/src/sensor.cpp#L362
... in `uvc_sensor::open()`, and here:
https://github.com/IntelRealSense/librealsense/blob/fc007cef1b9bb4f68dfdb540fcbea70aac46ebaa/src/sensor.cpp#L846
... in `hid_sensor::start()`.

This PR proposes to remove the first copy to improve performance. Instead of copying the data from the `platform::frame_object` into the temporary `frame` and from there on into the `frame_holder`'s frame, it can be directly copied from the `platform::frame_object` into the `frame_holder`'s frame, which should give a performance improvement that is especially relevant on slow platforms such as the Raspberry PI 4 that I currently work with.

The temporary `frame` object "`fr`" still seems to be necessary to be able to use it to call `_timestamp_reader->get_frame_timestamp_domain(fr)` (which I assumed does not try to access the frame's content; otherwise, this PR would need to be adapted). Aside from that, the code only seems to access `fr->additional_data` as far as I can tell.

Since `generate_frame_from_data()` does not create a valid `frame` anymore then, it should probably be renamed; maybe there are better ideas than `generate_empty_frame_from_data()` what I used.