### PR TITLE
dds_stream now inherits from dds_stream_base

### DIFF
--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -208,7 +208,8 @@ namespace librealsense
             {
                 if (ptr) _heap.deallocate(ptr);
             });
-            if (!token.get()) throw;
+            if (!token.get())
+                throw std::runtime_error( "no token in locked_transfer::send_receive" );
 
             std::lock_guard<std::recursive_mutex> lock(_local_mtx);
             return _uvc_sensor_base.invoke_powered([&]
@@ -350,7 +351,7 @@ namespace librealsense
         {
             T rv = 0;
             if (index + sizeof(T) >= data.size())
-                throw new std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
+                throw std::runtime_error("get_gvd_field - index out of bounds, buffer size: " +
                     std::to_string(data.size()) + ", index: " + std::to_string(index));
             for (int i = 0; i < sizeof(T); i++)
                 rv += data[index + i] << (i * 8);

--- a/third-party/realdds/include/realdds/dds-stream-profile.h
+++ b/third-party/realdds/include/realdds/dds-stream-profile.h
@@ -32,10 +32,11 @@ union dds_stream_uid
     }
 
     dds_stream_uid( int sid_, int index_ )
-        : whole( 0 )
-        , sid( static_cast< int16_t >( sid_ ))
-        , index( static_cast< int8_t >( index_ ))
-    {}
+    {
+        whole = 0;  // it covers an extra byte, which needs to be 0
+        sid = static_cast<int16_t>( sid_ );
+        index = static_cast<int8_t>( index_ );
+    }
 
     std::string to_string() const;
 };

