### PR TITLE
L515 FW version compatibility fix

### DIFF
--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -696,11 +696,14 @@ namespace librealsense
     {
         std::string fw_version = extract_firmware_version_string((const void*)image.data(), image.size());
 
-        auto it = ivcam2::device_to_fw_min_version.find(_pid);
-        if (it == ivcam2::device_to_fw_min_version.end())
-            throw std::runtime_error("Minimum firmware version has not been defined for this device!");
+        auto min_max_fw_it = ivcam2::device_to_fw_min_max_version.find(_pid);
+        if (min_max_fw_it == ivcam2::device_to_fw_min_max_version.end())
+            throw std::runtime_error("Min and Max firmware versions have not been defined for this device!");
 
-        return (firmware_version(fw_version) >= firmware_version(it->second));
+        // Limit L515 to FW versions within the 1.5.1.3-1.99.99.99 range to differenciate from the other products
+        return (firmware_version(fw_version) >= firmware_version(min_max_fw_it->second.first)) &&
+               (firmware_version(fw_version) <= firmware_version(min_max_fw_it->second.second));
+
     }
 
     notification l500_notification_decoder::decode(int value)

--- a/src/l500/l500-private.h
+++ b/src/l500/l500-private.h
@@ -258,14 +258,14 @@ namespace librealsense
 
         };
 
