### PR TITLE
Concurrency improvements

### DIFF
--- a/common/utilities/time/waiting-on.h
+++ b/common/utilities/time/waiting-on.h
@@ -30,15 +30,24 @@ public:
     class wait_state_t
     {
         T _value;
-        std::condition_variable _cv;
+        std::condition_variable &_cv;
+        std::mutex &_m;
         std::atomic_bool _valid{ true };
         std::mutex _m;
         friend class waiting_on;
 
     public:
-        wait_state_t() = default;   // allow default ctor
-        wait_state_t( T const & t )
-            : _value( t )
+        wait_state_t() = delete; // Do not allow default Ctor, we need the user's CV and Mutex
+        wait_state_t( std::condition_variable & cv, std::mutex & m )
+            : _cv( cv )
+            , _m( m )
+        {
+        }
+
+        wait_state_t( std::condition_variable &cv, std::mutex &m, T const & t )
+            : _cv( cv )
+            , _m( m )
+            , _value( t )
         {
         }
 
@@ -115,12 +124,12 @@ public:
     };
 
 public:
-    waiting_on()
-        : _ptr( std::make_shared< wait_state_t >() )
+    waiting_on( std::condition_variable & cv, std::mutex & m )
+        : _ptr( std::make_shared< wait_state_t >( cv, m ) )
     {
     }
-    waiting_on( T const & value )
-        : _ptr( std::make_shared< wait_state_t >( value ) )
+    waiting_on( std::condition_variable & cv, std::mutex & m, T const & value )
+        : _ptr( std::make_shared< wait_state_t >( cv, m, value ) )
     {
     }
 

