### PR TITLE
Print by topics in snapshot mode

### DIFF
--- a/tools/dds/dds-sniffer/CMakeLists.txt
+++ b/tools/dds/dds-sniffer/CMakeLists.txt
@@ -4,7 +4,10 @@
 
 project(rs-dds-sniffer)
 
-add_executable(${PROJECT_NAME} dds-sniffer.cpp)
+set(SRC dds-sniffer.cpp)
+set(INC dds-sniffer.hpp)
+
+add_executable(${PROJECT_NAME} ${INC} ${SRC})
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 

--- a/tools/dds/dds-sniffer/dds-sniffer.cpp
+++ b/tools/dds/dds-sniffer/dds-sniffer.cpp
@@ -4,6 +4,7 @@
 #include "dds-sniffer.hpp"
 
 #include <thread>
+#include <memory>
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
@@ -12,11 +13,12 @@
 #include <fastrtps/types/DynamicDataHelper.hpp>
 #include <fastrtps/types/DynamicDataFactory.h>
 
-#include "tclap/CmdLine.h"
-#include "tclap/ValueArg.h"
-#include "tclap/SwitchArg.h"
+#include <tclap/CmdLine.h>
+#include <tclap/ValueArg.h>
+#include <tclap/SwitchArg.h>
 
 using namespace TCLAP;
+constexpr uint8_t GUID_PROCESS_LOCATION = 4;
 
 int main( int argc, char ** argv ) try
 {
@@ -51,7 +53,7 @@ int main( int argc, char ** argv ) try
     }
 
     Sniffer snif;
-    if( snif.init( domain ) )
+    if( snif.init( domain, snapshot_arg.isSet() ) )
     {
         snif.run( seconds );
     }
