### PR TITLE
Update PPA public server key repo

### DIFF
--- a/doc/distribution_linux.md
+++ b/doc/distribution_linux.md
@@ -15,7 +15,7 @@ The steps are described in [Linux manual installation guide](./installation.md)
 
 ## Installing the packages:
 - Register the server's public key:  
-`sudo apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE`
+`sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE`
 In case the public key still cannot be retrieved, check and specify proxy settings: `export http_proxy="http://<proxy>:<port>"`  
 , and rerun the command. See additional methods in the following [link](https://unix.stackexchange.com/questions/361213/unable-to-add-gpg-key-with-apt-key-behind-a-proxy).  
 

--- a/doc/installation_jetson.md
+++ b/doc/installation_jetson.md
@@ -44,23 +44,15 @@ This guide comes with a script that allows to modify the kernel modules with Lib
 Note that this method provides binary installation compiled using the `-DFORCE_RSUSB_BACKEND=true` option elaborated above.
 
   1. Register the server's public key:  
-  ```
-  sudo apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE
+  ```sh
+  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE
   ```
 
     > In case the public key cannot be retrieved, check and specify proxy settings: `export http_proxy="http://<proxy>:<port>"`, and rerun the command. See additional methods in the following [link](https://unix.stackexchange.com/questions/361213/unable-to-add-gpg-key-with-apt-key-behind-a-proxy).  
 
-  2. Add the server to the list of repositories:
-
-  * Ubuntu 16:  
-  ```
-  sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo xenial main" -u
-  ```
-
-  * Ubuntu 18:
-  ```
-  sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo bionic main" -u
-  ```
+  2. Add the server to the list of repositories:  
+```sh
+sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo $(lsb_release -cs) main" -u```
 
   3. Install the SDK:
   ```


### PR DESCRIPTION
Fix PPA public key registration for X86 and Jetsons due to the deprecation of `keys.gnu.net`.  
Uses the [alternative server](https://github.com/IntelRealSense/librealsense/issues/9289#issuecomment-873457374) mentioned in #9289 by @hanzheteng.
Tracked on: LRS-204