### PR TITLE
Clone only the files of the tag for Tegra

### DIFF
--- a/scripts/Tegra/source_sync.sh
+++ b/scripts/Tegra/source_sync.sh
@@ -184,7 +184,7 @@ function DownloadAndSync {
 	else
 		echo "Downloading default $WHAT source..."
 
-		git clone "$REPO_URL" -n ${LDK_SOURCE_DIR} 2>&1 >/dev/null
+		git clone --depth 1 --branch $TAG "$REPO_URL" -n ${LDK_SOURCE_DIR} 2>&1 >/dev/null
 		if [ $? -ne 0 ]; then
 			echo "$2 source sync failed!"
 			echo ""


### PR DESCRIPTION
Cloning the Tegra kernel sources repository was taking so much time. It couldn't complete even once on my device. With this change*, it only retrieves the tagged version of the repository. The whole process can complete in less than 5 minutes.
[*] : https://stackoverflow.com/questions/20280726/how-to-git-clone-a-specific-tag