### PR TITLE
flexible-reader/-writer & dds-time

### DIFF
--- a/third-party/realdds/include/realdds/dds-defines.h
+++ b/third-party/realdds/include/realdds/dds-defines.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 
 namespace eprosima {
 namespace fastdds {
@@ -15,6 +17,7 @@ namespace rtps {
     struct GUID_t;
     struct GuidPrefix_t;
     struct EntityId_t;
+    class Time_t;
 }  // namespace rtps
 namespace types {
     class DynamicType_ptr;
@@ -25,6 +28,8 @@ namespace types {
 namespace realdds {
 
 
+using dds_time = eprosima::fastrtps::rtps::Time_t;
+using dds_nsec = int64_t;  // the type returned from dds_time::to_ns()
 using dds_guid = eprosima::fastrtps::rtps::GUID_t;
 using dds_guid_prefix = eprosima::fastrtps::rtps::GuidPrefix_t;
 using dds_entity_id = eprosima::fastrtps::rtps::EntityId_t;

--- a/third-party/realdds/include/realdds/dds-time.h
+++ b/third-party/realdds/include/realdds/dds-time.h
@@ -30,7 +30,7 @@ inline dds_time time_from( dds_nsec nanoseconds )
 
 // Easy way to format DDS time to a legible string, in milliseconds
 //
-class ms_s
+class timestr
 {
     std::string _s;
 
@@ -42,62 +42,62 @@ public:
 
 public:
     // absolute time
-    ms_s( dds_nsec const t, abs_t, no_suffix_t )
+    timestr( dds_nsec const t, abs_t, no_suffix_t )
         : _s( std::to_string( t / 1e6 ) )
     {
         if( _s.find( '.' ) != std::string::npos )
             while( _s.back() == '0' )
                 _s.pop_back();
     }
-    ms_s( dds_nsec const t, abs_t )  // with "ms" suffix by default
-        : ms_s( t, abs, no_suffix )
+    timestr( dds_nsec const t, abs_t )  // with "ms" suffix by default
+        : timestr( t, abs, no_suffix )
     {
         _s += "ms";
     }
 
     // expressed as time-since-start (for readability)
-    ms_s( dds_nsec const t, no_suffix_t )
-        : ms_s( t - since_start(), abs, no_suffix ) {}
-    ms_s( dds_nsec const t )
-        : ms_s( t - since_start(), abs ) {}
+    timestr( dds_nsec const t, no_suffix_t )
+        : timestr( t - since_start(), abs, no_suffix ) {}
+    timestr( dds_nsec const t )
+        : timestr( t - since_start(), abs ) {}
 
     // relative time (so +/- followed by the number)
-    ms_s( dds_nsec const delta, rel_t, no_suffix_t )
-        : ms_s( delta, abs, no_suffix )
+    timestr( dds_nsec const delta, rel_t, no_suffix_t )
+        : timestr( delta, abs, no_suffix )
     {
         ensure_sign( delta );
     }
-    ms_s( dds_nsec const delta, rel_t )  // with "ms" suffix by default
-        : ms_s( delta, abs )
+    timestr( dds_nsec const delta, rel_t )  // with "ms" suffix by default
+        : timestr( delta, abs )
     {
         ensure_sign( delta );
     }
 
     // diff between two absolute times
-    ms_s( dds_nsec const t, dds_nsec const start, no_suffix_t )
-        : ms_s( t - start, rel, no_suffix ) {}
-    ms_s( dds_nsec const t, dds_nsec const start )
-        : ms_s( t - start, rel ) {}
+    timestr( dds_nsec const t, dds_nsec const start, no_suffix_t )
+        : timestr( t - start, rel, no_suffix ) {}
+    timestr( dds_nsec const t, dds_nsec const start )
+        : timestr( t - start, rel ) {}
 
     // Rest are variations of the above
 
-    ms_s( realdds::dds_time const & t, realdds::dds_time const & start, no_suffix_t )
-        : ms_s( t.to_ns(), start.to_ns(), no_suffix ) {}
-    ms_s( realdds::dds_time const & t, realdds::dds_nsec const start, no_suffix_t )
-        : ms_s( t.to_ns(), start, no_suffix ) {}
-    ms_s( realdds::dds_nsec const t, realdds::dds_time const & start, no_suffix_t )
-        : ms_s( t, start.to_ns(), no_suffix ) {}
-    ms_s( realdds::dds_time const & t, no_suffix_t )
-        : ms_s( t.to_ns(), no_suffix ) {}
+    timestr( realdds::dds_time const & t, realdds::dds_time const & start, no_suffix_t )
+        : timestr( t.to_ns(), start.to_ns(), no_suffix ) {}
+    timestr( realdds::dds_time const & t, realdds::dds_nsec const start, no_suffix_t )
+        : timestr( t.to_ns(), start, no_suffix ) {}
+    timestr( realdds::dds_nsec const t, realdds::dds_time const & start, no_suffix_t )
+        : timestr( t, start.to_ns(), no_suffix ) {}
+    timestr( realdds::dds_time const & t, no_suffix_t )
+        : timestr( t.to_ns(), no_suffix ) {}
 
-    ms_s( realdds::dds_time const & t, realdds::dds_time const & start )
-        : ms_s( t.to_ns(), start.to_ns() ) {}
-    ms_s( realdds::dds_time const & t, realdds::dds_nsec const start )
-        : ms_s( t.to_ns(), start ) {}
-    ms_s( realdds::dds_nsec const t, realdds::dds_time const & start )
-        : ms_s( t, start.to_ns() ) {}
-    ms_s( realdds::dds_time const & t )
-        : ms_s( t.to_ns() ) {}
+    timestr( realdds::dds_time const & t, realdds::dds_time const & start )
+        : timestr( t.to_ns(), start.to_ns() ) {}
+    timestr( realdds::dds_time const & t, realdds::dds_nsec const start )
+        : timestr( t.to_ns(), start ) {}
+    timestr( realdds::dds_nsec const t, realdds::dds_time const & start )
+        : timestr( t, start.to_ns() ) {}
+    timestr( realdds::dds_time const & t )
+        : timestr( t.to_ns() ) {}
 
     std::string const & to_string() const { return _s; }
     operator std::string const &() const { return to_string(); }
@@ -116,11 +116,11 @@ private:
 };
 
 
-inline std::ostream & operator<<( std::ostream & os, ms_s const & ms )
+inline std::ostream & operator<<( std::ostream & os, timestr const & ms )
     { return( os << (std::string) ms ); }
-inline std::string operator+( std::string const & s, ms_s const & ms )
+inline std::string operator+( std::string const & s, timestr const & ms )
     { return s + (std::string) ms; }
-inline std::string operator+( ms_s const & ms, std::string const & s )
+inline std::string operator+( timestr const & ms, std::string const & s )
     { return (std::string) ms + s; }
 
 

--- a/third-party/realdds/include/realdds/dds-time.h
+++ b/third-party/realdds/include/realdds/dds-time.h
@@ -1,0 +1,127 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <realdds/dds-defines.h>
+#include <fastdds/rtps/common/Time_t.h>
+
+#include <string>
+
+
+namespace realdds {
+
+    
+inline dds_time now()
+{
+    dds_time t;
+    dds_time::now( t );
+    return t;
+}
+
+
+inline dds_time time_from( dds_nsec nanoseconds )
+{
+    dds_time t;
+    t.from_ns( nanoseconds );
+    return t;
+}
+
+
+// Easy way to format DDS time to a legible string, in milliseconds
+//
+class ms_s
+{
+    std::string _s;
+
+public:
+    enum abs_t { abs };
+    enum rel_t { rel };
+
+    enum no_suffix_t { no_suffix };
+
+public:
+    // absolute time
+    ms_s( dds_nsec const t, abs_t, no_suffix_t )
+        : _s( std::to_string( t / 1e6 ) )
+    {
+        if( _s.find( '.' ) != std::string::npos )
+            while( _s.back() == '0' )
+                _s.pop_back();
+    }
+    ms_s( dds_nsec const t, abs_t )  // with "ms" suffix by default
+        : ms_s( t, abs, no_suffix )
+    {
+        _s += "ms";
+    }
+
+    // expressed as time-since-start (for readability)
+    ms_s( dds_nsec const t, no_suffix_t )
+        : ms_s( t - since_start(), abs, no_suffix ) {}
+    ms_s( dds_nsec const t )
+        : ms_s( t - since_start(), abs ) {}
+
+    // relative time (so +/- followed by the number)
+    ms_s( dds_nsec const delta, rel_t, no_suffix_t )
+        : ms_s( delta, abs, no_suffix )
+    {
+        ensure_sign( delta );
+    }
+    ms_s( dds_nsec const delta, rel_t )  // with "ms" suffix by default
+        : ms_s( delta, abs )
+    {
+        ensure_sign( delta );
+    }
+
+    // diff between two absolute times
+    ms_s( dds_nsec const t, dds_nsec const start, no_suffix_t )
+        : ms_s( t - start, rel, no_suffix ) {}
+    ms_s( dds_nsec const t, dds_nsec const start )
+        : ms_s( t - start, rel ) {}
+
+    // Rest are variations of the above
+
+    ms_s( realdds::dds_time const & t, realdds::dds_time const & start, no_suffix_t )
+        : ms_s( t.to_ns(), start.to_ns(), no_suffix ) {}
+    ms_s( realdds::dds_time const & t, realdds::dds_nsec const start, no_suffix_t )
+        : ms_s( t.to_ns(), start, no_suffix ) {}
+    ms_s( realdds::dds_nsec const t, realdds::dds_time const & start, no_suffix_t )
+        : ms_s( t, start.to_ns(), no_suffix ) {}
+    ms_s( realdds::dds_time const & t, no_suffix_t )
+        : ms_s( t.to_ns(), no_suffix ) {}
+
+    ms_s( realdds::dds_time const & t, realdds::dds_time const & start )
+        : ms_s( t.to_ns(), start.to_ns() ) {}
+    ms_s( realdds::dds_time const & t, realdds::dds_nsec const start )
+        : ms_s( t.to_ns(), start ) {}
+    ms_s( realdds::dds_nsec const t, realdds::dds_time const & start )
+        : ms_s( t, start.to_ns() ) {}
+    ms_s( realdds::dds_time const & t )
+        : ms_s( t.to_ns() ) {}
+
+    std::string const & to_string() const { return _s; }
+    operator std::string const &() const { return to_string(); }
+
+private:
+    void ensure_sign( dds_nsec const delta )
+    {
+        if( delta > 0 )
+            _s.insert( 0, 1, '+' );
+    }
+    static dds_nsec since_start()
+    {
+        static realdds::dds_nsec start = realdds::now().to_ns();
+        return start;
+    }
+};
+
+
+inline std::ostream & operator<<( std::ostream & os, ms_s const & ms )
+    { return( os << (std::string) ms ); }
+inline std::string operator+( std::string const & s, ms_s const & ms )
+    { return s + (std::string) ms; }
+inline std::string operator+( ms_s const & ms, std::string const & s )
+    { return (std::string) ms + s; }
+
+
+}  // namespace realdds

--- a/third-party/realdds/include/realdds/topics/flexible/flexible-reader.h
+++ b/third-party/realdds/include/realdds/topics/flexible/flexible-reader.h
@@ -61,10 +61,9 @@ private:
     std::mutex _data_mutex;
 
 public:
-    flexible_reader( std::shared_ptr< dds_participant > const & participant,
-                     std::shared_ptr< dds_topic > const & topic );
+    flexible_reader( std::shared_ptr< dds_topic > const & topic );
     flexible_reader( std::shared_ptr< dds_participant > const & participant, std::string const & topic_name )
-        : flexible_reader( participant, flexible_msg::create_topic( participant, topic_name ) )
+        : flexible_reader( flexible_msg::create_topic( participant, topic_name ) )
     {
     }
 

--- a/third-party/realdds/include/realdds/topics/flexible/flexible-reader.h
+++ b/third-party/realdds/include/realdds/topics/flexible/flexible-reader.h
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <queue>
 #include <mutex>
+#include <condition_variable>
 
 
 namespace eprosima {

--- a/third-party/realdds/include/realdds/topics/flexible/flexible-reader.h
+++ b/third-party/realdds/include/realdds/topics/flexible/flexible-reader.h
@@ -1,0 +1,91 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+
+#include "flexible-msg.h"
+
+#include <fastdds/dds/subscriber/SampleInfo.hpp>
+
+#include <string>
+#include <memory>
+#include <chrono>
+#include <queue>
+#include <mutex>
+
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+struct SubscriptionMatchedStatus;
+}
+}  // namespace fastdds
+}  // namespace eprosima
+
+
+namespace realdds {
+
+
+class dds_participant;
+class dds_topic;
+class dds_topic_reader;
+
+
+namespace topics {
+
+
+// Ease-of-use helper, easily taking care of basic use-cases that just want to easily read from some topic.
+// E.g.:
+//     flexible_reader topic( participant, "topic-name" );
+//     ...
+//     auto msg = topic.read().msg;
+//
+class flexible_reader
+{
+    std::shared_ptr< dds_topic_reader > _reader;
+    int _n_writers = 0;
+
+public:
+    // We need to return both a message and the sample that goes with it, if needed
+    struct data_t
+    {
+        flexible_msg msg;
+        eprosima::fastdds::dds::SampleInfo sample;
+    };
+
+private:
+    std::queue< data_t > _data;
+    std::condition_variable _data_cv;
+    std::mutex _data_mutex;
+
+public:
+    flexible_reader( std::shared_ptr< dds_participant > const & participant,
+                     std::shared_ptr< dds_topic > const & topic );
+    flexible_reader( std::shared_ptr< dds_participant > const & participant, std::string const & topic_name )
+        : flexible_reader( participant, flexible_msg::create_topic( participant, topic_name ) )
+    {
+    }
+
+    std::string const & name() const;
+
+    // Block until data is available
+    void wait_for_data();
+    // Block, but throw on timeout
+    void wait_for_data( std::chrono::seconds timeout );
+
+    // Blocking -- waits until data is available
+    data_t read();
+    // Blocking -- but with a timeout (throws)
+    data_t read( std::chrono::seconds timeout );
+
+    bool empty() const { return _data.empty(); }
+
+private:
+    void on_subscription_matched( eprosima::fastdds::dds::SubscriptionMatchedStatus const & );
+    void on_data_available();
+};
+
+
+}  // namespace topics
+}  // namespace realdds

--- a/third-party/realdds/include/realdds/topics/flexible/flexible-writer.h
+++ b/third-party/realdds/include/realdds/topics/flexible/flexible-writer.h
@@ -1,0 +1,61 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+
+#include "flexible-msg.h"
+
+#include <third-party/json_fwd.hpp>
+
+#include <string>
+#include <memory>
+#include <chrono>
+
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+struct PublicationMatchedStatus;
+}
+}  // namespace fastdds
+}  // namespace eprosima
+
+
+namespace realdds {
+
+
+class dds_participant;
+class dds_topic;
+class dds_topic_writer;
+
+
+namespace topics {
+
+
+class flexible_writer
+{
+    std::shared_ptr< dds_topic_writer > _writer;
+    int _n_readers = 0;
+
+public:
+    flexible_writer( std::shared_ptr< dds_participant > const & participant,
+                     std::shared_ptr< dds_topic > const & topic );
+    flexible_writer( std::shared_ptr< dds_participant > const & participant, std::string const & topic_name )
+        : flexible_writer( participant, flexible_msg::create_topic( participant, topic_name ) )
+    {
+    }
+
+    std::string const & name() const;
+
+    void wait_for_readers( int n_readers, std::chrono::seconds timeout = std::chrono::seconds( 3 ) );
+
+    void write( nlohmann::json && json );
+
+private:
+    void on_publication_matched( eprosima::fastdds::dds::PublicationMatchedStatus const & status );
+};
+
+
+}  // namespace topics
+}  // namespace realdds

