### PR TITLE
removed warning from metadata pr

### DIFF
--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include <librealsense2/rs.hpp>
+#include "utilities/string/windows.h"
 
 #define MAX_KEY_LENGTH 255
 #define MAX_VALUE_NAME 16383
@@ -134,11 +135,7 @@ namespace rs2
                             std::wstring suffix = achKey;
                             device_id rdid;
 
-                            // converting suffix to string
-                            std::string a(suffix.length(), 0);
-                            std::transform(suffix.begin(), suffix.end(), a.begin(), [](wchar_t c) {
-                                return (char)c;
-                                });
+                            std::string a = utilities::string::windows::win_to_utf( suffix.c_str() );
 
                             if (parse_device_id(a, &rdid))
                             {

--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -195,7 +195,7 @@ namespace rs2
                 return false;
             }
 
-            return result;
+            return bool(result);
         }
 
         bool elevate_to_admin()

--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -133,7 +133,13 @@ namespace rs2
                         {
                             std::wstring suffix = achKey;
                             device_id rdid;
-                            auto a = std::string(suffix.begin(), suffix.end());
+
+                            // converting suffix to string
+                            std::string a(suffix.length(), 0);
+                            std::transform(suffix.begin(), suffix.end(), a.begin(), [](wchar_t c) {
+                                return (char)c;
+                                });
+
                             if (parse_device_id(a, &rdid))
                             {
                                 for (auto&& did : kvp.second)

--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -195,7 +195,7 @@ namespace rs2
                 return false;
             }
 
-            return bool(result);
+            return result == TRUE;
         }
 
         bool elevate_to_admin()

--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -51,7 +51,7 @@ def run( cmd, stdout = None, timeout = 200, append = False ):
             if append:
                 handle = open( stdout, "a" )
                 handle.write(
-                    "\n-----------------------------------TEST-SEPARATOR-----------------------------------\n\n" )
+                    "\n----------TEST-SEPARATOR----------\n\n" )
                 handle.flush()
             else:
                 handle = open( stdout, "w" )

--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -51,7 +51,7 @@ def run( cmd, stdout = None, timeout = 200, append = False ):
             if append:
                 handle = open( stdout, "a" )
                 handle.write(
-                    "\n---------------------------------------------------------------------------------\n\n" )
+                    "\n-----------------------------------TEST-SEPARATOR-----------------------------------\n\n" )
                 handle.flush()
             else:
                 handle = open( stdout, "w" )

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -237,7 +237,7 @@ def check_log_for_fails( path_to_log, testname, configuration = None, repetition
     results = None
     for ctx in file.grep( r'^test cases:\s*(\d+) \|\s*(\d+) (passed|failed)|^-+$', path_to_log ):
         m = ctx['match']
-        if m.string == "---------------------------------------------------------------------------------":
+        if re.fullmatch( r'^-+$', m.string):
             results = None
         else:
             results = m

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -235,9 +235,10 @@ def check_log_for_fails( path_to_log, testname, configuration = None, repetition
     if path_to_log is None:
         return False
     results = None
-    for ctx in file.grep( r'^test cases:\s*(\d+) \|\s*(\d+) (passed|failed)|^-{35}TEST-SEPARATOR-{35}$', path_to_log ):
+    for ctx in file.grep( r'^test cases:\s*(\d+) \|\s*(\d+) (passed|failed)|^----------TEST-SEPARATOR----------$',
+                          path_to_log ):
         m = ctx['match']
-        if m.string == "-----------------------------------TEST-SEPARATOR-----------------------------------":
+        if m.string == "----------TEST-SEPARATOR----------":
             results = None
         else:
             results = m

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -235,9 +235,9 @@ def check_log_for_fails( path_to_log, testname, configuration = None, repetition
     if path_to_log is None:
         return False
     results = None
-    for ctx in file.grep( r'^test cases:\s*(\d+) \|\s*(\d+) (passed|failed)|^-+$', path_to_log ):
+    for ctx in file.grep( r'^test cases:\s*(\d+) \|\s*(\d+) (passed|failed)|^-{35}TEST-SEPARATOR-{35}$', path_to_log ):
         m = ctx['match']
-        if re.fullmatch( r'^-+$', m.string):
+        if m.string == "-----------------------------------TEST-SEPARATOR-----------------------------------":
             results = None
         else:
             results = m

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -60,7 +60,7 @@ void init_device(py::module &m) {
 
             if (!depth_sens.supports(RS2_CAMERA_INFO_PHYSICAL_PORT))
             {
-                throw librealsense::invalid_value_exception("Device does not support checking metadata with thi API");
+                throw librealsense::invalid_value_exception("Device does not support checking metadata with this API");
             }
             std::string id = depth_sens.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT);
 

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -6,7 +6,6 @@ Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 #include <librealsense2/hpp/rs_device.hpp>
 #include <librealsense2/hpp/rs_record_playback.hpp> // for downcasts
 #include <../common/metadata-helper.h>
-#include <types.h>
 
 void init_device(py::module &m) {
     /** rs_device.hpp **/
@@ -60,7 +59,7 @@ void init_device(py::module &m) {
 
             if (!depth_sens.supports(RS2_CAMERA_INFO_PHYSICAL_PORT))
             {
-                throw librealsense::invalid_value_exception("Device does not support checking metadata with this API");
+                throw std::runtime_error("Device does not support checking metadata with this API");
             }
             std::string id = depth_sens.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT);
 


### PR DESCRIPTION
#9640 added a warning - this fixes it.
Fixes a problem in unit-test log separators, as well.