### PR TITLE
context json settings; change dds-server to not use DDS discovery

### DIFF
--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -23,6 +23,18 @@ extern "C" {
 rs2_context* rs2_create_context(int api_version, rs2_error** error);
 
 /**
+* \brief Creates RealSense context that is required for the rest of the API, and accepts a settings JSON.
+* \param[in] api_version Users are expected to pass their version of \c RS2_API_VERSION to make sure they are running the correct librealsense version.
+* \param[in] json_settings Pointer to a string containing a JSON configuration to use, or null if none
+*            Possible settings:
+*                dds-discovery - (bool) false to disable DDS discovery; defaults to true (requires BUILD_WITH_DDS)
+*                dds-domain - (int) the number of the domain discovery is on (requires BUILD_WITH_DDS)
+* \param[out] error  If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
+* \return            Context object
+*/
+rs2_context* rs2_create_context_ex(int api_version, const char * json_settings, rs2_error** error);
+
+/**
 * \brief Frees the relevant context object.
 * \param[in] context Object that is no longer needed
 */

--- a/include/librealsense2/hpp/rs_context.hpp
+++ b/include/librealsense2/hpp/rs_context.hpp
@@ -96,11 +96,11 @@ namespace rs2
     class context
     {
     public:
-        context()
+        context( char const * json_settings = nullptr )
         {
             rs2_error* e = nullptr;
             _context = std::shared_ptr<rs2_context>(
-                rs2_create_context(RS2_API_VERSION, &e),
+                rs2_create_context_ex( RS2_API_VERSION, json_settings, &e ),
                 rs2_delete_context);
             error::handle(e);
         }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -24,6 +24,9 @@
 #include "dds/dds-device-watcher.h"
 #endif
 
+#include <third-party/json.hpp>
+using json = nlohmann::json;
+
 #ifdef WITH_TRACKING
 #include "tm2/tm-info.h"
 #endif
@@ -98,20 +101,26 @@ namespace librealsense
         {rs_fourcc('M','J','P','G'), RS2_STREAM_COLOR},
     };
 
+
+    context::context()
+        : _devices_changed_callback( nullptr, []( rs2_devices_changed_callback* ) {} )
+    {
+        static bool version_logged = false;
+        if( ! version_logged )
+        {
+            version_logged = true;
+            LOG_DEBUG( "Librealsense " << std::string( std::begin( rs2_api_version ), std::end( rs2_api_version ) ) );
+        }
+    }
+
+
     context::context(backend_type type,
                      const char* filename,
                      const char* section,
                      rs2_recording_mode mode,
                      std::string min_api_version)
-        : _devices_changed_callback(nullptr, [](rs2_devices_changed_callback*){})
+        : context()
     {
-        static bool version_logged=false;
-        if (!version_logged)
-        {
-            version_logged = true;
-            LOG_DEBUG("Librealsense " << std::string(std::begin(rs2_api_version),std::end(rs2_api_version)));
-        }
-
         switch(type)
         {
         case backend_type::standard:
@@ -133,6 +142,56 @@ namespace librealsense
 
 #ifdef BUILD_WITH_DDS
        _dds_watcher = std::make_shared< dds_device_watcher >( 0 );
+#endif
+    }
+
+
+    template< class T >
+    static bool json_get_ex( json const & j, char const * key, T * pv )
+    {
+        auto it = j.find( key );
+        if( it == j.end()  ||  it->is_null() )
+            return false;
+        try
+        {
+            // This will throw for type mismatches, etc.
+            *pv = it->get< T >();
+        }
+        catch( std::exception const & e )
+        {
+            std::ostringstream s;
+            s << e.what() << " - while parsing '" << key << "'";
+            throw std::exception( s.str().c_str() );
+        }
+        LOG_DEBUG( key << " = " << *pv );
+        return true;
+    }
+    template < class T >
+    static T json_get( json const & j, char const * key, T const & d )
+    {
+        T v;
+        if( json_get_ex< T >( j, key, &v ) )
+            return v;
+        LOG_DEBUG( key << " = " << d << " (default)" );
+        return d;
+    }
+
+
+    context::context( char const * json_settings )
+        : context()
+    {
+        json settings = json_settings ? json::parse( json_settings ) : json();
+
+        _backend = platform::create_backend();  // standard type
+
+        environment::get_instance().set_time_service( _backend->create_time_service() );
+
+        _device_watcher = _backend->create_device_watcher();
+        assert( _device_watcher->is_stopped() );
+
+#ifdef BUILD_WITH_DDS
+        if( json_get< bool >( settings, "dds-discovery", true ) )
+            _dds_watcher = std::make_shared< dds_device_watcher >( json_get< int >( settings, "dds-domain", 0 ) );
 #endif
     }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -167,13 +167,13 @@ namespace librealsense
         return true;
     }
     template < class T >
-    static T json_get( json const & j, char const * key, T const & d )
+    static T json_get( json const & j, char const * key, T const & default_value )
     {
         T v;
         if( json_get_ex< T >( j, key, &v ) )
             return v;
-        LOG_DEBUG( key << " = " << d << " (default)" );
-        return d;
+        LOG_DEBUG( key << " = " << default_value << " (default)" );
+        return default_value;
     }
 
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -161,7 +161,7 @@ namespace librealsense
         {
             std::ostringstream s;
             s << e.what() << " - while parsing '" << key << "'";
-            throw std::exception( s.str().c_str() );
+            throw std::runtime_error( s.str() );
         }
         LOG_DEBUG( key << " = " << *pv );
         return true;

--- a/src/context.h
+++ b/src/context.h
@@ -105,12 +105,15 @@ namespace librealsense
 
     class context : public std::enable_shared_from_this<context>
     {
+        context();
     public:
         explicit context(backend_type type,
             const char* filename = nullptr,
             const char* section = nullptr,
             rs2_recording_mode mode = RS2_RECORDING_MODE_COUNT,
             std::string min_api_version = "0.0.0");
+
+        explicit context( char const * json_settings );
 
         void stop() { _device_watcher->stop(); }
         ~context();

--- a/src/dds/dds-device-watcher.cpp
+++ b/src/dds/dds-device-watcher.cpp
@@ -58,7 +58,7 @@ dds_device_watcher::dds_device_watcher( int domain_id )
                 _dds_devices[guid.entityId.to_uint32()]
                     = std::string( data.name().begin(), data.name().end() );
 
-                LOG_DEBUG( "DDS device writer GUID: " << guid.entityId.to_uint32() << " added" );
+                LOG_DEBUG( "DDS device writer GUID: " << guid.entityId.to_uint32() << " added on domain " << _domain_id );
 
                 // TODO - Call LRS callback to create the RS devices
                 // if( callback )
@@ -96,9 +96,12 @@ void dds_device_watcher::start( platform::device_changed_callback callback )
 
 void dds_device_watcher::stop()
 {
-    _active_object.stop();
-    //_callback_inflight.wait_until_empty();
-    LOG_DEBUG( "DDS device watcher stopped" );
+    if( ! is_stopped() )
+    {
+        _active_object.stop();
+        //_callback_inflight.wait_until_empty();
+        LOG_DEBUG( "DDS device watcher stopped" );
+    }
 }
 
 

--- a/src/l500/l500-serializable.cpp
+++ b/src/l500/l500-serializable.cpp
@@ -1,11 +1,11 @@
-//// License: Apache 2.0. See LICENSE file in root directory.
-//// Copyright(c) 2020 Intel Corporation. All Rights Reserved.
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
 #include <set>
 #include "l500-serializable.h"
 #include "l500-options.h"
-#include <../../../third-party/json.hpp>
-#include "serialized-utilities.h"
+#include <third-party/json.hpp>
+#include <src/serialized-utilities.h>
 
 namespace librealsense
 {

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -2,6 +2,7 @@ LIBRARY
 
 EXPORTS
     rs2_create_context
+    rs2_create_context_ex
     rs2_delete_context
     rs2_create_recording_context
     rs2_create_mock_context

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -172,6 +172,15 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error) BEGIN_API_CA
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version)
 
+rs2_context* rs2_create_context_ex(int api_version, const char * json_settings, rs2_error** error) BEGIN_API_CALL
+{
+    verify_version_compatibility(api_version);
+
+    return new rs2_context{
+        std::make_shared< librealsense::context >( json_settings ) };
+}
+HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version, json_settings)
+
 void rs2_delete_context(rs2_context* context) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(context);