@@ -92,8 +94,6 @@ Sniffer::Sniffer()
 
 Sniffer::~Sniffer()
 {
-    _running = false;
-
     for( const auto & it : _topics )
     {
         if( _subscriber != nullptr )
@@ -119,23 +119,29 @@ Sniffer::~Sniffer()
     _readers.clear();
 }
 
-bool Sniffer::init( eprosima::fastdds::dds::DomainId_t domain )
+bool Sniffer::init( eprosima::fastdds::dds::DomainId_t domain, bool snapshot )
 {
+    _snapshot = snapshot;
+
     eprosima::fastdds::dds::DomainParticipantQos participantQoS;
-    participantQoS.name( "dds-sniffer" );
+    participantQoS.name( "rs-dds-sniffer" );
     _participant = eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->create_participant( domain,
                                                                                                          participantQoS,
                                                                                                          this );
-
-    std::cout << "Creating a sniffer for domain " << domain << std::endl;
+    if( _snapshot )
+    {
+        std::cout << "rs-dds-sniffer taking a snapshot of domain " << domain << std::endl;
+    }
+    else
+    {
+        std::cout << "rs-dds-sniffer listening on domain " << domain << std::endl;
+    }
 
     return _participant != nullptr;
 }
 
 void Sniffer::run( uint32_t seconds )
 {
-    _running = true;
-
     if( seconds == 0 )
     {
         std::cin.ignore( std::numeric_limits< std::streamsize >::max() );
@@ -144,26 +150,95 @@ void Sniffer::run( uint32_t seconds )
     {
         std::this_thread::sleep_for( std::chrono::seconds( seconds ) );
     }
+
+    print_topics();
+}
+
+void Sniffer::print_topics()
+{
+    std::cout << std::endl;
+
+    for( auto topic : _discoveredTopics )
+    {
+        std::cout << topic.first << std::endl;
+        uint32_t indentation = 1;
+        for( auto writer : topic.second.writers )
+        {
+            print_writer( writer, indentation );
+        }
+        for( auto reader : topic.second.readers )
+        {
+            print_reader( reader, indentation );
+        }
+    }
+}
+
+void Sniffer::print_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation )
+{
+    auto iter = _discoveredParticipants.begin();
+    for( ; iter != _discoveredParticipants.end(); ++iter )
+    {
+        if( iter->first.guidPrefix == writer.guidPrefix )
+        {
+            uint16_t tmp;
+            memcpy( &tmp, &iter->first.guidPrefix.value[GUID_PROCESS_LOCATION], sizeof( tmp ) );
+            ident( indentation );
+            std::cout << "Writer of \"" << iter->second << "_" << std::hex << tmp << std::dec << "\"" << std::endl;
+            break;
+        }
+    }
+    if( iter == _discoveredParticipants.end() )
+    {
+        ident( indentation );
+        std::cout << "Writer of unknown participant" << std::endl;
+    }
+}
+
+void Sniffer::print_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation )
+{
+    auto iter = _discoveredParticipants.begin();
+    for( auto iter = _discoveredParticipants.begin(); iter != _discoveredParticipants.end(); ++iter )
+    {
+        if( iter->first.guidPrefix == reader.guidPrefix )
+        {
+            uint16_t tmp;
+            memcpy( &tmp, &iter->first.guidPrefix.value[GUID_PROCESS_LOCATION], sizeof( tmp ) );
+            ident( indentation );
+            std::cout << "Reader of \"" << iter->second << "_" << std::hex << tmp << std::dec << "\"" << std::endl;
+            break;
+        }
+    }
+    if( iter == _discoveredParticipants.end() )
+    {
+        ident( indentation );
+        std::cout << "Reader of unknown participant" << std::endl;
+    }
+}
+
+void Sniffer::ident( uint32_t indentation )
+{
+    while( indentation > 0 )
+    {
+        std::cout << "    ";
+        --indentation;
+    }
 }
 
 void Sniffer::on_data_available( eprosima::fastdds::dds::DataReader * reader )
 {
-    if( _running )
-    {
-        auto dataIter = _datas.find( reader );
+    auto dataIter = _datas.find( reader );
 
-        if( dataIter != _datas.end() )
+    if( dataIter != _datas.end() )
+    {
+        eprosima::fastrtps::types::DynamicData_ptr data = dataIter->second;
+        eprosima::fastdds::dds::SampleInfo info;
+        if( reader->take_next_sample( data.get(), &info ) == ReturnCode_t::RETCODE_OK )
         {
-            eprosima::fastrtps::types::DynamicData_ptr data = dataIter->second;
-            eprosima::fastdds::dds::SampleInfo info;
-            if( reader->take_next_sample( data.get(), &info ) == ReturnCode_t::RETCODE_OK )
+            if( info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE )
             {
-                if( info.instance_state == eprosima::fastdds::dds::ALIVE_INSTANCE_STATE )
-                {
-                    eprosima::fastrtps::types::DynamicType_ptr type = _readers[reader];
-                    std::cout << "Received data of type " << type->get_name() << std::endl;
-                    eprosima::fastrtps::types::DynamicDataHelper::print( data );
-                }
+                eprosima::fastrtps::types::DynamicType_ptr type = _readers[reader];
+                std::cout << "Received data of type " << type->get_name() << std::endl;
+                eprosima::fastrtps::types::DynamicDataHelper::print( data );
             }
         }
     }
@@ -172,24 +247,21 @@ void Sniffer::on_data_available( eprosima::fastdds::dds::DataReader * reader )
 void Sniffer::on_subscription_matched( eprosima::fastdds::dds::DataReader * reader,
                                        const eprosima::fastdds::dds::SubscriptionMatchedStatus & info )
 {
-    if( _running )
+    if( info.current_count_change == 1 )
     {
-        if( info.current_count_change == 1 )
-        {
-            _matched = info.current_count;  // MatchedStatus::current_count represents number of writers matched for a
-                                            // reader, total_count represents number of readers matched for a writer.
-            std::cout << "A reader has been added to the domain" << std::endl;
-        }
-        else if( info.current_count_change == -1 )
-        {
-            _matched = info.current_count;  // MatchedStatus::current_count represents number of writers matched for a
-                                            // reader, total_count represents number of readers matched for a writer.
-            std::cout << "A reader has been removed from the domain" << std::endl;
-        }
-        else
-        {
-            std::cout << "Invalid current_count_change value " << info.current_count_change << std::endl;
-        }
+        _matched = info.current_count;  // MatchedStatus::current_count represents number of writers matched for a
+                                        // reader, total_count represents number of readers matched for a writer.
+        std::cout << "A reader has been added to the domain" << std::endl;
+    }
+    else if( info.current_count_change == -1 )
+    {
+        _matched = info.current_count;  // MatchedStatus::current_count represents number of writers matched for a
+                                        // reader, total_count represents number of readers matched for a writer.
+        std::cout << "A reader has been removed from the domain" << std::endl;
+    }
+    else
+    {
+        std::cout << "Invalid current_count_change value " << info.current_count_change << std::endl;
     }
 }
 
@@ -200,96 +272,140 @@ void Sniffer::on_type_discovery( eprosima::fastdds::dds::DomainParticipant *,
                                  const eprosima::fastrtps::types::TypeObject *,
                                  eprosima::fastrtps::types::DynamicType_ptr dyn_type )
 {
-    if( _running )
+    eprosima::fastdds::dds::TypeSupport m_type( new eprosima::fastrtps::types::DynamicPubSubType( dyn_type ) );
+    m_type.register_type( _participant );
+
+    std::cout << "Discovered type: " << m_type->getName() << " from topic " << topic_name << std::endl;
+
+    // Create a data reader for the topic
+    if( _subscriber == nullptr )
     {
-        eprosima::fastdds::dds::TypeSupport m_type( new eprosima::fastrtps::types::DynamicPubSubType( dyn_type ) );
-        m_type.register_type( _participant );
+        _subscriber = _participant->create_subscriber( eprosima::fastdds::dds::SUBSCRIBER_QOS_DEFAULT, nullptr );
 
-        std::cout << "Discovered type: " << m_type->getName() << " from topic " << topic_name << std::endl;
-
-        // Create a data reader for the topic
         if( _subscriber == nullptr )
-        {
-            _subscriber = _participant->create_subscriber( eprosima::fastdds::dds::SUBSCRIBER_QOS_DEFAULT, nullptr );
-
-            if( _subscriber == nullptr )
-            {
-                return;
-            }
-        }
-
-        eprosima::fastdds::dds::Topic * topic = _participant->create_topic( topic_name.c_str(),
-                                                                            m_type->getName(),
-                                                                            eprosima::fastdds::dds::TOPIC_QOS_DEFAULT );
-        if( topic == nullptr )
         {
             return;
         }
-
-        eprosima::fastdds::dds::DataReader * reader = _subscriber->create_datareader( topic, _readerQoS, this );
-
-        _topics[reader] = topic;
-        _readers[reader] = dyn_type;
-        eprosima::fastrtps::types::DynamicData_ptr data( eprosima::fastrtps::types::DynamicDataFactory::get_instance()->create_data( dyn_type ) );
-        _datas[reader] = data;
     }
+
+    eprosima::fastdds::dds::Topic * topic = _participant->create_topic( topic_name.c_str(),
+                                                                        m_type->getName(),
+                                                                        eprosima::fastdds::dds::TOPIC_QOS_DEFAULT );
+    if( topic == nullptr )
+    {
+        return;
+    }
+
+    eprosima::fastdds::dds::DataReader * reader = _subscriber->create_datareader( topic, _readerQoS, this );
+
+    _topics[reader] = topic;
+    _readers[reader] = dyn_type;
+    eprosima::fastrtps::types::DynamicData_ptr data( eprosima::fastrtps::types::DynamicDataFactory::get_instance()->create_data( dyn_type ) );
+    _datas[reader] = data;
 }
 
 void Sniffer::on_publisher_discovery( eprosima::fastdds::dds::DomainParticipant *,
                                       eprosima::fastrtps::rtps::WriterDiscoveryInfo && info )
 {
-    if( _running )
+    switch( info.status )
     {
-        switch( info.status )
+    case eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER:
+        if( ! _snapshot )
         {
-        case eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER:
-            std::cout << "DataWriter publishing topic '" << info.info.topicName() << "' of type '"
-                      << info.info.typeName() << "' discovered" << std::endl;
-            break;
-        case eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER:
-            std::cout << "DataWriter publishing topic '" << info.info.topicName() << "' of type '"
-                      << info.info.typeName() << "' left the domain." << std::endl;
-            break;
+            std::cout << "DataWriter  " << info.info.guid() << " publishing topic '" << info.info.topicName()
+                      << "' of type '" << info.info.typeName() << "' discovered" << std::endl;
         }
+
+        if( _discoveredTopics.find( info.info.topicName().c_str() ) == _discoveredTopics.end() )
+        {
+            _discoveredTopics.insert( { info.info.topicName().c_str(), *std::make_unique< ReadersWriters >() } );
+        }
+        _discoveredTopics[info.info.topicName().c_str()].writers.push_back( info.info.guid() );
+        break;
+    case eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER:
+        if( ! _snapshot )
+        {
+            std::cout << "DataWriter  " << info.info.guid() << " publishing topic '" << info.info.topicName()
+                      << "' of type '" << info.info.typeName() << "' left the domain." << std::endl;
+        }
+
+        for( auto iter = _discoveredTopics[info.info.topicName().c_str()].writers.begin();
+             iter != _discoveredTopics[info.info.topicName().c_str()].writers.end();
+             ++iter )
+        {
+            if( *iter == info.info.guid() )
+            {
+                _discoveredTopics[info.info.topicName().c_str()].writers.erase( iter );
+                break;
+            }
+        }
+        break;
     }
 }
 
 void Sniffer::on_subscriber_discovery( eprosima::fastdds::dds::DomainParticipant *,
                                        eprosima::fastrtps::rtps::ReaderDiscoveryInfo && info )
 {
-    if( _running )
+    switch( info.status )
     {
-        switch( info.status )
+    case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER: {
+        if( ! _snapshot )
         {
-        case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER:
-            /* Process the case when a new reader was found in the domain */
-            std::cout << "DataReader reading topic '" << info.info.topicName() << "' of type '"
-                      << info.info.typeName() << "' discovered" << std::endl;
-            break;
-        case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER:
-            /* Process the case when a reader was removed from the domain */
-            std::cout << "DataReader reading topic '" << info.info.topicName() << "' of type '"
-                      << info.info.typeName() << "' left the domain." << std::endl;
-            break;
+            std::cout << "DataReader  " << info.info.guid() << " reading topic '" << info.info.topicName()
+                      << "' of type '" << info.info.typeName() << "' discovered" << std::endl;
         }
+        if( _discoveredTopics.find( info.info.topicName().c_str() ) == _discoveredTopics.end() )
+        {
+            _discoveredTopics.insert( { info.info.topicName().c_str(), *std::make_unique< ReadersWriters >() } );
+        }
+        _discoveredTopics[info.info.topicName().c_str()].readers.push_back( info.info.guid() );
+        break;
+    }
+    case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER:
+        if( ! _snapshot )
+        {
+            std::cout << "DataReader  " << info.info.guid() << " reading topic '" << info.info.topicName()
+                      << "' of type '" << info.info.typeName() << "' left the domain." << std::endl;
+        }
+        for( auto iter = _discoveredTopics[info.info.topicName().c_str()].readers.begin();
+             iter != _discoveredTopics[info.info.topicName().c_str()].readers.end();
+             ++iter )
+        {
+            if( *iter == info.info.guid() )
+            {
+                _discoveredTopics[info.info.topicName().c_str()].readers.erase( iter );
+                break;
+            }
+        }
+        break;
     }
 }
 
 void Sniffer::on_participant_discovery( eprosima::fastdds::dds::DomainParticipant *,
                                         eprosima::fastrtps::rtps::ParticipantDiscoveryInfo && info )
 {
-    if( _running )
+    uint16_t tmp( 0 );
+    switch( info.status )
     {
-        switch( info.status )
+    case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
+        if( ! _snapshot )
         {
-        case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
-            std::cout << "Participant '" << info.info.m_participantName << "' discovered" << std::endl;
-            break;
-        case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
-        case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
-            std::cout << "Participant " << info.info.m_participantName << "' left the domain." << std::endl;
-            break;
+            memcpy( &tmp, &info.info.m_guid.guidPrefix.value[GUID_PROCESS_LOCATION], sizeof( tmp ) );
+            std::cout << "Participant " << info.info.m_guid << " " << info.info.m_participantName << "_" << std::hex
+                      << tmp << std::dec << " discovered" << std::endl;
         }
+        _discoveredParticipants[info.info.m_guid] = info.info.m_participantName;
+        break;
+    case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
+    case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
+        if( ! _snapshot )
+        {
+            memcpy( &tmp, &info.info.m_guid.guidPrefix.value[GUID_PROCESS_LOCATION], sizeof( tmp ) );
+            std::cout << "Participant " << info.info.m_guid << " " << info.info.m_participantName << "_" << std::hex
+                      << tmp << std::dec << " left the domain." << std::endl;
+        }
+        _discoveredParticipants.erase( info.info.m_guid );
+        break;
     }
 }
 

--- a/tools/dds/dds-sniffer/dds-sniffer.hpp
+++ b/tools/dds/dds-sniffer/dds-sniffer.hpp
@@ -13,11 +13,11 @@
 #include <fastrtps/attributes/SubscriberAttributes.h>
 #include <fastdds/rtps/common/Guid.h>
 
-class Sniffer : public eprosima::fastdds::dds::DomainParticipantListener
+class dds_sniffer : public eprosima::fastdds::dds::DomainParticipantListener
 {
 public:
-    Sniffer();
-    ~Sniffer();
+    dds_sniffer();
+    ~dds_sniffer();
 
     bool init( eprosima::fastdds::dds::DomainId_t domain = 0, bool snapshot = false, bool machine_readable = false );
     void run( uint32_t seconds );
@@ -30,17 +30,17 @@ private:
     std::map< eprosima::fastdds::dds::DataReader *, eprosima::fastrtps::types::DynamicType_ptr > _readers;
     std::map< eprosima::fastdds::dds::DataReader *, eprosima::fastrtps::types::DynamicData_ptr > _datas;
 
-    std::map< eprosima::fastrtps::rtps::GUID_t, eprosima::fastrtps::string_255 > _discoveredParticipants;
-    struct ReadersWriters
+    std::map< eprosima::fastrtps::rtps::GUID_t, eprosima::fastrtps::string_255 > _discovered_participants;
+    struct topic_info
     {
         std::set< eprosima::fastrtps::rtps::GUID_t > readers;
         std::set< eprosima::fastrtps::rtps::GUID_t > writers;
     };
-    std::map< std::string, ReadersWriters > _discoveredTopics;
+    std::map< std::string, topic_info > _discovered_topics;
 
-    eprosima::fastrtps::SubscriberAttributes _subscriberAttributes;
+    eprosima::fastrtps::SubscriberAttributes _subscriber_attributes;
 
-    eprosima::fastdds::dds::DataReaderQos _readerQoS;
+    eprosima::fastdds::dds::DataReaderQos _reader_qos;
 
     std::atomic_int _matched = { 0 };
     bool _print_discoveries = false;
@@ -90,15 +90,15 @@ private:
     void save_topic_writer( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info );
     void remove_topic_writer( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info );
     void save_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
-    void save_max_indentation( const std::string && str );
     void remove_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
+    void save_max_indentation( const std::string && str );
 
     // Helper print functions
     void print_writer_discovered( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info, bool discovered ) const;
     void print_reader_discovered( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info, bool discovered ) const;
     void print_participant_discovered( const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo & info, bool discovered ) const;
-    void print_topics_machine_readable();
-    void print_topics();
+    void print_topics_machine_readable() const;
+    void print_topics() const;
     void ident( uint32_t indentation ) const;
     void print_topic_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation ) const;
     void print_topic_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation ) const;

--- a/tools/dds/dds-sniffer/dds-sniffer.hpp
+++ b/tools/dds/dds-sniffer/dds-sniffer.hpp
@@ -4,12 +4,14 @@
 #pragma once
 
 #include <map>
+#include <string>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastrtps/attributes/SubscriberAttributes.h>
+#include <fastdds/rtps/common/Guid.h>
 
 class Sniffer : public eprosima::fastdds::dds::DomainParticipantListener
 {
@@ -17,8 +19,10 @@ public:
     Sniffer();
     ~Sniffer();
 
-    bool init( eprosima::fastdds::dds::DomainId_t domain = 0 );
+    bool init( eprosima::fastdds::dds::DomainId_t domain = 0, bool snapshot = false );
     void run( uint32_t seconds );
+
+    void print_topics();
 
 private:
     eprosima::fastdds::dds::DomainParticipant * _participant;
@@ -28,12 +32,24 @@ private:
     std::map< eprosima::fastdds::dds::DataReader *, eprosima::fastrtps::types::DynamicType_ptr > _readers;
     std::map< eprosima::fastdds::dds::DataReader *, eprosima::fastrtps::types::DynamicData_ptr > _datas;
 
+    std::map< eprosima::fastrtps::rtps::GUID_t, eprosima::fastrtps::string_255 > _discoveredParticipants;
+    struct ReadersWriters
+    {
+        std::vector< eprosima::fastrtps::rtps::GUID_t > readers;
+        std::vector< eprosima::fastrtps::rtps::GUID_t > writers;
+    };
+    std::map< std::string, ReadersWriters > _discoveredTopics;
+
     eprosima::fastrtps::SubscriberAttributes _subscriberAttributes;
 
     eprosima::fastdds::dds::DataReaderQos _readerQoS;
 
     std::atomic_int _matched = { 0 };
-    bool _running = false;
+    bool _snapshot = false;
+
+    void print_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation );
+    void print_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation );
+    void ident( uint32_t indentation );
 
     void on_data_available( eprosima::fastdds::dds::DataReader * reader ) override;
 