--- a/common/utilities/time/waiting-on.h
+++ b/common/utilities/time/waiting-on.h
@@ -16,11 +16,12 @@ namespace time {
 // it and signal when we can continue...
 // 
 // In order to synchronize the users predicate, we expect the user to provide his conditional variable and mutex used to set the predicate.
-// As mentioned at the conditional variable documentation:
+// As mentioned at the conditional variable documentation: (https://en.cppreference.com/w/cpp/thread/condition_variable)
 //     The thread that intends to modify the shared variable has to
-//      1 .acquire a std::mutex(typically via std::lock_guard)
+//      1. acquire a std::mutex(typically via std::lock_guard)
 //      2. perform the modification while the lock is held
 //      3. execute notify_one or notify_all on the std::condition_variable(the lock does not need to be held for notification)
+// For more detailed information see https://www.modernescpp.com/index.php/c-core-guidelines-be-aware-of-the-traps-of-condition-variables
 template< class T >
 class waiting_on
 {

--- a/common/utilities/time/waiting-on.h
+++ b/common/utilities/time/waiting-on.h
@@ -15,10 +15,12 @@ namespace time {
 // Helper class -- encapsulate a variable of type T that we want to wait on: another thread will set
 // it and signal when we can continue...
 // 
-// We use the least amount of synchronization mechanisms: no effort is made to synchronize (usually,
-// it's not needed: only one thread will be writing to T, and the owner of T will be waiting on it)
-// so it's the responsibility of the user to do so if needed.
-//
+// In order to synchronize the users predicate, we expect the user to provide his conditional variable and mutex used to set the predicate.
+// As mentioned at the conditional variable documentation:
+//     The thread that intends to modify the shared variable has to
+//      1 .acquire a std::mutex(typically via std::lock_guard)
+//      2. perform the modification while the lock is held
+//      3. execute notify_one or notify_all on the std::condition_variable(the lock does not need to be held for notification)
 template< class T >
 class waiting_on
 {

--- a/common/utilities/time/waiting-on.h
+++ b/common/utilities/time/waiting-on.h
@@ -35,7 +35,6 @@ public:
         std::condition_variable &_cv;
         std::mutex &_m;
         std::atomic_bool _valid{ true };
-        std::mutex _m;
         friend class waiting_on;
 
     public:

--- a/src/concurrency.h
+++ b/src/concurrency.h
@@ -376,7 +376,7 @@ public:
     // Return when all items in the queue are finished (within a timeout).
     // If additional items are added while we're waiting, those will not be waited on!
     //
-    bool flush();
+    bool flush(std::chrono::steady_clock::duration timeout = std::chrono::seconds(10) );
 
 
 private:

--- a/unit-tests/LRS_linux_compile_pipeline.stats
+++ b/unit-tests/LRS_linux_compile_pipeline.stats
@@ -1,2 +1,2 @@
-warnings 14
+warnings 15
 

--- a/unit-tests/LRS_linux_compile_pipeline.stats
+++ b/unit-tests/LRS_linux_compile_pipeline.stats
@@ -1,2 +1,2 @@
-warnings 15
+warnings 14
 

--- a/unit-tests/utilities/concurrency/test-dispatcher.cpp
+++ b/unit-tests/utilities/concurrency/test-dispatcher.cpp
@@ -105,7 +105,7 @@ TEST_CASE("stop() notify flush to finish")
     dispatcher.start();
 
     stopwatch sw;
-    std::atomic_bool dispatched_end_verifier = false;
+    std::atomic_bool dispatched_end_verifier{ false };
     dispatcher.invoke( [&]( dispatcher::cancellable_timer c ) {
         std::cout << "Sleeping from inside invoke" << std::endl;
         std::this_thread::sleep_for( std::chrono::seconds( 5 ) );

--- a/unit-tests/utilities/concurrency/test-dispatcher.cpp
+++ b/unit-tests/utilities/concurrency/test-dispatcher.cpp
@@ -100,7 +100,7 @@ TEST_CASE("verify stop() not consuming high CPU usage")
 TEST_CASE("stop() notify flush to finish")
 {
     // On this test we check that if during a flush() another thread call stop(),
-    // than the flush CV we be triggered to exit and not wait a full 10 [sec] timeout
+    // than the flush CV will be triggered to exit and not wait a full timeout
     dispatcher dispatcher( 10 );
     dispatcher.start();
 

--- a/unit-tests/utilities/concurrency/test-dispatcher.cpp
+++ b/unit-tests/utilities/concurrency/test-dispatcher.cpp
@@ -58,7 +58,7 @@ TEST_CASE( "invoke and wait" )
     d.start();
     stopwatch sw;
     d.invoke_and_wait(func, []() {return false; }, true);
-    REQUIRE(sw.get_elapsed_ms() > 3000); // verify we get here only after the function call ended
+    REQUIRE( sw.get_elapsed() > std::chrono::seconds( 3 ) ); // verify we get here only after the function call ended
     d.stop();
 }
 
@@ -94,7 +94,7 @@ TEST_CASE("verify stop() not consuming high CPU usage")
     // We had an issue that stop() call cause a high CPU usage and therefore other operations stall, 
     // This test took > 9 seconds on an 8 cores PC, after the fix it took ~1.5 sec on 1 core run (on release configuration).
     // We allow 9 seconds to support debug configuration as well
-    REQUIRE(sw.get_elapsed_ms() < 9000);
+    REQUIRE( sw.get_elapsed() < std::chrono::seconds( 9 ) );
 }
 
 TEST_CASE("stop() notify flush to finish")
@@ -108,7 +108,7 @@ TEST_CASE("stop() notify flush to finish")
     std::atomic_bool dispatched_end_verifier{ false };
     dispatcher.invoke( [&]( dispatcher::cancellable_timer c ) {
         //std::cout << "Sleeping from inside invoke" << std::endl;
-        std::this_thread::sleep_for( std::chrono::seconds( 5 ) );
+        std::this_thread::sleep_for( std::chrono::seconds( 3 ) );
         //std::cout << "Sleeping from inside invoke - Done" << std::endl;
         dispatched_end_verifier = true;
     } );
@@ -116,20 +116,19 @@ TEST_CASE("stop() notify flush to finish")
     // Make sure the above invoke function is dispatched
     std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
 
-    std::thread t( [&]() {
+    std::thread stop_thread( [&]() {
         // Make sure we postpone the stop to after the flush call
         std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
         //std::cout << "Stopping dispatcher" << std::endl;
         dispatcher.stop();
     } );
 
-    auto timeout = std::chrono::seconds(10);
-    auto timeout_ms = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(timeout).count();
+    auto timeout = std::chrono::seconds(5);
     //std::cout << "Flushing dispatcher" << std::endl;
-    dispatcher.flush(timeout);
+    CHECK(!dispatcher.flush(timeout));
     // We expect that flush will be triggered by stop only after the dispatched function end.
     CHECK(dispatched_end_verifier);
     //std::cout << "Flushing is done" << std::endl;
-    CHECK( sw.get_elapsed_ms() < timeout_ms);
-    t.join();
+    CHECK( sw.get_elapsed() < timeout );
+    stop_thread.join();
 }

--- a/unit-tests/utilities/concurrency/test-dispatcher.cpp
+++ b/unit-tests/utilities/concurrency/test-dispatcher.cpp
@@ -107,9 +107,9 @@ TEST_CASE("stop() notify flush to finish")
     stopwatch sw;
     std::atomic_bool dispatched_end_verifier{ false };
     dispatcher.invoke( [&]( dispatcher::cancellable_timer c ) {
-        std::cout << "Sleeping from inside invoke" << std::endl;
+        //std::cout << "Sleeping from inside invoke" << std::endl;
         std::this_thread::sleep_for( std::chrono::seconds( 5 ) );
-        std::cout << "Sleeping from inside invoke - Done" << std::endl;
+        //std::cout << "Sleeping from inside invoke - Done" << std::endl;
         dispatched_end_verifier = true;
     } );
 
@@ -119,16 +119,17 @@ TEST_CASE("stop() notify flush to finish")
     std::thread t( [&]() {
         // Make sure we postpone the stop to after the flush call
         std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
-        std::cout << "Stopping dispatcher" << std::endl;
+        //std::cout << "Stopping dispatcher" << std::endl;
         dispatcher.stop();
     } );
 
     auto timeout = std::chrono::seconds(10);
     auto timeout_ms = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(timeout).count();
-    std::cout << "Flushing dispatcher" << std::endl;
+    //std::cout << "Flushing dispatcher" << std::endl;
     dispatcher.flush(timeout);
+    // We expect that flush will be triggered by stop only after the dispatched function end.
     CHECK(dispatched_end_verifier);
-    std::cout << "Flushing is done" << std::endl;
+    //std::cout << "Flushing is done" << std::endl;
     CHECK( sw.get_elapsed_ms() < timeout_ms);
     t.join();
 }

--- a/unit-tests/utilities/time/test-waiting-on.cpp
+++ b/unit-tests/utilities/time/test-waiting-on.cpp
@@ -3,16 +3,18 @@
 
 #include <unit-tests/catch.h>
 #include <common/utilities/time/waiting-on.h>
+#include <common/utilities/time/timer.h>
 #include <queue>
 
 using utilities::time::waiting_on;
+using namespace utilities::time;
 
 bool invoke( size_t delay_in_thread, size_t timeout )
 {
     std::condition_variable cv;
     std::mutex m;
     waiting_on< bool > invoked( cv, m, false );
-    
+
     auto invoked_in_thread = invoked.in_thread();
     auto lambda = [delay_in_thread, invoked_in_thread]() {
         // std::cout << "In thread" << std::endl;
@@ -20,13 +22,11 @@ bool invoke( size_t delay_in_thread, size_t timeout )
         // std::cout << "Signalling" << std::endl;
         invoked_in_thread.signal( true );
     };
-    //std::cout << "Starting thread" << std::endl;
+    // std::cout << "Starting thread" << std::endl;
     std::thread( lambda ).detach();
-    //std::cout << "Waiting" << std::endl;
-    invoked.wait_until( std::chrono::seconds( timeout ), [&]() {
-        return invoked;
-        } );
-    //std::cout << "After wait" << std::endl;
+    // std::cout << "Waiting" << std::endl;
+    invoked.wait_until( std::chrono::seconds( timeout ), [&]() { return invoked; } );
+    // std::cout << "After wait" << std::endl;
     return invoked;
 }
 
@@ -37,7 +37,7 @@ TEST_CASE( "Basic wait" )
 
 TEST_CASE( "Timeout" )
 {
-    REQUIRE( ! invoke( 10 /* seconds in thread */, 1 /* timeout */ ));
+    REQUIRE( ! invoke( 10 /* seconds in thread */, 1 /* timeout */ ) );
 }
 
 TEST_CASE( "Struct usage" )
@@ -50,7 +50,7 @@ TEST_CASE( "Struct usage" )
 
     std::condition_variable cv;
     std::mutex m;
-    waiting_on< value_t > output (cv, m);
+    waiting_on< value_t > output( cv, m );
     output->d = 2.;
 
     auto output_ = output.in_thread();
@@ -60,26 +60,24 @@ TEST_CASE( "Struct usage" )
         while( output->i < 30 )
         {
             std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
-            std::lock_guard<std::mutex> lock(m);
+            std::lock_guard< std::mutex > lock( m );
             ++output->i;
             output.signal();
         }
     } ).detach();
 
     // Within a second, i should reach ~20, but we'll ask it top stop when it reaches 10
-    output.wait_until( std::chrono::seconds( 1 ), [&]() {
-        return output->i == 10;
-        } );
+    output.wait_until( std::chrono::seconds( 1 ), [&]() { return output->i == 10; } );
 
     auto i1 = output->i.load();
-    CHECK( i1 >= 10 ); // the thread is still running!
+    CHECK( i1 >= 10 );  // the thread is still running!
     CHECK( i1 < 16 );
-    //std::cout << "i1= " << i1 << std::endl;
+    // std::cout << "i1= " << i1 << std::endl;
 
     std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
     auto i2 = output->i.load();
-    CHECK( i2 > i1 ); // the thread is still running!
-    //std::cout << "i2= " << i2 << std::endl;
+    CHECK( i2 > i1 );  // the thread is still running!
+    // std::cout << "i2= " << i2 << std::endl;
 
     // Wait until it's done, ~30x50ms = 1.5 seconds total
     REQUIRE( output->i < 30 );
@@ -87,10 +85,10 @@ TEST_CASE( "Struct usage" )
     REQUIRE( output->i == 30 );
 }
 
-TEST_CASE("Not invoked but still notified by destructor")
+TEST_CASE( "Not invoked but still notified by destructor" )
 {
     // Emulate some dispatcher
-    typedef std::function< void () > func;
+    typedef std::function< void() > func;
     auto dispatcher = new std::queue< func >;
 
     // Push some stuff onto it (not important what)
@@ -101,26 +99,24 @@ TEST_CASE("Not invoked but still notified by destructor")
     // Add something we'll be waiting on
     std::condition_variable cv;
     std::mutex m;
-    utilities::time::waiting_on< bool > invoked(cv, m, false);
-    dispatcher->push([invoked_in_thread = invoked.in_thread()]() { invoked_in_thread.signal(true); });
+    utilities::time::waiting_on< bool > invoked( cv, m, false );
+    dispatcher->push(
+        [invoked_in_thread = invoked.in_thread()]() { invoked_in_thread.signal( true ); } );
 
     // Destroy the dispatcher while we're waiting on the invocation!
-    std::thread([&]() {
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::thread( [&]() {
+        std::this_thread::sleep_for( std::chrono::seconds( 2 ) );
         delete dispatcher;
-        }).detach();
+    } ).detach();
 
-        // Wait for it -- we'd expect that, when 'invoked_in_thread' is destroyed, it'll wake us up and
-        // not wait for the timeout
-        auto wait_start = std::chrono::high_resolution_clock::now();
-        invoked.wait_until(std::chrono::seconds(5), [&]() {
-            return invoked;
-            });
-        auto wait_end = std::chrono::high_resolution_clock::now();
-        auto waited_ms = std::chrono::duration_cast<std::chrono::milliseconds>(wait_end - wait_start).count();
+    // Wait for it -- we'd expect that, when 'invoked_in_thread' is destroyed, it'll wake us up and
+    // not wait for the timeout
+    stopwatch sw;
+    invoked.wait_until( std::chrono::seconds( 5 ), [&]() { return invoked; } );
+    auto waited = sw.get_elapsed();
 
-        REQUIRE(waited_ms > 1990);
-        REQUIRE(waited_ms < 3000);    // Up to a second buffer
+    REQUIRE( waited > std::chrono::milliseconds( 1990 ) );
+    REQUIRE( waited < std::chrono::milliseconds( 3000 ) );  // Up to a second buffer
 }
 
 TEST_CASE( "Not invoked but still notified by predicate (stopped)" )
@@ -133,48 +129,37 @@ TEST_CASE( "Not invoked but still notified by predicate (stopped)" )
     // Destroy the dispatcher while we're waiting on the invocation!
     std::atomic_bool stopped( false );
     std::thread( [&]() {
-        std::this_thread::sleep_for( std::chrono::seconds( 2 ));
-        std::lock_guard<std::mutex> lock(m);
+        std::this_thread::sleep_for( std::chrono::seconds( 2 ) );
+        std::lock_guard< std::mutex > lock( m );
         stopped = true;
         cv.notify_all();
-        } ).detach();
+    } ).detach();
 
     // When 'stopped' is turned on , it'll wake us up and not wait for the timeout
