### PR TITLE
Should copy the module init file to the installation location also.

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -210,6 +210,10 @@ install(FILES "${CMAKE_BINARY_DIR}/wrappers/python/pyrealsense2ConfigVersion.cma
     DESTINATION ${CMAKECONFIG_PY_INSTALL_DIR}
 )
 
+install(FILES "${CMAKE_SOURCE_DIR}/wrappers/python/pyrealsense2/__init__.py"
+    DESTINATION ${PYTHON_INSTALL_DIR}
+)
+
 target_include_directories(pybackend2 PRIVATE ../../src)
 target_include_directories(pyrealsense2 PRIVATE ../../src)
 
@@ -247,6 +251,9 @@ if(BUILD_NETWORK_DEVICE)
 
     install(FILES "${CMAKE_BINARY_DIR}/wrappers/python/pyrealsense2-netConfigVersion.cmake"
       DESTINATION ${CMAKECONFIG_PY_INSTALL_DIR})
+
+    install(FILES "${CMAKE_SOURCE_DIR}/wrappers/python/pyrealsense2/__init__.py"
+      DESTINATION ${PYTHON_INSTALL_DIR})
 
 endif()
 


### PR DESCRIPTION
A while back I had submitted a patch through the issue tracker (#10199), but never got around to splitting it into multiple pull requests for the different functionality upgrades.

This first pull request is very simple and is solely intended to ensure that the package init file is copied to the right location during the 'make install' process.