--- a/tools/dds/dds-sniffer/dds-sniffer.hpp
+++ b/tools/dds/dds-sniffer/dds-sniffer.hpp
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <string>
+#include <mutex>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -46,7 +47,8 @@ private:
     bool _print_discoveries = false;
     bool _print_by_topics = false;
     bool _print_machine_readable = false;
-    uint32_t _max_indentation = 0;
+
+    mutable std::mutex _dds_entities_lock;
 
     void on_data_available( eprosima::fastdds::dds::DataReader * reader ) override;
 
@@ -91,15 +93,15 @@ private:
     void remove_topic_writer( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info );
     void save_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
     void remove_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
-    void calc_max_indentation();
+    uint32_t calc_max_indentation() const;
 
     // Helper print functions
     void print_writer_discovered( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info, bool discovered ) const;
     void print_reader_discovered( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info, bool discovered ) const;
     void print_participant_discovered( const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo & info, bool discovered ) const;
     void print_topics_machine_readable() const;
-    void print_topics();
+    void print_topics() const;
     void ident( uint32_t indentation ) const;
-    void print_topic_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation ) const;
-    void print_topic_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation ) const;
+    void print_topic_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation = 0) const;
+    void print_topic_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation = 0) const;
 };

--- a/tools/dds/dds-sniffer/dds-sniffer.hpp
+++ b/tools/dds/dds-sniffer/dds-sniffer.hpp
@@ -91,14 +91,14 @@ private:
     void remove_topic_writer( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info );
     void save_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
     void remove_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
