### PR TITLE
Fix UCAL inconsistencies

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -5723,9 +5723,10 @@ namespace rs2
                     something_to_show = true;
 
                     std::string device_pid = sub->s->supports(RS2_CAMERA_INFO_PRODUCT_ID) ? sub->s->get_info(RS2_CAMERA_INFO_PRODUCT_ID) : "unknown";
-                    const uint16_t RS410_PID = 0x0ad2; // ASR
-                    const uint16_t RS415_PID = 0x0ad3; // ASRC
-                    bool show_disclaimer = val_in_range(device_pid, { std::string("0AD2"), std::string("0AD3") });
+                    std::string device_usb_type = sub->s->supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR) ? sub->s->get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR) : "unknown";
+
+                    bool show_disclaimer = val_in_range(device_pid, { std::string("0AD2"), std::string("0AD3") }); // Specific for D410/5
+                    bool disable_fl_cal = ((device_pid == "0B5C") && (!starts_with(device_usb_type, "3."))); // D455@USB2
 
                     if (ImGui::Selectable("On-Chip Calibration"))
                     {
@@ -5770,33 +5771,41 @@ namespace rs2
                     {
                         try
                         {
-                            std::shared_ptr< subdevice_model> sub_color;
-                            for (auto&& sub2 : subdevices)
+                            if (disable_fl_cal)
                             {
-                                if (sub2->s->is<rs2::color_sensor>())
+                                auto disable_fl_notice = std::make_shared<fl_cal_limitation_model>();
+                                viewer.not_model->add_notification(disable_fl_notice);
+                            }
+                            else
+                            {
+                                std::shared_ptr< subdevice_model> sub_color;
+                                for (auto&& sub2 : subdevices)
                                 {
-                                    sub_color = sub2;
-                                    break;
+                                    if (sub2->s->is<rs2::color_sensor>())
+                                    {
+                                        sub_color = sub2;
+                                        break;
+                                    }
                                 }
+
+                                if (show_disclaimer)
+                                {
+                                    auto disclaimer_notice = std::make_shared<ucal_disclaimer_model>();
+                                    viewer.not_model->add_notification(disclaimer_notice);
+                                }
+                                auto manager = std::make_shared<on_chip_calib_manager>(viewer, sub, *this, dev, sub_color);
+                                auto n = std::make_shared<autocalib_notification_model>("", manager, false);
+                                viewer.not_model->add_notification(n);
+                                n->forced = true;
+                                n->update_state = autocalib_notification_model::RS2_CALIB_STATE_FL_INPUT;
+
+                                for (auto&& n : related_notifications)
+                                    if (dynamic_cast<autocalib_notification_model*>(n.get()))
+                                        n->dismiss(false);
+
+                                related_notifications.push_back(n);
+                                manager->start_fl_viewer();
                             }
-
-                            if (show_disclaimer)
-                            {
-                                auto disclaimer_notice = std::make_shared<ucal_disclaimer_model>();
-                                viewer.not_model->add_notification(disclaimer_notice);
-                            }
-                            auto manager = std::make_shared<on_chip_calib_manager>(viewer, sub, *this, dev, sub_color);
-                            auto n = std::make_shared<autocalib_notification_model>("", manager, false);
-                            viewer.not_model->add_notification(n);
-                            n->forced = true;
-                            n->update_state = autocalib_notification_model::RS2_CALIB_STATE_FL_INPUT;
-
-                            for (auto&& n : related_notifications)
-                                if (dynamic_cast<autocalib_notification_model*>(n.get()))
-                                    n->dismiss(false);
-
-                            related_notifications.push_back(n);
-                            manager->start_fl_viewer();
                         }
                         catch (const error& e)
                         {

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2034,10 +2034,10 @@ namespace rs2
                             break;
                         }
                     }
-                }                
+                }
             }
         }
-        return is_cal_format;   
+        return is_cal_format;
     }
 
     std::pair<int, int> subdevice_model::get_max_resolution(rs2_stream stream) const

--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -5726,7 +5726,8 @@ namespace rs2
                     std::string device_usb_type = sub->s->supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR) ? sub->s->get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR) : "unknown";
 
                     bool show_disclaimer = val_in_range(device_pid, { std::string("0AD2"), std::string("0AD3") }); // Specific for D410/5