-        static std::map<uint16_t, std::string> device_to_fw_min_version = {
-            { L500_RECOVERY_PID, "1.4.1.0"},
-            { L535_RECOVERY_PID, "1.4.1.0"},
-            { L500_USB2_RECOVERY_PID_OLD, "1.4.1.0"},
-            { L500_PID, "1.4.1.0"},
-            { L515_PID_PRE_PRQ, "1.4.1.0"},
-            { L515_PID, "1.4.1.0"},
-            { L535_PID, "1.4.1.0"}
+        static std::map<uint16_t, std::pair<std::string, std::string>> device_to_fw_min_max_version = {
+            { L500_RECOVERY_PID,            { "1.5.1.3", "1.99.99.99"}},
+            { L535_RECOVERY_PID,            { "1.5.1.3", "1.99.99.99"}},
+            { L500_USB2_RECOVERY_PID_OLD,   { "1.5.1.3", "1.99.99.99"}},
+            { L500_PID,                     { "1.5.1.3", "1.99.99.99"}},
+            { L515_PID_PRE_PRQ,             { "1.5.1.3", "1.99.99.99"}},
+            { L515_PID,                     { "1.5.1.3", "1.99.99.99"}},
+            { L535_PID,                     { "1.5.1.3", "1.99.99.99"}}
         };
 
         // Known FW error codes, if we poll for errors (RS2_OPTION_ERROR_POLLING_ENABLED)

--- a/unit-tests/live/dfu/test-device-fw-compatibility.py
+++ b/unit-tests/live/dfu/test-device-fw-compatibility.py
@@ -45,7 +45,7 @@ pid_to_min_fw_version = {  # D400 product line:
     '0B3A': d400_fw_min_version_2,  # D435I
     '0B49': d400_fw_min_version_1,  # D416
     '0B4B': d400_fw_min_version_1,  # D430I
-    '0B4D': d400_fw_min_version_1,  # D465
+    '0B4D': d400_fw_min_version_2,  # D465
     '0B52': d400_fw_min_version_1,  # D416_RGB
     '0B5B': d400_fw_min_version_3,  # D405
     '0B5C': d400_fw_min_version_2,  # D455

--- a/unit-tests/live/dfu/test-device-fw-compatibility.py
+++ b/unit-tests/live/dfu/test-device-fw-compatibility.py
@@ -16,8 +16,8 @@ d400_fw_min_version_1_prev = 'Signed_Image_UVC_5_8_14_0.bin'
 d400_fw_min_version_2_prev = 'Signed_Image_UVC_5_12_6_0.bin'
 d400_fw_min_version_3_prev = 'Signed_Image_UVC_5_12_11_0.bin'
 
-l500_fw_min_version = 'Signed_Image_UVC_1_4_1_0.bin'
-l500_fw_min_version_prev = 'Signed_Image_UVC_1_4_0_10.bin'
+l500_fw_min_version_valid = 'L5XX_FW_Image-1.5.1.3.bin'
+l500_fw_min_version_invalid = 'Signed_Image_UVC_1_4_1_0.bin'
 
 sr300_fw_min_version_1 = 'Signed_Image_UVC_3_21_0_0.bin'
 sr300_fw_min_version_2 = 'Signed_Image_UVC_3_27_0_0.bin'
@@ -50,13 +50,13 @@ pid_to_min_fw_version = {  # D400 product line:
     '0B5B': d400_fw_min_version_3,  # D405
     '0B5C': d400_fw_min_version_2,  # D455
     # L500 product line:
-    '0B55': l500_fw_min_version,  # L500_RECOVERY
-    '0B72': l500_fw_min_version,  # L535_RECOVERY
-    '0ADC': l500_fw_min_version,  # L500_USB2_RECOVERY_OLD
-    '0B0D': l500_fw_min_version,  # L500
-    '0B3D': l500_fw_min_version,  # L515_PRE_PRQ
-    '0B64': l500_fw_min_version,  # L515
-    '0B68': l500_fw_min_version,  # L535
+    '0B55': l500_fw_min_version_valid,  # L500_RECOVERY
+    '0B72': l500_fw_min_version_valid,  # L535_RECOVERY
+    '0ADC': l500_fw_min_version_valid,  # L500_USB2_RECOVERY_OLD
+    '0B0D': l500_fw_min_version_valid,  # L500
+    '0B3D': l500_fw_min_version_valid,  # L515_PRE_PRQ
+    '0B64': l500_fw_min_version_valid,  # L515
+    '0B68': l500_fw_min_version_valid,  # L535
     # SR300 product line:
     '0AA5': sr300_fw_min_version_1,  # SR300
     '0AB3': sr300_fw_min_version_1,  # SR300_RECOVERY
@@ -75,7 +75,7 @@ pid_to_max_fw_version = {  # SR300 product line:
 fw_previous_version = {d400_fw_min_version_1: d400_fw_min_version_1_prev,
                        d400_fw_min_version_2: d400_fw_min_version_2_prev,
                        d400_fw_min_version_3: d400_fw_min_version_3_prev,
-                       l500_fw_min_version: l500_fw_min_version_prev,
+                       l500_fw_min_version_valid: l500_fw_min_version_invalid,
                        # sr300_fw_min_version_1:sr300_fw_min_version_1_prev, no version before exists
                        sr300_fw_min_version_2: sr300_fw_min_version_2_prev,
                        sr300_fw_min_version_3: sr300_fw_min_version_3_prev
@@ -115,10 +115,11 @@ if pid in pid_to_min_fw_version:
         fw_image = bytearray(binary_file.read())
         check_firmware_compatible(updatable_device, fw_image)
 
+    # Negative
     if min_fw_version in fw_previous_version:
         one_before_min_fw_version = fw_previous_version[min_fw_version]
         one_before_min_fw_version_path = get_fw_version_path(product_line_dir, one_before_min_fw_version)
-        print("one before: " + one_before_min_fw_version)
+        print("firware version defined as non-compatible: " + one_before_min_fw_version)
         with open(one_before_min_fw_version_path, 'rb') as binary_file:
             fw_image = bytearray(binary_file.read())
             check_firmware_not_compatible(updatable_device, fw_image)

--- a/unit-tests/live/dfu/test-device-fw-compatibility.py
+++ b/unit-tests/live/dfu/test-device-fw-compatibility.py
@@ -16,7 +16,7 @@ d400_fw_min_version_1_prev = 'Signed_Image_UVC_5_8_14_0.bin'
 d400_fw_min_version_2_prev = 'Signed_Image_UVC_5_12_6_0.bin'
 d400_fw_min_version_3_prev = 'Signed_Image_UVC_5_12_11_0.bin'
 
-l500_fw_min_version_valid = 'L5XX_FW_Image-1.5.1.3.bin'
+l500_fw_min_version_valid = 'Signed_Image_UVC_1_5_1_3.bin'
 l500_fw_min_version_invalid = 'Signed_Image_UVC_1_4_1_0.bin'
 
 sr300_fw_min_version_1 = 'Signed_Image_UVC_3_21_0_0.bin'


### PR DESCRIPTION
L515 FW version prerequisites must be defined with min/max range to avoid cross-product versions reference.
Can be seen as a temporal solution since FW versions may overlap eventually.

Update L515 minimal downgradeable version to 1.5.1.3 instead of 1.4.1.0
Tracked on: RS5-11513, DSO-16641

