### PR TITLE
fix bug in Viewer syncer loop

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2114,7 +2114,8 @@ namespace rs2
         try {
             s->start([&, syncer](frame f)
             {
-                if (viewer.synchronization_enable && is_synchronized_frame(viewer, f))
+                // The condition here must match the condition inside render_loop()!
+                if( viewer.synchronization_enable )
                 {
                     syncer->invoke(f);
                 }


### PR DESCRIPTION
Found by Nir during sanity checks:

Switching to IR in 3D texture source froze the view.
The render_loop() depends only on `synchronization_enable` but sometimes we bypass it and so it cannot get the frames...

Tracked on [LRS-116]