### PR TITLE
Handle possible exceptions at dds-device

### DIFF
--- a/include/librealsense2/dds/dds-device.cpp
+++ b/include/librealsense2/dds/dds-device.cpp
@@ -344,24 +344,29 @@ size_t
 dds_device::foreach_video_profile( size_t sensor_index,
                                    std::function< void( const rs2_video_stream & profile, bool def_prof ) > fn ) const
 {
-    auto const & msg = _impl->_sensor_to_video_profiles.at( int( sensor_index ) );  // may throw!
-    for( size_t i = 0; i < msg.num_of_profiles; ++i )
+    auto const & msg = _impl->_sensor_to_video_profiles.find( int( sensor_index ) );
+    if(msg != _impl->_sensor_to_video_profiles.end())
     {
-        auto const & profile = msg.profiles[i];
-        rs2_video_stream prof;
-        prof.type   = profile.type;
-        prof.index  = profile.stream_index;
-        prof.uid    = profile.uid;
-        prof.width  = profile.width;
-        prof.height = profile.height;
-        prof.fps    = profile.framerate;
-        //TODO - bpp needed?
-        prof.fmt    = profile.format;
-        //TODO - add intrinsics
-        fn( prof, profile.default_profile );
+        for( size_t i = 0; i < msg->second.num_of_profiles; ++i )
+        {
+            auto const & profile = msg->second.profiles[i];
+            rs2_video_stream prof;
+            prof.type   = profile.type;
+            prof.index  = profile.stream_index;
+            prof.uid    = profile.uid;
+            prof.width  = profile.width;
+            prof.height = profile.height;
+            prof.fps    = profile.framerate;
+            //TODO - bpp needed?
+            prof.fmt    = profile.format;
+            //TODO - add intrinsics
+            fn( prof, profile.default_profile );
+        }
+
+        return msg->second.num_of_profiles;
     }
 
-    return msg.num_of_profiles;
+    return 0; //Not a video sensor, nothing to do
 }
 
 
@@ -369,21 +374,26 @@ size_t
 dds_device::foreach_motion_profile( size_t sensor_index,
                                     std::function< void( const rs2_motion_stream & profile, bool def_prof ) > fn ) const
 {
-    auto const & msg = _impl->_sensor_to_motion_profiles.at( int( sensor_index ) );  // may throw!
-    for( size_t i = 0; i < msg.num_of_profiles; ++i )
+    auto const& msg = _impl->_sensor_to_motion_profiles.find( int( sensor_index ) );
+    if (msg != _impl->_sensor_to_motion_profiles.end())
     {
-        auto const & profile = msg.profiles[i];
-        rs2_motion_stream prof;
-        prof.type   = profile.type;
-        prof.index  = profile.stream_index;
-        prof.uid    = profile.uid;
-        prof.fps    = profile.framerate;
-        prof.fmt    = profile.format;
-        //TODO - add intrinsics
-        fn( prof, profile.default_profile );
+        for( size_t i = 0; i < msg->second.num_of_profiles; ++i )
+        {
+            auto const & profile = msg->second.profiles[i];
+            rs2_motion_stream prof;
+            prof.type   = profile.type;
+            prof.index  = profile.stream_index;
+            prof.uid    = profile.uid;
+            prof.fps    = profile.framerate;
+            prof.fmt    = profile.format;
+            //TODO - add intrinsics
+            fn( prof, profile.default_profile );
+        }
+
+        return msg->second.num_of_profiles;
     }
 
-    return msg.num_of_profiles;
+    return 0; //Not a motion sensor, nothing to do
 }
 
 }  // namespace dds

