### PR TITLE
add rspy.repo.find_built_exe, Linux-compatible

### DIFF
--- a/unit-tests/py/rspy/repo.py
+++ b/unit-tests/py/rspy/repo.py
@@ -52,3 +52,31 @@ def pretty_fw_version( fw_version_as_string ):
     :return: a version with leading zeros removed, so as to be a little easier to read
     """
     return '.'.join( [str(int(c)) for c in fw_version_as_string.split( '.' )] )
+
+
+def find_built_exe( source, name ):
+    """
+    Find an executable that was built in the repo
+
+    :param source: The location of the exe's project, e.g. tools/convert
+    :param name: The name of the exe, without any platform-specific extensions like .exe
+    :return: The full path, or None, of the exe
+    """
+    exe = None
+    if platform.system() == 'Linux':
+        global build
+        exe = os.path.join( build, source, name )
+        if not os.path.isfile( exe ):
+            return None
+    else:
+        # In Windows, the name will be without extension and we need to find it somewhere
+        # in the path
+        import sys
+        for p in sys.path:
+            exe = os.path.join( p, name + '.exe' )
+            if os.path.isfile( exe ):
+                break
+        else:
+            return None
+    return exe
+

--- a/unit-tests/syncer/test-ts-eof.py
+++ b/unit-tests/syncer/test-ts-eof.py
@@ -93,17 +93,19 @@ sw.reset()
 #     [Color/1 #2 @33.333333]
 #     [Depth/0 #3 @50.000000]    <--- the frame that was "lost"
 #
-import subprocess, sys
-for p in sys.path:
-    rs_convert = os.path.join( p, 'rs-convert.exe' )
-    if os.path.isfile( rs_convert ):
-        subprocess.run( [rs_convert, '-i', filename, '-T'],
-                        stdout=None,
-                        stderr=subprocess.STDOUT,
-                        universal_newlines=True,
-                        timeout=10,
-                        check=True )
-        break
+from rspy import repo
+rs_convert = repo.find_built_exe( 'tools/convert', 'rs-convert' )
+if rs_convert:
+    import subprocess
+    subprocess.run( [rs_convert, '-i', filename, '-T'],
+                    stdout=None,
+                    stderr=subprocess.STDOUT,
+                    universal_newlines=True,
+                    timeout=10,
+                    check=False )  # don't fail on errors
+else:
+    log.w( 'no rs-covert was found!' )
+    log.d( 'sys.path=\n' + '\n    '.join( sys.path ) )
 
 test.finish()
 #


### PR DESCRIPTION
On Linux, test-ts-eof.py sometimes fails.
The rosbag dump doesn't work in Linux -- so hopefully this will give some clues...