### PR TITLE
Update installation_osx.md

### DIFF
--- a/doc/installation_osx.md
+++ b/doc/installation_osx.md
@@ -10,7 +10,7 @@
 2. Install the Homebrew package manager via terminal - [link](http://brew.sh/)
 3. Install the following packages via brew:
   * `brew install cmake libusb pkg-config`
-  * `brew cask install apenngrace/vulkan/vulkan-sdk`
+  * `brew install apenngrace/vulkan/vulkan-sdk`
 
 **Note** *librealsense* requires CMake version 3.8+ that can also be obtained via the [official CMake site](https://cmake.org/download/).  
 


### PR DESCRIPTION
Homebrew doesn't use "cask" anymore. IF you try this build process you get this error

Error: Unknown command: cask

I've updated the doc to use the new way of doing things. (Basically just trash the cask part of the install) Ive tested this works.