-                    bool disable_fl_cal = ((device_pid == "0B5C") && (!starts_with(device_usb_type, "3."))); // D455@USB2
+                    bool disable_fl_cal = (((device_pid == "0B5C") || show_disclaimer) &&
+                                            (!starts_with(device_usb_type, "3."))); // D410/D15/D455@USB2
 
                     if (ImGui::Selectable("On-Chip Calibration"))
                     {

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -1177,4 +1177,33 @@ namespace rs2
         hyperlink(win, "Errata", "https://dev.intelrealsense.com/docs/firmware-releases");
 
     }
+
+    fl_cal_limitation_model::fl_cal_limitation_model()
+        : notification_model()
+    {
+        enable_expand = false;
+        enable_dismiss = true;
+        enable_complex_dismiss = false;
+        pinned = false;
+        message = "Focal Length Calibration for D455\n"
+            " requires USB3 connection.\n"
+            "Please switch the connection port and rerun";
+    }
+
+    void fl_cal_limitation_model::draw_content(ux_window& win, int x, int y, float t, std::string& error_message)
+    {
+        ImGui::SetCursorScreenPos({ float(x + 9), float(y + 4) });
+
+        ImGui::GetWindowDrawList()->AddRectFilled({ float(x), float(y) },
+            { float(x + width), float(y + 25) }, ImColor(grey));
+
+        ImGui::Text("User Notification");
+
+        ImGui::SetCursorScreenPos({ float(x + 5), float(y + 25) });
+        ImGui::GetWindowDrawList()->AddRectFilled({ float(x+2), float(y+27) },
+            { float(x + width), float(y + 79) }, ImColor(orange));
+        ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
+        draw_text(get_title().c_str(), x, y, height - 50);
+        ImGui::PopStyleColor();
+    }
 }

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -1152,8 +1152,7 @@ namespace rs2
         enable_dismiss = true;
         enable_complex_dismiss = true; // Allow to inhibit the disclaimer
         pinned = false;
-        message = "Please refer to\n"
-            "and                 for D415 consideration\n"; // whitespaces used as a placeholder for hyperlink insertion
+
     }
 
     void ucal_disclaimer_model::draw_content(ux_window& win, int x, int y, float t, std::string& error_message)
@@ -1164,17 +1163,16 @@ namespace rs2
             { float(x + width), float(y + 25) }, ImColor(orange));
 
         ImGui::Text("Self-Calibration - Disclaimer");
-
         ImGui::SetCursorScreenPos({ float(x + 5), float(y + 27) });
-
         ImGui::PushStyleColor(ImGuiCol_Text, light_grey);
-        draw_text(get_title().c_str(), x, y, height - 50);
+        std::string message = "For D415 please refer to the links for details:";
+        draw_text(message.c_str(), x, y, 30);
         ImGui::PopStyleColor();
 
-        ImGui::SetCursorScreenPos({ float(x + 100), float(y + 27) });
-        hyperlink(win, "Self Calibration Whitepaper", "https://dev.intelrealsense.com/docs/self-calibration-for-depth-cameras");
-        ImGui::SetCursorScreenPos({ float(x + 35), float(y + 43) });
-        hyperlink(win, "Errata", "https://dev.intelrealsense.com/docs/firmware-releases");
+        ImGui::SetCursorScreenPos({ float(x + 10), float(y + 47) });
+        hyperlink(win, "1. Self-Calibration Whitepaper", "https://dev.intelrealsense.com/docs/self-calibration-for-depth-cameras");
+        ImGui::SetCursorScreenPos({ float(x + 10), float(y + 67) });
+        hyperlink(win, "2. Firmware Releases / Errata", "https://dev.intelrealsense.com/docs/firmware-releases");
 
     }
 
@@ -1185,7 +1183,7 @@ namespace rs2
         enable_dismiss = true;
         enable_complex_dismiss = false;
         pinned = false;
-        message = "Focal Length Calibration for D455\n"
+        message = "Focal-Length Calibration for this device\n"
             " requires USB3 connection.\n"
             "Please switch the connection port and rerun";
     }

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -273,6 +273,15 @@ namespace rs2
         int get_max_lifetime_ms() const override { return 15000; }
     };
 
