### PR TITLE
Replace DDS Server tool prints with logs

### DIFF
--- a/include/librealsense2/dds/dds-device-broadcaster.h
+++ b/include/librealsense2/dds/dds-device-broadcaster.h
@@ -84,7 +84,6 @@ private:
     eprosima::fastdds::dds::Topic * _topic;
     eprosima::fastdds::dds::TypeSupport _topic_type;
     std::unordered_map< std::string, dds_device_handle > _device_handle_by_sn;
-    rs2::context _ctx;
     dispatcher _dds_device_dispatcher;
     active_object<> _new_client_handler;
     std::condition_variable _new_client_cv;

--- a/include/librealsense2/dds/dds-participant.cpp
+++ b/include/librealsense2/dds/dds-participant.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <memory>
 #include "dds-participant.h"
+#include <librealsense2/utilities/easylogging/easyloggingpp.h>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -21,13 +22,11 @@ class dds_participant::dds_participant_listener
         switch( info.status )
         {
         case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DISCOVERED_PARTICIPANT:
-            std::cout << "Participant '" << info.info.m_participantName << "' discovered"
-                      << std::endl;
+            LOG_DEBUG( "Participant '" << info.info.m_participantName << "' discovered" );
             break;
         case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
         case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
-            std::cout << "Participant '" << info.info.m_participantName << "' disappeared"
-                      << std::endl;
+            LOG_DEBUG( "Participant '" << info.info.m_participantName << "' disappeared" );
             break;
         default:
             break;
@@ -58,12 +57,12 @@ dds_participant::~dds_participant()
 {
     if( _participant->has_active_entities() )
     {
-        std::cout << "participant has active entities!, deleting them all.." << std::endl;
+        LOG_DEBUG( "participant has active entities!, deleting them all.." );
         _participant->delete_contained_entities();
     }
 
 
     if( ! DomainParticipantFactory::get_instance()->delete_participant( _participant ) )
-        std::cout << "Failed deleting participant!" << std::endl;
+        LOG_ERROR(  "Failed deleting participant!" );
 }
 

--- a/tools/dds/dds-server/lrs-device-watcher.cpp
+++ b/tools/dds/dds-server/lrs-device-watcher.cpp
@@ -46,6 +46,7 @@ void lrs_device_watcher::run( std::function< void( rs2::device ) > add_device_cb
                 for( auto device_to_remove : devices_to_remove )
                 {
                     remove_device_cb( device_to_remove );
+                    std::cout << "Device '" << device_to_remove.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - removed" << std::endl;
                     strong_rs_device_list->erase( std::remove_if( strong_rs_device_list->begin(),
                                                            strong_rs_device_list->end(),
                                                            [&]( const rs2::device & dev ) {
@@ -59,6 +60,7 @@ void lrs_device_watcher::run( std::function< void( rs2::device ) > add_device_cb
                 {
                     add_device_cb( rs_device );
                     strong_rs_device_list->push_back(rs_device);
+                    std::cout << "Device '" << rs_device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - detected" << std::endl;
                 }
             }
         } );
@@ -72,5 +74,6 @@ void tools::lrs_device_watcher::notify_connected_devices_on_wake_up(
     {
         add_device_cb( connected_dev );
         _rs_device_list->push_back(connected_dev);
+        std::cout << "Device '" << connected_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - detected" << std::endl;
     }
 }

--- a/tools/dds/dds-server/rs-dds-server.cpp
+++ b/tools/dds/dds-server/rs-dds-server.cpp
@@ -98,7 +98,7 @@ try
 
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), 0);// Pend until CTRL + C is pressed 
 
-     std::cout << "Shutting down RS DDS Server..." << std::endl;
+    std::cout << "Shutting down RS DDS Server..." << std::endl;
 
     return EXIT_SUCCESS;
 }

--- a/tools/dds/dds-server/rs-dds-server.cpp
+++ b/tools/dds/dds-server/rs-dds-server.cpp
@@ -98,6 +98,8 @@ try
 
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), 0);// Pend until CTRL + C is pressed 
 
+     std::cout << "Shutting down RS DDS Server..." << std::endl;
+
     return EXIT_SUCCESS;
 }
 catch( const rs2::error & e )


### PR DESCRIPTION
Tracked on [LRS-428]

Use cout to print the main tool status and device status
Use logs for all other DDS classes

Note: the logs will only be printed when compiling with `SHARED_LIBS=OFF`