### PR TITLE
LibCI fixes (towards Linux enablement)

### DIFF
--- a/unit-tests/live/dfu/test-device-fw-compatibility.py
+++ b/unit-tests/live/dfu/test-device-fw-compatibility.py
@@ -6,9 +6,10 @@
 # test:device SR300*
 
 import pyrealsense2 as rs
-from rspy import test
+from rspy import test, libci
+import os
 
-fw_dir = 'C:/LibCI/data/FW/'
+fw_dir = os.path.join( libci.home, 'data/FW', '' )
 d400_fw_min_version_1 = 'Signed_Image_UVC_5_8_15_0.bin'
 d400_fw_min_version_2 = 'Signed_Image_UVC_5_12_7_100.bin'
 d400_fw_min_version_3 = 'Signed_Image_UVC_5_12_12_100.bin'

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -650,39 +650,47 @@ if __name__ == '__main__':
         usage()
     if args:
         usage()
-    if acroname:
-        if not acroname.hub:
-            acroname.connect()
-    action = 'list'
-    for opt,arg in opts:
-        if opt in ('--list'):
-            action = 'list'
-        elif opt in ('--all'):
-            if not acroname:
-                log.f( 'No acroname available' )
-            acroname.enable_ports( sleep_on_change = 5 )
-        elif opt in ('--port'):
-            if not acroname:
-                log.f( 'No acroname available' )
-            all_ports = acroname.all_ports()
-            str_ports = arg.split(',')
-            ports = [int(port) for port in str_ports if port.isnumeric() and int(port) in all_ports]
-            if len(ports) != len(str_ports):
-                log.f( 'Invalid ports', str_ports )
-            acroname.enable_ports( ports, disable_other_ports = True, sleep_on_change = 5 )
-        elif opt in ('--recycle'):
-            action = 'recycle'
-    if action == 'list':
-        query()
-        for sn in all():
-            device = get( sn )
-            print( '{port} {name:30} {sn:20} {handle}'.format(
-                sn = sn,
-                name = device.name,
-                port = device.port is None and '?' or device.port,
-                handle = device.handle
-                ))
-    elif action == 'recycle':
-        log.f( 'Not implemented yet' )
+    try:
+        if acroname:
+            if not acroname.hub:
+                acroname.connect()
+        action = 'list'
+        for opt,arg in opts:
+            if opt in ('--list'):
+                action = 'list'
+            elif opt in ('--all'):
+                if not acroname:
+                    log.f( 'No acroname available' )
+                acroname.enable_ports( sleep_on_change = 5 )
+            elif opt in ('--port'):
+                if not acroname:
+                    log.f( 'No acroname available' )
+                all_ports = acroname.all_ports()
+                str_ports = arg.split(',')
+                ports = [int(port) for port in str_ports if port.isnumeric() and int(port) in all_ports]
+                if len(ports) != len(str_ports):
+                    log.f( 'Invalid ports', str_ports )
+                acroname.enable_ports( ports, disable_other_ports = True, sleep_on_change = 5 )
+            elif opt in ('--recycle'):
+                action = 'recycle'
+            else:
+                usage()
+        if action == 'list':
+            query()
+            for sn in all():
+                device = get( sn )
+                print( '{port} {name:30} {sn:20} {handle}'.format(
+                    sn = sn,
+                    name = device.name,
+                    port = device.port is None and '?' or device.port,
+                    handle = device.handle
+                    ))
+        elif action == 'recycle':
+            log.f( 'Not implemented yet' )
+    finally:
+        #
+        # Disconnect from the Acroname -- if we don't it'll crash on Linux...
+        if acroname:
+            acroname.disconnect()
 
 

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
-import sys, os, re
+import sys, os, re, platform
 try:
     from rspy import log
 except ModuleNotFoundError:
