### PR TITLE
attempt at reducing warnings (U20)

### DIFF
--- a/src/linux/udev-device-watcher.cpp
+++ b/src/linux/udev-device-watcher.cpp
@@ -181,22 +181,21 @@ udev_device_watcher::~udev_device_watcher()
 {
     stop();
 
-    if( _udev_monitor_fd == -1 )
-        throw runtime_error( "monitor fd was -1" );
-
     /* Release the udev monitor */
-    udev_monitor_unref( _udev_monitor );
+    if( _udev_monitor )
+        udev_monitor_unref( _udev_monitor );
     _udev_monitor = nullptr;
     _udev_monitor_fd = -1;
 
     /* Clean up the udev context */
-    udev_unref( _udev_ctx );
+    if( _udev_ctx )
+        udev_unref( _udev_ctx );
     _udev_ctx = nullptr;
 }
 
 
 // Scan devices using udev
-bool udev_device_watcher::foreach_device( std::function< bool( struct udev_device * udev_dev ) > callback )
+void udev_device_watcher::foreach_device( std::function< void( struct udev_device * udev_dev ) > callback )
 {
     auto enumerator = udev_enumerate_new( _udev_ctx );
     if( ! enumerator )

--- a/src/linux/udev-device-watcher.h
+++ b/src/linux/udev-device-watcher.h
@@ -50,7 +50,7 @@ public:
     bool is_stopped() const override { return ! _active_object.is_active(); }
 
 private:
-    bool foreach_device( std::function< bool( struct udev_device* udev_dev ) > );
+    void foreach_device( std::function< void( struct udev_device* udev_dev ) > );
 };
 
 

--- a/third-party/realsense-file/rosbag/rosbag_storage/include/rosbag/bag_player.h
+++ b/third-party/realsense-file/rosbag/rosbag_storage/include/rosbag/bag_player.h
@@ -70,7 +70,7 @@ private:
     Callback cb_;
 };
 #ifdef _MSC_VER
-#pragma warning( disable : 4290 ) // Suppress warning C4290:C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
+//#pragma warning( disable : 4290 ) // Suppress warning C4290:C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
 #endif
 /* A class for playing back bag files at an API level. It supports
    relatime, as well as accelerated and slowed playback. */
@@ -78,7 +78,7 @@ class BagPlayer
 {
 public:
   /* Constructor expecting the filename of a bag */
-  BagPlayer(const std::string &filename) throw(BagException);
+  BagPlayer(const std::string &filename);
 
   /* Register a callback for a specific topic and type */
   template<class T>

--- a/third-party/realsense-file/rosbag/rosbag_storage/src/bag_player.cpp
+++ b/third-party/realsense-file/rosbag/rosbag_storage/src/bag_player.cpp
@@ -5,7 +5,7 @@
 namespace rosbag
 {
 
-BagPlayer::BagPlayer(const std::string &fname) throw(BagException) {
+BagPlayer::BagPlayer(const std::string &fname) {
     bag.open(fname, rosbag::bagmode::Read);
     rs2rosinternal::Time::init();
     View v(bag);

--- a/third-party/realsense-file/rosbag/rostime/src/time.cpp
+++ b/third-party/realsense-file/rosbag/rostime/src/time.cpp
@@ -95,9 +95,6 @@ namespace rs2rosinternal
    * (i.e. not exposed to users of the time classes)
    */
   void ros_walltime(uint32_t& sec, uint32_t& nsec) 
-#ifndef WIN32    
-    throw(NoHighPerformanceTimersException)
-#endif
   {
 #ifndef WIN32
 #if HAS_CLOCK_GETTIME

--- a/unit-tests/log/test-mixed-file-callback.cpp
+++ b/unit-tests/log/test-mixed-file-callback.cpp
@@ -10,7 +10,7 @@
 TEST_CASE( "Mixed file & callback logging", "[log]" ) {
 
     char filename[L_tmpnam];
-    tmpnam( filename );
+    REQUIRE( tmpnam( filename ));
 
     TRACE( "Filename logging to: " << filename );
     REQUIRE_NOTHROW( rs2::log_to_file( RS2_LOG_SEVERITY_ERROR, filename ));

--- a/unit-tests/log/test-mixed-file-console.cpp
+++ b/unit-tests/log/test-mixed-file-console.cpp
@@ -10,7 +10,7 @@
 TEST_CASE( "Mixed file & console logging", "[log]" ) {
 
     char filename[L_tmpnam];
-    tmpnam( filename );
+    REQUIRE( tmpnam( filename ));
 
     TRACE( "Filename logging to: " << filename );
     REQUIRE_NOTHROW( rs2::log_to_file( RS2_LOG_SEVERITY_ERROR, filename ));

--- a/unit-tests/log/test-two-files.cpp
+++ b/unit-tests/log/test-two-files.cpp
@@ -11,8 +11,8 @@ TEST_CASE( "Double file logging", "[log]" ) {
 
     // Try to log to multiple destinations: callback, console, file...
     char filename1[L_tmpnam], filename2[L_tmpnam];
-    tmpnam( filename1 );
-    tmpnam( filename2 );
+    REQUIRE( tmpnam( filename1 ));
+    REQUIRE( tmpnam( filename2 ));
 
     TRACE( "Filename1 logging to: " << filename1 );
     TRACE( "Filename2 logging to: " << filename2 );


### PR DESCRIPTION
U20 now has 14 warnings, same as U16.
See [here](https://rsjenkins.iil.intel.com/job/LRS_libci_pipeline/3108/) if needed.