-    void save_max_indentation( const std::string && str );
+    void calc_max_indentation();
 
     // Helper print functions
     void print_writer_discovered( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info, bool discovered ) const;
     void print_reader_discovered( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info, bool discovered ) const;
     void print_participant_discovered( const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo & info, bool discovered ) const;
     void print_topics_machine_readable() const;
-    void print_topics() const;
+    void print_topics();
     void ident( uint32_t indentation ) const;
     void print_topic_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation ) const;
     void print_topic_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation ) const;

--- a/tools/dds/dds-sniffer/dds-sniffer.hpp
+++ b/tools/dds/dds-sniffer/dds-sniffer.hpp
@@ -22,8 +22,6 @@ public:
     bool init( eprosima::fastdds::dds::DomainId_t domain = 0, bool snapshot = false );
     void run( uint32_t seconds );
 
-    void print_topics();
-
 private:
     eprosima::fastdds::dds::DomainParticipant * _participant;
     eprosima::fastdds::dds::Subscriber * _subscriber;
@@ -35,8 +33,8 @@ private:
     std::map< eprosima::fastrtps::rtps::GUID_t, eprosima::fastrtps::string_255 > _discoveredParticipants;
     struct ReadersWriters
     {
-        std::vector< eprosima::fastrtps::rtps::GUID_t > readers;
-        std::vector< eprosima::fastrtps::rtps::GUID_t > writers;
+        std::set< eprosima::fastrtps::rtps::GUID_t > readers;
+        std::set< eprosima::fastrtps::rtps::GUID_t > writers;
     };
     std::map< std::string, ReadersWriters > _discoveredTopics;
 