@@ -512,6 +512,12 @@ def _wait_for( serial_numbers, timeout = 5 ):
     :return: True if all have come online; False if timeout was reached
     """
     did_some_waiting = False
+    #
+    # In Linux, we don't have an active notification mechanism - we query devices every 5 seconds
+    # (see POLLING_DEVICES_INTERVAL_MS) - so we add extra timeout
+    if timeout and platform.system() == 'Linux':
+        timeout += 5
+    #
     while True:
         #
         have_all_devices = True

--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
-import re, os, subprocess, time, sys
+import re, os, subprocess, time, sys, platform
 from abc import ABC, abstractmethod
 
 from rspy import log, file
@@ -16,7 +16,10 @@ logdir = None
 # This is always a directory called "LibCI", but may be in different locations, in this order of priority:
 #     1. C:\LibCI  (on the LibCI machine)
 #     2. ~/LibCI   (in Windows, ~ is likely C:\Users\<username>)
-home = 'C:\\LibCI'
+if platform.system() == 'Linux':
+    home = '/usr/local/lib/ci'
+else:
+    home = 'C:\\LibCI'
 if not os.path.isdir( home ):
     home = os.path.normpath( os.path.expanduser( '~/LibCI' ))
 #

--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -357,23 +357,30 @@ class PyTest( Test ):
     @property
     def command( self ):
         cmd = [sys.executable]
-        # The unit-tests should only find module we've specifically added -- but Python may have site packages
-        # that are automatically made available. We want to avoid those:
-        #     -S     : don't imply 'import site' on initialization
-        # NOTE: exit() is defined in site.py and works only if the site module is imported!
-        cmd += ['-S']
+        #
+        # PYTHON FLAGS
+        #
         #     -u     : force the stdout and stderr streams to be unbuffered; same as PYTHONUNBUFFERED=1
         # With buffering we may end up losing output in case of crashes! (in Python 3.7 the text layer of the
         # streams is unbuffered, but we assume 3.6)
         cmd += ['-u']
+        #
         if sys.flags.verbose:
             cmd += ["-v"]
+        #
         cmd += [self.path_to_script]
+        #
+        # SCRIPT FLAGS
+        #
+        # If the script has a custom-arguments flag, then we don't pass any of the standard options
         if 'custom-args' not in self.config.flags:
+            #
             if log.is_debug_on():
                 cmd += ['--debug']
+            #
             if log.is_color_on():
                 cmd += ['--color']
+            #
             if self.config.context:
                 cmd += ['--context', self.config.context]
         return cmd

--- a/unit-tests/py/rspy/repo.py
+++ b/unit-tests/py/rspy/repo.py
@@ -1,16 +1,25 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
-import os
+import os, platform
+from rspy import log
 
 # this script is located in librealsense/unit-tests/py/rspy, so main repository is:
 root = os.path.dirname( os.path.dirname( os.path.dirname( os.path.dirname( os.path.abspath( __file__ )))))
 
 # Usually we expect the build directory to be directly under the root, named 'build'
-build = os.path.join( root, 'win10', 'win64', 'static' )
+# ... but first check the expected LibCI build directories:
+#
+if platform.system() == 'Linux':
+    build = os.path.join( root, 'x86_64', 'static' )
+else:
+    build = os.path.join( root, 'win10', 'win64', 'static' )
 if not os.path.isdir( build ):
+    #
     build = os.path.join( root, 'build' )
     if not os.path.isdir( build ):
+        log.w( 'repo.build directory wasn\'t found' )
+        log.d( 'repo.root=', root )
         build = None
 
 
@@ -19,11 +28,8 @@ def find_pyrs():
     :return: the location (absolute path) of the pyrealsense2 .so (linux) or .pyd (windows)
     """
     global build
-    import platform
-    system = platform.system()
-    linux = ( system == 'Linux'  and  "microsoft" not in platform.uname()[3].lower() )
     from rspy import file
-    if linux:
+    if platform.system() == 'Linux':
         for so in file.find( build, '(^|/)pyrealsense2.*\.so$' ):
             return os.path.join( build, so )
     else:

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -203,10 +203,9 @@ if not to_stdout:
 n_tests = 0
 
 # Figure out which sys.path we want the tests to see, assuming we have Python tests
-#     PYTHONPATH is what Python will ADD to sys.path for the child processes
+# PYTHONPATH is what Python will ADD to sys.path for child processes BEFORE any standard python paths
 # (We can simply change `sys.path` but any child python scripts won't see it; we change the environment instead)
 #
-# We also need to add the path to the python packages that the tests use
 os.environ["PYTHONPATH"] = current_dir + os.sep + "py"
 #
 if pyrs:

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -8,7 +8,7 @@
 
 import pyrealsense2 as rs, sys, os, subprocess
 from rspy import devices, log, test, file, repo
-import re
+import re, platform
 
 
 if not devices.acroname:
@@ -114,7 +114,11 @@ def find_image_or_exit( product_name, fw_version_regex = r'(\d+\.){3}(\d+)' ):
 
 # find the update tool exe
 fw_updater_exe = None
-for tool in file.find( repo.build, '(^|/)rs-fw-update.exe$' ):
+fw_updater_exe_regex = r'(^|/)rs-fw-update'
+if platform.system() == 'Windows':
+    fw_updater_exe_regex += r'\.exe'
+fw_updater_exe_regex += '$'
+for tool in file.find( repo.build, fw_updater_exe_regex ):
     fw_updater_exe = os.path.join( repo.build, tool )
 if not fw_updater_exe:
     log.f( "Could not find the update tool file (rs-fw-update.exe)" )


### PR DESCRIPTION
* remove -S from Python test runs
* libci.home fix for Linux; fix test-device-fw-compatibility
* repo.build fix for Linux (x86_64/static); fix test-fw-update
* 5-second extra timeouts in device waits

Tracked on [LRS-3]