### PR TITLE
Support for l4t 32.6.1

### DIFF
--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -61,7 +61,7 @@ case ${JETSON_L4T_VERSION} in
     PATCHES_REV="4.4.1"	# JP 4.4.1
     ;;
   *)
-    echo -e "\e[41mUnsipported JetPack revision ${JETSON_L4T_VERSION} aborting script\e[0m"
+    echo -e "\e[41mUnsupported JetPack revision ${JETSON_L4T_VERSION} aborting script\e[0m"
     exit;
     ;;
 esac


### PR DESCRIPTION
the latest supported jetson version 32.5.1 is not the latest official version from nvidia (32.6.1)

Instead of re-flashing my NVIDIA Jetson Xavier AGX with an old version i tested it with the kernel patch for 32.5.1 and it worked great. 

Maybe someone with a different NVIDIA Jetson Board can confirm.

Oh and also I fixed a typo I came across. 