### PR TITLE
Static build fix

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -44,7 +44,7 @@ jobs:
         cd build
         pwd
         ls        
-        cmake .. -G "Visual Studio 16 2019" -DPYTHON_EXECUTABLE=${{env.PYTHON_PATH}} -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.8 -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DFORCE_RSUSB_BACKEND=true
+        cmake .. -G "Visual Studio 16 2019" -DPYTHON_EXECUTABLE=${{env.PYTHON_PATH}} -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.8 -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DFORCE_RSUSB_BACKEND=true -DBUILD_DDS_BACKEND=true
 
     - name: Build
       # Build your program with the given configuration
@@ -185,7 +185,7 @@ jobs:
       shell: bash
       run: | 
         cd build
-        cmake .. -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true
+        cmake .. -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true -DBUILD_DDS_BACKEND=true
         cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4
         
     - name: Test
@@ -240,7 +240,7 @@ jobs:
           cd scripts && ./api_check.sh && cd ..
           mkdir build
           cd ./scripts && ./pr_check.sh && cd ../build
-          cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5
+          cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5 -DBUILD_DDS_BACKEND=true
           cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4
   
   

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -185,7 +185,7 @@ jobs:
       shell: bash
       run: | 
         cd build
-        cmake .. -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true -DBUILD_DDS_BACKEND=true
+        cmake .. -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true
         cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4
         
     - name: Test
@@ -240,9 +240,93 @@ jobs:
           cd scripts && ./api_check.sh && cd ..
           mkdir build
           cd ./scripts && ./pr_check.sh && cd ../build
-          cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5 -DBUILD_DDS_BACKEND=true
+          cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5
           cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4
+
+  Linux_testing_cpp_dds:
+    runs-on: ubuntu-18.04    
+    timeout-minutes: 60
+    env: 
+      RS_CPP_TEST: true
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Prebuild
+      shell: bash
+      run: |
+        cd scripts && ./api_check.sh && cd ..
+        mkdir build && cd build
+        export LRS_LOG_LEVEL="DEBUG";
+        sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
+        sudo apt-get update;
+        sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
+        sudo apt-get install -qq libusb-1.0-0-dev;
+        sudo apt-get install -qq libgtk-3-dev;
+        #sudo apt-get install gcc-5 g++-5;
+        #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
+        sudo apt-get install libglfw3-dev libglfw3;
+    
+    - name: Build
+      shell: bash
+      run: | 
+        cd build
+        cmake .. -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true -DBUILD_DDS_BACKEND=true
+        cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4
+        
+    - name: Test
+      shell: bash
+      id: test-step
+      # We set continue-on-error: true as a workaround for not skipping the upload log step on failure,
+      # The final step will check the return value from the test step and decide if to fail/pass the job
+      continue-on-error: true 
+      run: | 
+        export LRS_LOG_LEVEL="DEBUG";
+        cd build   
+        ./unit-tests/live-test -d yes -i [software-device]        
+
+    - name: Upload RS log artifact
+      uses: actions/upload-artifact@v2
+      with: 
+        name: Log file - Linux_testing_cpp
+        path: build/*.log
+        
+        
+    - name: Provide correct exit status for job 
+      shell: bash
+      run: |
+        if [ ${{steps.test-step.outcome}} = "failure" ];then
+           echo "Test step failed, please open it to view the reported issue"
+           exit 1
+        else
+           exit 0
+        fi
   
+  Linux_static_cpp_dds:
+      runs-on: ubuntu-18.04
+      timeout-minutes: 60
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Prebuild
+        shell: bash
+        run: |
+          sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
+          sudo apt-get update;
+          sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
+          sudo apt-get install -qq libusb-1.0-0-dev;
+          sudo apt-get install -qq libgtk-3-dev;
+          #sudo apt-get install gcc-5 g++-5;
+          #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
+          sudo apt-get install libglfw3-dev libglfw3;
+
+      - name: Build
+        shell: bash
+        run: |
+          cd scripts && ./api_check.sh && cd ..
+          mkdir build
+          cd ./scripts && ./pr_check.sh && cd ../build
+          cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5 -DBUILD_DDS_BACKEND=true
+          cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4  
   
   Linux_python_nodejs:
       runs-on: ubuntu-18.04     

--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -83,3 +83,5 @@ add_library(dds INTERFACE)
 target_include_directories(dds INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/fastdds/fastdds_install/include>)
 target_link_libraries(dds INTERFACE debug ${CMAKE_CURRENT_BINARY_DIR}/fastdds/fastdds_install/lib/${FASTDDS_DEBUG_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
 target_link_libraries(dds INTERFACE optimized ${CMAKE_CURRENT_BINARY_DIR}/fastdds/fastdds_install/lib/${FASTDDS_RELEASE_TARGET_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+install(TARGETS dds EXPORT realsense2Targets)

--- a/CMake/global_config.cmake
+++ b/CMake/global_config.cmake
@@ -94,12 +94,7 @@ macro(global_set_flags)
             add_definitions(-DCHECK_FOR_UPDATES)
         endif()
     endif()
-    
-    if(BUILD_DDS_BACKEND)
-        message(STATUS "Building with FastDDS")
-        include(CMake/external_fastdds.cmake)
-    endif()
-    
+        
     add_definitions(-D${BACKEND} -DUNICODE)
 endmacro()
 
@@ -120,7 +115,6 @@ macro(global_target_config)
             $<INSTALL_INTERFACE:include>
             PRIVATE ${USB_INCLUDE_DIRS}
     )
-
 
 
 endmacro()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ include(src/CMakeLists.txt)
 include(third-party/CMakeLists.txt)
 include(common/utilities/CMakeLists.txt)
 
+if(BUILD_DDS_BACKEND)
+    message(STATUS "Building with FastDDS")
+    include(CMake/external_fastdds.cmake)
+endif()
+
 # configure the project according to OS specific requirments
 # macro definition located at "CMake/<OS>_config.cmake"
 os_target_config()
@@ -107,3 +112,4 @@ if(IMPORT_DEPTH_CAM_FW)
 endif()
 
 include(CMake/embedd_udev_rules.cmake)
+


### PR DESCRIPTION
1. Fixed install error on static link
2. Add 2 GH action builds that build with DDS flag on, The tests are separated because I found out that FastDDS fail building with GNU 5.5, When building with GNU 7.5 it works (Opened a BUG on FastDDS https://github.com/eProsima/Fast-DDS/issues/2450)
3. Next step make /MT vs /MD work..