### PR TITLE
Syncer improvements & Concurrency fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/context.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/device.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/device_hub.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/dispatcher.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/environment.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/error-handling.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/firmware_logger_device.cpp"

--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -17,123 +17,173 @@ class single_consumer_queue
     std::deque<T> _queue;
     mutable std::mutex _mutex;
     std::condition_variable _deq_cv; // not empty signal
-    std::condition_variable _enq_cv; // not empty signal
+    std::condition_variable _enq_cv; // not full signal
 
-    unsigned int _cap;
+    unsigned int const _cap;
     bool _accepting;
 
-    // flush mechanism is required to abort wait on cv
-    // when need to stop
-    std::atomic<bool> _need_to_flush;
-    std::atomic<bool> _was_flushed;
-    std::function<void(T const &)> _on_drop_callback;
-public:
-    explicit single_consumer_queue<T>(unsigned int cap = QUEUE_MAX_SIZE, std::function<void(T const &)> on_drop_callback = nullptr)
-        : _queue(), _mutex(), _deq_cv(), _enq_cv(), _cap(cap), _accepting(true), _need_to_flush(false), _was_flushed(false), _on_drop_callback(on_drop_callback)
-    {}
+    std::function<void(T const &)> const _on_drop_callback;
 
+public:
+    explicit single_consumer_queue< T >( unsigned int cap = QUEUE_MAX_SIZE,
+                                         std::function< void( T const & ) > on_drop_callback = nullptr )
+        : _queue()
+        , _mutex()
+        , _deq_cv()
+        , _enq_cv()
+        , _cap( cap )
+        , _accepting( true )
+        , _on_drop_callback( on_drop_callback )
+    {
+    }
+
+    // Enqueue an item onto the queue.
+    // If the queue grows beyond capacity, the front will be removed, losing whatever was there!
     void enqueue(T&& item)
     {
         std::unique_lock<std::mutex> lock(_mutex);
-        if (_accepting)
+        if( ! _accepting )
         {
-            _queue.push_back(std::move(item));
-            if (_queue.size() > _cap)
+            if( _on_drop_callback )
+                _on_drop_callback( item );
+            return;
+        }
+
+        _queue.push_back(std::move(item));
+
+        if( _queue.size() > _cap )
+        {
+            if( _on_drop_callback )
+                _on_drop_callback( _queue.front() );
+            _queue.pop_front();
+        }
+
+        lock.unlock();
+
+        // We pushed something -- let others know there's something to dequeue
+        _deq_cv.notify_one();
+    }
+
+
+    // Enqueue an item, but wait for room if there isn't any
+    // Returns true if the enqueue succeeded
+    bool blocking_enqueue(T&& item)
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if( ! _accepting )
+        {
+            if( _on_drop_callback )
+                _on_drop_callback( item );
+            return false;
+        }
+
+        if( _queue.size() >= _cap )
+        {
+            _enq_cv.wait( lock );
+            if( ! _accepting )
             {
-                if (_on_drop_callback)
-                {
-                    _on_drop_callback(_queue.front());
-                }
-                _queue.pop_front();
+                // We shouldn't be adding anything to the queue when we're stopping
+                if( _on_drop_callback )
+                    _on_drop_callback( item );
+                return false;
             }
         }
+
+        _queue.push_back(std::move(item));
         lock.unlock();
+
+        // We pushed something -- let another know there's something to dequeue
         _deq_cv.notify_one();
-    }
 
-    void blocking_enqueue(T&& item)
-    {
-        auto pred = [this]()->bool { return _queue.size() < _cap || _need_to_flush; };
-
-        std::unique_lock<std::mutex> lock(_mutex);
-        if (_accepting)
-        {
-            _enq_cv.wait(lock, pred);
-            _queue.push_back(std::move(item));
-        }
-        lock.unlock();
-        _deq_cv.notify_one();
-    }
-
-
-    bool dequeue(T* item ,unsigned int timeout_ms)
-    {
-        std::unique_lock<std::mutex> lock(_mutex);
-        _accepting = true;
-        _was_flushed = false;
-        const auto ready = [this]() { return (_queue.size() > 0) || _need_to_flush; };
-        if (!ready() && !_deq_cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), ready))
-        {
-            return false;
-        }
-
-        if (_queue.size() <= 0)
-        {
-            return false;
-        }
-        *item = std::move(_queue.front());
-        _queue.pop_front();
-        _enq_cv.notify_one();
         return true;
     }
 
