### PR TITLE
Detect presets and automatically list them in Viewer

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -37,6 +37,7 @@
 #include "metadata-helper.h"
 #include "calibration-model.h"
 #include "sw-update/http-downloader.h"
+#include "utilities/filesystem/glob.h"
 
 using namespace rs400;
 using namespace nlohmann;
@@ -4027,6 +4028,21 @@ namespace rs2
         }
 
         refresh_notifications(viewer);
+
+        auto path = get_folder_path(special_folder::user_documents);
+        try
+        {
+            glob(path + "realsense2\\presets", "*.preset", [&](std::string file) 
+            {
+                advanced_mode_settings_file_names.insert(file);
+            }, false);
+                
+        }
+        catch (const std::exception&)
+        {
+            std::string msg = "Failed to get Documents folder";
+            LOG_WARNING("Failed to presets files : " << path);
+        }
     }
     void device_model::play_defaults(viewer_model& viewer)
     {

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -4032,9 +4032,19 @@ namespace rs2
         auto path = get_folder_path(special_folder::user_documents);
         try
         {
-            glob(path + "realsense2\\presets", "*.preset", [&](std::string file) 
+            std::string name = dev.get_info(RS2_CAMERA_INFO_NAME);
+            std::regex sku_regex("Intel RealSense ([a-zA-z]+\\d+[a-zA-z]*)");
+            std::smatch match;
+
+            std::string sku_name;
+            if (std::regex_search(name, match, sku_regex))
+                sku_name = std::string(match[1]);
+
+            glob(path + "librealsense2/presets", "*.preset", [&](std::string file) 
             {
-                advanced_mode_settings_file_names.insert(file);
+                std::regex file_name_regex(sku_name + ".*.preset");
+                if (std::regex_search(file, match, file_name_regex))
+                    advanced_mode_settings_file_names.insert(path + "librealsense2/presets/" +file);
             }, false);
                 
         }

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -4050,7 +4050,6 @@ namespace rs2
         }
         catch (const std::exception&)
         {
-            std::string msg = "Failed to get Documents folder";
             LOG_WARNING("Failed to presets files : " << path);
         }
     }

--- a/common/utilities/filesystem/glob.h
+++ b/common/utilities/filesystem/glob.h
@@ -262,6 +262,7 @@ static void glob_rec( const std::string & directory,
     }
     else
     {
+        auto e = GetLastError();
         throw std::runtime_error( librealsense::to_string() << "could not open directory: " << directory.c_str() );
     }
 }

--- a/common/utilities/filesystem/glob.h
+++ b/common/utilities/filesystem/glob.h
@@ -262,7 +262,6 @@ static void glob_rec( const std::string & directory,
     }
     else
     {
-        auto e = GetLastError();
         throw std::runtime_error( librealsense::to_string() << "could not open directory: " << directory.c_str() );
     }
 }


### PR DESCRIPTION
Search in `<User Documents>\librealsense2\presets\<Device Model Name> *.preset` files and show them on viewer preset combo box.

NOTE: the preset files are installed to <User Documents> but it can be overridden by applications such as OneDrive. The Windows installer installs to the overridden folder, but when the Viewer looks for them under Windows, it uses `FOLDERID_Documents` which returns the ORIGINAL user Documents path. This will be "fixed" in a follow-up PR.

Tracked on [LRS-208]