### PR TITLE
include USB info on pyrs device repr()

### DIFF
--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -45,8 +45,11 @@ void init_device(py::module &m) {
                 ss << " (FW update id: " << self.get_info(RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID);
             if (self.supports(RS2_CAMERA_INFO_FIRMWARE_VERSION))
                 ss << "  FW: " << self.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
-            if (self.supports(RS2_CAMERA_INFO_CAMERA_LOCKED))
-                ss << "  LOCKED: " << self.get_info(RS2_CAMERA_INFO_CAMERA_LOCKED);
+            if( self.supports( RS2_CAMERA_INFO_CAMERA_LOCKED )
+                && strcmp( "YES", self.get_info( RS2_CAMERA_INFO_CAMERA_LOCKED ) ) )
+                ss << "  UNLOCKED";
+            if( self.supports( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR ) )
+                ss << "  on USB" << self.get_info( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR );
             ss << ")>";
             return ss.str();
         });


### PR DESCRIPTION
```
<pyrealsense2.device: Intel RealSense L515 (S/N: f9440703  FW: 01.05.05.00  UNLOCKED  on USB3.2)>
```

Tracked on [LRS-129]