### PR TITLE
Set all the values of amc controls on start up.

### DIFF
--- a/src/l500/l500-options.cpp
+++ b/src/l500/l500-options.cpp
@@ -429,7 +429,7 @@ namespace librealsense
                     "ambient.",
                     this );
 
-                _preset->set_value( (float)preset );
+                _preset->set( (float)preset );
 
                 depth_sensor.register_option( RS2_OPTION_VISUAL_PRESET, _preset );
 


### PR DESCRIPTION
Fix for RS5-11488