### PR TITLE
Measurement line is not disappeared after disabling distance Button

### DIFF
--- a/common/measurement.cpp
+++ b/common/measurement.cpp
@@ -14,6 +14,7 @@ void measurement::enable() {
 void measurement::disable() { 
     state.points.clear(); 
     state.edges.clear();
+    state.polygons.clear();
     measurement_active = false;
     config_file::instance().set(configurations::viewer::is_measuring, false);
 }

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -715,7 +715,7 @@ namespace rs2
 
         // -------------------- Measure ----------------
 
-        std::string measure_tooltip = "Measure distance between points";
+        std::string measure_tooltip = "Measure distance between points\nHold shift to connect more than 2 points and measure area";
         if (!glsl_available) measure_tooltip += "\nRequires GLSL acceleration! \nEnable 2 checkboxes in Settings - Performance:  \n- Use GLSL for Rendering \n- Use GLSL for Processing ";
         if (_measurements.is_enabled())
         {


### PR DESCRIPTION
Revised tooltip to make it clear how to draw a polygon.

Tracked on [DSO-17043]