### PR TITLE
fix Controls option not begins with capital letter

### DIFF
--- a/wrappers/android/tools/camera/src/main/res/layout-land/activity_preview.xml
+++ b/wrappers/android/tools/camera/src/main/res/layout-land/activity_preview.xml
@@ -110,7 +110,7 @@
             android:textSize="14dp"
             android:textColor="#ffffff"
             android:backgroundTint="#000000"
-            android:text="controls"/>
+            android:text="Controls"/>
 
         <Space
             android:layout_width="0dp"


### PR DESCRIPTION
Changes:
Minor fix controls option not begins with capital letter

Tracked on: DSO-15651