### PR TITLE
fix CppCheck warning in string-utilities.h

### DIFF
--- a/common/utilities/string/string-utilities.h
+++ b/common/utilities/string/string-utilities.h
@@ -6,125 +6,136 @@
 #include <string>
 
 namespace utilities {
-	namespace string {
+namespace string {
 
-		template <typename T, typename std::enable_if <std::is_arithmetic<T>::value>::type* = nullptr> // check if T is arithmetic during compile
-		inline bool string_to_value(const std::string& str, T& result)
-		{
-			// Converts string to value via a given argument with desire type
-			// Input: 
-			//      - string of a number
-			//      - argument with T type
-			// returns:true if conversion succeeded
-			// NOTE for unsigned types:
-			// if T is unsinged and the given string represents a negative number (meaning it starts with '-'),
-			// then string_to_value returns false (rather than send the string to the std conversion function).
-			// The reason for that is, stoul will return return a number in that case rather than throwing an exception.
 
-			try
-			{
-				size_t last_char_idx;
-				if (std::is_integral<T>::value)
-				{
-					if (std::is_same<T, unsigned long>::value)
-					{
-						if (str[0] == '-') return false; //for explanation see 'NOTE for unsigned types'
-						result = static_cast<T>(std::stoul(str, &last_char_idx));
-					}
-					else if (std::is_same<T, unsigned long long>::value)
-					{
-						if (str[0] == '-') return false;
-						result = static_cast<T>(std::stoull(str, &last_char_idx));
-					}
-					else if (std::is_same<T, long>::value)
-					{
-						result = static_cast<T>(std::stol(str, &last_char_idx));
-					}
-					else if (std::is_same<T, long long>::value)
-					{
-						result = static_cast<T>(std::stoll(str, &last_char_idx));
-					}
-					else if (std::is_same<T, int>::value)
-					{
-						result = static_cast<T>(std::stoi(str, &last_char_idx));
-					}
-					else if (std::is_same<T, short>::value)
-					{// no dedicated function fot short in std
+template < typename T,
+           typename std::enable_if< std::is_arithmetic< T >::value >::
+               type * = nullptr >  // check if T is arithmetic during compile
+inline bool string_to_value( const std::string & str, T & result )
+{
+    // Converts string to value via a given argument with desire type
+    // Input:
+    //      - string of a number
+    //      - argument with T type
+    // returns:true if conversion succeeded
+    // NOTE for unsigned types:
+    // if T is unsinged and the given string represents a negative number (meaning it starts with
+    // '-'), then string_to_value returns false (rather than send the string to the std conversion
+    // function). The reason for that is, stoul will return return a number in that case rather than
+    // throwing an exception.
 
-						int check_value = std::stoi(str, &last_char_idx);
+    try
+    {
+        size_t last_char_idx = 0;
+        if( std::is_integral< T >::value )
+        {
+            if( std::is_same< T, unsigned long >::value )
+            {
+                if( str[0] == '-' )
+                    return false;  // for explanation see 'NOTE for unsigned types'
+                result = static_cast< T >( std::stoul( str, &last_char_idx ) );
+            }
+            else if( std::is_same< T, unsigned long long >::value )
+            {
+                if( str[0] == '-' )
+                    return false;
+                result = static_cast< T >( std::stoull( str, &last_char_idx ) );
+            }
+            else if( std::is_same< T, long >::value )
+            {
+                result = static_cast< T >( std::stol( str, &last_char_idx ) );
+            }
+            else if( std::is_same< T, long long >::value )
+            {
+                result = static_cast< T >( std::stoll( str, &last_char_idx ) );
+            }
+            else if( std::is_same< T, int >::value )
+            {
+                result = static_cast< T >( std::stoi( str, &last_char_idx ) );
+            }
+            else if( std::is_same< T, short >::value )
+            {  // no dedicated function fot short in std
 
-						if (check_value > std::numeric_limits<short>::max() || check_value < std::numeric_limits<short>::min())
-							throw std::out_of_range("short");
+                int check_value = std::stoi( str, &last_char_idx );
 
-						result = static_cast<T>(check_value);
+                if( check_value > std::numeric_limits< short >::max()
+                    || check_value < std::numeric_limits< short >::min() )
+                    throw std::out_of_range( "short" );
 
-					}
-					else if (std::is_same<T, unsigned int>::value)
-					{// no dedicated function in std - unsgined corresponds to 16 bit, and unsigned long corresponds to 32 bit
-						if (str[0] == '-')
-							return false;
+                result = static_cast< T >( check_value );
+            }
+            else if( std::is_same< T, unsigned int >::value )
+            {  // no dedicated function in std - unsgined corresponds to 16 bit, and unsigned long
+               // corresponds to 32 bit
+                if( str[0] == '-' )
+                    return false;
 
-						unsigned long check_value = std::stoul(str, &last_char_idx);
+                unsigned long check_value = std::stoul( str, &last_char_idx );
 
-						if (check_value > std::numeric_limits<unsigned int>::max())
-							throw std::out_of_range("unsigned int");
+                if( check_value > std::numeric_limits< unsigned int >::max() )
+                    throw std::out_of_range( "unsigned int" );
 
-						result = static_cast<T>(check_value);
+                result = static_cast< T >( check_value );
+            }
+            else if( std::is_same< T, unsigned short >::value
+                     || std::is_same< T, unsigned short >::value )
+            {  // no dedicated function in std - unsgined corresponds to 16 bit, and unsigned long
+               // corresponds to 32 bit
+                if( str[0] == '-' )
+                    return false;
 
-					}
-					else if (std::is_same<T, unsigned short>::value || std::is_same<T, unsigned short>::value)
-					{ // no dedicated function in std - unsgined corresponds to 16 bit, and unsigned long corresponds to 32 bit
-						if (str[0] == '-')
-							return false;
+                unsigned long check_value = std::stoul( str, &last_char_idx );
 
-						unsigned long check_value = std::stoul(str, &last_char_idx);
+                if( check_value > std::numeric_limits< unsigned short >::max() )
+                    throw std::out_of_range( "unsigned short" );
 
-						if (check_value > std::numeric_limits<unsigned short>::max())
-							throw std::out_of_range("unsigned short");
+                result = static_cast< T >( check_value );
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if( std::is_floating_point< T >::value )
+        {
+            if( std::is_same< T, float >::value )
+            {
+                result = static_cast< T >( std::stof( str, &last_char_idx ) );
+                if( ! std::isfinite( (float)result ) )
+                    return false;
+            }
+            else if( std::is_same< T, double >::value )
+            {
+                result = static_cast< T >( std::stod( str, &last_char_idx ) );
+                if( ! std::isfinite( (double)result ) )
+                    return false;
+            }
+            else if( std::is_same< T, long double >::value )
+            {
+                result = static_cast< T >( std::stold( str, &last_char_idx ) );
+                if( ! std::isfinite( (long double)result ) )
+                    return false;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        return str.size()
+            == last_char_idx;  // all the chars in the string are converted to the value (thus there
+                               // are no other chars other than numbers)
+    }
+    catch( const std::invalid_argument & )
+    {
+        return false;
+    }
+    catch( const std::out_of_range & )
+    {
+        return false;
+    }
+}
 
-						result = static_cast<T>(check_value);
 
-					}
-					else
-					{
-						return false;
-					}
-				}
-				else if (std::is_floating_point<T>::value)
-				{
-					if (std::is_same<T, float>::value)
-					{
-						result = static_cast<T>(std::stof(str, &last_char_idx));
-						if (!std::isfinite((float)result))
-							return false;
-					}
-					else if (std::is_same<T, double>::value)
-					{
-						result = static_cast<T>(std::stod(str, &last_char_idx));
-						if (!std::isfinite((double)result))
-							return false;
-					}
-					else if (std::is_same<T, long double>::value)
-					{
-						result = static_cast<T>(std::stold(str, &last_char_idx));
-						if (!std::isfinite((long double)result))
-							return false;
-					}
-					else
-					{
-						return false;
-					}
-				}
-				return str.size() == last_char_idx; // all the chars in the string are converted to the value (thus there are no other chars other than numbers)
-			}
-			catch (const std::invalid_argument&)
-			{
-				return false;
-			}
-			catch (const std::out_of_range&)
-			{
-				return false;
-			}
-		}
-	}  // namespace string
+}  // namespace string
 }  // namespace utilities

--- a/unit-tests/utilities/string/test-string-to-value.cpp
+++ b/unit-tests/utilities/string/test-string-to-value.cpp
@@ -1,10 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
-//#cmake:add-file ../../../common/utilities/string/string-utilities.h
-
 #include "common.h"
-#include "../../../common/utilities/string/string-utilities.h"
+#include <common/utilities/string/string-utilities.h>
 #include <ostream>
 using namespace utilities::string;
 


### PR DESCRIPTION
```
common\utilities\string\string-utilities.h:118:26: error: Uninitialized variable: last_char_idx [uninitvar]
    return str.size() == last_char_idx; // all the chars in the string are converted to the value (thus there are no other chars other than numbers)
                         ^
```
`last_char_idx` was uninitialized.
The file has a ton of tabs, too -- clang'ed it, sorry :)