--- a/third-party/realdds/include/realdds/dds-stream-profile.h
+++ b/third-party/realdds/include/realdds/dds-stream-profile.h
@@ -15,7 +15,7 @@ namespace realdds {
 
 union dds_stream_uid
 {
-    uint32_t whole;
+    uint32_t whole = 0;
     struct
     {
         int16_t sid;   // Stream ID; assigned by the server, but may not be unique because of index
@@ -32,7 +32,8 @@ union dds_stream_uid
     }
 
     dds_stream_uid( int sid_, int index_ )
-        : sid( static_cast< int16_t >( sid_ ))
+        : whole( 0 )
+        , sid( static_cast< int16_t >( sid_ ))
         , index( static_cast< int8_t >( index_ ))
     {}
 

--- a/third-party/realdds/include/realdds/dds-stream.h
+++ b/third-party/realdds/include/realdds/dds-stream.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "dds-stream-base.h"
 #include "dds-stream-profile.h"
 
 #include <functional>
@@ -14,25 +15,30 @@ namespace realdds {
 
 // Represents a stream of information (images, motion data, etc..) from a single source received via the DDS system.
 // A stream can have several profiles, i.e different data frequency, image resolution, etc..
-class dds_stream
+// 
+// This is a base class: you need to specify the type of stream via the instantiation of a video_stream, etc.
+//
+class dds_stream : public dds_stream_base
 {
+    typedef dds_stream_base super;
+
+protected:
+    dds_stream( std::string const & stream_name, std::string const & sensor_name );
+
+    // dds_stream_base
 public:
-    virtual const std::string & get_group_name() const = 0;
+    bool is_open() const override;
+    bool is_streaming() const override;
 
-    virtual size_t foreach_profile( std::function< void( const dds_stream_profile & prof, bool def_prof ) > fn ) const = 0;
-
-    virtual ~dds_stream() = default;
+    std::shared_ptr< dds_topic > const & get_topic() const override;
 };
 
 class dds_video_stream : public dds_stream
 {
+    typedef dds_stream super;
+
 public:
-    dds_video_stream( const std::string & group_name );
-
-    const std::string & get_group_name() const override;
-
-    void add_profile( dds_video_stream_profile && prof, bool default_profile );
-    size_t foreach_profile( std::function< void( const dds_stream_profile & prof, bool def_prof ) > fn ) const override;
+    dds_video_stream( std::string const & stream_name, std::string const & sensor_name );
 
 private:
     class impl;
@@ -41,13 +47,10 @@ private:
 
 class dds_motion_stream : public dds_stream
 {
+    typedef dds_stream super;
+
 public:
-    dds_motion_stream( const std::string & group_name );
-
-    const std::string & get_group_name() const override;
-
-    void add_profile( dds_motion_stream_profile && prof, bool default_profile );
-    size_t foreach_profile( std::function< void( const dds_stream_profile & prof, bool def_prof ) > fn ) const override;
+    dds_motion_stream( std::string const & stream_name, std::string const & sensor_name );
 
 private:
     class impl;

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -33,15 +33,15 @@ public:
     bool _running = false;
 
     size_t _expected_num_of_streams = 0;
-    std::map< dds_stream_uid, std::shared_ptr< dds_stream > > _streams;
+    std::map< std::string, std::shared_ptr< dds_stream > > _streams;
     std::atomic<uint32_t> _control_message_counter = { 0 };
 
     std::shared_ptr< dds_topic_reader > _notifications_reader;
     std::shared_ptr< dds_topic_writer > _control_writer;
 
-    impl( std::shared_ptr< dds_participant > const& participant,
-        dds_guid const& guid,
-        topics::device_info const& info );
+    impl( std::shared_ptr< dds_participant > const & participant,
+          dds_guid const & guid,
+          topics::device_info const & info );
 
     void run();
 

--- a/third-party/realdds/src/dds-stream-impl.h
+++ b/third-party/realdds/src/dds-stream-impl.h
@@ -11,27 +11,17 @@ namespace realdds {
 class dds_video_stream::impl
 {
 public:
-    impl( const std::string & group_name )
-        : _group_name( group_name )
+    impl()
     {
     }
-
-    std::string _group_name;
-
-    std::vector< std::pair< dds_video_stream_profile, bool > > _profiles; //Pair of profile and is default for stream
 };
 
 class dds_motion_stream::impl
 {
 public:
-    impl( const std::string & group_name )
-        : _group_name( group_name )
+    impl()
     {
     }
-
-    std::string _group_name;
-
-    std::vector< std::pair< dds_motion_stream_profile, bool > > _profiles; //Pair of profile and is default for stream
 };
 
 

--- a/third-party/realdds/src/dds-stream.cpp
+++ b/third-party/realdds/src/dds-stream.cpp
@@ -4,59 +4,48 @@
 #include <realdds/dds-stream.h>
 #include "dds-stream-impl.h"
 
-#include <stdexcept>
+#include <realdds/dds-exceptions.h>
+
 
 namespace realdds {
 
 
-dds_video_stream::dds_video_stream( const std::string & group_name )
-    : _impl( std::make_shared< dds_video_stream::impl >( group_name ) )
+dds_stream::dds_stream( std::string const & stream_name, std::string const & sensor_name )
+    : super( stream_name, sensor_name )
 {
 }
 
-const std::string & dds_video_stream::get_group_name() const
+
+bool dds_stream::is_open() const
 {
-    return _impl->_group_name;
+    return false;
 }
 
-void dds_video_stream::add_profile( dds_video_stream_profile && prof, bool default_profile )
+
+bool dds_stream::is_streaming() const
 {
-    _impl->_profiles.push_back( std::make_pair( std::move( prof ), default_profile ) );
+    return false;
 }
 
-size_t dds_video_stream::foreach_profile( std::function< void( const dds_stream_profile & prof, bool def_prof ) > fn ) const
-{
-    for ( auto & profile : _impl->_profiles )
-    {
-        fn( profile.first, profile.second );
-    }
 
-    return _impl->_profiles.size();
+std::shared_ptr< dds_topic > const & dds_stream::get_topic() const
+{
+    DDS_THROW( runtime_error, "stream '" + name() + "' must be open to get_topic()" );
 }
 
-dds_motion_stream::dds_motion_stream( const std::string & group_name )
-    : _impl( std::make_shared< dds_motion_stream::impl >( group_name ) )
+
+dds_video_stream::dds_video_stream( std::string const & stream_name, std::string const & sensor_name )
+    : super( stream_name, sensor_name )
+    , _impl( std::make_shared< dds_video_stream::impl >() )
 {
 }
 
-const std::string & dds_motion_stream::get_group_name() const
+
+dds_motion_stream::dds_motion_stream( std::string const & stream_name, std::string const & sensor_name )
+    : super( stream_name, sensor_name )
+    , _impl( std::make_shared< dds_motion_stream::impl >() )
 {
-    return _impl->_group_name;
 }
 
-void dds_motion_stream::add_profile( dds_motion_stream_profile && prof, bool default_profile )
-{
-    _impl->_profiles.push_back( std::make_pair( std::move( prof ), default_profile ) );
-}
-
-size_t dds_motion_stream::foreach_profile( std::function< void( const dds_stream_profile & prof, bool def_prof ) > fn ) const
-{
-    for ( auto & profile : _impl->_profiles )
-    {
-        fn( profile.first, profile.second );
-    }
-
-    return _impl->_profiles.size();
-}
 
 }  // namespace realdds

--- a/tools/dds/realdds-py/python.cpp
+++ b/tools/dds/realdds-py/python.cpp
@@ -450,11 +450,13 @@ PYBIND11_MODULE(NAME, m) {
         .def( "is_running", &dds_device::is_running )
         .def( "run", &dds_device::run, py::call_guard< py::gil_scoped_release >() )
         .def( "n_streams", &dds_device::number_of_streams )
-        .def( FN_FWD( dds_device,
-                      foreach_stream,
-                      ( std::shared_ptr< dds_stream > const & ),
-                      ( std::shared_ptr< dds_stream > const & stream ),
-                      callback( stream ); ) )
+        .def( "streams",
+              []( dds_device const & self ) {
+                  std::vector< std::shared_ptr< dds_stream > > streams;
+                  self.foreach_stream(
+                      [&]( std::shared_ptr< dds_stream > const & stream ) { streams.push_back( stream ); } );
+                  return streams;
+              } )
         .def( "__repr__", []( dds_device const & self ) {
             std::ostringstream os;
             os << "<" SNAME ".device ";

--- a/unit-tests/dds/test-device-init.py
+++ b/unit-tests/dds/test-device-init.py
@@ -35,6 +35,14 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         device.run()  # If no device is available in 30 seconds, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 1 )
+        for stream in device.streams():
+            profiles = stream.profiles()
+            test.check_equal( stream.name(), "s1" )
+            test.check_equal( stream.sensor_name(), "s1" )  # TODO: sensor name isn't communicated yet
+            test.check_equal( 1, len( profiles ))
+            test.check_equal( '<pyrealdds.video_stream_profile 0x2d0017 RGB8 9 Hz 10x10 @0 Bpp>', str(profiles[0]) )
+            test.check_equal( profiles[0].stream(), stream )
+            test.check_equal( stream.default_profile_index(), 0 )
         remote.run( 'close_server()', timeout=5 )
     except:
         test.unexpected_exception()
@@ -50,6 +58,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         device.run()  # If no device is available in 30 seconds, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 0 )
+        for stream in device.streams():
+            test.unreachable()
         remote.run( 'close_server()', timeout=5 )
     except:
         test.unexpected_exception()
@@ -61,11 +71,6 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     test.start( "Test no profiles... (should fail on server side)" )
     try:
         remote.run( 'test_no_profiles()', timeout=5 )
-        device = dds.device( participant, participant.create_guid(), info )
-        device.run()  # If no device is available in 30 seconds, this will throw
-        test.check( device.is_running() )
-        test.check_equal( device.n_streams(), 1 )
-        remote.run( 'close_server()', timeout=5 )
     except test.remote.Error as e:
         # this fails because streams require at least one profile
         test.check_exception( e, test.remote.Error, "RuntimeError: at least one profile is required to initialize stream 's1'" )

--- a/unit-tests/live/options/test-rgb-options-metadata-consistency.py
+++ b/unit-tests/live/options/test-rgb-options-metadata-consistency.py
@@ -36,7 +36,7 @@ def check_option_and_metadata_values(option, metadata, value_to_set, frame):
     changed = color_sensor.get_option(option)
     test.check_equal(changed, value_to_set)
     if frame.supports_frame_metadata(metadata):
-        changed_md = frame.get_frame_metadata(metadata)
+        changed_md = float( frame.get_frame_metadata(metadata) )
         test.check_equal(changed_md, value_to_set)
     else:
         print("metadata " + repr(metadata) + " not supported")
@@ -96,7 +96,7 @@ try:
 
         except:
             test.unexpected_exception()
-            
+
 except:
     print("The device found has no color sensor")
 finally:

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -201,16 +201,21 @@ def check_equal(result, expected, abort_if_failed = False):
         return False
     global n_assertions
     n_assertions += 1
-    if result != expected:
+    if type(expected) != type(result):
+        print_stack()
+        log.out( "    left  type:", type(result) )
+        log.out( "    right type:", type(expected) )
+    elif result != expected:
         print_stack()
         log.out( "    left  :", result )
         log.out( "    right :", expected )
-        check_failed()
-        if abort_if_failed:
-            abort()
-        return False
-    reset_info()
-    return True
+    else:
+        reset_info()
+        return True
+    check_failed()
+    if abort_if_failed:
+        abort()
+    return False
 
 
 def unreachable( abort_if_failed = False ):


### PR DESCRIPTION
Plus:
* fix throws; in locked_transfer::send_receive (found by cppcheck)
* fix bug in dds_stream_uid initialization (found by the new tests)
* replace pyrealdds.device.foreach_stream() with .stream()
* add stream checking to test-device-init

Tracked on LRS-502 (I think?)