### PR TITLE
Increase the syncer queue on model-views.h to avoid frame drops.

### DIFF
--- a/common/model-views.h
+++ b/common/model-views.h
@@ -388,39 +388,43 @@ namespace rs2
             auto shared_syncer = std::make_shared<rs2::asynchronous_syncer>();
 
             // This queue stores the output from the syncer, and has to be large enough to deal with
-            // slowdowns on the processing / rendering threads of the Viewer, to avoid frame drops.Frame
-            // drops can be pretty noticeable!
+            // slowdowns on the processing/rendering threads of the Viewer to avoid frame drops. Frame
+            // drops can be pretty noticeable to the user!
             //
-            // The syncer may also give out frames in bursts.This commonly happens, for example, when
-            // streams have different FPS, and is a known issue.Even with same - FPS streams, the actual
-            // FPS may change depending on a number of variables(e.g., exposure).When FPS is not the
-            // same between the streams, a latency is introduced and bursts from the syncer happen.
+            // The syncer may also give out frames in bursts. This commonly happens, for example, when
+            // streams have different FPS, and is a known issue. Even with same-FPS streams, the actual
+            // FPS may change depending on a number of variables (e.g., exposure). When FPS is not the
+            // same between the streams, a latency is introduced and bursts from the syncer are the
+            // result.
             //
-            // Bursts are so fast the other threads will never have a chance to pull them in time.For
-            //  example, the syncer output can be the following, all one after the other :
-            // [Color @ timestamp 100 (arrived @ 105), Infrared @ timestamp 100 (arrived at 150)]
-            // [Color @ timestamp 116 (arrived @ 120)]
-            // [Color @ timestamp 132 (arrived @ 145)]
-            // They are received one at a time, pushed into the syncer, which will wait and keep all of
-            //  them inside until a match with Infrared is possible.Once that happens, it will output
-            //  everything it has, resulting in a burst.
+            // Bursts are so fast the other threads will never have a chance to pull them in time. For
+            // example, the syncer output can be the following, all one after the other:
             //
-            // The queue size must therefore be big enough to deal with expected latency : the more
+            //     [Color: timestamp 100 (arrived @ 105), Infrared: timestamp 100 (arrived at 150)]
+            //     [Color: timestamp 116 (arrived @ 120)]
+            //     [Color: timestamp 132 (arrived @ 145)]
+            //
+            // They are received one at a time & pushed into the syncer, which will wait and keep all of
+            // them inside until a match with Infrared is possible. Once that happens, it will output
+            // everything it has as a burst.
+            //
+            // The queue size must therefore be big enough to deal with expected latency: the more
             // latency, the bigger the burst.
             //
             // Another option is to use an aggregator, similar to the behavior inside the pipeline.
             // But this still doesn't solve the issue of the bursts: we'll get frame drops in the fast
             // stream instead of the slow.
+            //
             rs2::frame_queue q(10);
 
-           _syncers.push_back({shared_syncer,q});
-           shared_syncer->start([this, q](rs2::frame f)
-           {
-               q.enqueue(f);
-               on_frame();
-           });
-           start();
-           return shared_syncer;
+            _syncers.push_back({shared_syncer,q});
+            shared_syncer->start([this, q](rs2::frame f)
+            {
+                q.enqueue(f);
+                on_frame();
+            });
+            start();
+            return shared_syncer;
         }
 
         void remove_syncer(std::shared_ptr<rs2::asynchronous_syncer> s)


### PR DESCRIPTION
This queue stores the output from the syncer, and has to be large enough to deal with slowdowns on the processing / rendering threads of the Viewer, to avoid frame drops.

The problem here wasn't slowdowns of the other thread -- it was bust output from the syncer, too fast for any other thread to deal with and causing drops. The bursts are caused by latency introduced on the USB/FW side when different streams have different FPS.

[tracked-on DSO-16419]

