### PR TITLE
Update GHA MacOS runner image to version 11

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -334,7 +334,7 @@ jobs:
 
 
   Mac_cpp:
-    runs-on: macos-10.15
+    runs-on: macos-11
     timeout-minutes: 60
     
     steps:


### PR DESCRIPTION
GTH runner for MacOS deprecated the macos-10.15 image starting 1/12/23
See https://github.com/actions/runner-images/issues/5583

This PR update our runner image to version 11

Tracked on [LRS-564]