### PR TITLE
Remove unused variable pid in ds5_advanced_mode_base constructor

### DIFF
--- a/src/ds5/advanced_mode/advanced_mode.cpp
+++ b/src/ds5/advanced_mode/advanced_mode.cpp
@@ -22,7 +22,6 @@ namespace librealsense
         };
 
         // "Remove IR Pattern" visual preset is available only for D400, D410, D415, D460, D465
-        std::string pid = _depth_sensor.get_info(RS2_CAMERA_INFO_PRODUCT_ID);
         _preset_opt = std::make_shared<advanced_mode_preset_option>(*this,
             _depth_sensor,
             option_range{ 0,


### PR DESCRIPTION
See GitHub[ bug#10336](https://github.com/IntelRealSense/librealsense/issues/10336)
Tracked on [DSO-18248]

Crash in applications when running x86 in Win10 with D405. This line is redundant (in all environments) and removing it fixes the crash.