+    stopwatch sw;
     auto wait_start = std::chrono::high_resolution_clock::now();
     invoked.wait_until( std::chrono::seconds( 5 ), [&]() {
         return invoked || stopped;  // Without stopped, invoked will be false and we'll wait again
                                     // even after we're signalled!
-        } );
+    } );
     auto wait_end = std::chrono::high_resolution_clock::now();
-    auto waited_ms = std::chrono::duration_cast<std::chrono::milliseconds>( wait_end - wait_start ).count();
+    auto waited = sw.get_elapsed();
 
-    REQUIRE( waited_ms > 1990 );
-    REQUIRE( waited_ms < 3000 );    // Up to a second buffer
+    REQUIRE( waited > std::chrono::milliseconds( 1990 ) );
+    REQUIRE( waited < std::chrono::milliseconds( 3000 ) );  // Up to a second buffer
 }
 
-TEST_CASE("Not invoked flush timeout expected")
+TEST_CASE( "Not invoked flush timeout expected" )
 {
-    // Emulate some dispatcher
-    typedef std::function< void() > func;
-    auto dispatcher = new std::queue< func >;
-
-    // Push some stuff onto it (not important what)
-    int i = 0;
-    dispatcher->push([&]() { ++i; });
-    dispatcher->push([&]() { ++i; });
-
     // Add something we'll be waiting on
     std::condition_variable cv;
     std::mutex m;
-    utilities::time::waiting_on< bool > invoked(cv, m, false);
-    dispatcher->push([invoked_in_thread = invoked.in_thread()]() { invoked_in_thread.signal(true); });
+    utilities::time::waiting_on< bool > invoked( cv, m, false );
 
-    auto wait_start = std::chrono::high_resolution_clock::now();
-    invoked.wait_until( std::chrono::seconds( 5 ), [&]() { return invoked; } );
-    auto wait_end = std::chrono::high_resolution_clock::now();
-    auto waited_ms
-        = std::chrono::duration_cast< std::chrono::milliseconds >( wait_end - wait_start ).count();
+    stopwatch sw;
+    auto timeout = std::chrono::seconds( 2 );
+    invoked.wait_until( timeout, [&]() { return invoked; } );
+    auto wait_time = sw.get_elapsed();
 
-    REQUIRE( waited_ms >= 5000 );
+    REQUIRE( wait_time >= timeout );
 }
