### PR TITLE
[Android] - fix resource issue handling issue

### DIFF
--- a/src/android/jni/frameset.cpp
+++ b/src/android/jni/frameset.cpp
@@ -15,6 +15,7 @@ Java_com_intel_realsense_librealsense_FrameSet_nAddRef(JNIEnv *env, jclass type,
 extern "C" JNIEXPORT void JNICALL
 Java_com_intel_realsense_librealsense_FrameSet_nRelease(JNIEnv *env, jclass type,
                                                         jlong handle) {
+    if(handle)
     rs2_release_frame(reinterpret_cast<rs2_frame *>(handle));
 }
 

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -190,7 +190,7 @@ namespace librealsense
 
     void frame::release()
     {
-        if (ref_count.fetch_sub(1) == 1)
+        if (ref_count.fetch_sub(1) == 1 && owner)
         {
             unpublish();
             on_release();

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -112,7 +112,7 @@ namespace librealsense
     }
     void frame_source::invoke_callback(frame_holder frame) const
     {
-        if (frame)
+        if (frame && frame.frame && frame.frame->get_owner())
         {
             auto callback = frame.frame->get_owner()->begin_callback();
             try

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLPointsFrame.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLPointsFrame.java
@@ -121,6 +121,12 @@ public class GLPointsFrame extends GLFrame {
     public synchronized void close() {
         if(mFrame != null)
             mFrame.close();
+
+        if (mTexture != null) {
+            mTexture.close();
+            mTexture = null;
+        }
+
         if(mGlTexture != null)
             GLES10.glDeleteTextures(1, mGlTexture);
         mGlTexture = null;

--- a/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLRenderer.java
+++ b/wrappers/android/librealsense/src/main/java/com/intel/realsense/librealsense/GLRenderer.java
@@ -26,21 +26,23 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
     private Colorizer mColorizer = new Colorizer();
     private Map<StreamType,Pointcloud> mPointcloud = null;
     private boolean mHasColorizedDepth = false;
+    private boolean mHasDepth = false;
 
     private boolean mHasColorYuy = false;
     private YuyDecoder mYuyDecoder = new YuyDecoder();
+    private boolean mShowPoints = false;
 
     public Map<Integer, Pair<String,Rect>> getRectangles() {
         return calcRectangles();
     }
 
     private boolean showPoints(){
-        return mPointcloud != null;
+        return mShowPoints;
     }
 
     private List<FilterInterface> createProcessingPipe(){
         List<FilterInterface> rv = new ArrayList<>();
-        if(!mHasColorizedDepth && !showPoints())
+        if(mHasDepth && !mHasColorizedDepth && !showPoints())
             rv.add(mColorizer);
 
         // convert yuyv into rgb8 for display and uv mapping
@@ -50,7 +52,7 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
         if(showPoints()){
             if(mHasColorRbg8 || mHasColorYuy)
                 rv.add(mPointcloud.get(StreamType.COLOR));
-            else
+            else if (mHasDepth)
                 rv.add(mPointcloud.get(StreamType.DEPTH));
         }
         return rv;
@@ -58,6 +60,7 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
 
     private FrameSet applyFilters(FrameSet frameSet, List<FilterInterface> filters){
         frameSet = frameSet.clone();
+
         for(FilterInterface f : filters){
             FrameSet newSet = frameSet.applyFilter(f);
             frameSet.close();
@@ -67,7 +70,8 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
     }
 
     public void upload(FrameSet frameSet) {
-        mHasColorRbg8 = mHasColorizedDepth = mHasColorYuy = false;
+        mHasColorRbg8 = mHasColorizedDepth = mHasColorYuy = mHasDepth = false;
+
         frameSet.foreach(new FrameCallback() {
             @Override
             public void onFrame(Frame f) {
@@ -76,27 +80,36 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
         });
 
         List<FilterInterface> filters = createProcessingPipe();
-        try(FrameSet processed = applyFilters(frameSet, filters)){
-            choosePointsTexture(processed);
-            processed.foreach(new FrameCallback() {
-                @Override
-                public void onFrame(Frame f) {
-                    addFrame(f);
-                    upload(f);
-                }
-            });
+
+        if (!showPoints() || (showPoints() && filters.size() > 0 && mHasDepth)) {
+            try (FrameSet processed = applyFilters(frameSet, filters)) {
+                    choosePointsTexture(processed);
+                    processed.foreach(new FrameCallback() {
+                        @Override
+                        public void onFrame(Frame f) {
+                            upload(f);
+                        }
+                    });
+            }
         }
     }
 
     private void choosePointsTexture(FrameSet frameSet){
-        if(!showPoints())
+        if(mPointsTexture != null) mPointsTexture.close();
+        mPointsTexture = null;
+
+        if(!showPoints()) {
             return;
+        }
+
         if(mHasColorRbg8 || mHasColorYuy)
             mPointsTexture = frameSet.first(StreamType.COLOR, StreamFormat.RGB8);
         else{
             try (Frame d = frameSet.first(StreamType.DEPTH, StreamFormat.Z16)) {
-                if(d != null)
+                if(d != null) {
                     mPointsTexture = mColorizer.process(d);
+                    d.close();
+                }
             }
         }
     }
@@ -111,8 +124,12 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
                 mHasColorYuy = true;
             }
 
-            if(sp.getType() == StreamType.DEPTH && sp.getFormat() == StreamFormat.RGB8) {
-                mHasColorizedDepth = true;
+            if(sp.getType() == StreamType.DEPTH) {
+                mHasDepth = true;
+
+                if (sp.getFormat() == StreamFormat.RGB8) {
+                    mHasColorizedDepth = true;
+                }
             }
         }
     }
@@ -122,13 +139,14 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
             if(!isFormatSupported(sp.getFormat()))
                 return;
             int uid = sp.getUniqueId();
+
             if(!mFrames.containsKey(uid)){
                 synchronized (mFrames) {
                     if(f.is(Extension.VIDEO_FRAME) && !showPoints())
                         mFrames.put(uid, new GLVideoFrame());
-                    if(f.is(Extension.MOTION_FRAME) && !showPoints())
+                    else if (f.is(Extension.MOTION_FRAME) && !showPoints())
                         mFrames.put(uid, new GLMotionFrame());
-                    if(f.is(Extension.POINTS))
+                    else if (f.is(Extension.POINTS))
                         mFrames.put(uid, new GLPointsFrame());
                 }
             }
@@ -149,6 +167,7 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
             GLFrame curr = mFrames.get(uid);
             if(curr == null)
                 return;
+
             curr.setFrame(f);
 
             if(mPointsTexture != null && curr instanceof GLPointsFrame){
@@ -161,8 +180,13 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
 
     public void clear() {
         synchronized (mFrames) {
-            for(Map.Entry<Integer,GLFrame> f : mFrames.entrySet())
-                f.getValue().close();
+            for(Map.Entry<Integer,GLFrame> f : mFrames.entrySet()) {
+                GLFrame frame = f.getValue();
+                if (frame instanceof GLPointsFrame)
+                    ((GLPointsFrame) frame).close();
+                else
+                    frame.close();
+            }
             mFrames.clear();
             mDeltaX = 0;
             mDeltaY = 0;
@@ -178,6 +202,8 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
 
             if(mPointsTexture != null) mPointsTexture.close();
             mPointsTexture = null;
+
+            mHasColorRbg8 = mHasColorizedDepth = mHasColorYuy = mHasDepth = false;
         }
     }
 
@@ -257,6 +283,8 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
     }
 
     public void showPointcloud(boolean showPoints) {
+        mShowPoints = showPoints;
+
         if(showPoints){
             if(mPointcloud != null)
                 return;
@@ -271,6 +299,9 @@ public class GLRenderer implements GLSurfaceView.Renderer, AutoCloseable{
                 pc.close();
             }
             mPointcloud = null;
+
+            if(mPointsTexture != null) mPointsTexture.close();
+            mPointsTexture = null;
         }
     }
 

--- a/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PreviewActivity.java
+++ b/wrappers/android/tools/camera/src/main/java/com/intel/realsense/camera/PreviewActivity.java
@@ -121,6 +121,8 @@ public class PreviewActivity extends AppCompatActivity {
                 mGLSurfaceView.clear();
                 clearLables();
                 mShow3D = !mShow3D;
+                mGLSurfaceView.showPointcloud(mShow3D);
+
                 m3dButton.setTextColor(mShow3D ? Color.YELLOW : Color.WHITE);
                 mGLSurfaceView.setVisibility(View.VISIBLE);
                 SharedPreferences sharedPref = getSharedPreferences(getString(R.string.app_settings), Context.MODE_PRIVATE);


### PR DESCRIPTION
This is part b fix to additional issues found when switching between 2d and 3d.

Changes:
1) release frame resources when switching between 2d and 3d
2) handle cases when only depth, no rgb, is part of the stream
3) handle cases when no depth is part of the stream 

Tracked on: DSO-16584

