### PR TITLE
Fix enum error

### DIFF
--- a/tools/rs-imu-calibration/rs-imu-calibration.py
+++ b/tools/rs-imu-calibration/rs-imu-calibration.py
@@ -78,10 +78,10 @@ def bytes_to_uint(bytes_array, order='little'):
 
 class imu_wrapper:
     class Status(enum.Enum):
-        idle = 0,
-        rotate = 1,
-        wait_to_stable = 2,
-        collect_data = 3
+        idle = "0"
+        rotate = "1"
+        wait_to_stable = "2"
+        collect_data = "3"
 
     def __init__(self):
         self.pipeline = None


### PR DESCRIPTION
Originally would cause error `Error: Enumeration keys must be strings: 0` when running `python rs-imu-calibration.py` despite having the `enum34` library installed

Fixed by changing the Status class to have `idle`, `rotate`, `wait_to_stable`, and `collect_data` as strings rather than numbers