### PR TITLE
adding gil_scoped_release to sensor open api methods

### DIFF
--- a/wrappers/python/pyrs_sensor.cpp
+++ b/wrappers/python/pyrs_sensor.cpp
@@ -38,7 +38,7 @@ void init_sensor(py::module &m) {
 
     py::class_<rs2::sensor, rs2::options> sensor(m, "sensor"); // No docstring in C++
     sensor.def("open", (void (rs2::sensor::*)(const rs2::stream_profile&) const) &rs2::sensor::open,
-               "Open sensor for exclusive access, by commiting to a configuration", "profile"_a)
+               "Open sensor for exclusive access, by commiting to a configuration", "profile"_a, py::call_guard<py::gil_scoped_release>())
         .def("supports", (bool (rs2::sensor::*)(rs2_camera_info) const) &rs2::sensor::supports,
              "Check if specific camera info is supported.", "info")
         .def("supports", (bool (rs2::sensor::*)(rs2_option) const) &rs2::options::supports,
@@ -50,7 +50,7 @@ void init_sensor(py::module &m) {
         }, "Register Notifications callback", "callback"_a)
         .def("open", (void (rs2::sensor::*)(const std::vector<rs2::stream_profile>&) const) &rs2::sensor::open,
              "Open sensor for exclusive access, by committing to a composite configuration, specifying one or "
-             "more stream profiles.", "profiles"_a)
+             "more stream profiles.", "profiles"_a, py::call_guard<py::gil_scoped_release>())
         .def("close", &rs2::sensor::close, "Close sensor for exclusive access.", py::call_guard<py::gil_scoped_release>())
         .def("start", [](const rs2::sensor& self, std::function<void(rs2::frame)> callback) {
             self.start(callback);


### PR DESCRIPTION
Since `sensor.open()` function is a process which takes time, we need to release the python `GIL` so that callbacks will still be received.
Tracked on LRS-519