+
+    // Remove one item; if unavailable, wait for it
+    // Return true if an item was removed -- otherwise, false
+    bool dequeue( T * item, unsigned int timeout_ms )
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+
+        if( _queue.empty() )
+        {
+            _deq_cv.wait_for( lock, std::chrono::milliseconds( timeout_ms ) );
+            if( _queue.empty() )
+                return false;
+        }
+
+        *item = std::move(_queue.front());
+        _queue.pop_front();
+
+        // We've made room -- let whoever is waiting for room know about it
+        _enq_cv.notify_one();
+
+        return true;
+    }
+
+    // Remove one item if available; do not wait for one
+    // Return true if an item was removed -- otherwise, false
     bool try_dequeue(T* item)
     {
         std::lock_guard< std::mutex > lock( _mutex );
-        _accepting = true;
-        if (_queue.size() > 0)
-        {
-            auto val = std::move(_queue.front());
-            _queue.pop_front();
-            *item = std::move(val);
-            _enq_cv.notify_one();
-            return true;
-        }
-        return false;
+        if( _queue.empty() )
+            return false;
+
+        *item = std::move(_queue.front());
+        _queue.pop_front();
+
+        // We've made room -- let whoever is waiting for room know about it
+        _enq_cv.notify_one();
+
+        return true;
     }
 
     bool peek(T** item)
     {
         std::lock_guard< std::mutex > lock( _mutex );
 
-        if (_queue.size() <= 0)
-        {
+        if (_queue.empty())
             return false;
-        }
+
         *item = &_queue.front();
         return true;
+    }
+
+    void stop()
+    {
+        std::lock_guard< std::mutex > lock( _mutex );
+
+        // We no longer accept any more items!
+        _accepting = false;
+
+        _clear();
     }
 
     void clear()
     {
         std::lock_guard< std::mutex > lock( _mutex );
+        _clear();
+    }
 
-        _accepting = false;
-        _need_to_flush = true;
-
-        _enq_cv.notify_all();
-        while (_queue.size() > 0)
+protected:
+	void _clear()
+	{
+        // Empty out the queue (TODO: why no just _queue.clear()?)
+        while( _queue.size() > 0 )
         {
-            auto item = std::move(_queue.front());
+            auto item = std::move( _queue.front() );
             _queue.pop_front();
         }
+
+        // Wake up anyone who is waiting for room to enqueue, or waiting for something to dequeue -- there's nothing now
+        _enq_cv.notify_all();
         _deq_cv.notify_all();
     }
 
+public:
     void start()
     {
         std::lock_guard< std::mutex > lock( _mutex );
-        _need_to_flush = false;
         _accepting = true;
     }
 
@@ -180,6 +230,11 @@ public:
     void clear()
     {
         _queue.clear();
+    }
+
+    void stop()
+    {
+        _queue.stop();
     }
 
     void start()
@@ -309,7 +364,7 @@ public:
             _was_stopped_cv.notify_all();
         }
 
-        _queue.clear();
+        _queue.stop();
 
         {
             std::unique_lock<std::mutex> lock(_was_flushed_mutex);
@@ -325,11 +380,10 @@ public:
     ~dispatcher()
     {
         stop();
-        _queue.clear();
         _is_alive = false;
 
-        if (_thread.joinable())
-        _thread.join();
+        if( _thread.joinable() )
+            _thread.join();
     }
 
     bool flush()

--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -154,8 +154,8 @@ public:
     }
 
 protected:
