### PR TITLE
Syncer unit-tests with software-device Python wrapper improvements

### DIFF
--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -201,6 +201,8 @@ namespace rs2
     class video_stream_profile : public stream_profile
     {
     public:
+        video_stream_profile() : stream_profile() {}
+
         /**
         * Stream profile instance which contains additional video attributes
         * \param[in] stream_profile sp - assign exisiting stream_profile to this instance.

--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -199,7 +199,11 @@ class single_consumer_frame_queue
     single_consumer_queue<T> _queue;
 
 public:
-    single_consumer_frame_queue<T>(unsigned int cap = QUEUE_MAX_SIZE) : _queue(cap) {}
+    single_consumer_frame_queue< T >( unsigned int cap = QUEUE_MAX_SIZE,
+                                      std::function< void( T const & ) > on_drop_callback = nullptr )
+        : _queue( cap, on_drop_callback )
+    {
+    }
 
     bool enqueue( T && item )
     {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -20,10 +20,12 @@ std::shared_ptr<matcher> matcher_factory::create(rs2_matchers matcher, std::vect
         return create_DLR_C_matcher(profiles);
     case RS2_MATCHER_DLR:
         return create_DLR_matcher(profiles);
-    case RS2_MATCHER_DEFAULT:default:
-        LOG_DEBUG("Created default matcher");
+    case RS2_MATCHER_DIC:
+    case RS2_MATCHER_DIC_C:
+        throw not_implemented_exception( "DIC matchers are not implemented!" );
+    case RS2_MATCHER_DEFAULT:
+    default:
         return create_timestamp_matcher(profiles);
-        break;
     }
 }
 stream_interface* librealsense::find_profile(rs2_stream stream, int index, std::vector<stream_interface*> profiles)

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -110,7 +110,9 @@ struct rs2_pipeline_profile
 struct rs2_frame_queue
 {
     explicit rs2_frame_queue(int cap)
-        : queue(cap)
+        : queue( cap, [cap]( librealsense::frame_holder const & fh ) {
+            LOG_DEBUG( "DROPPED queue (capacity= " << cap << ") frame " << frame_holder_to_string( fh ) );
+        } )
     {
     }
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -483,21 +483,21 @@ int rs2_is_stream_profile_default(const rs2_stream_profile* profile, rs2_error**
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, profile)
 
-void rs2_get_stream_profile_data(const rs2_stream_profile* mode, rs2_stream* stream, rs2_format* format, int* index, int* unique_id, int* framerate, rs2_error** error) BEGIN_API_CALL
+void rs2_get_stream_profile_data(const rs2_stream_profile* profile, rs2_stream* stream, rs2_format* format, int* index, int* unique_id, int* framerate, rs2_error** error) BEGIN_API_CALL
 {
-    VALIDATE_NOT_NULL(mode);
+    VALIDATE_NOT_NULL(profile);
     VALIDATE_NOT_NULL(stream);
     VALIDATE_NOT_NULL(format);
     VALIDATE_NOT_NULL(index);
     VALIDATE_NOT_NULL(unique_id);
 
-    *framerate = mode->profile->get_framerate();
-    *format = mode->profile->get_format();
-    *index = mode->profile->get_stream_index();
-    *stream = mode->profile->get_stream_type();
-    *unique_id = mode->profile->get_unique_id();
+    *framerate = profile->profile->get_framerate();
+    *format = profile->profile->get_format();
+    *index = profile->profile->get_stream_index();
+    *stream = profile->profile->get_stream_type();
+    *unique_id = profile->profile->get_unique_id();
 }
-HANDLE_EXCEPTIONS_AND_RETURN(, mode, stream, format, index, framerate)
+HANDLE_EXCEPTIONS_AND_RETURN(, profile, stream, format, index, framerate)
 
 void rs2_set_stream_profile_data(rs2_stream_profile* mode, rs2_stream stream, int index, rs2_format format, rs2_error** error) BEGIN_API_CALL
 {
@@ -1504,20 +1504,20 @@ int rs2_is_processing_block_extendable_to(const rs2_processing_block* f, rs2_ext
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, f, extension_type)
 
-int rs2_stream_profile_is(const rs2_stream_profile* f, rs2_extension extension_type, rs2_error** error) BEGIN_API_CALL
+int rs2_stream_profile_is(const rs2_stream_profile* profile, rs2_extension extension_type, rs2_error** error) BEGIN_API_CALL
 {
-    VALIDATE_NOT_NULL(f);
+    VALIDATE_NOT_NULL(profile);
     VALIDATE_ENUM(extension_type);
     switch (extension_type)
     {
-    case RS2_EXTENSION_VIDEO_PROFILE    : return VALIDATE_INTERFACE_NO_THROW(f->profile, librealsense::video_stream_profile_interface)  != nullptr;
-    case RS2_EXTENSION_MOTION_PROFILE   : return VALIDATE_INTERFACE_NO_THROW(f->profile, librealsense::motion_stream_profile_interface) != nullptr;
-    case RS2_EXTENSION_POSE_PROFILE     : return VALIDATE_INTERFACE_NO_THROW(f->profile, librealsense::pose_stream_profile_interface)   != nullptr;
+    case RS2_EXTENSION_VIDEO_PROFILE    : return VALIDATE_INTERFACE_NO_THROW(profile->profile, librealsense::video_stream_profile_interface)  != nullptr;
+    case RS2_EXTENSION_MOTION_PROFILE   : return VALIDATE_INTERFACE_NO_THROW(profile->profile, librealsense::motion_stream_profile_interface) != nullptr;
+    case RS2_EXTENSION_POSE_PROFILE     : return VALIDATE_INTERFACE_NO_THROW(profile->profile, librealsense::pose_stream_profile_interface)   != nullptr;
     default:
         return false;
     }
 }
-HANDLE_EXCEPTIONS_AND_RETURN(0, f, extension_type)
+HANDLE_EXCEPTIONS_AND_RETURN(0, profile, extension_type)
 
 rs2_device* rs2_context_add_device(rs2_context* ctx, const char* file, rs2_error** error) BEGIN_API_CALL
 {

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -125,7 +125,7 @@ def print_stack():
     #     File "C:/work/git/lrs\unit-tests\py\rspy\test.py", line 87, in print_stack
     #       stack = traceback.format_stack()
     stack = stack[:-2]
-    for line in reversed( stack ):
+    for line in stack:
         print( line, end = '' )  # format_stack() adds \n
 
 
@@ -189,8 +189,8 @@ def check_equal(result, expected, abort_if_failed = False):
     n_assertions += 1
     if result != expected:
         print_stack()
-        print( "    result  :", result )
-        print( "    expected:", expected )
+        print( "    left  :", result )
+        print( "    right :", expected )
         check_failed()
         if abort_if_failed:
             abort()
@@ -204,7 +204,12 @@ def unreachable( abort_if_failed = False ):
     Used to assert that a certain section of code (exp: an if block) is not reached
     :param abort_if_failed: If True and this function is reached the test will be aborted
     """
-    check(False, abort_if_failed)
+    global n_assertions
+    n_assertions += 1
+    print_stack()
+    check_failed()
+    if abort_if_failed:
+        abort()
 
 
 def unexpected_exception():
@@ -341,18 +346,20 @@ def reset_info(persistent = False):
     if persistent:
         test_info.clear()
     else:
+        new_info = test_info.copy()
         for name, information in test_info.items():
             if not information.persistent:
-                test_info.pop(name)
+                new_info.pop(name)
+        test_info = new_info
 
 
 def print_info():
     global test_info
     if not test_info: # No information is stored
         return
-    print("Printing information")
+    #print("Printing information")
     for name, information in test_info.items():
-        print("Name:", name, "        value:", information.value)
+        print( f"  {name} = {information.value}" )
     reset_info()
 
 

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -152,7 +152,7 @@ def abort():
     sys.exit( 1 )
 
 
-def check(exp, abort_if_failed = False):
+def check( exp, description = None, abort_if_failed = False):
     """
     Basic function for asserting expressions.
     :param exp: An expression to be asserted, if false the assertion failed
@@ -163,7 +163,10 @@ def check(exp, abort_if_failed = False):
     n_assertions += 1
     if not exp:
         print_stack()
-        print( "    check failed; received", exp )
+        if description:
+            print( f"    {description}" )
+        else:
+            print( f"    check failed; received {exp}" )
         check_failed()
         if abort_if_failed:
             abort()
@@ -359,7 +362,7 @@ def print_info():
         return
     #print("Printing information")
     for name, information in test_info.items():
-        print( f"  {name} = {information.value}" )
+        print( f"    {name} : {information.value}" )
     reset_info()
 
 

--- a/unit-tests/syncer/sw.py
+++ b/unit-tests/syncer/sw.py
@@ -1,0 +1,149 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
+import pyrealsense2 as rs
+from rspy import log, test
+
+
+# Constants
+#
+domain = rs.timestamp_domain.hardware_clock       # For either depth/color
+#
+# To be set before init()
+#
+fps_c = fps_d = 60
+w = 640
+h = 480
+bpp = 2  # bytes
+
+
+def init():
+    """
+    """
+    global gap_c, gap_d
+    gap_d = 1000 / fps_d
+    gap_c = 1000 / fps_c
+    #
+    global pixels, w, h
+    pixels = bytearray( b'\x00' * ( w * h * 2 ))  # Dummy data
+    #
+    global device
+    device = rs.software_device()
+    device.create_matcher( rs.matchers.default )  # Compare all streams according to timestamp
+    #
+    global depth_sensor, color_sensor
+    depth_sensor = device.add_sensor( "Depth" )
+    color_sensor = device.add_sensor( "Color" )
+    #
+    depth_stream = rs.video_stream()
+    depth_stream.type = rs.stream.depth
+    depth_stream.uid = 0
+    depth_stream.width = 640
+    depth_stream.height = 480
+    depth_stream.bpp = 2
+    depth_stream.fmt = rs.format.z16
+    depth_stream.fps = fps_d
+    #
+    global depth_profile
+    depth_profile = rs.video_stream_profile( depth_sensor.add_video_stream( depth_stream ))
+    #
+    color_stream = rs.video_stream()
+    color_stream.type = rs.stream.color
+    color_stream.uid = 1
+    color_stream.width = 640
+    color_stream.height = 480
+    color_stream.bpp = 2
+    color_stream.fmt = rs.format.rgba8
+    color_stream.fps = fps_c
+    #
+    global color_profile
+    color_profile = rs.video_stream_profile( color_sensor.add_video_stream( color_stream ))
+    #
+    global syncer
+    syncer = rs.syncer( 100 )  # We don't want to lose any frames so uses a big queue size (default is 1)
+
+
+def start():
+    """
+    """
+    global depth_profile, color_profile, depth_sensor, color_sensor, syncer
+    depth_sensor.open( depth_profile )
+    color_sensor.open( color_profile )
+    depth_sensor.start( syncer )
+    color_sensor.start( syncer )
+
+
+def generate_depth_frame( frame_number, timestamp ):
+    """
+    """
+    global depth_profile, domain, pixels, depth_sensor, w, bpp
+    #
+    depth_frame = rs.software_video_frame()
+    depth_frame.pixels = pixels
+    depth_frame.stride = w * bpp
+    depth_frame.bpp = bpp
+    depth_frame.frame_number = frame_number
+    depth_frame.timestamp = timestamp
+    depth_frame.domain = domain
+    depth_frame.profile = depth_profile
+    #
+    log.d( "-->", depth_frame )
+    depth_sensor.on_video_frame( depth_frame )
+
+def generate_color_frame( frame_number, timestamp ):
+    """
+    """
+    global color_profile, domain, pixels, color_sensor, w, bpp
+    #
+    color_frame = rs.software_video_frame()
+    color_frame.pixels = pixels
+    color_frame.stride = w * bpp
+    color_frame.bpp = bpp
+    color_frame.frame_number = frame_number
+    color_frame.timestamp = timestamp
+    color_frame.domain = domain
+    color_frame.profile = color_profile
+    #
+    log.d( "-->", color_frame )
+    color_sensor.on_video_frame( color_frame )
+
+def generate_depth_and_color( frame_number, timestamp ):
+    generate_depth_frame( frame_number, timestamp )
+    generate_color_frame( frame_number, timestamp )
+
+def expect( depth_frame = None, color_frame = None, nothing_else = False ):
+    """
+    Looks at the syncer queue and gets the next frame from it if available, checking its contents
+    against the expected frame numbers.
+    """
+    global syncer
+    fs = syncer.poll_for_frames()  # NOTE: will never be None
+    if not fs:
+        test.check( depth_frame is None, "expected a depth frame" )
+        test.check( color_frame is None, "expected a color frame" )
+        return False
+
+    log.d( "Got", fs )
+
+    depth = fs.get_depth_frame()
+    test.info( "actual depth", depth )
+    test.check_equal( depth_frame is None, not depth )
+    if depth_frame is not None and depth:
+        test.check_equal( depth.get_frame_number(), depth_frame )
+    
+    color = fs.get_color_frame()
+    test.info( "actual color", color )
+    test.check_equal( color_frame is None, not color )
+    if color_frame is not None and color:
+        test.check_equal( color.get_frame_number(), color_frame )
+
+    if nothing_else:
+        fs = syncer.poll_for_frames()
+        test.info( "Expected nothing else; actual", fs )
+        test.check( not fs )
+
+    return True
+
+def expect_nothing():
+    expect( nothing_else = True )
+

--- a/unit-tests/syncer/test-ts-diff-fps.py
+++ b/unit-tests/syncer/test-ts-diff-fps.py
@@ -1,0 +1,258 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
+import pyrealsense2 as rs
+from rspy import log, test
+
+
+# The timestamp jumps are closely correlated to the FPS passed to the video streams:
+# syncer expects frames to arrive every 1000/FPS milliseconds!
+fps_d = 100
+fps_c =  10
+gap_d = 1000 / fps_d
+gap_c = 1000 / fps_c
+domain = rs.timestamp_domain.hardware_clock
+
+def generate_depth_frame( frame_number, timestamp ):
+    """
+    """
+    global depth_profile, domain, pixels, depth_sensor
+    #
+    depth_frame = rs.software_video_frame()
+    depth_frame.pixels = pixels
+    depth_frame.stride = 640 * 2  # W * bpp
+    depth_frame.bpp = 2
+    depth_frame.frame_number = frame_number
+    depth_frame.timestamp = timestamp
+    depth_frame.domain = domain
+    depth_frame.profile = depth_profile
+    #
+    log.d( "-->", depth_frame )
+    depth_sensor.on_video_frame( depth_frame )
+
+def generate_color_frame( frame_number, timestamp ):
+    """
+    """
+    global color_profile, domain, pixels, color_sensor
+    #
+    color_frame = rs.software_video_frame()
+    color_frame.pixels = pixels
+    color_frame.stride = 640 * 2  # W * bpp
+    color_frame.bpp = 2
+    color_frame.frame_number = frame_number
+    color_frame.timestamp = timestamp
+    color_frame.domain = domain
+    color_frame.profile = color_profile
+    #
+    log.d( "-->", color_frame )
+    color_sensor.on_video_frame( color_frame )
+
+def generate_depth_and_color( frame_number, timestamp ):
+    generate_depth_frame( frame_number, timestamp )
+    generate_color_frame( frame_number, timestamp )
+
+def expect( depth_frame = None, color_frame = None, nothing_else = False ):
+    """
+    Looks at the syncer queue and gets the next frame from it if available, checking its contents
+    against the expected frame numbers.
+    """
+    global syncer
+    fs = syncer.poll_for_frames()  # NOTE: will never be None
+    if not fs:
+        test.check( depth_frame is None, "expected a depth frame" )
+        test.check( color_frame is None, "expected a color frame" )
+        return False
+
+    log.d( "Got", fs )
+
+    depth = fs.get_depth_frame()
+    test.info( "actual depth", depth )
+    test.check_equal( depth_frame is None, not depth )
+    if depth_frame is not None and depth:
+        test.check_equal( depth.get_frame_number(), depth_frame )
+    
+    color = fs.get_color_frame()
+    test.info( "actual color", color )
+    test.check_equal( color_frame is None, not color )
+    if color_frame is not None and color:
+        test.check_equal( color.get_frame_number(), color_frame )
+
+    if nothing_else:
+        fs = syncer.poll_for_frames()
+        test.info( "Expected nothing else; actual", fs )
+        test.check( not fs )
+
+    return True
+
+def expect_nothing():
+    expect( nothing_else = True )
+
+
+###############################################################################
+#
+device = rs.software_device()
+depth_sensor = device.add_sensor( "Depth" )
+color_sensor = device.add_sensor( "Color" )
+
+depth_stream = rs.video_stream()
+depth_stream.type = rs.stream.depth
+depth_stream.uid = 0
+depth_stream.width = 640
+depth_stream.height = 480
+depth_stream.bpp = 2
+depth_stream.fmt = rs.format.z16
+depth_stream.fps = fps_d
+
+depth_profile = rs.video_stream_profile( depth_sensor.add_video_stream( depth_stream ))
+
+color_stream = rs.video_stream()
+color_stream.type = rs.stream.color
+color_stream.uid = 1
+color_stream.width = 640
+color_stream.height = 480
+color_stream.bpp = 2
+color_stream.fmt = rs.format.rgba8
+color_stream.fps = fps_c
+
+color_profile = rs.video_stream_profile( color_sensor.add_video_stream( color_stream ))
+
+device.create_matcher( rs.matchers.default )  # Compare all streams according to timestamp
+
+syncer = rs.syncer( 100 )  # We don't want to lose any frames so uses a big queue size (default is 1)
+
+depth_sensor.open( depth_profile )
+color_sensor.open( color_profile )
+depth_sensor.start( syncer )
+color_sensor.start( syncer )
+
+domain = rs.timestamp_domain.hardware_clock
+pixels = bytearray( b'\x00' * ( 640 * 480 * 2 ))
+
+
+#############################################################################################
+#
+test.start( "Wait for framesets" )
+
+# It can take a few frames for the syncer to actually produce a matched frameset (it doesn't
+# know what to match to in the beginning)
+
+# D  C  @timestamp
+# -- -- -----------
+# 0     @0
+# 1     @10
+#    0  @0
+#
+generate_depth_frame( frame_number = 0, timestamp = gap_d * 0 )
+generate_depth_frame( 1, gap_d * 1 )  # @10
+generate_color_frame( 0, gap_c * 0 )  # @0 -- small latency
+expect( depth_frame = 0 )                          # syncer doesn't know about color yet
+expect( depth_frame = 1 )
+#expect( color_frame = 0, nothing_else = True )
+# We'd expect C0 to not wait for another frame, but it does: @0 is comparable to @20 (D.NE)
+# because it's using C.fps (10 fps -> 100 gap / 2 = 50ms error, so 0~=20)!
+expect_nothing()
+
+# 2     @20
+generate_depth_frame( 2, gap_d * 2 )
+expect( depth_frame = 2, color_frame = 0, nothing_else = True )
+
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Depth waits for next Color" )
+
+# 3     @ 30
+# 4     @ 40
+# 5     @ 50
+# 6     @ 60
+# 7     @ 70
+# 8     @ 80
+# 9     @ 90
+# 10    @100 -> wait
+# 11    @110
+#
+generate_depth_frame(  3, gap_d *  3 ); expect( depth_frame =  3 )
+generate_depth_frame(  4, gap_d *  4 ); expect( depth_frame =  4 )
+generate_depth_frame(  5, gap_d *  5 ); expect( depth_frame =  5 )
+generate_depth_frame(  6, gap_d *  6 ); expect( depth_frame =  6 )
+generate_depth_frame(  7, gap_d *  7 ); expect( depth_frame =  7 )
+generate_depth_frame(  8, gap_d *  8 ); expect( depth_frame =  8 )
+generate_depth_frame(  9, gap_d *  9 ); expect( depth_frame =  9 )
+generate_depth_frame( 10, gap_d * 10 ); #expect( depth_frame = 10 )
+# C.NE is @100, so it should wait...
+expect_nothing()
+generate_depth_frame( 11, gap_d * 11 );
+expect_nothing()
+
+#    1  @100 -> release (D10,C1) and (D11)
+generate_color_frame(  1, gap_c *  1 );  # @100 -- small latency
+expect( depth_frame = 10, color_frame = 1 )
+expect( depth_frame = 11 )
+expect_nothing()
+
+# 12    @120 doesn't wait
+generate_depth_frame( 12, gap_d * 12 );
+expect( depth_frame = 12 )
+expect_nothing()
+
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Color is early" )
+
+# 13    @130
+# 14    @140
+# 15    @150
+# 16    @160
+# 17    @170
+#    2  @200 -> wait
+# 18    @180 -> (D18,C2) ?! why not wait for (D20,C2) ?!
+#
+generate_depth_frame( 13, gap_d * 13 ); expect( depth_frame = 13 )
+generate_depth_frame( 14, gap_d * 14 ); expect( depth_frame = 14 )
+generate_depth_frame( 15, gap_d * 15 ); expect( depth_frame = 15 )
+generate_depth_frame( 16, gap_d * 16 ); expect( depth_frame = 16 )
+generate_depth_frame( 17, gap_d * 17 ); expect( depth_frame = 17 )
+
+generate_color_frame( 2, gap_c * 2 ); expect_nothing()
+# We're waiting for D.NE @180, because it's comparable (using min fps of the two)
+
+generate_depth_frame( 18, gap_d * 18 )
+# Now we get both back:
+expect( depth_frame = 18, color_frame = 2, nothing_else = True )
+
+# But wait... why match C@200 to D@180 and not wait for D@200??
+# If we used the faster FPS of the two, 180!=200: we'd get D18, D19, then (D20,C20)
+#expect( depth_frame = 18, nothing_else = True )
+#generate_depth_frame( 19, gap_d * 19 )
+#expect( depth_frame = 19, nothing_else = True )
+#generate_depth_frame( 20, gap_d * 20 )
+#expect( depth_frame = 20, color_frame = 2, nothing_else = True )
+
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Stop depth" )
+
+generate_color_frame( 3, gap_c * 3 )  # @300
+
+# D.NE is @190, plus 7*gap_d gives a cutout of @260, so the frame shouldn't wait for depth
+# to arrive, but it does:
+expect_nothing()
+
+# The reason is that it's not using gap_d: it's using gap_c, so cutout is @890:
+generate_color_frame( 4, gap_c * 8 )
+expect_nothing()
+generate_color_frame( 5, gap_c * 9 )
+expect( color_frame = 3 )
+expect( color_frame = 4 )
+expect( color_frame = 5 )
+expect_nothing()
+
+test.finish()
+#
+#############################################################################################
+test.print_results_and_exit()

--- a/unit-tests/syncer/test-ts-diff-fps.py
+++ b/unit-tests/syncer/test-ts-diff-fps.py
@@ -3,130 +3,15 @@
 
 import pyrealsense2 as rs
 from rspy import log, test
+import sw
 
 
 # The timestamp jumps are closely correlated to the FPS passed to the video streams:
 # syncer expects frames to arrive every 1000/FPS milliseconds!
-fps_d = 100
-fps_c =  10
-gap_d = 1000 / fps_d
-gap_c = 1000 / fps_c
-domain = rs.timestamp_domain.hardware_clock
-
-def generate_depth_frame( frame_number, timestamp ):
-    """
-    """
-    global depth_profile, domain, pixels, depth_sensor
-    #
-    depth_frame = rs.software_video_frame()
-    depth_frame.pixels = pixels
-    depth_frame.stride = 640 * 2  # W * bpp
-    depth_frame.bpp = 2
-    depth_frame.frame_number = frame_number
-    depth_frame.timestamp = timestamp
-    depth_frame.domain = domain
-    depth_frame.profile = depth_profile
-    #
-    log.d( "-->", depth_frame )
-    depth_sensor.on_video_frame( depth_frame )
-
-def generate_color_frame( frame_number, timestamp ):
-    """
-    """
-    global color_profile, domain, pixels, color_sensor
-    #
-    color_frame = rs.software_video_frame()
-    color_frame.pixels = pixels
-    color_frame.stride = 640 * 2  # W * bpp
-    color_frame.bpp = 2
-    color_frame.frame_number = frame_number
-    color_frame.timestamp = timestamp
-    color_frame.domain = domain
-    color_frame.profile = color_profile
-    #
-    log.d( "-->", color_frame )
-    color_sensor.on_video_frame( color_frame )
-
-def generate_depth_and_color( frame_number, timestamp ):
-    generate_depth_frame( frame_number, timestamp )
-    generate_color_frame( frame_number, timestamp )
-
-def expect( depth_frame = None, color_frame = None, nothing_else = False ):
-    """
-    Looks at the syncer queue and gets the next frame from it if available, checking its contents
-    against the expected frame numbers.
-    """
-    global syncer
-    fs = syncer.poll_for_frames()  # NOTE: will never be None
-    if not fs:
-        test.check( depth_frame is None, "expected a depth frame" )
-        test.check( color_frame is None, "expected a color frame" )
-        return False
-
-    log.d( "Got", fs )
-
-    depth = fs.get_depth_frame()
-    test.info( "actual depth", depth )
-    test.check_equal( depth_frame is None, not depth )
-    if depth_frame is not None and depth:
-        test.check_equal( depth.get_frame_number(), depth_frame )
-    
-    color = fs.get_color_frame()
-    test.info( "actual color", color )
-    test.check_equal( color_frame is None, not color )
-    if color_frame is not None and color:
-        test.check_equal( color.get_frame_number(), color_frame )
-
-    if nothing_else:
-        fs = syncer.poll_for_frames()
-        test.info( "Expected nothing else; actual", fs )
-        test.check( not fs )
-
-    return True
-
-def expect_nothing():
-    expect( nothing_else = True )
-
-
-###############################################################################
-#
-device = rs.software_device()
-depth_sensor = device.add_sensor( "Depth" )
-color_sensor = device.add_sensor( "Color" )
-
-depth_stream = rs.video_stream()
-depth_stream.type = rs.stream.depth
-depth_stream.uid = 0
-depth_stream.width = 640
-depth_stream.height = 480
-depth_stream.bpp = 2
-depth_stream.fmt = rs.format.z16
-depth_stream.fps = fps_d
-
-depth_profile = rs.video_stream_profile( depth_sensor.add_video_stream( depth_stream ))
-
-color_stream = rs.video_stream()
-color_stream.type = rs.stream.color
-color_stream.uid = 1
-color_stream.width = 640
-color_stream.height = 480
-color_stream.bpp = 2
-color_stream.fmt = rs.format.rgba8
-color_stream.fps = fps_c
-
-color_profile = rs.video_stream_profile( color_sensor.add_video_stream( color_stream ))
-
-device.create_matcher( rs.matchers.default )  # Compare all streams according to timestamp
-
-syncer = rs.syncer( 100 )  # We don't want to lose any frames so uses a big queue size (default is 1)
-
-depth_sensor.open( depth_profile )
-color_sensor.open( color_profile )
-depth_sensor.start( syncer )
-color_sensor.start( syncer )
-
-domain = rs.timestamp_domain.hardware_clock
-pixels = bytearray( b'\x00' * ( 640 * 480 * 2 ))
+sw.fps_d = 100
+sw.fps_c =  10
+sw.init()
+sw.start()
 
 
 #############################################################################################
@@ -142,19 +27,19 @@ test.start( "Wait for framesets" )
 # 1     @10
 #    0  @0
 #
-generate_depth_frame( frame_number = 0, timestamp = gap_d * 0 )
-generate_depth_frame( 1, gap_d * 1 )  # @10
-generate_color_frame( 0, gap_c * 0 )  # @0 -- small latency
-expect( depth_frame = 0 )                          # syncer doesn't know about color yet
-expect( depth_frame = 1 )
+sw.generate_depth_frame( frame_number = 0, timestamp = sw.gap_d * 0 )
+sw.generate_depth_frame( 1, sw.gap_d * 1 )  # @10
+sw.generate_color_frame( 0, sw.gap_c * 0 )  # @0 -- small latency
+sw.expect( depth_frame = 0 )                          # syncer doesn't know about color yet
+sw.expect( depth_frame = 1 )
 #expect( color_frame = 0, nothing_else = True )
 # We'd expect C0 to not wait for another frame, but it does: @0 is comparable to @20 (D.NE)
 # because it's using C.fps (10 fps -> 100 gap / 2 = 50ms error, so 0~=20)!
-expect_nothing()
+sw.expect_nothing()
 
 # 2     @20
-generate_depth_frame( 2, gap_d * 2 )
-expect( depth_frame = 2, color_frame = 0, nothing_else = True )
+sw.generate_depth_frame( 2, sw.gap_d * 2 )
+sw.expect( depth_frame = 2, color_frame = 0, nothing_else = True )
 
 test.finish()
 #
@@ -172,29 +57,29 @@ test.start( "Depth waits for next Color" )
 # 10    @100 -> wait
 # 11    @110
 #
-generate_depth_frame(  3, gap_d *  3 ); expect( depth_frame =  3 )
-generate_depth_frame(  4, gap_d *  4 ); expect( depth_frame =  4 )
-generate_depth_frame(  5, gap_d *  5 ); expect( depth_frame =  5 )
-generate_depth_frame(  6, gap_d *  6 ); expect( depth_frame =  6 )
-generate_depth_frame(  7, gap_d *  7 ); expect( depth_frame =  7 )
-generate_depth_frame(  8, gap_d *  8 ); expect( depth_frame =  8 )
-generate_depth_frame(  9, gap_d *  9 ); expect( depth_frame =  9 )
-generate_depth_frame( 10, gap_d * 10 ); #expect( depth_frame = 10 )
+sw.generate_depth_frame(  3, sw.gap_d *  3 ); sw.expect( depth_frame =  3 )
+sw.generate_depth_frame(  4, sw.gap_d *  4 ); sw.expect( depth_frame =  4 )
+sw.generate_depth_frame(  5, sw.gap_d *  5 ); sw.expect( depth_frame =  5 )
+sw.generate_depth_frame(  6, sw.gap_d *  6 ); sw.expect( depth_frame =  6 )
+sw.generate_depth_frame(  7, sw.gap_d *  7 ); sw.expect( depth_frame =  7 )
+sw.generate_depth_frame(  8, sw.gap_d *  8 ); sw.expect( depth_frame =  8 )
+sw.generate_depth_frame(  9, sw.gap_d *  9 ); sw.expect( depth_frame =  9 )
+sw.generate_depth_frame( 10, sw.gap_d * 10 ); #sw.expect( depth_frame = 10 )
 # C.NE is @100, so it should wait...
-expect_nothing()
-generate_depth_frame( 11, gap_d * 11 );
-expect_nothing()
+sw.expect_nothing()
+sw.generate_depth_frame( 11, sw.gap_d * 11 );
+sw.expect_nothing()
 
 #    1  @100 -> release (D10,C1) and (D11)
-generate_color_frame(  1, gap_c *  1 );  # @100 -- small latency
-expect( depth_frame = 10, color_frame = 1 )
-expect( depth_frame = 11 )
-expect_nothing()
+sw.generate_color_frame(  1, sw.gap_c *  1 );  # @100 -- small latency
+sw.expect( depth_frame = 10, color_frame = 1 )
+sw.expect( depth_frame = 11 )
+sw.expect_nothing()
 
 # 12    @120 doesn't wait
-generate_depth_frame( 12, gap_d * 12 );
-expect( depth_frame = 12 )
-expect_nothing()
+sw.generate_depth_frame( 12, sw.gap_d * 12 );
+sw.expect( depth_frame = 12 )
+sw.expect_nothing()
 
 test.finish()
 #
@@ -210,25 +95,25 @@ test.start( "Color is early" )
 #    2  @200 -> wait
 # 18    @180 -> (D18,C2) ?! why not wait for (D20,C2) ?!
 #
-generate_depth_frame( 13, gap_d * 13 ); expect( depth_frame = 13 )
-generate_depth_frame( 14, gap_d * 14 ); expect( depth_frame = 14 )
-generate_depth_frame( 15, gap_d * 15 ); expect( depth_frame = 15 )
-generate_depth_frame( 16, gap_d * 16 ); expect( depth_frame = 16 )
-generate_depth_frame( 17, gap_d * 17 ); expect( depth_frame = 17 )
+sw.generate_depth_frame( 13, sw.gap_d * 13 ); sw.expect( depth_frame = 13 )
+sw.generate_depth_frame( 14, sw.gap_d * 14 ); sw.expect( depth_frame = 14 )
+sw.generate_depth_frame( 15, sw.gap_d * 15 ); sw.expect( depth_frame = 15 )
+sw.generate_depth_frame( 16, sw.gap_d * 16 ); sw.expect( depth_frame = 16 )
+sw.generate_depth_frame( 17, sw.gap_d * 17 ); sw.expect( depth_frame = 17 )
 
-generate_color_frame( 2, gap_c * 2 ); expect_nothing()
+sw.generate_color_frame( 2, sw.gap_c * 2 ); sw.expect_nothing()
 # We're waiting for D.NE @180, because it's comparable (using min fps of the two)
 
-generate_depth_frame( 18, gap_d * 18 )
+sw.generate_depth_frame( 18, sw.gap_d * 18 )
 # Now we get both back:
-expect( depth_frame = 18, color_frame = 2, nothing_else = True )
+sw.expect( depth_frame = 18, color_frame = 2, nothing_else = True )
 
 # But wait... why match C@200 to D@180 and not wait for D@200??
 # If we used the faster FPS of the two, 180!=200: we'd get D18, D19, then (D20,C20)
 #expect( depth_frame = 18, nothing_else = True )
-#generate_depth_frame( 19, gap_d * 19 )
+#generate_depth_frame( 19, sw.gap_d * 19 )
 #expect( depth_frame = 19, nothing_else = True )
-#generate_depth_frame( 20, gap_d * 20 )
+#generate_depth_frame( 20, sw.gap_d * 20 )
 #expect( depth_frame = 20, color_frame = 2, nothing_else = True )
 
 test.finish()
@@ -237,20 +122,20 @@ test.finish()
 #
 test.start( "Stop depth" )
 
-generate_color_frame( 3, gap_c * 3 )  # @300
+sw.generate_color_frame( 3, sw.gap_c * 3 )  # @300
 
 # D.NE is @190, plus 7*gap_d gives a cutout of @260, so the frame shouldn't wait for depth
 # to arrive, but it does:
-expect_nothing()
+sw.expect_nothing()
 
 # The reason is that it's not using gap_d: it's using gap_c, so cutout is @890:
-generate_color_frame( 4, gap_c * 8 )
-expect_nothing()
-generate_color_frame( 5, gap_c * 9 )
-expect( color_frame = 3 )
-expect( color_frame = 4 )
-expect( color_frame = 5 )
-expect_nothing()
+sw.generate_color_frame( 4, sw.gap_c * 8 )
+sw.expect_nothing()
+sw.generate_color_frame( 5, sw.gap_c * 9 )
+sw.expect( color_frame = 3 )
+sw.expect( color_frame = 4 )
+sw.expect( color_frame = 5 )
+sw.expect_nothing()
 
 test.finish()
 #

--- a/unit-tests/syncer/test-ts-same-fps.py
+++ b/unit-tests/syncer/test-ts-same-fps.py
@@ -3,126 +3,14 @@
 
 import pyrealsense2 as rs
 from rspy import log, test
+import sw
 
 
 # The timestamp jumps are closely correlated to the FPS passed to the video streams:
 # syncer expects frames to arrive every 1000/FPS milliseconds!
-fps = 60
-gap = 16  # 1000 / fps
-domain = rs.timestamp_domain.hardware_clock
-
-def generate_depth_frame( frame_number, timestamp ):
-    """
-    """
-    global depth_profile, domain, pixels, depth_sensor
-    #
-    depth_frame = rs.software_video_frame()
-    depth_frame.pixels = pixels
-    depth_frame.stride = 640 * 2  # W * bpp
-    depth_frame.bpp = 2
-    depth_frame.frame_number = frame_number
-    depth_frame.timestamp = timestamp
-    depth_frame.domain = domain
-    depth_frame.profile = depth_profile
-    #
-    log.d( "-->", depth_frame )
-    depth_sensor.on_video_frame( depth_frame )
-
-def generate_color_frame( frame_number, timestamp ):
-    """
-    """
-    global color_profile, domain, pixels, color_sensor
-    #
-    color_frame = rs.software_video_frame()
-    color_frame.pixels = pixels
-    color_frame.stride = 640 * 2  # W * bpp
-    color_frame.bpp = 2
-    color_frame.frame_number = frame_number
-    color_frame.timestamp = timestamp
-    color_frame.domain = domain
-    color_frame.profile = color_profile
-    #
-    log.d( "-->", color_frame )
-    color_sensor.on_video_frame( color_frame )
-
-def generate_depth_and_color( frame_number, timestamp ):
-    generate_depth_frame( frame_number, timestamp )
-    generate_color_frame( frame_number, timestamp )
-
-def expect( depth_frame = None, color_frame = None, nothing_else = False ):
-    """
-    Looks at the syncer queue and gets the next frame from it if available, checking its contents
-    against the expected frame numbers.
-    """
-    global syncer
-    fs = syncer.poll_for_frames()  # NOTE: will never be None
-    if not fs:
-        test.check( depth_frame is None, "expected a depth frame" )
-        test.check( color_frame is None, "expected a color frame" )
-        return False
-
-    log.d( "Got", fs )
-
-    depth = fs.get_depth_frame()
-    test.info( "actual depth", depth )
-    test.check_equal( depth_frame is None, not depth )
-    if depth_frame is not None and depth:
-        test.check_equal( depth.get_frame_number(), depth_frame )
-    
-    color = fs.get_color_frame()
-    test.info( "actual color", color )
-    test.check_equal( color_frame is None, not color )
-    if color_frame is not None and color:
-        test.check_equal( color.get_frame_number(), color_frame )
-
-    if nothing_else:
-        fs = syncer.poll_for_frames()
-        test.info( "Expected nothing else; actual", fs )
-        test.check( not fs )
-
-    return True
-
-
-###############################################################################
-#
-device = rs.software_device()
-depth_sensor = device.add_sensor( "Depth" )
-color_sensor = device.add_sensor( "Color" )
-
-depth_stream = rs.video_stream()
-depth_stream.type = rs.stream.depth
-depth_stream.uid = 0
-depth_stream.width = 640
-depth_stream.height = 480
-depth_stream.bpp = 2
-depth_stream.fmt = rs.format.z16
-depth_stream.fps = fps
-
-depth_profile = rs.video_stream_profile( depth_sensor.add_video_stream( depth_stream ))
-
-#    depth_sensor.add_read_only_option(RS2_OPTION_DEPTH_UNITS, 0.001f);
-
-color_stream = rs.video_stream()
-color_stream.type = rs.stream.color
-color_stream.uid = 1
-color_stream.width = 640
-color_stream.height = 480
-color_stream.bpp = 2
-color_stream.fmt = rs.format.rgba8
-color_stream.fps = fps
-
-color_profile = rs.video_stream_profile( color_sensor.add_video_stream( color_stream ))
-
-device.create_matcher( rs.matchers.default )  # Compare all streams according to timestamp
-
-syncer = rs.syncer( 100 )  # We don't want to lose any frames so uses a big queue size (default is 1)
-
-depth_sensor.open( depth_profile )
-color_sensor.open( color_profile )
-depth_sensor.start( syncer )
-color_sensor.start( syncer )
-
-pixels = bytearray( b'\x00' * ( 640 * 480 * 2 ))
+sw.fps_c = sw.fps_d = 60
+sw.init()
+sw.start()
 
 
 #############################################################################################
@@ -132,14 +20,14 @@ test.start( "Wait for framesets" )
 # It can take a few frames for the syncer to actually produce a matched frameset (it doesn't
 # know what to match to in the beginning)
 
-generate_depth_and_color( frame_number = 0, timestamp = 0 )
-expect( depth_frame = 0 )                          # syncer doesn't know about color yet
-expect( color_frame = 0, nothing_else = True )     # less than next expected of D
+sw.generate_depth_and_color( frame_number = 0, timestamp = 0 )
+sw.expect( depth_frame = 0 )                          # syncer doesn't know about color yet
+sw.expect( color_frame = 0, nothing_else = True )     # less than next expected of D
 #
 # NOTE: if the syncer queue wasn't 100 (see above) then we'd only get the color frame!
 #
-generate_depth_and_color( 1, gap * 1 )
-expect( depth_frame = 1, color_frame = 1, nothing_else = True )  # frameset 1
+sw.generate_depth_and_color( 1, sw.gap_d * 1 )
+sw.expect( depth_frame = 1, color_frame = 1, nothing_else = True )  # frameset 1
 
 test.finish()
 #
@@ -147,12 +35,12 @@ test.finish()
 #
 test.start( "Keep going" )
 
-generate_depth_and_color( 2, gap * 2 )
-expect( depth_frame = 2, color_frame = 2, nothing_else = True )  # frameset 2
-generate_depth_and_color( 3, gap * 3 )
-generate_depth_and_color( 4, gap * 4 )
-expect( depth_frame = 3, color_frame = 3 )                       # frameset 3
-expect( depth_frame = 4, color_frame = 4, nothing_else = True )  # frameset 4
+sw.generate_depth_and_color( 2, sw.gap_d * 2 )
+sw.expect( depth_frame = 2, color_frame = 2, nothing_else = True )  # frameset 2
+sw.generate_depth_and_color( 3, sw.gap_d * 3 )
+sw.generate_depth_and_color( 4, sw.gap_d * 4 )
+sw.expect( depth_frame = 3, color_frame = 3 )                       # frameset 3
+sw.expect( depth_frame = 4, color_frame = 4, nothing_else = True )  # frameset 4
 
 test.finish()
 #
@@ -160,13 +48,13 @@ test.finish()
 #
 test.start( "Stop giving color; wait_for_frames() should throw (after 5s)" )
 
-generate_depth_frame( 5, gap * 5 )
+sw.generate_depth_frame( 5, sw.gap_d * 5 )
 
 # We expect the syncer to try and wait for a Color frame to fit the Depth we just gave it.
 # The syncer relies on frame inputs to actually run -- and, if we wait for a frame, we're
 # not feeding it frames so can't get back any, either.
 try:
-    fs = syncer.wait_for_frames()
+    fs = sw.syncer.wait_for_frames()
 except RuntimeError as e:
     test.check_exception( e, RuntimeError, "Frame did not arrive in time!" )
 else:
@@ -186,18 +74,18 @@ test.start( "try_wait_for_frames() allows us to keep feeding frames; eventually 
 # The last color frame we sent was at gap*4, so it's next expected at gap*5 plus a buffer of gap*7
 # (see the code in the syncer)... so we expect depth frame 5 to be released only when we're past gap*12
 
-generate_depth_frame( 6, gap * 6 )
-expect( nothing_else = True )
-generate_depth_frame( 7, gap * 12 )
-expect( nothing_else = True )
-generate_depth_frame( 8, gap * 13 )
+sw.generate_depth_frame( 6, sw.gap_d * 6 )
+sw.expect( nothing_else = True )
+sw.generate_depth_frame( 7, sw.gap_d * 11.5 )
+sw.expect( nothing_else = True )
+sw.generate_depth_frame( 8, sw.gap_d * 12.5 )
 #
 # We'll get all frames in a burst. Again, if the syncer queue was 1, we'd only get the last!
 #
-expect( depth_frame = 5 )
-expect( depth_frame = 6 )
-expect( depth_frame = 7 )
-expect( depth_frame = 8, nothing_else = True )
+sw.expect( depth_frame = 5 )
+sw.expect( depth_frame = 6 )
+sw.expect( depth_frame = 7 )
+sw.expect( depth_frame = 8, nothing_else = True )
 
 test.finish()
 #

--- a/unit-tests/syncer/test-ts-same-fps.py
+++ b/unit-tests/syncer/test-ts-same-fps.py
@@ -1,0 +1,205 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+
+import pyrealsense2 as rs
+from rspy import log, test
+
+
+# The timestamp jumps are closely correlated to the FPS passed to the video streams:
+# syncer expects frames to arrive every 1000/FPS milliseconds!
+fps = 60
+gap = 16  # 1000 / fps
+domain = rs.timestamp_domain.hardware_clock
+
+def generate_depth_frame( frame_number, timestamp ):
+    """
+    """
+    global depth_profile, domain, pixels, depth_sensor
+    #
+    depth_frame = rs.software_video_frame()
+    depth_frame.pixels = pixels
+    depth_frame.stride = 640 * 2  # W * bpp
+    depth_frame.bpp = 2
+    depth_frame.frame_number = frame_number
+    depth_frame.timestamp = timestamp
+    depth_frame.domain = domain
+    depth_frame.profile = depth_profile
+    #
+    log.d( "-->", depth_frame )
+    depth_sensor.on_video_frame( depth_frame )
+
+def generate_color_frame( frame_number, timestamp ):
+    """
+    """
+    global color_profile, domain, pixels, color_sensor
+    #
+    color_frame = rs.software_video_frame()
+    color_frame.pixels = pixels
+    color_frame.stride = 640 * 2  # W * bpp
+    color_frame.bpp = 2
+    color_frame.frame_number = frame_number
+    color_frame.timestamp = timestamp
+    color_frame.domain = domain
+    color_frame.profile = color_profile
+    #
+    log.d( "-->", color_frame )
+    color_sensor.on_video_frame( color_frame )
+
+def generate_depth_and_color( frame_number, timestamp ):
+    generate_depth_frame( frame_number, timestamp )
+    generate_color_frame( frame_number, timestamp )
+
+def expect( depth_frame = None, color_frame = None, nothing_else = False ):
+    """
+    Looks at the syncer queue and gets the next frame from it if available, checking its contents
+    against the expected frame numbers.
+    """
+    global syncer
+    fs = syncer.poll_for_frames()  # NOTE: will never be None
+    if not fs:
+        test.check( depth_frame is None, "expected a depth frame" )
+        test.check( color_frame is None, "expected a color frame" )
+        return False
+
+    log.d( "Got", fs )
+
+    depth = fs.get_depth_frame()
+    test.info( "actual depth", depth )
+    test.check_equal( depth_frame is None, not depth )
+    if depth_frame is not None and depth:
+        test.check_equal( depth.get_frame_number(), depth_frame )
+    
+    color = fs.get_color_frame()
+    test.info( "actual color", color )
+    test.check_equal( color_frame is None, not color )
+    if color_frame is not None and color:
+        test.check_equal( color.get_frame_number(), color_frame )
+
+    if nothing_else:
+        fs = syncer.poll_for_frames()
+        test.info( "Expected nothing else; actual", fs )
+        test.check( not fs )
+
+    return True
+
+
+###############################################################################
+#
+device = rs.software_device()
+depth_sensor = device.add_sensor( "Depth" )
+color_sensor = device.add_sensor( "Color" )
+
+depth_stream = rs.video_stream()
+depth_stream.type = rs.stream.depth
+depth_stream.uid = 0
+depth_stream.width = 640
+depth_stream.height = 480
+depth_stream.bpp = 2
+depth_stream.fmt = rs.format.z16
+depth_stream.fps = fps
+
+depth_profile = rs.video_stream_profile( depth_sensor.add_video_stream( depth_stream ))
+
+#    depth_sensor.add_read_only_option(RS2_OPTION_DEPTH_UNITS, 0.001f);
+
+color_stream = rs.video_stream()
+color_stream.type = rs.stream.color
+color_stream.uid = 1
+color_stream.width = 640
+color_stream.height = 480
+color_stream.bpp = 2
+color_stream.fmt = rs.format.rgba8
+color_stream.fps = fps
+
+color_profile = rs.video_stream_profile( color_sensor.add_video_stream( color_stream ))
+
+device.create_matcher( rs.matchers.default )  # Compare all streams according to timestamp
+
+syncer = rs.syncer( 100 )  # We don't want to lose any frames so uses a big queue size (default is 1)
+
+depth_sensor.open( depth_profile )
+color_sensor.open( color_profile )
+depth_sensor.start( syncer )
+color_sensor.start( syncer )
+
+pixels = bytearray( b'\x00' * ( 640 * 480 * 2 ))
+
+
+#############################################################################################
+#
+test.start( "Wait for framesets" )
+
+# It can take a few frames for the syncer to actually produce a matched frameset (it doesn't
+# know what to match to in the beginning)
+
+generate_depth_and_color( frame_number = 0, timestamp = 0 )
+expect( depth_frame = 0 )                          # syncer doesn't know about color yet
+expect( color_frame = 0, nothing_else = True )     # less than next expected of D
+#
+# NOTE: if the syncer queue wasn't 100 (see above) then we'd only get the color frame!
+#
+generate_depth_and_color( 1, gap * 1 )
+expect( depth_frame = 1, color_frame = 1, nothing_else = True )  # frameset 1
+
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Keep going" )
+
+generate_depth_and_color( 2, gap * 2 )
+expect( depth_frame = 2, color_frame = 2, nothing_else = True )  # frameset 2
+generate_depth_and_color( 3, gap * 3 )
+generate_depth_and_color( 4, gap * 4 )
+expect( depth_frame = 3, color_frame = 3 )                       # frameset 3
+expect( depth_frame = 4, color_frame = 4, nothing_else = True )  # frameset 4
+
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Stop giving color; wait_for_frames() should throw (after 5s)" )
+
+generate_depth_frame( 5, gap * 5 )
+
+# We expect the syncer to try and wait for a Color frame to fit the Depth we just gave it.
+# The syncer relies on frame inputs to actually run -- and, if we wait for a frame, we're
+# not feeding it frames so can't get back any, either.
+try:
+    fs = syncer.wait_for_frames()
+except RuntimeError as e:
+    test.check_exception( e, RuntimeError, "Frame did not arrive in time!" )
+else:
+    test.info( "Unexpected frameset", fs )
+    test.unreachable()
+
+test.finish()
+#
+#############################################################################################
+#
+test.start( "try_wait_for_frames() allows us to keep feeding frames; eventually we get one" )
+
+# The syncer will not immediately release framesets because it's still waiting for a color frame to
+# match Depth #10. But, if we advance the timestamp sufficiently, it should eventually release it
+# as it deems Color "inactive".
+
+# The last color frame we sent was at gap*4, so it's next expected at gap*5 plus a buffer of gap*7
+# (see the code in the syncer)... so we expect depth frame 5 to be released only when we're past gap*12
+
+generate_depth_frame( 6, gap * 6 )
+expect( nothing_else = True )
+generate_depth_frame( 7, gap * 12 )
+expect( nothing_else = True )
+generate_depth_frame( 8, gap * 13 )
+#
+# We'll get all frames in a burst. Again, if the syncer queue was 1, we'd only get the last!
+#
+expect( depth_frame = 5 )
+expect( depth_frame = 6 )
+expect( depth_frame = 7 )
+expect( depth_frame = 8, nothing_else = True )
+
+test.finish()
+#
+#############################################################################################
+test.print_results_and_exit()

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -69,7 +69,7 @@ void init_frame(py::module &m) {
             std::stringstream ss;
             if (auto vf = self.as<rs2::video_stream_profile>())
             {
-                ss << "<" SNAME ".video_stream_profile: "
+                ss << "<" SNAME ".[video_]stream_profile: "
                     << vf.stream_type() << "(" << vf.stream_index() << ") " << vf.width()
                     << "x" << vf.height() << " @ " << vf.fps() << "fps "
                     << vf.format() << ">";

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -138,19 +138,26 @@ void init_frame(py::module &m) {
         // No apply_filter?
         .def( "__repr__", []( const rs2::frame &self )
         {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "<" << SNAME << ".frame";
-            if( auto fs = self.as< rs2::frameset >() )
+            if( ! self )
             {
-                ss << "set";
-                for( auto sf : fs )
-                    ss << " " << rs2_format_to_string( sf.get_profile().format() );
+                ss << " NULL";
             }
             else
             {
-                ss << " " << rs2_format_to_string( self.get_profile().format() );
+                if( auto fs = self.as< rs2::frameset >() )
+                {
+                    ss << "set";
+                    for( auto sf : fs )
+                        ss << " " << rs2_format_to_string( sf.get_profile().format() );
+                }
+                else
+                {
+                    ss << " " << rs2_format_to_string( self.get_profile().format() );
+                }
+                ss << " #" << self.get_frame_number();
             }
-            ss << " #" << self.get_frame_number();
             ss << ">";
             return ss.str();
         });

--- a/wrappers/python/pyrs_internal.cpp
+++ b/wrappers/python/pyrs_internal.cpp
@@ -2,7 +2,7 @@
 Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 
 #include "python.hpp"
-#include "../include/librealsense2/hpp/rs_internal.hpp"
+#include <librealsense2/hpp/rs_internal.hpp>
 #include <cstring>
 
 void init_internal(py::module &m) {
@@ -39,34 +39,78 @@ void init_internal(py::module &m) {
         .def_readwrite("fps", &rs2_pose_stream::fps)
         .def_readwrite("fmt", &rs2_pose_stream::fmt);
 
-    py::class_<rs2_software_video_frame> software_video_frame(m, "software_video_frame", "All the parameters "
-                                                              "required to define a video frame.");
-    software_video_frame.def(py::init([]() { rs2_software_video_frame f{}; f.deleter = nullptr; return f; })) // guarantee deleter is set to nullptr
-        .def_property("pixels", [](const rs2_software_video_frame& self) {
-            // TODO: Not all formats (e.g. RAW10) are properly handled (see struct FmtToType in python.hpp)
-            auto vp = rs2::stream_profile(self.profile).as<rs2::video_stream_profile>();
-            size_t size = fmt_to_value<itemsize>(vp.format());
-            size_t upp = self.bpp / size;
-            if (upp == 1)
-                return BufData(self.pixels, size, fmt_to_value<fmtstring>(vp.format()), 2,
-                    { (size_t)vp.height(), (size_t)vp.width() }, { vp.width()*size, size });
-            else
-                return BufData(self.pixels, size, fmt_to_value<fmtstring>(vp.format()), 3,
-                    { (size_t)vp.height(), (size_t)vp.width(), upp }, { vp.width()*upp*size, upp*size, size });
-        }, [](rs2_software_video_frame& self, py::buffer buf) {
-            if (self.deleter) self.deleter(self.pixels);
-            auto data = buf.request();
-            self.pixels = new uint8_t[data.size*data.itemsize]; // fwiw, might be possible to convert data.format -> underlying data type
-            std::memcpy(self.pixels, data.ptr, data.size*data.itemsize);
-            self.deleter = [](void* ptr){ delete[] ptr; };
-        })
+    py::class_< rs2_software_video_frame >( m,
+                                            "software_video_frame",
+                                            "All the parameters required to define a video frame" )
+        .def( py::init( []() {
+            rs2_software_video_frame f;
+            f.deleter = nullptr;
+            f.pixels = nullptr;
+            f.profile = nullptr;
+            return f;
+        } ) )  // guarantee deleter is set to nullptr
+        .def_property(
+            "pixels",
+            []( const rs2_software_video_frame & self ) {
+                if( ! self.profile || ! self.pixels )
+                    return BufData( nullptr, 1, "b", 0 );
+                // TODO: Not all formats (e.g. RAW10) are properly handled (see struct FmtToType in
+                // python.hpp)
+                auto vp = rs2::stream_profile( self.profile ).as< rs2::video_stream_profile >();
+                size_t size = fmt_to_value< itemsize >( vp.format() );
+                size_t upp = self.bpp / size;
+                if( upp == 1 )
+                    return BufData( self.pixels,
+                                    size,
+                                    fmt_to_value< fmtstring >( vp.format() ),
+                                    2,
+                                    { (size_t)vp.height(), (size_t)vp.width() },
+                                    { vp.width() * size, size } );
+                else
+                    return BufData( self.pixels,
+                                    size,
+                                    fmt_to_value< fmtstring >( vp.format() ),
+                                    3,
+                                    { (size_t)vp.height(), (size_t)vp.width(), upp },
+                                    { vp.width() * upp * size, upp * size, size } );
+            },
+            []( rs2_software_video_frame & self, py::buffer buf ) {
+                if( self.deleter )
+                    self.deleter( self.pixels );
+                auto data = buf.request();
+                if( ! data.size || ! data.itemsize )
+                {
+                    self.pixels = nullptr;
+                    self.deleter = nullptr;
+                }
+                else
+                {
+                    self.pixels
+                        = new uint8_t[data.size
+                                      * data.itemsize];  // fwiw, might be possible to convert
+                                                         // data.format -> underlying data type
+                    std::memcpy( self.pixels, data.ptr, data.size * data.itemsize );
+                    self.deleter = []( void * ptr ) {
+                        delete[] ptr;
+                    };
+                }
+            } )
         .def_readwrite("stride", &rs2_software_video_frame::stride)
         .def_readwrite("bpp", &rs2_software_video_frame::bpp)
         .def_readwrite("timestamp", &rs2_software_video_frame::timestamp)
         .def_readwrite("domain", &rs2_software_video_frame::domain)
         .def_readwrite("frame_number", &rs2_software_video_frame::frame_number)
-        .def_property("profile", [](const rs2_software_video_frame& self) { return rs2::stream_profile(self.profile).as<rs2::video_stream_profile>(); },
-                      [](rs2_software_video_frame& self, rs2::video_stream_profile profile) { self.profile = profile.get(); });
+        .def_property(
+            "profile",
+            []( const rs2_software_video_frame & self ) {
+                if( ! self.profile )
+                    return rs2::video_stream_profile();
+                else
+                    return rs2::stream_profile( self.profile ).as< rs2::video_stream_profile >();
+            },
+            []( rs2_software_video_frame & self, rs2::video_stream_profile const & profile ) {
+                self.profile = profile.get();
+            } );
 
     py::class_<rs2_software_motion_frame> software_motion_frame(m, "software_motion_frame", "All the parameters "
                                                                 "required to define a motion frame.");
@@ -118,8 +162,12 @@ void init_internal(py::module &m) {
     /** rs_internal.hpp **/
     // rs2::software_sensor
     py::class_<rs2::software_sensor, rs2::sensor> software_sensor(m, "software_sensor");
-    software_sensor.def("add_video_stream", &rs2::software_sensor::add_video_stream, "Add video stream to software sensor",
-                        "video_stream"_a, "is_default"_a=false)
+    software_sensor
+        .def( "add_video_stream",
+              &rs2::software_sensor::add_video_stream,
+              "Add video stream to software sensor",
+              "video_stream"_a,
+              "is_default"_a = false )
         .def("add_motion_stream", &rs2::software_sensor::add_motion_stream, "Add motion stream to software sensor",
             "motion_stream"_a, "is_default"_a = false)
         .def("add_pose_stream", &rs2::software_sensor::add_pose_stream, "Add pose stream to software sensor",

--- a/wrappers/python/pyrs_internal.cpp
+++ b/wrappers/python/pyrs_internal.cpp
@@ -110,7 +110,20 @@ void init_internal(py::module &m) {
             },
             []( rs2_software_video_frame & self, rs2::video_stream_profile const & profile ) {
                 self.profile = profile.get();
-            } );
+            } )
+        .def( "__repr__", []( const rs2_software_video_frame& self ) {
+            std::ostringstream ss;
+            ss << "<" << SNAME << ".software_video_frame";
+            if( self.profile )
+            {
+                rs2::stream_profile profile( self.profile );
+                ss << " " << rs2_format_to_string( profile.format() );
+            }
+            ss << " #" << self.frame_number;
+            ss << " @" << self.timestamp;
+            ss << ">";
+            return ss.str();
+        } );
 
     py::class_<rs2_software_motion_frame> software_motion_frame(m, "software_motion_frame", "All the parameters "
                                                                 "required to define a motion frame.");


### PR DESCRIPTION
* fix py rs2_software_video_frame pixels and profile crashes
* add on_drop_callback to single_consumer_frame_queue (like single_cons… …
* added dropped frame log messages to rs2 queue
* fix rspy.test reversed stack, exception with info printout
* added description arg for rspy.test.check()
* fix Python null frame repr() crash
* add Python repr() for software_video_frame

Tracked on LRS-94