### PR TITLE
add missing dependence for build kernel module

### DIFF
--- a/scripts/patch-realsense-ubuntu-lts-hwe.sh
+++ b/scripts/patch-realsense-ubuntu-lts-hwe.sh
@@ -99,6 +99,8 @@ then
 	#Ubuntu 18.04 kernel 4.18 + 20.04/ 5.4
 	require_package bison
 	require_package flex
+	# required if kernel >=5.11
+	require_package dwarves
 fi
 
 # Get the linux kernel and change into source tree


### PR DESCRIPTION
from 5.11, the command "pahole" is required for building kernel with BTF support.
ubuntu kernel has enabled BTF support. but the "pahole" package is not installed by default.