--- a/include/librealsense2/dds/dds-device.cpp
+++ b/include/librealsense2/dds/dds-device.cpp
@@ -345,28 +345,29 @@ dds_device::foreach_video_profile( size_t sensor_index,
                                    std::function< void( const rs2_video_stream & profile, bool def_prof ) > fn ) const
 {
     auto const & msg = _impl->_sensor_to_video_profiles.find( int( sensor_index ) );
-    if(msg != _impl->_sensor_to_video_profiles.end())
-    {
-        for( size_t i = 0; i < msg->second.num_of_profiles; ++i )
-        {
-            auto const & profile = msg->second.profiles[i];
-            rs2_video_stream prof;
-            prof.type   = profile.type;
-            prof.index  = profile.stream_index;
-            prof.uid    = profile.uid;
-            prof.width  = profile.width;
-            prof.height = profile.height;
-            prof.fps    = profile.framerate;
-            //TODO - bpp needed?
-            prof.fmt    = profile.format;
-            //TODO - add intrinsics
-            fn( prof, profile.default_profile );
-        }
 
-        return msg->second.num_of_profiles;
+    if (msg == _impl->_sensor_to_video_profiles.end())
+    {
+        return 0; //Not a video sensor, nothing to do
     }
 
-    return 0; //Not a video sensor, nothing to do
+    for( size_t i = 0; i < msg->second.num_of_profiles; ++i )
+    {
+        auto const & profile = msg->second.profiles[i];
+        rs2_video_stream prof;
+        prof.type   = profile.type;
+        prof.index  = profile.stream_index;
+        prof.uid    = profile.uid;
+        prof.width  = profile.width;
+        prof.height = profile.height;
+        prof.fps    = profile.framerate;
+        //TODO - bpp needed?
+        prof.fmt    = profile.format;
+        //TODO - add intrinsics
+        fn( prof, profile.default_profile );
+    }
+
+    return msg->second.num_of_profiles;
 }
 
 
@@ -375,25 +376,26 @@ dds_device::foreach_motion_profile( size_t sensor_index,
                                     std::function< void( const rs2_motion_stream & profile, bool def_prof ) > fn ) const
 {
     auto const& msg = _impl->_sensor_to_motion_profiles.find( int( sensor_index ) );
-    if (msg != _impl->_sensor_to_motion_profiles.end())
-    {
-        for( size_t i = 0; i < msg->second.num_of_profiles; ++i )
-        {
-            auto const & profile = msg->second.profiles[i];
-            rs2_motion_stream prof;
-            prof.type   = profile.type;
-            prof.index  = profile.stream_index;
-            prof.uid    = profile.uid;
-            prof.fps    = profile.framerate;
-            prof.fmt    = profile.format;
-            //TODO - add intrinsics
-            fn( prof, profile.default_profile );
-        }
 
-        return msg->second.num_of_profiles;
+    if (msg == _impl->_sensor_to_motion_profiles.end())
+    {
+        return 0; //Not a motion sensor, nothing to do
     }
 
-    return 0; //Not a motion sensor, nothing to do
+    for( size_t i = 0; i < msg->second.num_of_profiles; ++i )
+    {
+        auto const & profile = msg->second.profiles[i];
+        rs2_motion_stream prof;
+        prof.type   = profile.type;
+        prof.index  = profile.stream_index;
+        prof.uid    = profile.uid;
+        prof.fps    = profile.framerate;
+        prof.fmt    = profile.format;
+        //TODO - add intrinsics
+        fn( prof, profile.default_profile );
+    }
+
+    return msg->second.num_of_profiles;
 }
 
 }  // namespace dds

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -446,7 +446,7 @@ namespace librealsense
                 } );
             for( size_t i = 0; i < count; ++i )
             {
-                software_sensor & sensor = get_software_sensor( int( i ) );
+                software_sensor & sensor = get_software_sensor( i );
                 _dds_dev->foreach_video_profile( i, [&]( const rs2_video_stream& profile, bool default_profile ) {
                     sensor.add_video_stream( profile, default_profile );
                 } );

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -54,7 +54,7 @@ namespace librealsense
         _user_destruction_callback = std::move(callback);
     }
 
-    software_sensor& software_device::get_software_sensor(int index)
+    software_sensor& software_device::get_software_sensor( size_t index)
     {
         if (index >= _software_sensors.size())
         {

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -20,7 +20,7 @@ namespace librealsense
 
         software_sensor& add_software_sensor(const std::string& name);
 
-        software_sensor& get_software_sensor(int index);
+        software_sensor& get_software_sensor( size_t index);
 
         void set_matcher_type(rs2_matchers matcher);
         

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -230,11 +230,6 @@ int main(int argc, char** argv) try
     if (!playback_dev_file.empty())
         d = ctx.load_device(playback_dev_file.data());
 
-#ifdef BUILD_WITH_DDS
-    //Sleep needed because DDS discovery process takes time
-    std::this_thread::sleep_for( std::chrono::seconds( 5 ) );
-#endif
-
     auto devices_list = ctx.query_devices();
     size_t device_count = devices_list.size();
     if (!device_count)

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -230,6 +230,11 @@ int main(int argc, char** argv) try
     if (!playback_dev_file.empty())
         d = ctx.load_device(playback_dev_file.data());
 
+#ifdef BUILD_WITH_DDS
+    //Sleep needed because DDS discovery process takes time
+    std::this_thread::sleep_for( std::chrono::seconds( 5 ) );
+#endif
+
     auto devices_list = ctx.query_devices();
     size_t device_count = devices_list.size();
     if (!device_count)


### PR DESCRIPTION
Following Eran's PR about handling compilation warnings

Handling possible exception at dds-device: using find and check return value instead of using at() and exception