### PR TITLE
Fix two undefined behavior issues (pipeline/config, elpp)

### DIFF
--- a/src/pipeline/config.h
+++ b/src/pipeline/config.h
@@ -60,7 +60,7 @@ namespace librealsense
             std::mutex _mtx;
             bool _enable_all_streams = false;
             std::shared_ptr<profile> _resolved_profile;
-            bool _playback_loop;
+            bool _playback_loop = false;
             std::vector<std::pair<rs2_stream, int>> _streams_to_disable;
         };
     }

--- a/third-party/easyloggingpp/src/easylogging++.h
+++ b/third-party/easyloggingpp/src/easylogging++.h
@@ -3810,7 +3810,6 @@ class Helpers : base::StaticClass {
   }
   static inline void validateFileRolling(Logger* logger, Level level) {
     if (logger == nullptr) return;
-    if (ELPP == nullptr) return;
     logger->m_typedConfigurations->validateFileRolling(level, ELPP->preRollOutCallback());
   }
 };

--- a/third-party/easyloggingpp/src/easylogging++.h
+++ b/third-party/easyloggingpp/src/easylogging++.h
@@ -3810,6 +3810,7 @@ class Helpers : base::StaticClass {
   }
   static inline void validateFileRolling(Logger* logger, Level level) {
     if (logger == nullptr) return;
+    if (ELPP == nullptr) return;
     logger->m_typedConfigurations->validateFileRolling(level, ELPP->preRollOutCallback());
   }
 };


### PR DESCRIPTION
pipeline/config: initialize playback_loop

We found a UBSan complaint of the value 173 being stored into a boolean in the copy constructor.

third-party/easyloggingpp: work around global init order bug

The validateFileRolling function is called during the static initialization of an el::Storage, but it tries to access the global el::Storage. Clang compiles this into a branch to ud1. Instead, just skip the function call.

PiperOrigin-RevId: 471841322

---

The easylogging patch was the quick-and-dirty method to get our binaries to stop crashing. If you have suggestions for a better patch, I'm willing to explore them.