### PR TITLE
fix #10617 rs-software-device black output

### DIFF
--- a/examples/software-device/rs-software-device.cpp
+++ b/examples/software-device/rs-software-device.cpp
@@ -142,9 +142,6 @@ int main(int argc, char * argv[]) try
                                 W, H, 60, BPP,
                                 RS2_FORMAT_Z16, depth_intrinsics });
 
-    depth_sensor.add_read_only_option(RS2_OPTION_DEPTH_UNITS, 0.001f);
-
-
     auto color_stream = color_sensor.add_video_stream({  RS2_STREAM_COLOR, 0, 1, texture.x,
                                 texture.y, 60, texture.bpp,
                                 RS2_FORMAT_RGBA8, color_intrinsics });
@@ -174,7 +171,7 @@ int main(int argc, char * argv[]) try
                                        depth_frame.x * depth_frame.bpp,  // Stride
                                        depth_frame.bpp,
                                        timestamp, domain, frame_number,
-                                       depth_stream } );
+                                       depth_stream, 0.001f } );  // depth unit
 
 
         color_sensor.on_video_frame( { texture.frame.data(),     // Frame pixels from capture API
@@ -194,8 +191,10 @@ int main(int argc, char * argv[]) try
         if (depth && color)
         {
             if (auto as_depth = depth.as<rs2::depth_frame>())
+            {
+                pc.map_to(color);
                 points = pc.calculate(as_depth);
-            pc.map_to(color);
+            }
 
             // Upload the color frame to OpenGL
             app_state.tex.upload(color);


### PR DESCRIPTION
Changes:
Fix [GitHub] #10617 LRS example program rs-software-device has a black output on Windows 10

Tracked on: DSO-18356