-

--- a/unit-tests/utilities/time/test-waiting-on.cpp
+++ b/unit-tests/utilities/time/test-waiting-on.cpp
@@ -87,22 +87,12 @@ TEST_CASE( "Struct usage" )
     REQUIRE( output->i == 30 );
 }
 
-TEST_CASE( "Not invoked but still notified" )
+TEST_CASE( "Not invoked but still notified by predicate (stopped)" )
 {
-    // Emulate some dispatcher
-    typedef std::function< void () > func;
-    auto dispatcher = new std::queue< func >;
-
-    // Push some stuff onto it (not important what)
-    int i = 0;
-    dispatcher->push( [&]() { ++i; } );
-    dispatcher->push( [&]() { ++i; } );
-    
     // Add something we'll be waiting on
     std::condition_variable cv;
     std::mutex m;
     utilities::time::waiting_on< bool > invoked( cv, m, false );
-    dispatcher->push( [invoked_in_thread = invoked.in_thread()]() { invoked_in_thread.signal( true ); } );
 
     // Destroy the dispatcher while we're waiting on the invocation!
     std::atomic_bool stopped( false );
@@ -110,11 +100,10 @@ TEST_CASE( "Not invoked but still notified" )
         std::this_thread::sleep_for( std::chrono::seconds( 2 ));
         std::lock_guard<std::mutex> lock(m);
         stopped = true;
-        delete dispatcher;
+        cv.notify_all();
         } ).detach();
 
