### PR TITLE
Adding condition for M1 Mac to color-formats-converter has_avx check

### DIFF
--- a/src/proc/color-formats-converter.cpp
+++ b/src/proc/color-formats-converter.cpp
@@ -18,7 +18,7 @@
 #include <tmmintrin.h> // For SSSE3 intrinsics
 #endif
 
-#if defined (ANDROID) || (defined (__linux__) && !defined (__x86_64__))
+#if defined (ANDROID) || (defined (__linux__) && !defined (__x86_64__)) || ((defined(__arm64__) && defined(__APPLE__)) || defined(__aarch64__))
 
 bool has_avx() { return false; }
 


### PR DESCRIPTION
Without this condition, it tries to include cpuid.h, which is x86 only, so was stopping the build on M1 Mac.