### PR TITLE
clean up rs-enumerate-devices tab output; add --verbose

### DIFF
--- a/include/librealsense2/hpp/rs_context.hpp
+++ b/include/librealsense2/hpp/rs_context.hpp
@@ -104,6 +104,10 @@ namespace rs2
                 rs2_delete_context);
             error::handle(e);
         }
+        context( std::string const & json_settings )
+            : context( json_settings.c_str() )
+        {
+        }
 
         /**
         * create a static snapshot of all connected devices at the time of the call

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -423,9 +423,10 @@ int main(int argc, char** argv) try
                 w_stream += 2;
 
                 // Heading
-                cout << "    ";
                 if( verbose )
-                    cout << "       ";  // (sid,index)
+                    cout << "   (UID.IDX)  ";
+                else
+                    cout << "    ";
                 cout << setw( w_stream ) << "STREAM";
                 if( video_stream )
                     cout << setw( w_res ) << "RESOLUTION";
@@ -437,7 +438,7 @@ int main(int argc, char** argv) try
                 {
                     cout << "    ";
                     if( verbose )
-                        cout << '(' << profile.unique_id() << '.' << profile.stream_index() << ")  ";
+                        cout << " (" << profile.unique_id() << '.' << profile.stream_index() << ")    ";
                     cout << setw( w_stream ) << profile.stream_name();
                     if (auto video = profile.as<video_stream_profile>())
                     {

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -193,6 +193,7 @@ int main(int argc, char** argv) try
     SwitchArg show_calibration_data_arg( "c", "calib_data", "Show extrinsic and intrinsic of all subdevices" );
     SwitchArg show_defaults("d", "defaults", "Show the default streams configuration");
     SwitchArg only_sw_arg( "", "sw-only", "Show only software devices (playback, dds, etc. -- but not USB/HID/etc.)" );
+    SwitchArg verbose_arg( "v", "verbose", "Show extra information" );
     ValueArg<string> show_playback_device_arg("p", "playback_device", "Inspect and enumerate playback device (from file)",
         false, "", "Playback device - ROSBag record full path");
     cmd.add(debug_arg);
@@ -201,6 +202,7 @@ int main(int argc, char** argv) try
     cmd.add(show_options_arg);
     cmd.add(show_calibration_data_arg);
     cmd.add(only_sw_arg);
+    cmd.add(verbose_arg);
 #ifdef BUILD_WITH_DDS
     ValueArg< int > domain_arg( "", "dds-domain", "Set the DDS domain ID", false, 0, "domain ID" );
     cmd.add( domain_arg );
@@ -221,6 +223,7 @@ int main(int argc, char** argv) try
     bool show_calibration_data = show_calibration_data_arg.getValue();
     bool show_modes = !(compact_view || short_view);
     auto playback_dev_file = show_playback_device_arg.getValue();
+    bool verbose = verbose_arg.getValue();
 
     if ((short_view || compact_view) && (show_options || show_calibration_data))
     {
@@ -386,25 +389,49 @@ int main(int argc, char** argv) try
 
         if (show_modes)
         {
-            for (auto&& sensor : dev.query_sensors())
-            {
-                cout << "Stream Profiles supported by " << sensor.get_info(RS2_CAMERA_INFO_NAME) << endl;
+            size_t w_res = 12;
+            size_t w_fps = 10;
+            size_t w_format = 10;
 
-                cout << " Supported modes:\n" << setw(16) << "    stream" << setw(16)
-                    << " resolution" << setw(10) << " fps" << setw(10) << " format" << endl;
+            for( auto&& sensor : dev.query_sensors() )
+            {
+                cout << "Stream Profiles supported by " << sensor.get_info( RS2_CAMERA_INFO_NAME ) << endl;
+                cout << " Supported modes:\n";
+
+                size_t w_stream = 10;
+                bool video_stream = false;
+                for( auto&& profile : sensor.get_stream_profiles() )
+                {
+                    w_stream = std::max( profile.stream_name().length(), w_stream );
+                    if( auto video = profile.as<video_stream_profile>() )
+                        video_stream = true;
+                }
+                w_stream += 2;
+
+                // Heading
+                cout << "    ";
+                if( verbose )
+                    cout << "       ";  // (sid,index)
+                cout << setw( w_stream ) << "STREAM";
+                if( video_stream )
+                    cout << setw( w_res ) << "RESOLUTION";
+                cout << setw( w_fps ) << "FPS";
+                cout << setw( w_format ) << "FORMAT";
+                cout << endl;
                 // Show which streams are supported by this device
                 for (auto&& profile : sensor.get_stream_profiles())
                 {
+                    cout << "    ";
+                    if( verbose )
+                        cout << '(' << profile.unique_id() << '.' << profile.stream_index() << ")  ";
+                    cout << setw( w_stream ) << profile.stream_name();
                     if (auto video = profile.as<video_stream_profile>())
                     {
-                        cout << "    " << profile.stream_name() << "\t  " << video.width() << "x"
-                            << video.height() << "\t@ " << profile.fps() << setw(6) << "Hz\t" << profile.format() << endl;
+                        cout << setw( w_res ) << ( std::to_string( video.width() ) + 'x' + std::to_string( video.height() ));
                     }
-                    else
-                    {
-                        cout << "    " << profile.stream_name() << "\t N/A\t\t@ " << profile.fps()
-                            << setw(6) << "Hz\t" << profile.format() << endl;
-                    }
+                    cout << setw( w_fps ) << ( "@ " + std::to_string( profile.fps() ) + "Hz" );
+                    cout << setw( w_format ) << profile.format();
+                    cout << endl;
                 }
 
                 cout << endl;


### PR DESCRIPTION
Misc changes to clean up my branch.
The `rs-enumerate-devices` output was using tabs, therefore was (usually) misaligned.
I also added a `--verbose` flag which, right now, only adds the `(sid,index)` pair to each profiles so we can check it.