### PR TITLE
Remove memory-extrinsics test

### DIFF
--- a/unit-tests/live/memory/test-extrinsics.cpp
+++ b/unit-tests/live/memory/test-extrinsics.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 //#cmake: static!
+//#test:donotrun
 //#test:device D435
 //#test:donotrun:!nightly
 //#test:timeout 480

--- a/unit-tests/live/memory/test-extrinsics.cpp
+++ b/unit-tests/live/memory/test-extrinsics.cpp
@@ -4,7 +4,6 @@
 //#cmake: static!
 //#test:donotrun
 //#test:device D435
-//#test:donotrun:!nightly
 //#test:timeout 480
 
 #include <numeric>


### PR DESCRIPTION
Remove memory-extrinsics test from nightly run because it is not stable