+    struct fl_cal_limitation_model : public notification_model
+    {
+        fl_cal_limitation_model();
+
+        void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
+        int calc_height() override { return 100; }
+        int get_max_lifetime_ms() const override { return 10000; }
+    };
+
     class export_manager : public process_manager
     {
     public:

--- a/common/notifications.h
+++ b/common/notifications.h
@@ -269,7 +269,7 @@ namespace rs2
         ucal_disclaimer_model();
 
         void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;
-        int calc_height() override { return 100; }
+        int calc_height() override { return 110; }
         int get_max_lifetime_ms() const override { return 15000; }
     };
 

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -136,8 +136,9 @@ namespace rs2
         try
         {
             auto profiles = _sub->get_selected_profiles();
-            _sub->stop(_viewer.not_model);
-            if (_sub_color.get())
+            if (_sub->streaming)
+                _sub->stop(_viewer.not_model);
+            if (_sub_color.get() && _sub_color->streaming)
                 _sub_color->stop(_viewer.not_model);
 
             // Wait until frames from all active profiles stop arriving
@@ -260,7 +261,7 @@ namespace rs2
             // Select FPS value
             for (int i = 0; i < _sub->shared_fps_values.size(); i++)
             {
-                if (_sub->shared_fps_values[i] == 30)
+                if (_sub->shared_fps_values[i] == 6)
                     _sub->ui.selected_shared_fps_id = i;
             }
 
@@ -409,7 +410,7 @@ namespace rs2
                 _sub->s->set_option(RS2_OPTION_THERMAL_COMPENSATION, 0.f);
             }
 
-            bool run_fl_calib = ( (action == RS2_CALIB_ACTION_FL_CALIB) && (w == 1280) && (h == 720) && (fps == 30));
+            bool run_fl_calib = ( (action == RS2_CALIB_ACTION_FL_CALIB) && (w == 1280) && (h == 720));
             if (action == RS2_CALIB_ACTION_TARE_GROUND_TRUTH)
             {
                 _uid = 1;
@@ -901,6 +902,7 @@ namespace rs2
     {
         try
         {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // W/A that allows for USB2 exposure to settle
             constexpr int frames_required = 25;
 
             rs2::frame_queue left(frames_required,true);
@@ -1089,12 +1091,20 @@ namespace rs2
 
         _restored = false;
 
+        auto fps = 30;
+        if (_sub->dev.supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
+        {
+            std::string desc = _sub->dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
+            if (!starts_with(desc, "3."))
+                fps = 6; //USB2 bandwidth limitation for 720P RGB/DI
+        }
+
         if (action != RS2_CALIB_ACTION_TARE_GROUND_TRUTH && action != RS2_CALIB_ACTION_UVMAPPING_CALIB)
         {
             if (!_was_streaming)
             {
                 if (action == RS2_CALIB_ACTION_FL_CALIB)
-                    try_start_viewer(848, 480, 30, invoke);
+                    try_start_viewer(848, 480, fps, invoke);
                 else
                     try_start_viewer(0, 0, 0, invoke);
             }
@@ -1116,13 +1126,6 @@ namespace rs2
         if (action == RS2_CALIB_ACTION_FL_CALIB || action == RS2_CALIB_ACTION_UVMAPPING_CALIB)
             _viewer.is_3d_view = false;
 
-        auto fps = 30;
-        if (_sub->dev.supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
-        {
-            std::string desc = _sub->dev.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
-            if (!starts_with(desc, "3."))
-                fps = 5; //USB2 bandwidth limitation for 720P RGB/DI
-        }
 
         if (action == RS2_CALIB_ACTION_FL_CALIB || action == RS2_CALIB_ACTION_TARE_GROUND_TRUTH || action == RS2_CALIB_ACTION_UVMAPPING_CALIB)
             try_start_viewer(1280, 720, fps, invoke);

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -195,6 +195,7 @@ namespace rs2
             _sub->ui.selected_format_id.clear();
             _sub->ui.selected_format_id[_uid] = 0;
 
+            _sub->ui.selected_shared_fps_id = 0; // For Ground Truth default is the lowest common FPS for USB2/# compatibility
             // Select FPS value
             for (int i = 0; i < _sub->shared_fps_values.size(); i++)
             {
@@ -261,7 +262,7 @@ namespace rs2
             // Select FPS value
             for (int i = 0; i < _sub->shared_fps_values.size(); i++)
             {
-                if (_sub->shared_fps_values[i] == 6)
+                if (val_in_range(_sub->shared_fps_values[i], {5,6}))
                     _sub->ui.selected_shared_fps_id = i;
             }
 


### PR DESCRIPTION
Viewer-specific fixes and refinements:
- Enable preview with ROI for GT after HW reset event
- Improve FL robustness in USB2 mode by adding more time for camera's exposure to settle
-  Add blocking notification when invoking FL-Calib for D455 at USB2 mode.
Tracked on : DSO-17819, DSO-17820