--- a/third-party/realdds/include/realdds/topics/flexible/flexible-writer.h
+++ b/third-party/realdds/include/realdds/topics/flexible/flexible-writer.h
@@ -39,10 +39,9 @@ class flexible_writer
     int _n_readers = 0;
 
 public:
-    flexible_writer( std::shared_ptr< dds_participant > const & participant,
-                     std::shared_ptr< dds_topic > const & topic );
+    flexible_writer( std::shared_ptr< dds_topic > const & topic );
     flexible_writer( std::shared_ptr< dds_participant > const & participant, std::string const & topic_name )
-        : flexible_writer( participant, flexible_msg::create_topic( participant, topic_name ) )
+        : flexible_writer( flexible_msg::create_topic( participant, topic_name ) )
     {
     }
 

--- a/third-party/realdds/src/topics/flexible-reader.cpp
+++ b/third-party/realdds/src/topics/flexible-reader.cpp
@@ -95,7 +95,7 @@ void flexible_reader::on_data_available()
     {
         data_t data;
         if( ! flexible_msg::take_next( *_reader, &data.msg, &data.sample ) )
-            assert( ! msg.is_valid() );
+            assert( ! data.is_valid() );
         if( ! data.msg.is_valid() )
         {
             if( ! got_something )

--- a/third-party/realdds/src/topics/flexible-reader.cpp
+++ b/third-party/realdds/src/topics/flexible-reader.cpp
@@ -61,7 +61,7 @@ flexible_reader::data_t flexible_reader::read()
         data = std::move( _data.front() );
         _data.pop();
     }
-    LOG_DEBUG( name() << ".read_sample @" << ms_s( now(), data.sample.reception_timestamp ) );
+    LOG_DEBUG( name() << ".read_sample @" << timestr( now(), data.sample.reception_timestamp ) );
     return data;
 }
 
