### PR TITLE
Handle SEMAPHORE_TIMEOUT error on set_pu command (Windows)

### DIFF
--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -621,7 +621,7 @@ namespace librealsense
                         // We found 2 cases when we want to return false and let the backend retry mechanism call another set command.
                         // DEVICE_NOT_READY_ERROR: Can be return if the device is busy, not a real error.
                         // SEMAPHORE_TIMEOUT_ERROR: We get this error at a very low statistics when setting multiple PU commands (i.e. gain command)
-                        // It is not expected but we decided to raise a log_debug and allow a retry on that case.
+                        // It is not expected but we decided to raise a log_debug and allow a retry on that case [DSO-17181].
                         if( hr == DEVICE_NOT_READY_ERROR || hr == SEMAPHORE_TIMEOUT_ERROR )
                         {
                             if( hr == SEMAPHORE_TIMEOUT_ERROR )


### PR DESCRIPTION
fix #7129 
tracked on [DSO-17181]