@@ -45,11 +43,9 @@ private:
     eprosima::fastdds::dds::DataReaderQos _readerQoS;
 
     std::atomic_int _matched = { 0 };
-    bool _snapshot = false;
-
-    void print_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation );
-    void print_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation );
-    void ident( uint32_t indentation );
+    bool _print_discoveries = false;
+    bool _print_by_topics = false;
+    uint32_t _max_indentation = 0;
 
     void on_data_available( eprosima::fastdds::dds::DataReader * reader ) override;
 
@@ -88,4 +84,20 @@ private:
                                        const eprosima::fastrtps::string_255 topic_name,
                                        const eprosima::fastrtps::string_255 type_name,
                                        const eprosima::fastrtps::types::TypeInformation & type_information ) override;
+
+    // Topics data-base functions
+    void save_topic_writer( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info );
+    void remove_topic_writer( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info );
+    void save_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
+    void save_max_indentation( const std::string && str );
+    void remove_topic_reader( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info );
+
+    // Helper print functions
+    void print_writer_discovered( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info, bool discovered ) const;
+    void print_reader_discovered( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info, bool discovered ) const;
+    void print_participant_discovered( const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo & info, bool discovered ) const;
+    void print_topics();
+    void ident( uint32_t indentation ) const;
+    void print_topic_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation ) const;
+    void print_topic_reader( const eprosima::fastrtps::rtps::GUID_t & reader, uint32_t indentation ) const;
 };

