### PR TITLE
syncer fix: didn't release frames with inactive stream

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -667,7 +667,7 @@ namespace librealsense
         // our queue size and per-stream archive size allow.
         auto const fps = get_fps( waiting_to_be_released );
 
-        rs2_time_t now = last_arrived->get_frame_timestamp();;
+        rs2_time_t now = last_arrived->get_frame_timestamp();
         if( now > next_expected )
         {
             // Wait for the missing stream frame to arrive -- up to a cutout: anything more and we

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -384,7 +384,7 @@ namespace librealsense
                         LOG_IF_ENABLE( "... missing " << i->get_name() << ", next expected "
                                                       << _next_expected[i],
                                        env );
-                        if( skip_missing_stream( synced_frames, i, last_arrived, env ) )
+                        if( skip_missing_stream( *curr_sync, i, last_arrived, env ) )
                         {
                             LOG_IF_ENABLE( "...     ignoring it", env );
                             continue;
@@ -486,21 +486,17 @@ namespace librealsense
     }
 
     bool
-    frame_number_composite_matcher::skip_missing_stream( std::vector< matcher * > const & synced,
+    frame_number_composite_matcher::skip_missing_stream( frame_interface const * const synced_frame,
                                                          matcher * missing,
                                                          frame_interface const * last_arrived,
                                                          const syncronization_environment & env )
     {
-        frame_holder* synced_frame;
-
          if(!missing->get_active())
              return true;
 
-        _frames_queue[synced[0]].peek( [&]( frame_holder & fh ) { synced_frame = &fh; } );
-
         auto next_expected = _next_expected[missing];
 
-        if((*synced_frame)->get_frame_number() - next_expected > 4 || (*synced_frame)->get_frame_number() < next_expected)
+        if(synced_frame->get_frame_number() - next_expected > 4 || synced_frame->get_frame_number() < next_expected)
         {
             return true;
         }
@@ -603,7 +599,7 @@ namespace librealsense
         // We let skip_missing_stream clean any inactive missing streams
     }
 
-    bool timestamp_composite_matcher::skip_missing_stream( std::vector< matcher * > const & synced,
+    bool timestamp_composite_matcher::skip_missing_stream( frame_interface const * waiting_to_be_released,
                                                            matcher * missing,
                                                            frame_interface const * last_arrived,
                                                            const syncronization_environment & env )
@@ -615,9 +611,6 @@ namespace librealsense
             return true;
 
         //LOG_IF_ENABLE( "...     matcher " << synced[0]->get_name(), env );
-        rs2_time_t timestamp = last_arrived->get_frame_timestamp();;
-        rs2_timestamp_domain domain = last_arrived->get_frame_timestamp_domain();;
-        auto fps = _fps[missing];
 
         auto next_expected = _next_expected[missing];
         // LOG_IF_ENABLE( "...     next    " << std::fixed << next_expected, env );
@@ -625,25 +618,71 @@ namespace librealsense
         auto it = _next_expected_domain.find( missing );
         if( it != _next_expected_domain.end() )
         {
-            if( it->second != domain )
+            if( it->second != last_arrived->get_frame_timestamp_domain() )
             {
                 // LOG_IF_ENABLE( "...     not the same domain: frameset not ready!", env );
                 return false;
             }
         }
-        // next expected of the missing stream didn't updated yet
-        if( timestamp > next_expected )
+
+        // We want to calculate a cutout for inactive stream detection: if we wait too long past
+        // this cutout, then the missing stream is inactive and we no longer wait for it.
+        // 
+        //     cutout = next expected + threshold
+        //     threshold = 7 * gap = 7 * (1000 / FPS)
+        // 
+        // 
+        // E.g.:
+        // 
+        //     D: 100 fps ->  10 ms gap
+        //     C: 10 fps  -> 100 ms gap
+        // 
+        //     D  C  @timestamp
+        //     -- -- ----------
+        //     1     0   -> release (we don't know about a missing stream yet, so don't get here)
+        //       ...
+        //     6     50  -> release (D6); next expected (NE) -> 60
+        //        1  0   -> release (C1); NE -> 100                                  <----- LATENCY
+        //     7  ?  60  -> release (D7) (not comparable to NE because we use fps of 100!)
+        //       ...
+        //     11 ?  100 -> wait for C (now comparable); cutout is 100+7*10 = 170
+        //     12 ?  110 -> wait (> NE, < cutout)
+        //       ...
+        //     19 ?  180 > 170 -> release (D11); mark C inactive (> cutout)
+        //                        release (D12) ... (D19)  (no missing streams, so don't get here)
+        //     20    190 -> release (D20) (no missing streams, so don't get here)
+        //       ...
+        // 
+        // But, if C had arrived before D19:
+        // 
+        //       ...
+        //        2  100 -> release (D11, C2) (nothing missing); NE -> 200
+        //        ?         release (D12) ... (D18) (C missing but 100 not comparable to NE 200)
+        //     19 ?  180 -> release (D19)
+        //     20 ?  190 -> release (D20)
+        //     21 ?  200 -> wait for C (comparable to NE 200)
+        // 
+        // 
+        // The threshold is a function of the FPS, but note we can't keep more frames than
+        // our queue size and per-stream archive size allow.
+        auto const fps = get_fps( waiting_to_be_released );
+
+        rs2_time_t now = last_arrived->get_frame_timestamp();;
+        if( now > next_expected )
         {
-            // Wait up to 10*gap for the missing stream frame to arrive -- anything more and we
+            // Wait for the missing stream frame to arrive -- up to a cutout: anything more and we
             // let the frameset be ready without it...
             auto gap = 1000.f / fps;
-            auto threshold = 10 * gap;
-            if( timestamp - next_expected < threshold )
+            // NOTE: the threshold is a function of the gap; the bigger it is, the more latency
+            // between the streams we're willing to live with. Each gap is a frame so we are limited
+            // by the number of frames we're willing to keep (which is our queue limit)
+            auto threshold = 7 * gap;  // really 7+1 because NE is already 1 away
+            if( now - next_expected < threshold )
             {
                 //LOG_IF_ENABLE( "...     still below threshold of {10*gap}" << threshold, env );
                 return false;
             }
-            LOG_IF_ENABLE( "...     exceeded threshold of {10*gap}" << threshold << "; deactivating matcher!", env );
+            LOG_IF_ENABLE( "...     exceeded cutout of {NE+7*gap}" << ( next_expected + threshold ) << "; deactivating matcher!", env );
 
             auto const q_it = _frames_queue.find( missing );
             if( q_it != _frames_queue.end() )
@@ -652,9 +691,12 @@ namespace librealsense
                     _frames_queue.erase( q_it );
             }
             missing->set_active( false );
+            return true;
         }
 
-        return ! are_equivalent( timestamp, next_expected, fps );
+        return ! are_equivalent( waiting_to_be_released->get_frame_timestamp(),
+                                 next_expected,
+                                 fps );  // should be min fps to match behavior elsewhere?
     }
 
     bool timestamp_composite_matcher::are_equivalent( double a, double b, unsigned int fps )

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -615,18 +615,9 @@ namespace librealsense
             return true;
 
         //LOG_IF_ENABLE( "...     matcher " << synced[0]->get_name(), env );
-        rs2_time_t timestamp;
-        rs2_timestamp_domain domain;
-        unsigned int fps;
-        _frames_queue[synced[0]].peek( [&]( frame_holder & fh ) {
-            //LOG_IF_ENABLE( "...     frame   " << frame_holder_to_string( fh ), env );
-
-            // TODO the FPS is used for threshold calc and should be taken from MISSING stream
-            fps = get_fps( fh );
-        } );
-
-        timestamp = last_arrived->get_frame_timestamp();
-        domain = last_arrived->get_frame_timestamp_domain();
+        rs2_time_t timestamp = last_arrived->get_frame_timestamp();;
+        rs2_timestamp_domain domain = last_arrived->get_frame_timestamp_domain();;
+        auto fps = _fps[missing];
 
         auto next_expected = _next_expected[missing];
         // LOG_IF_ENABLE( "...     next    " << std::fixed << next_expected, env );

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -679,7 +679,7 @@ namespace librealsense
             auto threshold = 7 * gap;  // really 7+1 because NE is already 1 away
             if( now - next_expected < threshold )
             {
-                //LOG_IF_ENABLE( "...     still below threshold of {10*gap}" << threshold, env );
+                //LOG_IF_ENABLE( "...     still below cutout of {NE+7*gap}" << ( next_expected + threshold ), env );
                 return false;
             }
             LOG_IF_ENABLE( "...     exceeded cutout of {NE+7*gap}" << ( next_expected + threshold ) << "; deactivating matcher!", env );

--- a/src/sync.h
+++ b/src/sync.h
@@ -128,7 +128,7 @@ namespace librealsense
 
         virtual bool are_equivalent(frame_holder& a, frame_holder& b) = 0;
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) = 0;
-        virtual bool skip_missing_stream( std::vector< matcher * > const & synced,
+        virtual bool skip_missing_stream( frame_interface const * waiting_to_be_released,
                                           matcher * missing,
                                           frame_interface const * last_arrived,
                                           const syncronization_environment & env )
@@ -166,7 +166,7 @@ namespace librealsense
         void sync(frame_holder f, const syncronization_environment& env) override;
         virtual bool are_equivalent(frame_holder& a, frame_holder& b) override { return false; }
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) override { return false; }
-        virtual bool skip_missing_stream( std::vector< matcher * > const & synced,
+        virtual bool skip_missing_stream( frame_interface const * waiting_to_be_released,
                                           matcher * missing,
                                           frame_interface const * last_arrived,
                                           const syncronization_environment & env ) override
@@ -191,7 +191,7 @@ namespace librealsense
         virtual void update_last_arrived(frame_holder& f, matcher* m) override;
         bool are_equivalent(frame_holder& a, frame_holder& b) override;
         bool is_smaller_than(frame_holder& a, frame_holder& b) override;
-        bool skip_missing_stream( std::vector< matcher * > const & synced,
+        bool skip_missing_stream( frame_interface const * waiting_to_be_released,
                                   matcher * missing,
                                   frame_interface const * last_arrived,
                                   const syncronization_environment & env ) override;
@@ -211,7 +211,7 @@ namespace librealsense
         bool is_smaller_than(frame_holder& a, frame_holder& b) override;
         virtual void update_last_arrived(frame_holder& f, matcher* m) override;
         void clean_inactive_streams(frame_holder& f) override;
-        bool skip_missing_stream( std::vector< matcher * > const & synced,
+        bool skip_missing_stream( frame_interface const * waiting_to_be_released,
                                   matcher * missing,
                                   frame_interface const * last_arrived,
                                   const syncronization_environment & env ) override;

--- a/src/sync.h
+++ b/src/sync.h
@@ -130,6 +130,7 @@ namespace librealsense
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) = 0;
         virtual bool skip_missing_stream( std::vector< matcher * > const & synced,
                                           matcher * missing,
+                                          frame_interface const * last_arrived,
                                           const syncronization_environment & env )
             = 0;
         virtual void clean_inactive_streams(frame_holder& f) = 0;
@@ -167,6 +168,7 @@ namespace librealsense
         virtual bool is_smaller_than(frame_holder& a, frame_holder& b) override { return false; }
         virtual bool skip_missing_stream( std::vector< matcher * > const & synced,
                                           matcher * missing,
+                                          frame_interface const * last_arrived,
                                           const syncronization_environment & env ) override
         {
             return false;
@@ -191,6 +193,7 @@ namespace librealsense
         bool is_smaller_than(frame_holder& a, frame_holder& b) override;
         bool skip_missing_stream( std::vector< matcher * > const & synced,
                                   matcher * missing,
+                                  frame_interface const * last_arrived,
                                   const syncronization_environment & env ) override;
         void clean_inactive_streams(frame_holder& f) override;
         void update_next_expected( std::shared_ptr< matcher > const & matcher,
@@ -210,12 +213,13 @@ namespace librealsense
         void clean_inactive_streams(frame_holder& f) override;
         bool skip_missing_stream( std::vector< matcher * > const & synced,
                                   matcher * missing,
+                                  frame_interface const * last_arrived,
                                   const syncronization_environment & env ) override;
         void update_next_expected( std::shared_ptr< matcher > const & matcher,
                                    const frame_holder & f ) override;
 
     private:
-        unsigned int get_fps(const frame_holder & f);
+        unsigned int get_fps( frame_interface const * f );
         bool are_equivalent( double a, double b, unsigned int fps );
         std::map<matcher*, double> _last_arrived;
         std::map<matcher*, unsigned int> _fps;


### PR DESCRIPTION
It was comparing to the wrong timestamp.

Reduced the threshold used to detect inactive streams (10 -> 7 gaps), which can also reduce ability to handle big latency. But it's more important to reduce change of reaching the current queue limit of 10 frames.

Unit-test that shows this is WIP, to follow in another PR.

Tracked on [LRS-275]