### PR TITLE
fix test to use local pyrealsense

### DIFF
--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -630,7 +630,10 @@ else:
         # u'/sys/devices/pci0000:00/0000:00:14.0/usb2/2-3/2-3.3/2-3.3.1/2-3.3.1:1.0/video4linux/video0'
         #
         split_location = physical_port.split( '/' )
-        port_location = split_location[-4]
+        if len(split_location) > 4:
+            port_location = split_location[-4]
+        else:   #rsusb
+            port_location = split_location[0]
         # location example: 2-3.3.1
         return port_location
     #

--- a/unit-tests/py/rspy/repo.py
+++ b/unit-tests/py/rspy/repo.py
@@ -30,6 +30,9 @@ def find_pyrs():
     global build
     from rspy import file
     if platform.system() == 'Linux':
+        for so in file.find( os.path.abspath('.'), '(^|/)pyrealsense2.*\.so$' ):
+            return os.path.join( os.path.abspath('.'), so )
+
         for so in file.find( build, '(^|/)pyrealsense2.*\.so$' ):
             return os.path.join( build, so )
     else:

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -15,6 +15,7 @@ messages in case of a failed check
 """
 
 import os, sys, subprocess, traceback, platform
+import pyrealsense2 as rs
 
 from rspy import log
 
@@ -39,7 +40,6 @@ if '--context' in sys.argv:
 # If --rslog flag was sent, enable LibRS logging (LOG_DEBUG, etc.)
 try:
     sys.argv.remove( '--rslog' )
-    import pyrealsense2 as rs
     rs.log_to_console( rs.log_severity.debug )
 except ValueError as e:
     pass  # No --rslog passed in
@@ -86,7 +86,6 @@ def find_first_device_or_exit():
     :return: the first device that was found, if no device is found the test is skipped. That way we can still run
         the unit-tests when no device is connected and not fail the tests that check a connected device
     """
-    import pyrealsense2 as rs
     c = rs.context()
     if not c.devices.size():  # if no device is connected we skip the test
         log.f("No device found")
@@ -103,7 +102,6 @@ def find_devices_by_product_line_or_exit( product_line ):
         That way we can still run the unit-tests when no device is connected
         and not fail the tests that check a connected device
     """
-    import pyrealsense2 as rs
     c = rs.context()
     devices_list = c.query_devices(product_line)
     if devices_list.size() == 0:


### PR DESCRIPTION
The current implementation assumes building is done in the "build" directory.
Sometimes you want to build in other directories.
This PR makes the test use the pyrealsense and librealsense.so from the current directory instead of the one from 'build' directory.