@@ -74,7 +74,7 @@ flexible_reader::data_t flexible_reader::read( std::chrono::seconds timeout )
         data = std::move( _data.front() );
         _data.pop();
     }
-    LOG_DEBUG( name() << ".read_sample @" << ms_s( now(), data.sample.reception_timestamp ) );
+    LOG_DEBUG( name() << ".read_sample @" << timestr( now(), data.sample.reception_timestamp ) );
     return data;
 }
 
@@ -103,8 +103,8 @@ void flexible_reader::on_data_available()
             break;
         }
         auto & received = data.sample.reception_timestamp;
-        LOG_DEBUG( name() << ".on_data_available @" << ms_s( received.to_ns(), ms_s::no_suffix )
-                          << ms_s( notify_time, received, ms_s::no_suffix ) << ms_s( now(), notify_time ) << " "
+        LOG_DEBUG( name() << ".on_data_available @" << timestr( received.to_ns(), timestr::no_suffix )
+                          << timestr( notify_time, received, timestr::no_suffix ) << timestr( now(), notify_time ) << " "
                           << data.msg.json_data().dump() );
         got_something = true;
         {

--- a/third-party/realdds/src/topics/flexible-reader.cpp
+++ b/third-party/realdds/src/topics/flexible-reader.cpp
@@ -19,8 +19,7 @@ namespace realdds {
 namespace topics {
 
 
-flexible_reader::flexible_reader( std::shared_ptr< dds_participant > const & participant,
-                                  std::shared_ptr< dds_topic > const & topic )
+flexible_reader::flexible_reader( std::shared_ptr< dds_topic > const & topic )
     : _reader( std::make_shared< dds_topic_reader >( topic ) )
 {
     _reader->on_subscription_matched( [this]( eprosima::fastdds::dds::SubscriptionMatchedStatus const & status ) {

--- a/third-party/realdds/src/topics/flexible-reader.cpp
+++ b/third-party/realdds/src/topics/flexible-reader.cpp
@@ -95,7 +95,7 @@ void flexible_reader::on_data_available()
     {
         data_t data;
         if( ! flexible_msg::take_next( *_reader, &data.msg, &data.sample ) )
-            assert( ! data.is_valid() );
+            assert( ! data.msg.is_valid() );
         if( ! data.msg.is_valid() )
         {
             if( ! got_something )

--- a/third-party/realdds/src/topics/flexible-reader.cpp
+++ b/third-party/realdds/src/topics/flexible-reader.cpp
@@ -1,0 +1,120 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#include <realdds/topics/flexible/flexible-reader.h>
+
+#include <realdds/dds-topic-reader.h>
+#include <realdds/dds-topic.h>
+#include <realdds/dds-utilities.h>
+#include <realdds/dds-time.h>
+
+#include <fastdds/dds/topic/Topic.hpp>
+
+#include <librealsense2/utilities/easylogging/easyloggingpp.h>
+#include <librealsense2/utilities/time/timer.h>
+#include <third-party/json.hpp>
+
+
+namespace realdds {
+namespace topics {
+
+
+flexible_reader::flexible_reader( std::shared_ptr< dds_participant > const & participant,
+                                  std::shared_ptr< dds_topic > const & topic )
+    : _reader( std::make_shared< dds_topic_reader >( topic ) )
+{
+    _reader->on_subscription_matched( [this]( eprosima::fastdds::dds::SubscriptionMatchedStatus const & status ) {
+        this->on_subscription_matched( status );
+    } );
+    _reader->on_data_available( [this]() { this->on_data_available(); } );
+    _reader->run();
+}
+
+
+std::string const & flexible_reader::name() const
+{
+    return _reader->topic()->get()->get_name();
+}
+
+
+void flexible_reader::wait_for_data()
+{
+    std::unique_lock< std::mutex > lock( _data_mutex );
+    _data_cv.wait( lock );
+}
+
+
+void flexible_reader::wait_for_data( std::chrono::seconds timeout )
+{
+    std::unique_lock< std::mutex > lock( _data_mutex );
+    if( std::cv_status::timeout == _data_cv.wait_for( lock, timeout ) )
+        DDS_THROW( runtime_error, "timed out waiting for data" );
+}
+
+
+flexible_reader::data_t flexible_reader::read()
+{
+    wait_for_data();
+    data_t data;
+    {
+        std::lock_guard< std::mutex > lock( _data_mutex );
+        data = std::move( _data.front() );
+        _data.pop();
+    }
+    LOG_DEBUG( name() << ".read_sample @" << ms_s( now(), data.sample.reception_timestamp ) );
+    return data;
+}
+
+flexible_reader::data_t flexible_reader::read( std::chrono::seconds timeout )
+{
+    wait_for_data( timeout );
+    data_t data;
+    {
+        std::lock_guard< std::mutex > lock( _data_mutex );
+        data = std::move( _data.front() );
+        _data.pop();
+    }
+    LOG_DEBUG( name() << ".read_sample @" << ms_s( now(), data.sample.reception_timestamp ) );
+    return data;
+}
+
+
+void flexible_reader::on_subscription_matched( eprosima::fastdds::dds::SubscriptionMatchedStatus const & status )
+{
+    _n_writers += status.current_count_change;
+    LOG_DEBUG( name() << ".on_subscription_matched " << ( status.current_count_change > 0 ? "+" : "" )
+                      << status.current_count_change << " -> " << _n_writers );
+}
+
+
+void flexible_reader::on_data_available()
+{
+    auto notify_time = now();
+    bool got_something = false;
+    while( 1 )
+    {
+        data_t data;
+        if( ! flexible_msg::take_next( *_reader, &data.msg, &data.sample ) )
+            assert( ! msg.is_valid() );
+        if( ! data.msg.is_valid() )
+        {
+            if( ! got_something )
+                DDS_THROW( runtime_error, "expected message not received!" );
+            break;
+        }
+        auto & received = data.sample.reception_timestamp;
+        LOG_DEBUG( name() << ".on_data_available @" << ms_s( received.to_ns(), ms_s::no_suffix )
+                          << ms_s( notify_time, received, ms_s::no_suffix ) << ms_s( now(), notify_time ) << " "
+                          << data.msg.json_data().dump() );
+        got_something = true;
+        {
+            std::lock_guard< std::mutex > lock( _data_mutex );
+            _data.emplace( std::move( data ) );
+        }
+        _data_cv.notify_one();
+    }
+}
+
+
+}  // namespace topics
+}  // namespace realdds

--- a/third-party/realdds/src/topics/flexible-writer.cpp
+++ b/third-party/realdds/src/topics/flexible-writer.cpp
@@ -19,8 +19,7 @@ namespace realdds {
 namespace topics {
 
 
-flexible_writer::flexible_writer( std::shared_ptr< dds_participant > const & participant,
-                                  std::shared_ptr< dds_topic > const & topic )
+flexible_writer::flexible_writer( std::shared_ptr< dds_topic > const & topic )
     : _writer( std::make_shared< dds_topic_writer >( topic ) )
 {
     _writer->on_publication_matched( [this]( eprosima::fastdds::dds::PublicationMatchedStatus const & status ) {

--- a/third-party/realdds/src/topics/flexible-writer.cpp
+++ b/third-party/realdds/src/topics/flexible-writer.cpp
@@ -1,0 +1,71 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#include <realdds/topics/flexible/flexible-writer.h>
+
+#include <realdds/dds-topic-writer.h>
+#include <realdds/dds-topic.h>
+#include <realdds/dds-utilities.h>
+#include <realdds/dds-time.h>
+
+#include <fastdds/dds/topic/Topic.hpp>
+
+#include <librealsense2/utilities/easylogging/easyloggingpp.h>
+#include <librealsense2/utilities/time/timer.h>
+#include <third-party/json.hpp>
+
+
+namespace realdds {
+namespace topics {
+
+
+flexible_writer::flexible_writer( std::shared_ptr< dds_participant > const & participant,
+                                  std::shared_ptr< dds_topic > const & topic )
+    : _writer( std::make_shared< dds_topic_writer >( topic ) )
+{
+    _writer->on_publication_matched( [this]( eprosima::fastdds::dds::PublicationMatchedStatus const & status ) {
+        this->on_publication_matched( status );
+    } );
+    _writer->run();
+}
+
+
+std::string const & flexible_writer::name() const
+{
+    return _writer->topic()->get()->get_name();
+}
+
+
+void flexible_writer::wait_for_readers( int n_readers, std::chrono::seconds timeout )
+{
+    utilities::time::timer timer( timeout );
+    while( _n_readers < n_readers )
+    {
+        if( timer.has_expired() )
+            DDS_THROW( runtime_error, "timed out waiting for " + std::to_string( n_readers ) + " readers" );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
+    }
+}
+
+
+void flexible_writer::write( nlohmann::json && json )
+{
+    std::string json_string = json.dump();
+    flexible_msg msg( std::move( json ) );
+    auto write_time = now();
+    msg.write_to( *_writer );
+    LOG_DEBUG( name() << ".write JSON " << json_string << " @" << ms_s( write_time, ms_s::no_suffix )
+                      << ms_s( now(), write_time ) );
+}
+
+
+void flexible_writer::on_publication_matched( eprosima::fastdds::dds::PublicationMatchedStatus const & status )
+{
+    _n_readers += status.current_count_change;
+    LOG_DEBUG( name() << ".on_publication_matched " << ( status.current_count_change > 0 ? "+" : "" )
+                      << status.current_count_change << " -> " << _n_readers );
+}
+
+
+}  // namespace topics
+}  // namespace realdds

--- a/third-party/realdds/src/topics/flexible-writer.cpp
+++ b/third-party/realdds/src/topics/flexible-writer.cpp
@@ -54,8 +54,8 @@ void flexible_writer::write( nlohmann::json && json )
     flexible_msg msg( std::move( json ) );
     auto write_time = now();
     msg.write_to( *_writer );
-    LOG_DEBUG( name() << ".write JSON " << json_string << " @" << ms_s( write_time, ms_s::no_suffix )
-                      << ms_s( now(), write_time ) );
+    LOG_DEBUG( name() << ".write JSON " << json_string << " @" << timestr( write_time, timestr::no_suffix )
+                      << timestr( now(), write_time ) );
 }
 
 

--- a/tools/dds/realdds-py/python.cpp
+++ b/tools/dds/realdds-py/python.cpp
@@ -355,22 +355,22 @@ PYBIND11_MODULE(NAME, m) {
 
     // We need a timestamp function that returns timestamps in the same domain as the sample-info timestamps
     using realdds::dds_nsec;
-    using realdds::ms_s;
+    using realdds::timestr;
     m.def( "now", []() { return realdds::now().to_ns(); } );
 
-    py::enum_< ms_s::no_suffix_t >( m, "no_suffix_t" );
-    m.attr( "no_suffix" ) = ms_s::no_suffix;
-    py::enum_< ms_s::rel_t >( m, "rel_t" );
-    m.attr( "rel" ) = ms_s::rel;
-    py::enum_< ms_s::abs_t >( m, "abs_t" );
-    m.attr( "abs" ) = ms_s::abs;
+    py::enum_< timestr::no_suffix_t >( m, "no_suffix_t" );
+    m.attr( "no_suffix" ) = timestr::no_suffix;
+    py::enum_< timestr::rel_t >( m, "rel_t" );
+    m.attr( "rel" ) = timestr::rel;
+    py::enum_< timestr::abs_t >( m, "abs_t" );
+    m.attr( "abs" ) = timestr::abs;
 
-    m.def( "ms_s", []( dds_nsec t ) { return ms_s( t ).to_string(); } );
-    m.def( "ms_s", []( dds_nsec t, ms_s::no_suffix_t ) { return ms_s( t, ms_s::no_suffix ).to_string(); } );
-    m.def( "ms_s", []( dds_nsec dt, ms_s::rel_t ) { return ms_s( dt, ms_s::rel ).to_string(); } );
-    m.def( "ms_s", []( dds_nsec dt, ms_s::rel_t, ms_s::no_suffix_t ) { return ms_s( dt, ms_s::rel, ms_s::no_suffix ).to_string(); } );
-    m.def( "ms_s", []( dds_nsec t1, dds_nsec t2 ) { return ms_s( t1, t2 ).to_string(); } );
-    m.def( "ms_s", []( dds_nsec t1, dds_nsec t2, ms_s::no_suffix_t ) { return ms_s( t1, t2, ms_s::no_suffix ).to_string(); } );
+    m.def( "timestr", []( dds_nsec t ) { return timestr( t ).to_string(); } );
+    m.def( "timestr", []( dds_nsec t, timestr::no_suffix_t ) { return timestr( t, timestr::no_suffix ).to_string(); } );
+    m.def( "timestr", []( dds_nsec dt, timestr::rel_t ) { return timestr( dt, timestr::rel ).to_string(); } );
+    m.def( "timestr", []( dds_nsec dt, timestr::rel_t, timestr::no_suffix_t ) { return timestr( dt, timestr::rel, timestr::no_suffix ).to_string(); } );
+    m.def( "timestr", []( dds_nsec t1, dds_nsec t2 ) { return timestr( t1, t2 ).to_string(); } );
+    m.def( "timestr", []( dds_nsec t1, dds_nsec t2, timestr::no_suffix_t ) { return timestr( t1, t2, timestr::no_suffix ).to_string(); } );
 
     typedef std::shared_ptr< dds_topic > flexible_msg_create_topic( std::shared_ptr< dds_participant > const &,
                                                                     char const * );

--- a/tools/dds/realdds-py/python.cpp
+++ b/tools/dds/realdds-py/python.cpp
@@ -352,6 +352,13 @@ PYBIND11_MODULE(NAME, m) {
         .def( "source_timestamp", []( SampleInfo const & self ) { return self.source_timestamp.to_ns(); } )
         .def( "reception_timestamp", []( SampleInfo const & self ) { return self.reception_timestamp.to_ns(); } );
 
+    // We need a timestamp function that returns timestamps in the same domain as the sample-info timestamps
+    m.def( "now", []() {
+        eprosima::fastrtps::rtps::Time_t t;
+        eprosima::fastrtps::rtps::Time_t::now( t );
+        return t.to_ns();
+    } );
+
     typedef std::shared_ptr< dds_topic > flexible_msg_create_topic( std::shared_ptr< dds_participant > const &,
                                                                     char const * );
     py::class_< flexible_msg >( m, "flexible_msg" )

--- a/unit-tests/dds/flexible.py
+++ b/unit-tests/dds/flexible.py
@@ -5,14 +5,7 @@ import pyrealdds as dds
 from rspy import log
 from time import sleep
 import threading
-
-
-from pyrealdds import ms_s, no_suffix, rel, abs
-#no_suffix = ''
-#rel = '+'
-#since_start = dds.now()
-#def ms_s( ns, suffix="ms", format="" ):
-#    return f'{ns / 1000000.:{format}}{suffix}'
+from pyrealdds import timestr, no_suffix, rel, abs
 
 
 class writer:
@@ -52,7 +45,7 @@ class writer:
         now = dds.now()
         msgs = str(msg)
         msg.write_to( self.writer )
-        log.d( f'{self.name}.write {msgs} @{ms_s(now,no_suffix)}{ms_s(dds.now(),now)}' )
+        log.d( f'{self.name}.write {msgs} @{timestr(now,no_suffix)}{timestr(dds.now(),now)}' )
 
     def stop( self ):
         self.writer = self.handle = None
@@ -109,7 +102,7 @@ class reader:
                     raise RuntimeError( "expected message not received!" )
                 break
             received = sample.reception_timestamp()
-            log.d( f'{self.name}.on_data_available @{ms_s(received,no_suffix)}{ms_s(now,received,no_suffix)}{ms_s(dds.now(),now)} {msg}' )
+            log.d( f'{self.name}.on_data_available @{timestr(received,no_suffix)}{timestr(now,received,no_suffix)}{timestr(dds.now(),now)} {msg}' )
             self.data += [msg]
             self.samples += [sample]
             got_something = True
@@ -125,7 +118,7 @@ class reader:
         if self.empty():
             self._got_something.clear()
         sample = self.samples.pop(0)
-        log.d( f'{self.name}.read_sample @{ms_s(dds.now(),sample.reception_timestamp())}' )
+        log.d( f'{self.name}.read_sample @{timestr(dds.now(),sample.reception_timestamp())}' )
         return (msg,sample)
 
     def read( self, timeout=3.0 ):

--- a/unit-tests/dds/flexible.py
+++ b/unit-tests/dds/flexible.py
@@ -1,0 +1,138 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+import pyrealdds as dds
+from rspy import log
+from time import sleep
+import threading
+
+
+def _ns_as_ms( ns ):
+    return str(ns / 1000000.) + "ms"
+
+
+class writer:
+    """
+    Just to enable simple one-line syntax:
+        flexible.writer( "blah" ).write( '{"field" : 1}' )
+    """
+
+    def __init__( self, participant, topic, qos = None ):
+        if type(topic) is str:
+            self.handle = dds.flexible_msg.create_topic( participant, topic )
+        elif type(topic) is dds.topic:
+            self.handle = topic
+        else:
+            raise RuntimeError( "invalid 'topic' argument: " + type(topic) )
+        self.n_readers = 0
+        self.writer = dds.topic_writer( self.handle )
+        self.writer.on_publication_matched( self._on_publication_matched )
+        self.writer.run( qos or dds.topic_writer.qos() )
+
+    def _on_publication_matched( self, writer, d_readers ):
+        log.d( "on_publication_matched", d_readers )
+        self.n_readers += d_readers
+
+    def wait_for_readers( self, n_readers = 1, timeout = 3.0 ):
+        while self.n_readers < n_readers:
+            timeout -= 0.25
+            if timeout > 0:
+                sleep( 0.25 )
+            else:
+                raise RuntimeError( "timed out waiting for reader" )
+
+    def write( self, json_string ):
+        msg = dds.flexible_msg( json_string )
+        log.d( "writing", msg )
+        msg.write_to( self.writer )
+
+    def stop( self ):
+        self.writer = self.handle = None
+
+
+class reader:
+    """
+    Just to enable simple one-line syntax:
+        msg = flexible.reader( "blah" ).read()
+    """
+
+    def __init__( self, participant, topic, qos = None ):
+        if type(topic) is str:
+            self.handle = dds.flexible_msg.create_topic( participant, topic )
+        elif type(topic) is dds.topic:
+            self.handle = topic
+        else:
+            raise RuntimeError( "invalid 'topic' argument: " + type(topic) )
+        self.n_writers = 0
+        self.data = []
+        self.samples = []
+        self._got_something = threading.Event()
+        self.reader = dds.topic_reader( self.handle )
+        self.reader.on_data_available( self._on_data_available )
+        self.reader.on_subscription_matched( self._on_subscription_matched )
+        self.reader.run( qos or dds.topic_reader.qos() )
+
+    def _on_subscription_matched( self, reader, d_writers ):
+        self.n_writers += d_writers
+        log.d( "on_subscription_matched", reader.topic().name(), d_writers, '=', self.n_writers )
+
+    def wait_for_writers( self, n_writers = 1, timeout = 3.0 ):
+        """
+        Wait until a writer/publisher has our topic open
+        """
+        while self.n_writers != n_writers:
+            timeout -= 0.25
+            if timeout > 0:
+                sleep( 0.25 )
+            else:
+                raise RuntimeError( f"timed out waiting for {n_writers} writers" )
+
+    def _on_data_available( self, reader ):
+        topic_name = reader.topic().name()
+        log.d( "on_data_available", topic_name )
+        got_something = False
+        while True:
+            sample = dds.sample_info()
+            msg = dds.flexible_msg.take_next( reader, sample )
+            if not msg:
+                if not got_something:
+                    raise RuntimeError( "expected message not received!" )
+                break
+            log.d( "received", '@T+' + _ns_as_ms(sample.reception_timestamp()-sample.source_timestamp()), msg )
+            self.data += [msg]
+            self.samples += [sample]
+            got_something = True
+            self._got_something.set()
+
+    def read_sample( self, timeout=3.0 ):
+        """
+        :param timeout: if empty, wait for this many seconds then raise an error
+        :return: the next sample read
+        """
+        self.wait_for_data( timeout=timeout )
+        msg = self.data.pop(0)
+        if self.empty():
+            self._got_something.clear()
+        sample = self.samples.pop(0)
+        return (msg,sample)
+
+    def read( self, timeout=3.0 ):
+        """
+        :param timeout: if empty, wait for this many seconds then raise an error
+        :return: the next sample read
+        """
+        msg, sample = self.read_sample( timeout=timeout )
+        return msg
+
+    def wait_for_data( self, timeout = 3.0 ):
+        """
+        Wait until data is available or timeout seconds. If still none, raises an error.
+        """
+        if not self._got_something.wait( timeout ):
+            raise RuntimeError( "timed out waiting for data" )
+
+    def empty( self ):
+        """
+        :return: True if no data is available
+        """
+        return not self.data

--- a/unit-tests/dds/streaming-server.py
+++ b/unit-tests/dds/streaming-server.py
@@ -3,55 +3,13 @@
 
 import pyrealdds as dds
 from rspy import log, test
-import json
-from time import sleep
+import flexible
 
 dds.debug( True, log.nested )
 
 
 participant = dds.participant()
 participant.init( 123, "streaming-server" )
-
-
-
-class flexible_writer:
-    """
-    Just to enable simple one-line syntax:
-        flexible_writer( "blah" ).write( '{"field" : 1}' )
-    """
-
-    def __init__( self, name, qos = None ):
-        if type(name) is str:
-            self.handle = dds.flexible_msg.create_topic( participant, name )
-        elif type(name) is dds.topic:
-            self.handle = name
-        else:
-            raise RuntimeError( "invalid 'name' argument: " + type(name) )
-        self.n_readers = 0
-        self.writer = dds.topic_writer( self.handle )
-        self.writer.on_publication_matched( self._on_publication_matched )
-        self.writer.run( qos or dds.topic_writer.qos() )
-
-    def _on_publication_matched( self, writer, d_readers ):
-        log.d( "on_publication_matched", d_readers )
-        self.n_readers += d_readers
-
-    def wait_for_reader( self, n_readers = 1, timeout = 3.0 ):
-        while self.n_readers < n_readers:
-            timeout -= 0.25
-            if timeout > 0:
-                sleep( 0.25 )
-            else:
-                raise RuntimeError( "timed out waiting for reader" )
-
-    def write( self, json_string ):
-        msg = dds.flexible_msg( json_string )
-        log.d( "writing", msg )
-        msg.write_to( self.writer )
-
-    def stop( self ):
-        self.writer = self.handle = None
-
 
 
 # From here down, we're in "interactive" mode (see test-device-init.py)

--- a/unit-tests/dds/streaming-server.py
+++ b/unit-tests/dds/streaming-server.py
@@ -14,10 +14,10 @@ participant.init( 123, "streaming-server" )
 
 
 
-class flexible_topic:
+class flexible_writer:
     """
     Just to enable simple one-line syntax:
-        flexible_topic( "blah" ).write( '{"field" : 1}' )
+        flexible_writer( "blah" ).write( '{"field" : 1}' )
     """
 
     def __init__( self, name, qos = None ):

--- a/unit-tests/dds/test-streaming.py
+++ b/unit-tests/dds/test-streaming.py
@@ -20,10 +20,10 @@ def ns_as_ms( ns ):
     return str(ns / 1000000.) + "ms"
 
 
-class flexible_topic:
+class flexible_reader:
     """
     Just to enable simple one-line syntax:
-        msg = flexible_topic( "blah" ).read()
+        msg = flexible_reader( "blah" ).read()
     """
 
     def __init__( self, name, qos = None ):
@@ -114,13 +114,13 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     test.start( "Test 1W:1R, 1 message..." )
     try:
-        remote.run( 'topic = flexible_topic( "1w1r" )', timeout=5 )
+        remote.run( 'topic = flexible_writer( "1w1r" )', timeout=5 )
         # NOTE: technically, we could combine everything into a single command:
         #      Topic("blah").write( ... )
         # and it would do everything, including destroy the Topic instance with the writer etc.
         # This doesn't work! If the writer is destroyed before we've had a chance to get the message,
         # the message will get lost...
-        topic = flexible_topic( "1w1r" )
+        topic = flexible_reader( "1w1r" )
         # We may wait for the data before we even see the writer... so wait for the writer first!
         topic.wait_for_writers()
         # Same for the writer:
@@ -140,8 +140,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     test.start( "Test 1W:1R, N messages..." )
     try:
-        remote.run( 'topic = flexible_topic( "1w1rNm" )', timeout=5 )
-        topic = flexible_topic( "1w1rNm" )
+        remote.run( 'topic = flexible_writer( "1w1rNm" )', timeout=5 )
+        topic = flexible_reader( "1w1rNm" )
         topic.wait_for_writers()
         remote.run( 'topic.wait_for_reader()', timeout=5 )
         remote.run( 'topic.write( """' + sample1_json + '""" )', timeout=5 )
@@ -165,9 +165,9 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     test.start( "Test 1W:2R, one message..." )
     try:
-        remote.run( 'topic = flexible_topic( "1w2r" )', timeout=5 )
-        r1 = flexible_topic( "1w2r" )
-        r2 = flexible_topic( r1.handle )
+        remote.run( 'topic = flexible_writer( "1w2r" )', timeout=5 )
+        r1 = flexible_reader( "1w2r" )
+        r2 = flexible_reader( r1.handle )
         r1.wait_for_writers()
         r2.wait_for_writers()
         remote.run( 'topic.wait_for_reader( 2 )', timeout=5 )

--- a/unit-tests/dds/test-streaming.py
+++ b/unit-tests/dds/test-streaming.py
@@ -11,89 +11,10 @@ log.nested = 'C  '
 
 from time import sleep
 import json
+import flexible
 
 participant = dds.participant()
 participant.init( 123, "test-streaming" )
-
-
-def ns_as_ms( ns ):
-    return str(ns / 1000000.) + "ms"
-
-
-class flexible_reader:
-    """
-    Just to enable simple one-line syntax:
-        msg = flexible_reader( "blah" ).read()
-    """
-
-    def __init__( self, name, qos = None ):
-        if type(name) is str:
-            self.handle = dds.flexible_msg.create_topic( participant, name )
-        elif type(name) is dds.topic:
-            self.handle = name
-        else:
-            raise RuntimeError( "invalid 'name' argument: " + type(name) )
-        self.n_writers = 0
-        self.data = []
-        self.reader = dds.topic_reader( self.handle )
-        self.reader.on_data_available( self._on_data_available )
-        self.reader.on_subscription_matched( self._on_subscription_matched )
-        self.reader.run( qos or dds.topic_reader.qos() )
-
-    def _on_subscription_matched( self, reader, d_writers ):
-        self.n_writers += d_writers
-        log.d( "on_subscription_matched", reader.topic().name(), d_writers, '=', self.n_writers )
-
-    def wait_for_writers( self, n_writers = 1, timeout = 3.0 ):
-        """
-        Wait until a writer/publisher has our topic open
-        """
-        while self.n_writers != n_writers:
-            timeout -= 0.25
-            if timeout > 0:
-                sleep( 0.25 )
-            else:
-                raise RuntimeError( f"timed out waiting for {n_writers} writers" )
-
-    def _on_data_available( self, reader ):
-        topic_name = reader.topic().name()
-        log.d( "on_data_available", topic_name )
-        sample = dds.sample_info()
-        got_something = False
-        while True:
-            msg = dds.flexible_msg.take_next( reader, sample )
-            if not msg:
-                if not got_something:
-                    log.e( "expected message not received!" )
-                break
-            log.d( "received", '@T+' + ns_as_ms(sample.reception_timestamp()-sample.source_timestamp()), msg )
-            self.data += [msg]
-            got_something = True
-
-    def read( self, timeout = 3.0 ):
-        """
-        :param timeout: if empty, wait for this many seconds then raise an error
-        :return: the next sample read
-        """
-        self.wait_for_data( timeout=timeout )
-        return self.data.pop(0)
-
-    def wait_for_data( self, timeout = 3.0 ):
-        """
-        Wait until data is available or timeout seconds. If still none, raises an error.
-        """
-        while not self.data:
-            timeout -= 0.25
-            if timeout > 0:
-                sleep( 0.25 )
-            else:
-                raise RuntimeError( "timed out waiting for data" )
-
-    def empty( self ):
-        """
-        :return: True if no data is available
-        """
-        return not self.data
 
 
 sample1 = { 'id' : 'test-message', 'n' : 1, 'content' : { 'int' : 1, 'float' : 2.0, 'array' : [ 1, 2.0, 'hello' ] } }
@@ -114,17 +35,17 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     test.start( "Test 1W:1R, 1 message..." )
     try:
-        remote.run( 'topic = flexible_writer( "1w1r" )', timeout=5 )
+        remote.run( 'topic = flexible.writer( participant, "1w1r" )', timeout=5 )
         # NOTE: technically, we could combine everything into a single command:
         #      Topic("blah").write( ... )
         # and it would do everything, including destroy the Topic instance with the writer etc.
         # This doesn't work! If the writer is destroyed before we've had a chance to get the message,
         # the message will get lost...
-        topic = flexible_reader( "1w1r" )
+        topic = flexible.reader( participant, "1w1r" )
         # We may wait for the data before we even see the writer... so wait for the writer first!
         topic.wait_for_writers()
         # Same for the writer:
-        remote.run( 'topic.wait_for_reader()', timeout=5 )
+        remote.run( 'topic.wait_for_readers()', timeout=5 )
         remote.run( 'topic.write( """' + sample1_json + '""" )', timeout=5 )
         msg = topic.read()
         test.check( topic.empty() )
@@ -140,10 +61,10 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     test.start( "Test 1W:1R, N messages..." )
     try:
-        remote.run( 'topic = flexible_writer( "1w1rNm" )', timeout=5 )
-        topic = flexible_reader( "1w1rNm" )
+        remote.run( 'topic = flexible.writer( participant, "1w1rNm" )', timeout=5 )
+        topic = flexible.reader( participant, "1w1rNm" )
         topic.wait_for_writers()
-        remote.run( 'topic.wait_for_reader()', timeout=5 )
+        remote.run( 'topic.wait_for_readers()', timeout=5 )
         remote.run( 'topic.write( """' + sample1_json + '""" )', timeout=5 )
         remote.run( 'topic.write( """' + sample2_json + '""" )', timeout=5 )
         remote.run( 'topic.write( """' + sample3_json + '""" )', timeout=5 )
@@ -165,12 +86,12 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     test.start( "Test 1W:2R, one message..." )
     try:
-        remote.run( 'topic = flexible_writer( "1w2r" )', timeout=5 )
-        r1 = flexible_reader( "1w2r" )
-        r2 = flexible_reader( r1.handle )
+        remote.run( 'topic = flexible.writer( participant, "1w2r" )', timeout=5 )
+        r1 = flexible.reader( participant, "1w2r" )
+        r2 = flexible.reader( participant, r1.handle )
         r1.wait_for_writers()
         r2.wait_for_writers()
-        remote.run( 'topic.wait_for_reader( 2 )', timeout=5 )
+        remote.run( 'topic.wait_for_readers( 2 )', timeout=5 )
         remote.run( 'topic.write( """' + sample1_json + '""" )', timeout=5 )
         msg1 = r1.read()
         msg2 = r2.read()


### PR DESCRIPTION
This is an evolution of the flexible_topic as discussed also in my previous PR.
It's not called `flexible.writer` and `flexible.reader` in Python.
I also ended up porting it to C++ (for use in the POC) because of issues I encountered in Python that I'm still trying to solve.
To that end (the C++ version) I needed ways to quantify time in a DDS-compatible way (`Time_t`) and so I added `dds_time` and `dds_nsec`. For control over string representation of that time, I created `ms_s` (supposed to stand for "milliseconds as string"; open to better names, as long as they're short) which works rather nicely.

The POC sides (H and E) aren't here, but they're working nicely and currently just do time synchronization. Not sure I want to include them (in tools/dds/).