### PR TITLE
Fix build fail due missing operator= in popup

### DIFF
--- a/common/viewer.h
+++ b/common/viewer.h
@@ -15,21 +15,13 @@ namespace rs2
 {
     struct popup
     {
-        const std::string header;
-        const std::string message;
-        std::function<void()> custom_command;
+        std::string header;
+        std::string message;
+        std::function< void() > custom_command;
 
-        bool operator ==(const popup& p)
+        bool operator==( const popup & p ) const
         {
             return p.message == message;
-        }
-      
-        popup& operator =(const popup& p)
-        {
-            const_cast<std::string&>(header) = p.header;
-            const_cast<std::string&>(message) = p.message;
-            const_cast<std::function<void()>&>(custom_command) = p.custom_command;
-            return *this;
         }
     };
 

--- a/common/viewer.h
+++ b/common/viewer.h
@@ -23,6 +23,14 @@ namespace rs2
         {
             return p.message == message;
         }
+      
+        popup& operator =(const popup& p)
+        {
+            const_cast<std::string&>(header) = p.header;
+            const_cast<std::string&>(message) = p.message;
+            const_cast<std::function<void()>&>(custom_command) = p.custom_command;
+            return *this;
+        }
     };
 
     class viewer_model;


### PR DESCRIPTION
Fix build failure after PR #10809 in [Windows ](https://github.com/IntelRealSense/librealsense/runs/8233185499?check_suite_focus=true) and [Linux](https://github.com/IntelRealSense/librealsense/runs/8233184752?check_suite_focus=true) due missing operator= in [common/viewer.h#16](https://github.com/IntelRealSense/librealsense/blob/development/common/viewer.h#L16) which is required by [std::vector::erase](https://github.com/IntelRealSense/librealsense/blob/development/common/viewer.cpp#L1126) when having const members.

### Workaround
this can also be solved by making the struct popup's members `header`, `message` and `custom_command` non-const instead of using `const_cast`.