### PR TITLE
Use `--depth 1` with `git fetch`

### DIFF
--- a/scripts/patch-realsense-ubuntu-lts.sh
+++ b/scripts/patch-realsense-ubuntu-lts.sh
@@ -116,7 +116,7 @@ then
 	kernel_full_num=$(echo $LINUX_BRANCH | cut -d '-' -f 1,2)
 	kernel_git_tag=$(git ls-remote --tags origin | grep "${kernel_full_num}\." | grep '[^^{}]$' | tail -n 1 | awk -F/ '{print $NF}')
 	echo -e "\e[32mFetching Ubuntu LTS tag \e[47m${kernel_git_tag}\e[0m \e[32m to the local kernel sources folder\e[0m"
-	git fetch origin tag ${kernel_git_tag} --no-tags
+	git fetch origin tag ${kernel_git_tag} --no-tags --depth 1
 
 	# Verify that there are no trailing changes., warn the user to make corrective action if needed
 	if [ $(git status | grep 'modified:' | wc -l) -ne 0 ];


### PR DESCRIPTION
`git fetch` takes a super long time. Adding `--depth 1` speeds it up significantly without changing the behavior of the script.