### PR TITLE
Update Python wrapper readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Information about the Intel® RealSense™ technology at [www.intelrealsense.com
 
 Intel has EOLed the LiDAR, Facial Authentication, and Tracking product lines. These products have been discontinued and will no longer be available for new orders.
 
-Intel WILL continue to sell and support stereo products including the following: D410, D415, D430, D450 modules and D415, D435, D435i, D455 depth cameras. We will also continue the work to support and develop our LibRealSense open source SDK.
+Intel WILL continue to sell and support stereo products including the following: D410, D415, D430, , D401 ,D450 modules and D415, D435, D435i, D435f, D405, D455, D457 depth cameras. We will also continue the work to support and develop our LibRealSense open source SDK.
 
 In the future, Intel and the RealSense team will focus our new development on advancing innovative technologies that better support our core businesses and IDM 2.0 strategy.
 

--- a/readme.md
+++ b/readme.md
@@ -16,16 +16,13 @@ Information about the Intel® RealSense™ technology at [www.intelrealsense.com
 
 > :open_file_folder: Don't have access to a RealSense camera? Check-out [sample data](./doc/sample-data.md)
 
-## Special notice from Intel® RealSense™ regarding the recent press announcement
+## Update on Recent Changes to the RealSense Product Line
 
-Intel has decided to wind down the RealSense business and is announcing the EOL of LiDAR, Facial Authentication, and Tracking product lines this month. Intel will continue to provide Stereo products to its current distribution customers.  Intel will focus our new development on advancing innovative technologies that better support our core businesses and IDM 2.0 strategy.
-The products identified in this notification will be discontinued and unavailable for additional orders after Feb 28, 2022.
+Intel has EOLed the LiDAR, Facial Authentication, and Tracking product lines. These products have been discontinued and will no longer be available for new orders.
 
-The following Stereo Product Lines WILL continue to be supported: D410, D415, D430, D450 modules and D415, D435, D435i, D455 depth cameras. 
+Intel WILL continue to sell and support stereo products including the following: D410, D415, D430, D450 modules and D415, D435, D435i, D455 depth cameras. We will also continue the work to support and develop our LibRealSense open source SDK.
 
-We will also continue the work to support and develop our LibRealSense open source SDK.
-
-In the coming future Intel and the RealSense team will focus our new development on advancing innovative technologies that better support our core businesses and IDM 2.0 strategy.
+In the future, Intel and the RealSense team will focus our new development on advancing innovative technologies that better support our core businesses and IDM 2.0 strategy.
 
 ## Building librealsense - Using vcpkg
 

--- a/wrappers/python/readme.md
+++ b/wrappers/python/readme.md
@@ -45,7 +45,8 @@ Windows users can install the RealSense SDK 2.0 from the release tab to get pre-
   * `make -j4`
   * `sudo make install`
 4. update your PYTHONPATH environment variable to add the path to the pyrealsense library
-  * `export PYTHONPATH=$PYTHONPATH:/usr/local/lib`
+  * export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.6/pyrealsense2
+  * Please Refer youtube vid comment : https://www.youtube.com/watch?v=EeT-pzM8n-o
 5. Alternatively, copy the build output (`librealsense2.so` and `pyrealsense2.so`) next to your script.
   * **Note:** Python 3 module filenames may contain additional information, e.g. `pyrealsense2.cpython-35m-arm-linux-gnueabihf.so`)
 


### PR DESCRIPTION
The previous instruction assumes the library to be installed in the `/usr/local/lib` whereas it actually gets installed in  `/usr/local/lib/python/pyrealsense2`