### PR TITLE
Fix a x86_64 processor test in 'color-formats-converter.cpp'.

### DIFF
--- a/src/proc/color-formats-converter.cpp
+++ b/src/proc/color-formats-converter.cpp
@@ -18,7 +18,7 @@
 #include <tmmintrin.h> // For SSSE3 intrinsics
 #endif
 
-#if defined (ANDROID) || (defined (__linux__) && !defined (__x86_64__))
+#if defined (ANDROID) || !(defined (_M_IX64) || defined (__x86_64__))
 
 bool has_avx() { return false; }
 


### PR DESCRIPTION
We have added librealsense to Conan package manager which is similar to vcpkg. Compiling librealsense for Apple M1 processor on CI revealed the following compilation error.

AVX should only be used on x86_64 processors. On Apple M1 platform the `#if` evaluates false here since `ANDROID` and `__linux__` are not defined resulting in invalid `cpuid` call.

Replacement '#if' should properly test for x86_64 processor architecture on GCC, Clang and MSVC.