-    // Wait for it -- we'd expect that, when 'invoked_in_thread' is destroyed, it'll wake us up and
-    // not wait for the timeout
+    // When 'stopped' is turned on , it'll wake us up and not wait for the timeout
     auto wait_start = std::chrono::high_resolution_clock::now();
     invoked.wait_until( std::chrono::seconds( 5 ), [&]() {
         return invoked || stopped;  // Without stopped, invoked will be false and we'll wait again
@@ -126,3 +115,66 @@ TEST_CASE( "Not invoked but still notified" )
     REQUIRE( waited_ms > 1990 );
     REQUIRE( waited_ms < 3000 );    // Up to a second buffer
 }
+
+TEST_CASE("Not invoked but still notified by destructor")
+{
+    // Emulate some dispatcher
+    typedef std::function< void() > func;
+    auto dispatcher = new std::queue< func >;
+
+    // Push some stuff onto it (not important what)
+    int i = 0;
+    dispatcher->push([&]() { ++i; });
+    dispatcher->push([&]() { ++i; });
+
+    // Add something we'll be waiting on
+    std::condition_variable cv;
+    std::mutex m;
+    utilities::time::waiting_on< bool > invoked(cv, m, false);
+    dispatcher->push([invoked_in_thread = invoked.in_thread()]() { invoked_in_thread.signal(true); });
+
+    // Destroy the dispatcher while we're waiting on the invocation!
+    std::thread([&]() {
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        delete dispatcher;
+        }).detach();
+
+        // Wait for it -- we'd expect that, when 'invoked_in_thread' is destroyed, it'll wake us up and
+        // not wait for the timeout
+        auto wait_start = std::chrono::high_resolution_clock::now();
+        invoked.wait_until(std::chrono::seconds(5), [&]() {
+            return invoked;
+            });
+        auto wait_end = std::chrono::high_resolution_clock::now();
+        auto waited_ms = std::chrono::duration_cast<std::chrono::milliseconds>(wait_end - wait_start).count();
+
+        REQUIRE(waited_ms > 1990);
+        REQUIRE(waited_ms < 3000);    // Up to a second buffer
+}
+
+TEST_CASE("Not invoked flush timeout expected")
+{
+    // Emulate some dispatcher
+    typedef std::function< void() > func;
+    auto dispatcher = new std::queue< func >;
+
+    // Push some stuff onto it (not important what)
+    int i = 0;
+    dispatcher->push([&]() { ++i; });
+    dispatcher->push([&]() { ++i; });
+
+    // Add something we'll be waiting on
+    std::condition_variable cv;
+    std::mutex m;
+    utilities::time::waiting_on< bool > invoked(cv, m, false);
+    dispatcher->push([invoked_in_thread = invoked.in_thread()]() { invoked_in_thread.signal(true); });
+
+    auto wait_start = std::chrono::high_resolution_clock::now();
+    invoked.wait_until( std::chrono::seconds( 5 ), [&]() { return invoked; } );
+    auto wait_end = std::chrono::high_resolution_clock::now();
+    auto waited_ms
+        = std::chrono::duration_cast< std::chrono::milliseconds >( wait_end - wait_start ).count();
+
+    REQUIRE( waited_ms >= 5000 );
+}
+


### PR DESCRIPTION
Improve `dispatcher::flush()` and `waiting_on<>` so that the stopped mutex/cv are used -- otherwise the stopped signal may not stop the wait and we get a timeout.

Tracked on [LRS-329]