### PR TITLE
Fix pointcloud for L515

### DIFF
--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -504,6 +504,9 @@ namespace librealsense
     {
         try
         {
+            auto depth_units = get_option(RS2_OPTION_DEPTH_UNITS).query();
+            set_frame_metadata_modifier([&](frame_additional_data& data) {data.depth_units = depth_units; });
+
             _user_requests = requests;
 
             auto is_ir_requested

--- a/src/l500/l500-depth.cpp
+++ b/src/l500/l500-depth.cpp
@@ -505,7 +505,7 @@ namespace librealsense
         try
         {
             auto depth_units = get_option(RS2_OPTION_DEPTH_UNITS).query();
-            set_frame_metadata_modifier([&](frame_additional_data& data) {data.depth_units = depth_units; });
+            set_frame_metadata_modifier([&, depth_units](frame_additional_data& data) {data.depth_units = depth_units; });
 
             _user_requests = requests;
 

--- a/src/l500/l500-depth.h
+++ b/src/l500/l500-depth.h
@@ -242,6 +242,15 @@ namespace librealsense
             return get_l500_recommended_proccesing_blocks();
         };
 
+        void set_frame_metadata_modifier(on_frame_md callback) override
+        {
+            _metadata_modifier = callback;
+            auto s = get_raw_sensor().get();
+            auto uvc = As< librealsense::uvc_sensor >(s);
+            if (uvc)
+                uvc->set_frame_metadata_modifier(callback);
+        }
+
         float read_baseline() const override;
         float read_znorm();
 

--- a/unit-tests/live/memory/test-extrinsics.cpp
+++ b/unit-tests/live/memory/test-extrinsics.cpp
@@ -334,8 +334,7 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
 
         }
         // 3. "most" iterations have time to first frame delay below a defined threshold
-        // REMOVED : this part is a duplication of : test-t2ff-pipeline.py and test-t2ff-sensor.py
-        /*std::map<std::string, double> delay_thresholds;
+        std::map<std::string, double> delay_thresholds;
         // D400
         delay_thresholds["Accel"] = 1200; // ms
         delay_thresholds["Color"] = 1200; // ms
@@ -380,6 +379,6 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
                 CHECK(*it <= delay_thresholds[stream]);
             }
         }
-        */
+
     }
 }

--- a/unit-tests/live/memory/test-extrinsics.cpp
+++ b/unit-tests/live/memory/test-extrinsics.cpp
@@ -334,7 +334,8 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
 
         }
         // 3. "most" iterations have time to first frame delay below a defined threshold
-        std::map<std::string, double> delay_thresholds;
+        // REMOVED : this part is a duplication of : test-t2ff-pipeline.py and test-t2ff-sensor.py
+        /*std::map<std::string, double> delay_thresholds;
         // D400
         delay_thresholds["Accel"] = 1200; // ms
         delay_thresholds["Color"] = 1200; // ms
@@ -379,6 +380,6 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
                 CHECK(*it <= delay_thresholds[stream]);
             }
         }
-
+        */
     }
 }


### PR DESCRIPTION
Fix for #9154 making the L500 series lose (all 0s) 3D pointcloud in the Viewer.

Tracked on [LRS-240]