### PR TITLE
Fix compilation with GCC 10+

### DIFF
--- a/src/libusb/libusb.h
+++ b/src/libusb/libusb.h
@@ -7,15 +7,15 @@
 #if 0
 In file included from /home/administrator/lrs/src/libusb/request-libusb.h:6:0,
     from /home/administrator/lrs/src/libusb/request-libusb.cpp:4:
-/usr/include/libusb-1.0/libusb.h:736:4: warning: ISO C++ forbids zero-size array ‘dev_capability_data’ [-Wpedantic]
+/usr/include/libusb-1.0/libusb.h:736:4: warning: ISO C++ forbids zero-size array 'dev_capability_data' [-Wpedantic]
     [0] /* non-standard, but usually working code */
     ^
-/usr/include/libusb-1.0/libusb.h:767:4: warning: ISO C++ forbids zero-size array ‘dev_capability’ [-Wpedantic]
+/usr/include/libusb-1.0/libusb.h:767:4: warning: ISO C++ forbids zero-size array 'dev_capability' [-Wpedantic]
     [0] /* non-standard, but usually working code */
     ^
 In file included from /home/administrator/lrs/src/libusb/request-libusb.h:6:0,
     from /home/administrator/lrs/src/libusb/request-libusb.cpp:4:
-/usr/include/libusb-1.0/libusb.h:1260:4: warning: ISO C++ forbids zero-size array ‘iso_packet_desc’ [-Wpedantic]
+/usr/include/libusb-1.0/libusb.h:1260:4: warning: ISO C++ forbids zero-size array 'iso_packet_desc' [-Wpedantic]
     [0] /* non-standard, but usually working code */
     ^
 #endif


### PR DESCRIPTION
The current release v2.51.1 fails to compile with more recent GCC versions starting from 10. The header file `src/libusb/libusb.h` uses a `#if 0` preprocessor directive to specify a comment block. That comment contains the Unicode character `´` (Left Single Quotation Mark, U+2018) which is rejected by the compiler.

If gcc versions greater than 9 are used, compilation fails. Here the try to compile librealsense on Ubuntu with gcc 11 (`g++ --version`: Ubuntu 11.2.0-19ubuntu1):

```
[ 66%] Building CXX object CMakeFiles/realsense2.dir/src/libusb/context-libusb.cpp.o
In file included from /home/robot/librealsense/src/libusb/context-libusb.h:10,
                 from /home/robot/librealsense/src/libusb/context-libusb.cpp:4:
/home/robot/librealsense/src/libusb/libusb.h:10:82: error: extended character ‘ is not valid in an identifier
```

This fix replaces the rejected Unicode character with a plain ASCII single quote `'`. 