--- a/tools/dds/dds-sniffer/dds-sniffer.hpp
+++ b/tools/dds/dds-sniffer/dds-sniffer.hpp
@@ -19,7 +19,7 @@ public:
     Sniffer();
     ~Sniffer();
 
-    bool init( eprosima::fastdds::dds::DomainId_t domain = 0, bool snapshot = false );
+    bool init( eprosima::fastdds::dds::DomainId_t domain = 0, bool snapshot = false, bool machine_readable = false );
     void run( uint32_t seconds );
 
 private:
@@ -45,6 +45,7 @@ private:
     std::atomic_int _matched = { 0 };
     bool _print_discoveries = false;
     bool _print_by_topics = false;
+    bool _print_machine_readable = false;
     uint32_t _max_indentation = 0;
 
     void on_data_available( eprosima::fastdds::dds::DataReader * reader ) override;
@@ -96,6 +97,7 @@ private:
     void print_writer_discovered( const eprosima::fastrtps::rtps::WriterDiscoveryInfo & info, bool discovered ) const;
     void print_reader_discovered( const eprosima::fastrtps::rtps::ReaderDiscoveryInfo & info, bool discovered ) const;
     void print_participant_discovered( const eprosima::fastrtps::rtps::ParticipantDiscoveryInfo & info, bool discovered ) const;
+    void print_topics_machine_readable();
     void print_topics();
     void ident( uint32_t indentation ) const;
     void print_topic_writer( const eprosima::fastrtps::rtps::GUID_t & writer, uint32_t indentation ) const;


### PR DESCRIPTION
When running in snapshot mode print readers/writers grouped by topic.
Also supporting nested topics (delimited by '/').
See attached photo for output example.
![Print by topic](https://user-images.githubusercontent.com/100071798/166698937-5378f3c9-ff46-4e20-9d27-bf8968473a97.PNG)
.