### PR TITLE
fix type and method err for Python3

### DIFF
--- a/wrappers/python/readme.md
+++ b/wrappers/python/readme.md
@@ -91,16 +91,16 @@ try:
 
         # Print a simple text-based representation of the image, by breaking it into 10x20 pixel regions and approximating the coverage of pixels within one meter
         coverage = [0]*64
-        for y in xrange(480):
-            for x in xrange(640):
+        for y in range(480):
+            for x in range(640):
                 dist = depth.get_distance(x, y)
                 if 0 < dist and dist < 1:
-                    coverage[x/10] += 1
+                    coverage[x//10] += 1
 
             if y%20 is 19:
                 line = ""
                 for c in coverage:
-                    line += " .:nhBXWW"[c/25]
+                    line += " .:nhBXWW"[c//25]
                 coverage = [0]*64
                 print(line)
 


### PR DESCRIPTION
Change the index to int type to avoid type error.
Change the xrange() to range() to run in Python3 (also works in Python2).