### PR TITLE
bugfix: next_pixel_in_line

### DIFF
--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -3707,7 +3707,7 @@ void next_pixel_in_line(float curr[2], const float start[2], const float end[2])
     else
     {
         curr[1] = end[1] > curr[1] ? curr[1] + 1 : curr[1] - 1;
-        curr[0] = end[0] - ((end[1] + curr[1]) / line_slope);
+        curr[0] = end[0] - ((end[1] - curr[1]) / line_slope);
     }
 }
 


### PR DESCRIPTION
should be "-" instead of "+" for correct calculation of next pixel in "else" case