### PR TITLE
Fix device_watcher; start it on register_internal_device_callback

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -818,6 +818,7 @@ namespace librealsense
         public:
             virtual void start(device_changed_callback callback) = 0;
             virtual void stop() = 0;
+            virtual bool is_stopped() const = 0;
             virtual ~device_watcher() {};
         };
     }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -465,7 +465,6 @@ namespace librealsense
             });
             _device_watcher_active = true;
         }
-            
 
         return callback_id;
     }
@@ -475,7 +474,7 @@ namespace librealsense
         std::lock_guard<std::mutex> lock(_devices_changed_callbacks_mtx);
         _devices_changed_callbacks.erase(cb_id);
 
-        if (_devices_changed_callback == nullptr && _devices_changed_callbacks.size() == 0)
+        if (_device_watcher_active && _devices_changed_callback == nullptr && _devices_changed_callbacks.size() == 0)
         {
             _device_watcher->stop();
             _device_watcher_active = false;
@@ -485,11 +484,12 @@ namespace librealsense
     void context::set_devices_changed_callback(devices_changed_callback_ptr callback)
     {
         std::lock_guard<std::mutex> lock(_devices_changed_callbacks_mtx);
+        _devices_changed_callback = std::move(callback);
+
         if (_device_watcher_active == false)
         {
             _device_watcher->stop();
 
-            _devices_changed_callback = std::move(callback);
             _device_watcher->start([this](platform::backend_device_group old, platform::backend_device_group curr)
             {
                 on_device_changed(old, curr, _playback_devices, _playback_devices);

--- a/src/context.h
+++ b/src/context.h
@@ -144,6 +144,8 @@ namespace librealsense
 
         std::shared_ptr<platform::backend> _backend;
         std::shared_ptr<platform::device_watcher> _device_watcher;
+        bool _device_watcher_active;
+
         std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
 

--- a/src/context.h
+++ b/src/context.h
@@ -141,10 +141,10 @@ namespace librealsense
         void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
         int find_stream_profile(const stream_interface& p);
         std::shared_ptr<lazy<rs2_extrinsics>> fetch_edge(int from, int to);
+        void start_device_watcher();
 
         std::shared_ptr<platform::backend> _backend;
         std::shared_ptr<platform::device_watcher> _device_watcher;
-        bool _device_watcher_active;
 
         std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -146,7 +146,7 @@ namespace librealsense
             win_event_device_watcher(const backend * backend)
             {
                 _data._backend = backend;
-                _data._stopped = false;
+                _data._stopped = true;
                 _data._last = backend_device_group(backend->query_uvc_devices(), backend->query_usb_devices(), backend->query_hid_devices());
             }
             ~win_event_device_watcher() { stop(); }
@@ -169,6 +169,12 @@ namespace librealsense
                     if (_thread.joinable()) _thread.join();
                 }
             }
+
+            bool is_stopped() const override
+            {
+                return _data._stopped;
+            }
+
         private:
             std::thread _thread;
             std::mutex _m;

--- a/src/mock/recorder.cpp
+++ b/src/mock/recorder.cpp
@@ -649,6 +649,10 @@ namespace librealsense
             }, _entity_id, call_type::device_watcher_stop);
         }
 
+        bool record_device_watcher::is_stopped() const
+        {
+            return _source_watcher->is_stopped();
+        }
 
         void record_uvc_device::probe_and_commit(stream_profile profile, frame_callback callback, int buffers)
         {
@@ -1214,6 +1218,11 @@ namespace librealsense
                 _alive = false;
                 _dispatcher.stop();
             }
+        }
+
+        bool playback_device_watcher::is_stopped() const
+        {
+            return !_alive.load();
         }
 
         void playback_device_watcher::raise_callback(backend_device_group old, backend_device_group curr)

--- a/src/mock/recorder.h
+++ b/src/mock/recorder.h
@@ -415,6 +415,7 @@ namespace librealsense
 
             void stop() override;
 
+            bool is_stopped() const override;
         private:
             const record_backend* _owner;
             std::shared_ptr<device_watcher> _source_watcher;
@@ -492,7 +493,7 @@ namespace librealsense
             ~playback_device_watcher();
             void start(device_changed_callback callback) override;
             void stop() override;
-
+            bool is_stopped() const override;
             void raise_callback(backend_device_group old, backend_device_group curr);
 
         private:

--- a/src/types.h
+++ b/src/types.h
@@ -1625,6 +1625,11 @@ namespace librealsense
             _callback_inflight.wait_until_empty();
         }
 
+        bool is_stopped() const override
+        {
+            return !_active_object.is_active();
+        }
+
     private:
         active_object<> _active_object;
 


### PR DESCRIPTION
Device_hub API registers for events using `register_internal_device_callback` but this didn't start the device-watcher... we weren't getting device change notifications.

Tracked on DSO-11850
