### PR TITLE
Lower Linux device polling interval to 2 seconds

### DIFF
--- a/src/backend.h
+++ b/src/backend.h
@@ -30,7 +30,8 @@
 const uint16_t MAX_RETRIES                 = 100;
 const uint8_t  DEFAULT_V4L2_FRAME_BUFFERS  = 4;
 const uint16_t DELAY_FOR_RETRIES           = 50;
-const int      POLLING_DEVICES_INTERVAL_MS = 5000;
+const int      DISCONNECT_PERIOD_MS        = 6000;
+const int      POLLING_DEVICES_INTERVAL_MS = 2000;
 
 const uint8_t MAX_META_DATA_SIZE          = 0xff; // UVC Metadata total length
                                             // is limited by (UVC Bulk) design to 255 bytes

--- a/src/ds5/ds5-device.cpp
+++ b/src/ds5/ds5-device.cpp
@@ -144,7 +144,7 @@ namespace librealsense
             _hw_monitor->send( cmd );
 
             // We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
-            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = (POLLING_DEVICES_INTERVAL_MS + 1000) / DELAY_FOR_RETRIES;
+            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = DISCONNECT_PERIOD_MS / DELAY_FOR_RETRIES;
             for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {
                 // If the device was detected as removed we assume the device is entering update mode

--- a/src/ivcam/sr300.cpp
+++ b/src/ivcam/sr300.cpp
@@ -347,7 +347,7 @@ namespace librealsense
             _hw_monitor->send( cmd );
 
             // We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
-            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = (POLLING_DEVICES_INTERVAL_MS + 1000) / DELAY_FOR_RETRIES;
+            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = DISCONNECT_PERIOD_MS / DELAY_FOR_RETRIES;
 
             for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {

--- a/src/l500/l500-device.cpp
+++ b/src/l500/l500-device.cpp
@@ -352,7 +352,7 @@ namespace librealsense
             _hw_monitor->send( cmd );
 
             // We allow 6 seconds because on Linux the removal status is updated at a 5 seconds rate.
-            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = (POLLING_DEVICES_INTERVAL_MS + 1000) / DELAY_FOR_RETRIES;
+            const int MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP = DISCONNECT_PERIOD_MS / DELAY_FOR_RETRIES;
             for( auto i = 0; i < MAX_ITERATIONS_FOR_DEVICE_DISCONNECTED_LOOP; i++ )
             {
                 // If the device was detected as removed we assume the device is entering update mode


### PR DESCRIPTION
tracked on [LRS-234]

The time for enumeration when there are no changes is on average 0.005s, when there are changes it is 0.15s. So polling every 2s shouldn't cause too much burden on the system.  