### PR TITLE
Addressing LRS-462 Viewer IR frames switch

### DIFF
--- a/common/model-views.cpp
+++ b/common/model-views.cpp
@@ -2491,7 +2491,7 @@ namespace rs2
         glPopAttrib();
     }
 
-    bool stream_model::is_stream_visible()
+    bool stream_model::is_stream_visible() const
     {
         if (dev &&
             (dev->is_paused() ||
@@ -4381,7 +4381,17 @@ namespace rs2
         for (auto&& f : first)
         {
             auto first_uid = f.get_profile().unique_id();
-            if (auto second_f = second.first_or_default(f.get_profile().stream_type()))
+
+            frame second_f;
+            if (f.get_profile().stream_type() == RS2_STREAM_INFRARED)
+            {
+                second_f = second.get_infrared_frame( f.get_profile().stream_index() );
+            }
+            else
+            {
+                second_f = second.first_or_default( f.get_profile().stream_type() );
+            }
+            if ( second_f )
             {
                 auto second_uid = second_f.get_profile().unique_id();
 

--- a/common/model-views.h
+++ b/common/model-views.h
@@ -747,7 +747,7 @@ namespace rs2
     public:
         stream_model();
         std::shared_ptr<texture_buffer> upload_frame(frame&& f);
-        bool is_stream_visible();
+        bool is_stream_visible() const;
         void update_ae_roi_rect(const rect& stream_rect, const mouse_info& mouse, std::string& error_message);
         void show_frame(const rect& stream_rect, const mouse_info& g, std::string& error_message);
         rect get_normalized_zoom(const rect& stream_rect, const mouse_info& g, bool is_middle_clicked, float zoom_val);


### PR DESCRIPTION
model-views post_processing_filters populate viewer::streams_origin to map filtered frames to original streams. Using first_or_default for mapping infrared streams is not always OK.

Changed to using get_infrared_frame(index) when type is RS2_STREAM_INFRARED