--- a/src/serialized-utilities.h
+++ b/src/serialized-utilities.h
@@ -1,11 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
 #pragma once
 #include <string>
 #include <map>
 #include <types.h>
-#include <../third-party/json.hpp>
+#include <third-party/json.hpp>
 
 
 namespace librealsense

--- a/tools/dds/dds-server/dds-server.cpp
+++ b/tools/dds/dds-server/dds-server.cpp
@@ -10,7 +10,7 @@
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
-#include "../../../src/dds/msg/devicesPubSubTypes.h"
+#include <src/dds/msg/devicesPubSubTypes.h>
 
 // We align the DDS topic name to ROS2 as it expect the 'rt/' prefix for the topic name
 #define ROS2_PREFIX( name ) std::string( "rt/" ).append( name )
@@ -23,6 +23,9 @@ dds_server::dds_server()
     , _publisher( nullptr )
     , _topic( nullptr )
     , _type_support_ptr( new devicesPubSubType() )
+    , _ctx( "{"
+            "\"dds-discovery\" : false"
+            "}" )
 {
 }
 bool dds_server::init( DomainId_t domain_id )

--- a/tools/dds/dds-server/rs-dds-server.cpp
+++ b/tools/dds/dds-server/rs-dds-server.cpp
@@ -17,14 +17,18 @@ try
     CmdLine cmd( "librealsense rs-dds-server tool, use CTRL + C to stop..", ' ' );
     ValueArg< eprosima::fastdds::dds::DomainId_t > domain_arg( "d",
                                                                "domain",
-                                                               "select domain ID to listen on",
+                                                               "Select domain ID to listen on",
                                                                false,
                                                                0,
                                                                "0-232" );
