### PR TITLE
CUDA build fix

### DIFF
--- a/src/cuda/rscuda_utils.cuh
+++ b/src/cuda/rscuda_utils.cuh
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <memory>
+#include <cassert>
 
 // CUDA headers
 #include <cuda_runtime.h>

--- a/src/proc/cuda/cuda-pointcloud.cpp
+++ b/src/proc/cuda/cuda-pointcloud.cpp
@@ -13,11 +13,11 @@ namespace librealsense
     const float3 * pointcloud_cuda::depth_to_points(
         rs2::points output,
         const rs2_intrinsics &depth_intrinsics,
-        const rs2::depth_frame& depth_frame,
-        float depth_scale)
+        const rs2::depth_frame& depth_frame)
     {
         auto image = output.get_vertices();
         auto depth_data = (uint16_t*)depth_frame.get_data();
+        auto depth_scale = depth_frame.get_units();
 #ifdef RS2_USE_CUDA
         rscuda::deproject_depth_cuda((float*)image, depth_intrinsics, depth_data, depth_scale);
 #endif

--- a/src/proc/cuda/cuda-pointcloud.h
+++ b/src/proc/cuda/cuda-pointcloud.h
@@ -14,7 +14,6 @@ namespace librealsense
         const float3 * depth_to_points(
             rs2::points output,
             const rs2_intrinsics &depth_intrinsics,
-            const rs2::depth_frame& depth_frame,
-            float depth_scale) override;
+            const rs2::depth_frame& depth_frame) override;
     };
 }


### PR DESCRIPTION
Hot-fix to propagate depth-units refactoring into CUDA-enabled build. Required for 510 branch.
Rectifies #9154