-	void _clear()
-	{
+    void _clear()
+    {
         _queue.clear();
 
         // Wake up anyone who is waiting for room to enqueue, or waiting for something to dequeue -- there's nothing now

--- a/src/dispatcher.cpp
+++ b/src/dispatcher.cpp
@@ -1,0 +1,115 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
+#include "concurrency.h"
+
+
+dispatcher::dispatcher( unsigned int cap, std::function< void( action ) > on_drop_callback )
+    : _queue( cap, on_drop_callback )
+    , _was_stopped( true )
+    , _is_alive( true )
+{
+    // We keep a running thread that takes stuff off our queue and dispatches them
+    _thread = std::thread([&]()
+    {
+        int timeout_ms = 5000;
+        while( _is_alive )
+        {
+            std::function< void( cancellable_timer ) > item;
+
+            if( _queue.dequeue( &item, timeout_ms ) )
+            {
+                cancellable_timer time(this);
+
+                try
+                {
+                    // While we're dispatching the item, we cannot stop!
+                    std::lock_guard< std::mutex > lock( _dispatch_mutex );
+                    item( time );
+                }
+                catch( ... )
+                {
+                }
+            }
+        }
+    });
+}
+
+
+dispatcher::~dispatcher()
+{
+    // Don't get into any more dispatches
+    _is_alive = false;
+
+    // Stop whatever's in-progress, if any
+    stop();
+
+    // Wait until our worker thread quits
+    if( _thread.joinable() )
+        _thread.join();
+}
+
+
+void dispatcher::start()
+{
+    std::lock_guard< std::mutex > lock( _was_stopped_mutex );
+    _was_stopped = false;
+
+    _queue.start();
+}
+
+
+void dispatcher::stop()
+{
+    // With the following commented-out if, we have issues!
+    // It seems stop is called multiple times and the queues are somehow waiting on something after
+    // the first time. If we return, those queues aren't woken! If we continue, the only effect will
+    // be to notify_all and we get good behavior...
+    // 
+    //if( _was_stopped )
+    //    return;
+
+    // First things first: don't accept any more incoming stuff, and get rid of anything
+    // pending
+    _queue.stop();
+
+    // Signal we've stopped so any sleeping dispatched will wake up immediately
+    {
+        std::lock_guard< std::mutex > lock( _was_stopped_mutex );
+        _was_stopped = true;
+        _was_stopped_cv.notify_all();
+    }
+
+    // Wait until any dispatched is done...
+    {
+        std::lock_guard< std::mutex > lock( _dispatch_mutex );
+        assert( _queue.empty() );
+    }
+}
+
+
+// Return when all items in the queue are finished (within a timeout).
+// If additional items are added while we're waiting, those will not be waited on!
+//
+bool dispatcher::flush()
+{
+    std::mutex m;
+    std::condition_variable cv;
+    bool invoked = false;
+    auto wait_sucess = std::make_shared<std::atomic_bool>(true);
+    invoke([&, wait_sucess](cancellable_timer t)
+    {
+        ///TODO: use _queue to flush, and implement properly
+        if (_was_stopped || !(*wait_sucess))
+            return;
+
+        {
+            std::lock_guard<std::mutex> locker(m);
+            invoked = true;
+        }
+        cv.notify_one();
+    });
+    std::unique_lock<std::mutex> locker(m);
+    *wait_sucess = cv.wait_for(locker, std::chrono::seconds(10), [&]() { return invoked || _was_stopped; });
+    return *wait_sucess;
+}

--- a/src/ds5/ds5-thermal-monitor.cpp
+++ b/src/ds5/ds5-thermal-monitor.cpp
@@ -50,7 +50,7 @@ namespace librealsense
 
     void ds5_thermal_monitor::polling(dispatcher::cancellable_timer cancellable_timer)
     {
-        if (cancellable_timer.try_sleep(_poll_intervals_ms))
+        if (cancellable_timer.try_sleep( std::chrono::milliseconds( _poll_intervals_ms )))
         {
             try
             {

--- a/src/error-handling.cpp
+++ b/src/error-handling.cpp
@@ -45,7 +45,7 @@ namespace librealsense
 
     void polling_error_handler::polling(dispatcher::cancellable_timer cancellable_timer)
     {
-         if (cancellable_timer.try_sleep(_poll_intervals_ms))
+         if (cancellable_timer.try_sleep( std::chrono::milliseconds( _poll_intervals_ms )))
          {
              try
              {

--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -249,7 +249,7 @@ namespace librealsense
     {
         update_diff_time();
         unsigned int time_to_sleep = _poll_intervals_ms + _coefs.is_full() * (9 * _poll_intervals_ms);
-        if (!cancellable_timer.try_sleep(time_to_sleep))
+        if (!cancellable_timer.try_sleep( std::chrono::milliseconds( time_to_sleep )))
         {
             LOG_DEBUG("Notification: time_diff_keeper polling loop is being shut-down");
         }

--- a/src/media/playback/playback_sensor.h
+++ b/src/media/playback/playback_sensor.h
@@ -118,7 +118,7 @@ namespace librealsense
                 {
                     device_serializer::nanoseconds sleep_for = calc_sleep();
                     if (sleep_for.count() > 0)
-                        t.try_sleep(sleep_for.count() * 1e-6);
+                        t.try_sleep( sleep_for );
 
                     LOG_DEBUG("callback--> "<< frame_holder_to_string(*pf));
                     if(is_paused())

--- a/src/pipeline/aggregator.cpp
+++ b/src/pipeline/aggregator.cpp
@@ -120,7 +120,7 @@ namespace librealsense
         void aggregator::stop()
         {
             _accepting = false;
-            _queue->clear();
+            _queue->stop();
         }
     }
 }

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -55,6 +55,11 @@ namespace librealsense
             LOG_DEBUG( "--> syncing " << frame_holder_to_string( frame ));
             {
                 std::lock_guard<std::mutex> lock(_mutex);
+                if( ! _matcher->get_active() )
+                {
+                    LOG_DEBUG( "matcher was stopped: NOT DISPATCHING FRAME!" );
+                    return;
+                }
                 _matcher->dispatch(std::move(frame), { source, _matches, log });
             }
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -78,7 +78,12 @@ namespace librealsense
         :matcher({stream})
     {
         _streams_type = {stream_type};
-        _name = std::string(rs2_stream_to_string(stream_type));
+
+        std::ostringstream ss;
+        ss << rs2_stream_to_string( stream_type );
+        ss << '/';
+        ss << stream;
+        _name = ss.str();
     }
 
     void identity_matcher::dispatch(frame_holder f, const syncronization_environment& env)

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -256,10 +256,11 @@ namespace librealsense
 
     void composite_matcher::stop()
     {
-        for (auto& fq : _frames_queue)
-        {
-            fq.second.clear();
-        }
+        set_active( false );
+        for( auto & fq : _frames_queue )
+            fq.second.stop();
+        for( auto m : _matchers )
+            m.second->stop();
     }
 
     std::string

--- a/src/types.h
+++ b/src/types.h
@@ -1594,7 +1594,7 @@ namespace librealsense
 
         void polling(dispatcher::cancellable_timer cancellable_timer)
         {
-            if(cancellable_timer.try_sleep(POLLING_DEVICES_INTERVAL_MS))
+            if(cancellable_timer.try_sleep( std::chrono::milliseconds( POLLING_DEVICES_INTERVAL_MS )))
             {
                 platform::backend_device_group curr(_backend->query_uvc_devices(), _backend->query_usb_devices(), _backend->query_hid_devices());
                 if(list_changed(_devices_data.uvc_devices, curr.uvc_devices ) ||

--- a/unit-tests/LRS_windows_compile_pipeline.stats
+++ b/unit-tests/LRS_windows_compile_pipeline.stats
@@ -1,2 +1,2 @@
-warnings 29
+warnings 28
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -78,6 +78,8 @@ set(RAW_RS
     ../../src/log.cpp
     ../../src/backend.h
     ../../src/backend.cpp
+    ../../src/backend.cpp
+    ../../src/dispatcher.cpp
 )
 
 if(UNIX)

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -78,7 +78,6 @@ set(RAW_RS
     ../../src/log.cpp
     ../../src/backend.h
     ../../src/backend.cpp
-    ../../src/backend.cpp
     ../../src/dispatcher.cpp
 )
 


### PR DESCRIPTION
Following the deadlock that Nir experienced, reworked some stuff (and not all because of the deadlock):
* split off dispatcher code into dispatcher.cpp
* syncer (timestamp) inactive stream handling moved into skip_missing_stream
* syncer identity_matcher names now include the stream index
* single_consumer_queue::_mutex is now mutable; size() and empty() const
* revised logic inside single_consumer_queue
* revised logic inside dispatcher
* cancellable_time::try_sleep() is now templated, requires actual chrono duration (and not just its ::Rep)
* syncer stop() calls now percolate recursively to shut down all queues; new syncs do nothing if syncer was stopped
* fix 1 warning on the way :)