+    SwitchArg debug_arg( "", "debug", "Enable debug logging", false );
 
     cmd.add( domain_arg );
+    cmd.add( debug_arg );
     cmd.parse( argc, argv );
 
+    if( debug_arg.isSet() )
+        rs2::log_to_console( RS2_LOG_SEVERITY_DEBUG );
     if( domain_arg.isSet() )
     {
         domain = domain_arg.getValue();

--- a/wrappers/python/pyrs_context.cpp
+++ b/wrappers/python/pyrs_context.cpp
@@ -17,7 +17,8 @@ void init_context(py::module &m) {
     // Not binding devices_changed_callback, templated
 
     py::class_<rs2::context> context(m, "context", "Librealsense context class. Includes realsense API version.");
-    context.def(py::init<>())
+    context.def( py::init<>() )
+        .def( py::init< char const * >() )
         .def("query_devices", (rs2::device_list(rs2::context::*)() const) &rs2::context::query_devices, "Create a static"
              " snapshot of all connected devices at the time of the call.")
         .def( "query_devices", ( rs2::device_list( rs2::context::* )(int) const ) & rs2::context::query_devices, "Create a static"


### PR DESCRIPTION
* rs2::context() now can accept JSON settings
** `dds-discovery` - (bool) `false` to disable discovery; defaults to `true`
** `dds-domain` - (int) the domain to use for discovery
* rs-dds-server now disables discovery

Tracked on [TODO]