### PR TITLE
Send supported options in discovery stream-header

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -418,10 +418,11 @@ namespace librealsense
         {
         }
 
-        void set( float value ) override {}; //TODO - implement
-        float query() const override { return 0.0f; }; //TODO - implement
-        bool is_enabled() const override { return true; };
-        const char * get_description() const override { return _dds_opt->get_description().c_str(); };
+        void set( float value ) override {} //TODO - implement
+        float query() const override { return 0.0f; } //TODO - implement
+
+        bool is_enabled() const override { return true; }
+        const char * get_description() const override { return _dds_opt->get_description().c_str(); }
     };
 
     class dds_sensor_proxy : public software_sensor
@@ -602,21 +603,21 @@ namespace librealsense
         void add_option( std::shared_ptr< realdds::dds_option > option )
         {
             //Convert name to rs2_option type
-            rs2_option opt_type = RS2_OPTION_COUNT;
+            rs2_option option_id = RS2_OPTION_COUNT;
             for( size_t i = 0; i < static_cast< size_t >( RS2_OPTION_COUNT ); i++ )
             {
                 if( option->get_name().compare( get_string( static_cast< rs2_option >( i ) ) ) == 0 )
                 {
-                    opt_type = static_cast< rs2_option >( i );
+                    option_id = static_cast< rs2_option >( i );
                     break;
                 }
             }
 
-            if( opt_type == RS2_OPTION_COUNT )
+            if( option_id == RS2_OPTION_COUNT )
                 throw librealsense::invalid_value_exception( to_string() << "Option " << option->get_name() << " type not found" );
 
             auto opt = std::make_shared< rs2_dds_option >( option );
-            register_option( opt_type, opt );
+            register_option( option_id, opt );
         }
 
         //float get_option( rs2_option option ) const override;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -33,6 +33,7 @@
 #endif //BUILD_WITH_DDS
 
 #include <librealsense2/utilities/json.h>
+
 using json = nlohmann::json;
 
 #ifdef WITH_TRACKING
@@ -579,6 +580,33 @@ namespace librealsense
             software_sensor::close();
         }
 
+        void add_option( const realdds::dds_option & option )
+        {
+            //Convert name to rs2_option type
+            rs2_option opt_type = RS2_OPTION_BACKLIGHT_COMPENSATION;
+            for( size_t i = 0; i < RS2_OPTION_COUNT; i++ )
+            {
+                if( option.get_name().compare( get_string( static_cast< rs2_option >( i ) ) ) == 0 )
+                {
+                    opt_type = static_cast< rs2_option >( i );
+                    break;
+                }
+            }
+            option_range range = { option.get_range().min, option.get_range().max,
+                                   option.get_range().step, option.get_range().default_value };
+            auto opt = std::make_shared< float_option_with_description< rs2_option > >( range, option.get_description() );
+            try
+            {
+                opt->set( option.get_value() );
+            }
+            catch( invalid_value_exception e )
+            {
+                //Some options are received with bad values unless certain conditions exist when they're queried
+                LOG_ERROR( "Cannot set value for option " << option.get_name() << ". " << e.what() );
+            }
+            register_option( opt_type, opt );
+        }
+
         //float get_option( rs2_option option ) const override;
         //void set_option( rs2_option option, float value ) const override;
 
@@ -664,12 +692,12 @@ namespace librealsense
             , _dds_dev( dev )
         {
             LOG_DEBUG( "=====> dds-device-proxy " << this << " created on top of dds-device " << _dds_dev.get() );
-            auto & info = dev->device_info();
-            register_info( RS2_CAMERA_INFO_NAME, info.name );
-            register_info( RS2_CAMERA_INFO_PRODUCT_LINE, info.product_line );
-            register_info( RS2_CAMERA_INFO_SERIAL_NUMBER, info.serial );
-            register_info( RS2_CAMERA_INFO_CAMERA_LOCKED, info.locked ? "YES" : "NO" );
-            register_info( RS2_CAMERA_INFO_PHYSICAL_PORT, info.topic_root );
+            auto & dev_info = dev->device_info();
+            register_info( RS2_CAMERA_INFO_NAME, dev_info.name );
+            register_info( RS2_CAMERA_INFO_PRODUCT_LINE, dev_info.product_line );
+            register_info( RS2_CAMERA_INFO_SERIAL_NUMBER, dev_info.serial );
+            register_info( RS2_CAMERA_INFO_CAMERA_LOCKED, dev_info.locked ? "YES" : "NO" );
+            register_info( RS2_CAMERA_INFO_PHYSICAL_PORT, dev_info.topic_root );
 
             //Assumes dds_device initialization finished
             struct sensor_info
@@ -691,21 +719,21 @@ namespace librealsense
                 count = ( count > 1 ) ? 1 : 0;
             // Now we can finally assign (sid,index):
             _dds_dev->foreach_stream( [&]( std::shared_ptr< realdds::dds_stream > const & stream ) {
-                auto & info = sensor_name_to_info[stream->sensor_name()];
-                if( ! info.proxy )
+                auto & sensor_info = sensor_name_to_info[stream->sensor_name()];
+                if( ! sensor_info.proxy )
                 {
                     // This is a new sensor we haven't seen yet
-                    info.proxy = std::make_shared< dds_sensor_proxy >( stream->sensor_name(), this, _dds_dev );
-                    info.sensor_index = add_sensor( info.proxy );
-                    assert( info.sensor_index == _software_sensors.size() );
-                    _software_sensors.push_back( info.proxy );
+                    sensor_info.proxy = std::make_shared< dds_sensor_proxy >( stream->sensor_name(), this, _dds_dev );
+                    sensor_info.sensor_index = add_sensor( sensor_info.proxy );
+                    assert( sensor_info.sensor_index == _software_sensors.size() );
+                    _software_sensors.push_back( sensor_info.proxy );
                 }
                 auto stream_type = to_rs2_stream_type( stream->type_string() );
                 sid_index sidx( stream_type, counts[stream_type]++ );
-                info.proxy->add_dds_stream( sidx, stream );
+                sensor_info.proxy->add_dds_stream( sidx, stream );
                 LOG_DEBUG( sidx.to_string() << " " << stream->sensor_name() << " : " << stream->name() );
 
-                software_sensor & sensor = get_software_sensor( info.sensor_index );
+                software_sensor & sensor = get_software_sensor( sensor_info.sensor_index );
                 auto video_stream = std::dynamic_pointer_cast< realdds::dds_video_stream >( stream );
                 auto motion_stream = std::dynamic_pointer_cast< realdds::dds_motion_stream >( stream );
                 auto & profiles = stream->profiles();
@@ -730,6 +758,12 @@ namespace librealsense
                                 std::static_pointer_cast< realdds::dds_motion_stream_profile >( profile ) ),
                             profile == default_profile );
                     }
+                }
+
+                auto & options = stream->options();
+                for( auto & option : options )
+                {
+                    sensor_info.proxy->add_option( *option );
                 }
             } );  // End foreach_stream lambda
         } //End dds_device_proxy constructor

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -69,8 +69,6 @@ public:
 
     void publish_image( const std::string & stream_name, const uint8_t * data, size_t size );
     void publish_notification( topics::flexible_msg && );
-    void set_option( const dds_option & option );
-    void get_option( dds_option & option );
     
     typedef std::function< void( const nlohmann::json & msg ) > control_callback;
     void on_open_streams( control_callback callback ) { _open_streams_callback = std::move( callback ); }

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <realdds/dds-option.h>
 #include <librealsense2/utilities/concurrency/concurrency.h>
 #include <third-party/json_fwd.hpp>
 
@@ -31,7 +32,6 @@ class dds_subscriber;
 class dds_stream_server;
 class dds_notification_server;
 class dds_topic_reader;
-class dds_option;
 struct image_header;
 
 
@@ -58,7 +58,8 @@ public:
     // A server is not valid until init() is called with a list of streams that we want to publish.
     // On successful return from init(), each of the streams will be alive so clients will be able
     // to subscribe.
-    void init( const std::vector< std::shared_ptr< dds_stream_server > > & streams );
+    void init( const std::vector< std::shared_ptr< dds_stream_server > > & streams,
+               const dds_options & options );
 
     bool is_valid() const { return( nullptr != _notification_server.get() ); }
     bool operator!() const { return ! is_valid(); }
@@ -68,8 +69,8 @@ public:
 
     void publish_image( const std::string & stream_name, const uint8_t * data, size_t size );
     void publish_notification( topics::flexible_msg && );
-    void set_option( const std::string & stream_name, const dds_option & option );
-    void get_option( const std::string & stream_name, dds_option & option );
+    void set_option( const dds_option & option );
+    void get_option( dds_option & option );
     
     typedef std::function< void( const nlohmann::json & msg ) > control_callback;
     void on_open_streams( control_callback callback ) { _open_streams_callback = std::move( callback ); }

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -31,6 +31,7 @@ class dds_subscriber;
 class dds_stream_server;
 class dds_notification_server;
 class dds_topic_reader;
+class dds_option;
 struct image_header;
 
 
@@ -67,6 +68,8 @@ public:
 
     void publish_image( const std::string & stream_name, const uint8_t * data, size_t size );
     void publish_notification( topics::flexible_msg && );
+    void set_option( const std::string & stream_name, const dds_option & option );
+    void get_option( const std::string & stream_name, dds_option & option );
     
     typedef std::function< void( const nlohmann::json & msg ) > control_callback;
     void on_open_streams( control_callback callback ) { _open_streams_callback = std::move( callback ); }
@@ -85,6 +88,7 @@ private:
     dispatcher _control_dispatcher;
     control_callback _open_streams_callback = nullptr;
     control_callback _close_streams_callback = nullptr;
+    std::atomic< size_t > _message_counter = 0;
 };  // class dds_device_server
 
 

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -88,7 +88,7 @@ private:
     dispatcher _control_dispatcher;
     control_callback _open_streams_callback = nullptr;
     control_callback _close_streams_callback = nullptr;
-    std::atomic< size_t > _message_counter = 0;
+    std::atomic< size_t > _message_counter { 0 };
 };  // class dds_device_server
 
 

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -55,6 +55,9 @@ public:
     void open( const dds_stream_profiles & profiles );
     void close( const dds_streams & streams );
 
+    void set_option_value( std::shared_ptr< dds_option > option, float value );
+    float query_option_value( std::shared_ptr< dds_option > option );
+
 private:
     class impl;
     std::shared_ptr< impl > _impl;

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -51,6 +51,7 @@ public:
     size_t number_of_streams() const;
 
     size_t foreach_stream( std::function< void( std::shared_ptr< dds_stream > stream ) > fn ) const;
+    size_t foreach_option( std::function< void( std::shared_ptr< dds_option > option ) > fn ) const;
 
     void open( const dds_stream_profiles & profiles );
     void close( const dds_streams & streams );

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -1,0 +1,53 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+
+#include <third-party/json_fwd.hpp>
+
+#include <string>
+
+
+namespace realdds {
+
+
+struct dds_option_range
+{
+    float min;
+    float max;
+    float step;
+    float default_value;
+};
+
+class dds_option
+{
+    std::string _name;
+    float _value;
+    dds_option_range _range;
+    std::string _description;
+
+    dds_option( nlohmann::json const & j );
+
+public:
+    dds_option() = default;
+
+    std::string get_name() const { return _name; }
+    void set_name( std::string description ) { _name = description; }
+
+    float get_value() const { return _value; }
+    void set_value(float val) { _value = val; }
+
+    dds_option_range get_range() const { return _range; }
+    void set_range( dds_option_range range ) { _range = range; }
+
+    std::string get_description() const { return _description; }
+    void set_description( std::string description ) { _description = description; }
+
+    nlohmann::json to_json() const;
+    static std::shared_ptr< dds_option > from_json( nlohmann::json const & j );
+};
+
+typedef std::vector< std::shared_ptr< dds_option > > dds_options;
+
+}  // namespace realdds

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -7,33 +7,34 @@
 #include <third-party/json_fwd.hpp>
 
 #include <string>
+#include <vector>
 
 
 namespace realdds {
 
-
 struct dds_option_range
 {
-    float min;
-    float max;
-    float step;
-    float default_value;
+    float min = 0.0f;
+    float max = 0.0f;
+    float step = 0.0f;
+    float default_value = 0.0f;
 };
 
 class dds_option
 {
     std::string _name;
-    float _value;
+    float _value = 0.0f;
     dds_option_range _range;
     std::string _description;
 
-    dds_option( nlohmann::json const & j );
+    std::string _owner_name; //To identify device or stream having this option
+
+    dds_option( nlohmann::json const & j, const std::string & owner_name );
 
 public:
-    dds_option() = default;
+    dds_option( const std::string & name, const std::string & owner_name );
 
-    std::string get_name() const { return _name; }
-    void set_name( std::string description ) { _name = description; }
+    const std::string & get_name() const { return _name; }
 
     float get_value() const { return _value; }
     void set_value(float val) { _value = val; }
@@ -41,11 +42,13 @@ public:
     dds_option_range get_range() const { return _range; }
     void set_range( dds_option_range range ) { _range = range; }
 
-    std::string get_description() const { return _description; }
+    const std::string & get_description() const { return _description; }
     void set_description( std::string description ) { _description = description; }
 
+    const std::string & owner_name() const { return _owner_name; }
+
     nlohmann::json to_json() const;
-    static std::shared_ptr< dds_option > from_json( nlohmann::json const & j );
+    static std::shared_ptr< dds_option > from_json( nlohmann::json const & j, const std::string & stream_name );
 };
 
 typedef std::vector< std::shared_ptr< dds_option > > dds_options;

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -44,7 +44,7 @@ public:
     void set_range( const dds_option_range & range ) { _range = range; }
 
     const std::string & get_description() const { return _description; }
-    void set_description( std::string description ) { _description = description; }
+    void set_description( const std::string & description ) { _description = description; }
 
 
     nlohmann::json to_json() const;

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -35,6 +35,7 @@ public:
     dds_option( const std::string & name, const std::string & owner_name );
 
     const std::string & get_name() const { return _name; }
+    const std::string & owner_name() const { return _owner_name; }
 
     float get_value() const { return _value; }
     void set_value(float val) { _value = val; }
@@ -45,7 +46,6 @@ public:
     const std::string & get_description() const { return _description; }
     void set_description( std::string description ) { _description = description; }
 
-    const std::string & owner_name() const { return _owner_name; }
 
     nlohmann::json to_json() const;
     static std::shared_ptr< dds_option > from_json( nlohmann::json const & j, const std::string & stream_name );

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -40,8 +40,8 @@ public:
     float get_value() const { return _value; }
     void set_value(float val) { _value = val; }
 
-    dds_option_range get_range() const { return _range; }
-    void set_range( dds_option_range range ) { _range = range; }
+    const dds_option_range & get_range() const { return _range; }
+    void set_range( const dds_option_range & range ) { _range = range; }
 
     const std::string & get_description() const { return _description; }
     void set_description( std::string description ) { _description = description; }

--- a/third-party/realdds/include/realdds/dds-stream-base.h
+++ b/third-party/realdds/include/realdds/dds-stream-base.h
@@ -36,9 +36,7 @@ public:
 
     // Init functions can only be called once!
     void init_profiles( dds_stream_profiles const & profiles, int default_profile_index = 0 );
-    void init_profiles( dds_stream_profiles && profiles, int default_profile_index = 0 );
     void init_options( dds_options const & options );
-    void init_options( dds_options && options );
 
     std::string const & name() const { return _name; }
     std::string const & sensor_name() const { return _sensor_name; }
@@ -58,8 +56,6 @@ public:
 protected:
     // Allows custom checking of each profile from init_profiles() - if there's a problem, throws
     virtual void check_profile( std::shared_ptr< dds_stream_profile > const & ) const;
-
-    void init_profiles_common( dds_stream_profiles const & profiles, int default_profile_index );
 };
 
 

--- a/third-party/realdds/include/realdds/dds-stream-base.h
+++ b/third-party/realdds/include/realdds/dds-stream-base.h
@@ -5,6 +5,7 @@
 
 
 #include "dds-stream-profile.h"
+#include "dds-option.h"
 
 #include <memory>
 #include <string>
@@ -26,19 +27,22 @@ protected:
     std::string const _sensor_name;
     int _default_profile_index = 0;
     dds_stream_profiles _profiles;
+    dds_options _options;
 
     dds_stream_base( std::string const & stream_name, std::string const & sensor_name );
     
 public:
     virtual ~dds_stream_base() = default;
 
-    // This function can only be called once!
+    // Init functions can only be called once!
     void init_profiles( dds_stream_profiles const & profiles, int default_profile_index = 0 );
+    void init_options( dds_options const & options );
 
     std::string const & name() const { return _name; }
     std::string const & sensor_name() const { return _sensor_name; }
     dds_stream_profiles const & profiles() const { return _profiles; }
     int default_profile_index() const { return _default_profile_index; }
+    dds_options const & options() const { return _options; }
 
     // For serialization, we need a string representation of the stream type (also the profile types)
     virtual char const * type_string() const = 0;

--- a/third-party/realdds/include/realdds/dds-stream-base.h
+++ b/third-party/realdds/include/realdds/dds-stream-base.h
@@ -36,7 +36,9 @@ public:
 
     // Init functions can only be called once!
     void init_profiles( dds_stream_profiles const & profiles, int default_profile_index = 0 );
+    void init_profiles( dds_stream_profiles && profiles, int default_profile_index = 0 );
     void init_options( dds_options const & options );
+    void init_options( dds_options && options );
 
     std::string const & name() const { return _name; }
     std::string const & sensor_name() const { return _sensor_name; }
@@ -56,6 +58,8 @@ public:
 protected:
     // Allows custom checking of each profile from init_profiles() - if there's a problem, throws
     virtual void check_profile( std::shared_ptr< dds_stream_profile > const & ) const;
+
+    void init_profiles_common( dds_stream_profiles const & profiles, int default_profile_index );
 };
 
 

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -7,6 +7,7 @@
 #include <realdds/dds-topic-reader.h>
 #include <realdds/dds-topic-writer.h>
 #include <realdds/dds-subscriber.h>
+#include <realdds/dds-option.h>
 #include <realdds/topics/flexible/flexible-msg.h>
 
 #include <fastdds/dds/publisher/DataWriter.hpp>
@@ -240,6 +241,12 @@ bool dds_device::impl::init()
                     stream->init_profiles( profiles, default_profile_index );
                     LOG_DEBUG( "... stream '" << stream_name << "' (" << _streams.size() << "/" << n_streams_expected
                                               << ") received with " << profiles.size() << " profiles" );
+
+                    dds_options options;
+                    for( auto & option : j["options"] )
+                        options.push_back( dds_option::from_json( option ) );
+                    stream->init_options( options );
+
                     if( _streams.size() >= n_streams_expected )
                         state = state_type::DONE;
                 }

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -265,7 +265,7 @@ bool dds_device::impl::init()
                     LOG_DEBUG( "... stream '" << stream_name << "' (" << _streams.size() << "/" << n_streams_expected
                                               << ") received with " << profiles.size() << " profiles" );
 
-                    stream->init_profiles( std::move( profiles ), default_profile_index );
+                    stream->init_profiles( profiles, default_profile_index );
                 }
                 else if( state_type::WAIT_FOR_STREAMS_INFO == state && id == "stream-options" )
                 {
@@ -283,7 +283,7 @@ bool dds_device::impl::init()
                         options.push_back( dds_option::from_json( option, stream_it->second->name() ) );
                     }
 
-                    stream_it->second->init_options( std::move( options ) );
+                    stream_it->second->init_options( options );
 
                     if( _streams.size() >= n_streams_expected &&
                         n_stream_options_received == n_streams_expected )

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -6,6 +6,7 @@
 #include <realdds/dds-device.h>
 #include <realdds/dds-stream-profile.h>
 #include <realdds/dds-utilities.h>
+#include <realdds/dds-option.h>
 #include <realdds/topics/device-info/device-info-msg.h>
 #include <realdds/topics/flexible/flexible-msg.h>
 
@@ -43,6 +44,8 @@ public:
 
     std::shared_ptr< dds_topic_reader > _notifications_reader;
     std::shared_ptr< dds_topic_writer > _control_writer;
+
+    dds_options _options;
 
     impl( std::shared_ptr< dds_participant > const & participant,
           dds_guid const & guid,

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -97,15 +97,15 @@ static void on_discovery_device_header( size_t const n_streams, const dds_option
     } );
     notifications.add_discovery_notification( std::move( device_header ) );
 
-    auto opt_json = nlohmann::json();
+    auto device_options = nlohmann::json::array();
     for( auto & opt : options )
-        opt_json.push_back( std::move( opt->to_json() ) );
-    topics::flexible_msg device_options( json {
+        device_options.push_back( std::move( opt->to_json() ) );
+    topics::flexible_msg device_options_message( json {
         { "id", "device-options" },
         { "n-options", options.size() },
-        { "options" , opt_json }
+        { "options" , device_options }
         } );
-    notifications.add_discovery_notification( std::move( device_options ) );
+    notifications.add_discovery_notification( std::move( device_options_message ) );
 }
 
 
@@ -130,16 +130,16 @@ static void on_discovery_stream_header( std::shared_ptr< dds_stream_server > con
     topics::flexible_msg notification( msg );
     notifications.add_discovery_notification( std::move( notification ) );
 
-    auto opt_json = nlohmann::json();
+    auto stream_options = nlohmann::json::array();
     for( auto & opt : stream->options() )
-        opt_json.push_back( std::move( opt->to_json() ) );
-    topics::flexible_msg stream_options( json {
+        stream_options.push_back( std::move( opt->to_json() ) );
+    topics::flexible_msg stream_options_message( json {
         { "id", "stream-options" },
         { "stream-name", stream->name() },
         { "n-options", stream->options().size() },
-        { "options" , opt_json }
+        { "options" , stream_options }
         } );
-    notifications.add_discovery_notification( std::move( stream_options ) );
+    notifications.add_discovery_notification( std::move( stream_options_message ) );
 }
 
 
@@ -220,28 +220,4 @@ void dds_device_server::handle_control_message( topics::flexible_msg control_mes
         if ( _close_streams_callback )
             _close_streams_callback( j );
     }
-}
-
-void dds_device_server::set_option( const dds_option & option )
-{
-    topics::flexible_msg notification( json {
-        { "id", "set-option" },
-        { "counter", _message_counter++ },
-        { "owner-name", option.owner_name() },
-        { "option", option.to_json() }
-        } );
-
-    publish_notification( std::move( notification ) );
-}
-
-void dds_device_server::get_option( dds_option & option )
-{
-    topics::flexible_msg notification( json {
-        { "id", "get-option" },
-        { "counter", _message_counter++ },
-        { "owner-name", option.owner_name() },
-        { "option", option.to_json() }
-        } );
-
-    publish_notification( std::move( notification ) );
 }

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -113,6 +113,16 @@ size_t dds_device::foreach_stream( std::function< void( std::shared_ptr< dds_str
     return _impl->_streams.size();
 }
 
+size_t dds_device::foreach_option( std::function< void( std::shared_ptr< dds_option > option ) > fn ) const
+{
+    for( auto const & option : _impl->_options)
+    {
+        fn( option );
+    }
+
+    return _impl->_options.size();
+}
+
 void dds_device::open( const dds_stream_profiles & profiles )
 {
     _impl->open( profiles );

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -88,7 +88,7 @@ dds_notification_server::dds_notification_server( std::shared_ptr< dds_publisher
     // finished the handshake and can receivethe messages.
     // If history is too small writer will not be able to re-transmit needed samples.
     // Setting history to cover known use-cases plus some spare
-    wqos.history().depth = 16;
+    wqos.history().depth = 24;
 
     _writer->run( wqos );
 }

--- a/third-party/realdds/src/dds-option.cpp
+++ b/third-party/realdds/src/dds-option.cpp
@@ -11,32 +11,44 @@ using nlohmann::json;
 namespace realdds {
 
 
-dds_option::dds_option( nlohmann::json const & j )
+dds_option::dds_option( const std::string & name, const std::string & owner_name )
+    : _name( name )
+    , _owner_name( owner_name )
 {
-    int index = 0;
-    _name = utilities::json::get< std::string >( j, index++ );
-    _value = utilities::json::get< float >( j, index++ );
-    _range.min = utilities::json::get< float >( j, index++ );
-    _range.max = utilities::json::get< float >( j, index++ );
-    _range.step = utilities::json::get< float >( j, index++ );
-    _range.default_value = utilities::json::get< float >( j, index++ );
-    _description = utilities::json::get< std::string >( j, index++ );
-
-    if( index != j.size() )
-        DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
 }
 
 
-/* static  */ std::shared_ptr< dds_option > dds_option::from_json(nlohmann::json const & j)
+dds_option::dds_option( nlohmann::json const & j, const std::string & owner_name )
 {
-    return std::shared_ptr< dds_option >( new dds_option( j ) );
+    _name                = j["name"];
+    _value               = j["value"];
+    _range.min           = j["range-min"];
+    _range.max           = j["range-max"];
+    _range.step          = j["range-step"];
+    _range.default_value = j["range-default"];
+    _description         = j["description"];
+
+    _owner_name = owner_name;
+}
+
+
+/* static  */ std::shared_ptr< dds_option > dds_option::from_json(nlohmann::json const & j, const std::string & owner_name )
+{
+    return std::shared_ptr< dds_option >( new dds_option( j, owner_name ) );
 }
 
 
 nlohmann::json dds_option::to_json() const
 {
-    // Note - same order as construction!
-    return json::array( { _name, _value, _range.min, _range.max, _range.step, _range.default_value, _description } );
+    return json( {
+        { "name", _name },
+        { "value", _value },
+        { "range-min", _range.min },
+        { "range-max", _range.max },
+        { "range-step", _range.step },
+        { "range-default", _range.default_value },
+        { "description", _description }
+        } );
 }
 
 }  // namespace realdds

--- a/third-party/realdds/src/dds-option.cpp
+++ b/third-party/realdds/src/dds-option.cpp
@@ -20,13 +20,13 @@ dds_option::dds_option( const std::string & name, const std::string & owner_name
 
 dds_option::dds_option( nlohmann::json const & j, const std::string & owner_name )
 {
-    _name                = j["name"];
-    _value               = j["value"];
-    _range.min           = j["range-min"];
-    _range.max           = j["range-max"];
-    _range.step          = j["range-step"];
-    _range.default_value = j["range-default"];
-    _description         = j["description"];
+    _name                = utilities::json::get< std::string >( j, "name" );
+    _value               = utilities::json::get< float >( j, "value" );
+    _range.min           = utilities::json::get< float >( j, "range-min" );
+    _range.max           = utilities::json::get< float >( j, "range-max" );
+    _range.step          = utilities::json::get< float >( j, "range-step" );
+    _range.default_value = utilities::json::get< float >( j, "range-default" );
+    _description         = utilities::json::get< std::string >( j, "description" );
 
     _owner_name = owner_name;
 }

--- a/third-party/realdds/src/dds-option.cpp
+++ b/third-party/realdds/src/dds-option.cpp
@@ -1,0 +1,42 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#include <realdds/dds-option.h>
+#include <realdds/dds-exceptions.h>
+
+#include <librealsense2/utilities/json.h>
+using nlohmann::json;
+
+
+namespace realdds {
+
+
+dds_option::dds_option( nlohmann::json const & j )
+{
+    int index = 0;
+    _name = utilities::json::get< std::string >( j, index++ );
+    _value = utilities::json::get< float >( j, index++ );
+    _range.min = utilities::json::get< float >( j, index++ );
+    _range.max = utilities::json::get< float >( j, index++ );
+    _range.step = utilities::json::get< float >( j, index++ );
+    _range.default_value = utilities::json::get< float >( j, index++ );
+    _description = utilities::json::get< std::string >( j, index++ );
+
+    if( index != j.size() )
+        DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
+}
+
+
+/* static  */ std::shared_ptr< dds_option > dds_option::from_json(nlohmann::json const & j)
+{
+    return std::shared_ptr< dds_option >( new dds_option( j ) );
+}
+
+
+nlohmann::json dds_option::to_json() const
+{
+    // Note - same order as construction!
+    return json::array( { _name, _value, _range.min, _range.max, _range.step, _range.default_value, _description } );
+}
+
+}  // namespace realdds

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -11,6 +11,7 @@
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastrtps/types/DynamicDataFactory.h>
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
+#include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 
 #include <map>
 #include <mutex>
@@ -132,6 +133,11 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
 
     // Indicates for how much time should a remote DomainParticipant consider the local DomainParticipant to be alive.
     pqos.wire_protocol().builtin.discovery_config.leaseDuration = { 10, 0 };  // [sec,nsec]
+
+    //Disable shared memory, use only UDP
+    auto udp_transport = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
+    pqos.transport().use_builtin_transports = false;
+    pqos.transport().user_transports.push_back( udp_transport );
 
     // Listener will call DataReaderListener::on_data_available for a specific reader,
     // not SubscriberListener::on_data_on_readers for any reader

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -12,6 +12,7 @@
 #include <fastrtps/types/DynamicDataFactory.h>
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
+#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
 
 #include <map>
 #include <mutex>
@@ -138,6 +139,9 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
     auto udp_transport = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
     pqos.transport().use_builtin_transports = false;
     pqos.transport().user_transports.push_back( udp_transport );
+    //auto shm_transport = std::make_shared<eprosima::fastdds::rtps::SharedMemTransportDescriptor>();
+    //pqos.transport().use_builtin_transports = false;
+    //pqos.transport().user_transports.push_back( shm_transport );
 
     // Listener will call DataReaderListener::on_data_available for a specific reader,
     // not SubscriberListener::on_data_on_readers for any reader

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -12,7 +12,6 @@
 #include <fastrtps/types/DynamicDataFactory.h>
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
-#include <fastdds/rtps/transport/shared_mem/SharedMemTransportDescriptor.h>
 
 #include <map>
 #include <mutex>
@@ -136,12 +135,12 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
     pqos.wire_protocol().builtin.discovery_config.leaseDuration = { 10, 0 };  // [sec,nsec]
 
     //Disable shared memory, use only UDP
+    //Disabling because sometimes, after improper destruction (e.g. stopping debug) the shared memory is not opened
+    //correctly and the application is stuck. eProsima is working on it. Manual solution delete shared memory files,
+    //C:\ProgramData\eprosima\fastrtps_interprocess on Windows, /dev/shm on Linux
     auto udp_transport = std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
     pqos.transport().use_builtin_transports = false;
     pqos.transport().user_transports.push_back( udp_transport );
-    //auto shm_transport = std::make_shared<eprosima::fastdds::rtps::SharedMemTransportDescriptor>();
-    //pqos.transport().use_builtin_transports = false;
-    //pqos.transport().user_transports.push_back( shm_transport );
 
     // Listener will call DataReaderListener::on_data_available for a specific reader,
     // not SubscriberListener::on_data_on_readers for any reader

--- a/third-party/realdds/src/dds-stream-base.cpp
+++ b/third-party/realdds/src/dds-stream-base.cpp
@@ -16,7 +16,7 @@ dds_stream_base::dds_stream_base( std::string const & name,
 }
 
 
-void dds_stream_base::init_profiles_common( dds_stream_profiles const & profiles, int default_profile_index )
+void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, int default_profile_index )
 {
     if( !_profiles.empty() )
         DDS_THROW( runtime_error, "stream '" + _name + "' profiles are already initialized" );
@@ -35,20 +35,8 @@ void dds_stream_base::init_profiles_common( dds_stream_profiles const & profiles
         check_profile( profile );
         profile->init_stream( self );
     }
-}
 
-
-void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, int default_profile_index )
-{
-    init_profiles_common( profiles, default_profile_index );
     _profiles = profiles;
-}
-
-
-void dds_stream_base::init_profiles( dds_stream_profiles && profiles, int default_profile_index )
-{
-    init_profiles_common( profiles, default_profile_index );
-    _profiles = std::move( profiles );
 }
 
 
@@ -58,15 +46,6 @@ void dds_stream_base::init_options( dds_options const & options )
         DDS_THROW( runtime_error, "stream '" + _name + "' options are already initialized" );
 
     _options = options;
-}
-
-
-void dds_stream_base::init_options( dds_options && options )
-{
-    if( !_options.empty() )
-        DDS_THROW( runtime_error, "stream '" + _name + "' options are already initialized" );
-
-    _options = std::move( options );
 }
 
 

--- a/third-party/realdds/src/dds-stream-base.cpp
+++ b/third-party/realdds/src/dds-stream-base.cpp
@@ -16,23 +16,39 @@ dds_stream_base::dds_stream_base( std::string const & name,
 }
 
 
-void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, int default_profile_index )
+void dds_stream_base::init_profiles_common( dds_stream_profiles const & profiles, int default_profile_index )
 {
-    if( ! _profiles.empty() )
+    if( !_profiles.empty() )
         DDS_THROW( runtime_error, "stream '" + _name + "' profiles are already initialized" );
     if( profiles.empty() )
         DDS_THROW( runtime_error, "at least one profile is required to initialize stream '" + _name + "'" );
+
+    _default_profile_index = default_profile_index;
     if( _default_profile_index < 0 || _default_profile_index >= profiles.size() )
         DDS_THROW( runtime_error,
-                   "invalid default profile index (" + std::to_string( _default_profile_index ) + " for "
-                       + std::to_string( profiles.size() ) + " stream profiles" );
+            "invalid default profile index (" + std::to_string( _default_profile_index ) + " for "
+            + std::to_string( profiles.size() ) + " stream profiles" );
+
     auto self = weak_from_this();
     for( auto const & profile : profiles )
     {
         check_profile( profile );
         profile->init_stream( self );
     }
+}
+
+
+void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, int default_profile_index )
+{
+    init_profiles_common( profiles, default_profile_index );
     _profiles = profiles;
+}
+
+
+void dds_stream_base::init_profiles( dds_stream_profiles && profiles, int default_profile_index )
+{
+    init_profiles_common( profiles, default_profile_index );
+    _profiles = std::move( profiles );
 }
 
 
@@ -42,6 +58,15 @@ void dds_stream_base::init_options( dds_options const & options )
         DDS_THROW( runtime_error, "stream '" + _name + "' options are already initialized" );
 
     _options = options;
+}
+
+
+void dds_stream_base::init_options( dds_options && options )
+{
+    if( !_options.empty() )
+        DDS_THROW( runtime_error, "stream '" + _name + "' options are already initialized" );
+
+    _options = std::move( options );
 }
 
 

--- a/third-party/realdds/src/dds-stream-base.cpp
+++ b/third-party/realdds/src/dds-stream-base.cpp
@@ -19,7 +19,7 @@ dds_stream_base::dds_stream_base( std::string const & name,
 void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, int default_profile_index )
 {
     if( ! _profiles.empty() )
-        DDS_THROW( runtime_error, "stream '" + _name + "' is already initialized" );
+        DDS_THROW( runtime_error, "stream '" + _name + "' profiles are already initialized" );
     if( profiles.empty() )
         DDS_THROW( runtime_error, "at least one profile is required to initialize stream '" + _name + "'" );
     if( _default_profile_index < 0 || _default_profile_index >= profiles.size() )
@@ -33,6 +33,15 @@ void dds_stream_base::init_profiles( dds_stream_profiles const & profiles, int d
         profile->init_stream( self );
     }
     _profiles = profiles;
+}
+
+
+void dds_stream_base::init_options( dds_options const & options )
+{
+    if( !_options.empty() )
+        DDS_THROW( runtime_error, "stream '" + _name + "' options are already initialized" );
+
+    _options = options;
 }
 
 

--- a/tools/dds/dds-server/lrs-device-watcher.cpp
+++ b/tools/dds/dds-server/lrs-device-watcher.cpp
@@ -68,7 +68,7 @@ void tools::lrs_device_watcher::notify_connected_devices_on_wake_up(
     std::function< void( rs2::device ) > add_device_cb )
 {
     auto connected_dev_list = _ctx.query_devices();
-    for( auto & connected_dev : connected_dev_list )
+    for( auto connected_dev : connected_dev_list )
     {
         std::cout << "Device '" << connected_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - detected" << std::endl;
         add_device_cb( connected_dev );

--- a/tools/dds/dds-server/lrs-device-watcher.cpp
+++ b/tools/dds/dds-server/lrs-device-watcher.cpp
@@ -68,7 +68,7 @@ void tools::lrs_device_watcher::notify_connected_devices_on_wake_up(
     std::function< void( rs2::device ) > add_device_cb )
 {
     auto connected_dev_list = _ctx.query_devices();
-    for( auto connected_dev : connected_dev_list )
+    for( auto & connected_dev : connected_dev_list )
     {
         std::cout << "Device '" << connected_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - detected" << std::endl;
         add_device_cb( connected_dev );

--- a/tools/dds/dds-server/rs-dds-server.cpp
+++ b/tools/dds/dds-server/rs-dds-server.cpp
@@ -180,7 +180,7 @@ std::vector< std::shared_ptr< realdds::dds_stream_server > > get_supported_strea
                 sensor.close();
             }
         }
-        server->init_options( std::move( options ) );
+        server->init_options( options );
         servers.push_back( server );
     }
     return servers;

--- a/tools/dds/dds-server/rs-dds-server.cpp
+++ b/tools/dds/dds-server/rs-dds-server.cpp
@@ -64,12 +64,11 @@ std::vector< std::shared_ptr< realdds::dds_stream_server > > get_supported_strea
     std::map< std::string, std::string > stream_name_to_sensor_name;
     std::map< std::string, std::shared_ptr< realdds::dds_stream_server > > stream_name_to_server;
 
-    std::map< std::string, realdds::dds_options > sensor_name_to_options;
-
+    //Iterate over all profiles of all sensors and build appropriate dds_stream_servers
     for( auto sensor : dev.query_sensors() )
     {
         std::string const sensor_name = sensor.get_info( RS2_CAMERA_INFO_NAME );
-        auto stream_profiles = sensor.get_stream_profiles();
+        auto stream_profiles = sensor.get_stream_profiles();        
         std::for_each( stream_profiles.begin(), stream_profiles.end(), [&]( const rs2::stream_profile & sp ) {
             std::string stream_name = sp.stream_name();
             stream_name_to_sensor_name[stream_name] = sensor_name;
@@ -120,33 +119,9 @@ std::vector< std::shared_ptr< realdds::dds_stream_server > > get_supported_strea
             profiles.push_back( profile );
             LOG_DEBUG( stream_name << ": " << profile->to_string() );
         } );
-
-        //Get all sensor supported options
-        auto supported_options = sensor.get_supported_options();
-        //Hack - some options can be queried only if streaming so start sensor and close after query
-        sensor.open( sensor.get_stream_profiles()[0] );
-        sensor.start( []( rs2::frame f ) {} );
-        std::this_thread::sleep_for( std::chrono::milliseconds( 1000 ) );
-        for( auto option : supported_options )
-        {
-            auto dds_opt = std::make_shared< realdds::dds_option >();
-            try
-            {
-                dds_opt->set_name( sensor.get_option_name( option ) );
-                dds_opt->set_value( sensor.get_option( option ) );
-                dds_opt->set_range( to_realdds( sensor.get_option_range( option ) ) );
-                dds_opt->set_description( sensor.get_option_description( option ) );
-            }
-            catch( ... )
-            {
-                LOG_ERROR( "Cannot query details of option " << option );
-                continue; //Some options can be queried only if certain conditions exist skip them for now
-            }
-            sensor_name_to_options[sensor_name].push_back( dds_opt );
-        }
-        sensor.stop();
-        sensor.close();
     }
+
+    //Iterate over the mapped streams and initialize 
     std::vector< std::shared_ptr< realdds::dds_stream_server > > servers;
     for( auto & it : stream_name_to_profiles )
     {
@@ -171,7 +146,41 @@ std::vector< std::shared_ptr< realdds::dds_stream_server > > get_supported_strea
             continue;
         }
         server->init_profiles( profiles, default_profile_index );
-        server->init_options( sensor_name_to_options[sensor_name] ); //TODO - filter options relevant for stream type
+
+        realdds::dds_options options;
+        //Get supported options for this stream
+        for( auto sensor : dev.query_sensors() )
+        {
+            std::string const sensor_name = sensor.get_info( RS2_CAMERA_INFO_NAME );
+            if( server->sensor_name().compare( sensor_name ) == 0 )
+            {
+                //Get all sensor supported options
+                auto supported_options = sensor.get_supported_options();
+                //Hack - some options can be queried only if streaming so start sensor and close after query
+                sensor.open( sensor.get_stream_profiles()[0] );
+                sensor.start( []( rs2::frame f ) {} );
+                for( auto option : supported_options )
+                {
+                    auto dds_opt = std::make_shared< realdds::dds_option >( sensor.get_option_name( option ),
+                                                                            server->name() );
+                    try
+                    {
+                        dds_opt->set_value( sensor.get_option( option ) );
+                        dds_opt->set_range( to_realdds( sensor.get_option_range( option ) ) );
+                        dds_opt->set_description( sensor.get_option_description( option ) );
+                    }
+                    catch( ... )
+                    {
+                        LOG_ERROR( "Cannot query details of option " << option );
+                        continue; //Some options can be queried only if certain conditions exist skip them for now
+                    }
+                    options.push_back( dds_opt ); //TODO - filter options relevant for stream type
+                }
+                sensor.stop();
+                sensor.close();
+            }
+        }
+        server->init_options( std::move( options ) );
         servers.push_back( server );
     }
     return servers;
@@ -314,8 +323,11 @@ try
             // Create a supported streams list for initializing the relevant DDS topics
             auto supported_streams = get_supported_streams( dev );
 
+            //TODO - get all device level options
+            realdds::dds_options dev_options;
+
             // Initialize the DDS device server with the supported streams
-            dds_device_server->init( supported_streams );
+            dds_device_server->init( supported_streams, dev_options );
 
             // Keep a pair of device controller and server per RS device
             device_handlers_list.emplace( dev, device_handler{ dev_info, dds_device_server, lrs_device_controller } );

--- a/tools/dds/realdds-py/python.cpp
+++ b/tools/dds/realdds-py/python.cpp
@@ -452,7 +452,12 @@ PYBIND11_MODULE(NAME, m) {
         .def( "remove_device", &dds_device_broadcaster::remove_device );
 
     using realdds::dds_option_range;
-    py::class_< dds_option_range >( m, "dds_option_range" );
+    py::class_< dds_option_range >( m, "dds_option_range" )
+        .def( py::init<>() )
+        .def_readwrite( "min", &dds_option_range::min )
+        .def_readwrite( "max", &dds_option_range::max )
+        .def_readwrite( "step", &dds_option_range::step )
+        .def_readwrite( "default_value", &dds_option_range::default_value );
 
     using realdds::dds_option;
     py::class_< dds_option, std::shared_ptr< dds_option > >( m, "dds_option" )
@@ -652,6 +657,12 @@ PYBIND11_MODULE(NAME, m) {
                   self.foreach_stream(
                       [&]( std::shared_ptr< dds_stream > const & stream ) { streams.push_back( stream ); } );
                   return streams;
+              } )
+        .def( "options",
+              []( dds_device const & self ) {
+                  std::vector< std::shared_ptr< dds_option > > options;
+                  self.foreach_option( [&]( std::shared_ptr< dds_option > const & option ) { options.push_back( option ); } );
+                  return options;
               } )
         .def( "__repr__", []( dds_device const & self ) {
             std::ostringstream os;

--- a/tools/dds/realdds-py/python.cpp
+++ b/tools/dds/realdds-py/python.cpp
@@ -499,6 +499,7 @@ PYBIND11_MODULE(NAME, m) {
         .def( "type_string", &dds_stream_base::type_string )
         .def( "profiles", &dds_stream_base::profiles )
         .def( "init_profiles", &dds_stream_base::init_profiles )
+        .def( "init_options", &dds_stream_base::init_options )
         .def( "default_profile_index", &dds_stream_base::default_profile_index )
         .def( "is_open", &dds_stream_base::is_open )
         .def( "is_streaming", &dds_stream_base::is_streaming )

--- a/tools/dds/realdds-py/python.cpp
+++ b/tools/dds/realdds-py/python.cpp
@@ -451,6 +451,22 @@ PYBIND11_MODULE(NAME, m) {
         .def( "add_device", &dds_device_broadcaster::add_device )
         .def( "remove_device", &dds_device_broadcaster::remove_device );
 
+    using realdds::dds_option_range;
+    py::class_< dds_option_range >( m, "dds_option_range" );
+
+    using realdds::dds_option;
+    py::class_< dds_option, std::shared_ptr< dds_option > >( m, "dds_option" )
+        .def( py::init< std::string const &, std::string const & >() )
+        .def( "get_name", &dds_option::get_name )
+        .def( "owner_name", &dds_option::owner_name )
+        .def( "get_value", &dds_option::get_value )
+        .def( "set_value", &dds_option::set_value )
+        .def( "get_range", &dds_option::get_range )
+        .def( "set_range", &dds_option::set_range )
+        .def( "get_description", &dds_option::get_description )
+        .def( "set_description", &dds_option::set_description )
+        .def( "to_json", []( dds_option const & self ) { return self.to_json().dump(); } );
+
     using realdds::dds_stream_format;
     py::class_< dds_stream_format >( m, "stream_format" )
         .def( py::init<>() )
@@ -501,6 +517,7 @@ PYBIND11_MODULE(NAME, m) {
         .def( "init_profiles", &dds_stream_base::init_profiles )
         .def( "init_options", &dds_stream_base::init_options )
         .def( "default_profile_index", &dds_stream_base::default_profile_index )
+        .def( "options", &dds_stream_base::options )
         .def( "is_open", &dds_stream_base::is_open )
         .def( "is_streaming", &dds_stream_base::is_streaming )
         .def( "get_topic", &dds_stream_base::get_topic );

--- a/unit-tests/dds/d435i.py
+++ b/unit-tests/dds/d435i.py
@@ -24,7 +24,7 @@ def build( participant ):
     color = color_stream()
     #
     d435i = dds.device_server( participant, device_info.topic_root )
-    d435i.init( [accel, color, depth, gyro, ir1, ir2] )
+    d435i.init( [accel, color, depth, gyro, ir1, ir2], [] )
     return d435i
 
 

--- a/unit-tests/dds/d435i.py
+++ b/unit-tests/dds/d435i.py
@@ -38,6 +38,7 @@ def accel_stream_profiles():
 def accel_stream():
     stream = dds.accel_stream_server( "Accel", "Motion Module" )
     stream.init_profiles( accel_stream_profiles(), 0 )
+    stream.init_options( motion_module_options() )
     return stream
 
 
@@ -51,6 +52,7 @@ def gyro_stream_profiles():
 def gyro_stream():
     stream = dds.gyro_stream_server( "Gyro", "Motion Module" )
     stream.init_profiles( gyro_stream_profiles(), 0 )
+    stream.init_options( motion_module_options() )
     return stream
 
 
@@ -94,6 +96,7 @@ def depth_stream_profiles():
 def depth_stream():
     stream = dds.depth_stream_server( "Depth", "Stereo Module" )
     stream.init_profiles( depth_stream_profiles(), 0 )
+    stream.init_options( stereo_module_options() )
     return stream
 
 
@@ -141,6 +144,7 @@ def ir_stream_profiles():
 def ir_stream( number ):
     stream = dds.ir_stream_server( "Infrared " + str(number), "Stereo Module" )
     stream.init_profiles( ir_stream_profiles(), 0 )
+    stream.init_options( stereo_module_options() )
     return stream
 
 
@@ -345,4 +349,405 @@ def color_stream_profiles():
 def color_stream():
     stream = dds.color_stream_server( "Color",  "RGB Camera" )
     stream.init_profiles( color_stream_profiles(), 0 )
+    stream.init_options( rgb_camera_options() )
     return stream
+
+def stereo_module_options():
+    options = []
+    option_range = dds.dds_option_range()
+
+    option = dds.dds_option( "Exposure", "Stereo Module" )
+    option.set_value( 8500 )
+    option_range.min = 1
+    option_range.max = 200000
+    option_range.step = 1
+    option_range.default_value = 8500
+    option.set_range( option_range )
+    option.set_description( "Depth Exposure (usec)" )
+    options.append( option )
+    option = dds.dds_option( "Gain", "Stereo Module" )
+    option.set_value( 16 )
+    option_range.min = 16
+    option_range.max = 248
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "UVC image gain" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto Exposure", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable Auto Exposure" )
+    options.append( option )
+    option = dds.dds_option( "Visual Preset", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 5
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Advanced-Mode Preset" )
+    options.append( option )
+    option = dds.dds_option( "Laser Power", "Stereo Module" )
+    option.set_value( 150 )
+    option_range.min = 0
+    option_range.max = 360
+    option_range.step = 30
+    option_range.default_value = 150
+    option.set_range( option_range )
+    option.set_description( "Manual laser power in mw. applicable only when laser power mode is set to Manual" )
+    options.append( option )
+    option = dds.dds_option( "Emitter Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Emitter select, 0-disable all emitters, 1-enable laser, 2-enable laser auto (opt), 3-enable LED (opt)" )
+    options.append( option )
+    option = dds.dds_option( "Frames Queue Size", "Stereo Module" )
+    option.set_value( 16 )
+    option_range.min = 0
+    option_range.max = 32
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Max number of frames you can hold at a given time. Increasing this number will reduce frame drops but increase latency, and vice versa" )
+    options.append( option )
+    option = dds.dds_option( "Error Polling Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Enable / disable polling of camera internal errors" )
+    options.append( option )
+    option = dds.dds_option( "Output Trigger Enabled", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Generate trigger from the camera to external device once per frame" )
+    options.append( option )
+    option = dds.dds_option( "Depth Units", "Stereo Module" )
+    option.set_value( 0.001 )
+    option_range.min = 1e-06
+    option_range.max = 0.01
+    option_range.step = 1e-06
+    option_range.default_value = 0.001
+    option.set_range( option_range )
+    option.set_description( "Number of meters represented by a single depth unit" )
+    options.append( option )
+    option = dds.dds_option( "Stereo Baseline", "Stereo Module" )
+    option.set_value( 49.864 )
+    option_range.min = 49.864
+    option_range.max = 49.864
+    option_range.step = 0
+    option_range.default_value = 49.864
+    option.set_range( option_range )
+    option.set_description( "Distance in mm between the stereo imagers" )
+    options.append( option )
+    option = dds.dds_option( "Inter Cam Sync Mode", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 260
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Inter-camera synchronization mode: 0:Default, 1:Master, 2:Slave, 3:Full Salve, 4-258:Genlock with burst count of 1-255 frames for each trigger, 259 and 260 for two frames per trigger with laser ON-OFF and OFF-ON." )
+    options.append( option )
+    option = dds.dds_option( "Emitter On Off", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Alternating emitter pattern, toggled on/off on per-frame basis" )
+    options.append( option )
+    option = dds.dds_option( "Global Time Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable global timestamp" )
+    options.append( option )
+    option = dds.dds_option( "Emitter Always On", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Emitter always on mode: 0:disabled(default), 1:enabled" )
+    options.append( option )
+    option = dds.dds_option( "Hdr Enabled", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Name", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 3
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Size", "Stereo Module" )
+    option.set_value( 2 )
+    option_range.min = 2
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 2
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Id", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Limit", "Stereo Module" )
+    option.set_value( 200000 )
+    option_range.min = 1
+    option_range.max = 200000
+    option_range.step = 1
+    option_range.default_value = 8500
+    option.set_range( option_range )
+    option.set_description( "Exposure limit is in microseconds. If the requested exposure limit is greater than frame time, it will be set to frame time at runtime. Setting will not take effect until next streaming session." )
+    options.append( option )
+    option = dds.dds_option( "Auto Gain Limit", "Stereo Module" )
+    option.set_value( 248 )
+    option_range.min = 16
+    option_range.max = 248
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Gain limits ranges from 16 to 248. If the requested gain limit is less than 16, it will be set to 16. If the requested gain limit is greater than 248, it will be set to 248. Setting will not take effect until next streaming session." )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Limit Toggle", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Toggle Auto-Exposure Limit" )
+    options.append( option )
+    option = dds.dds_option( "Auto Gain Limit Toggle", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Toggle Auto-Gain Limit" )
+    options.append( option )
+
+    return options
+
+def rgb_camera_options():
+    options = []
+    option_range = dds.dds_option_range()
+
+    option = dds.dds_option( "Backlight Compensation", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Enable / disable backlight compensation" )
+    options.append( option )
+    option = dds.dds_option( "Brightness", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = -64
+    option_range.max = 64
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "UVC image brightness" )
+    options.append( option )
+    option = dds.dds_option( "Contrast", "RGB Camera" )
+    option.set_value( 50 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 50
+    option.set_range( option_range )
+    option.set_description( "UVC image contrast" )
+    options.append( option )
+    option = dds.dds_option( "Exposure", "RGB Camera" )
+    option.set_value( 156 )
+    option_range.min = 1
+    option_range.max = 10000
+    option_range.step = 1
+    option_range.default_value = 156
+    option.set_range( option_range )
+    option.set_description( "Controls exposure time of color camera. Setting any value will disable auto exposure" )
+    options.append( option )
+    option = dds.dds_option( "Gain", "RGB Camera" )
+    option.set_value( 6 )
+    option_range.min = 0
+    option_range.max = 128
+    option_range.step = 1
+    option_range.default_value = 64
+    option.set_range( option_range )
+    option.set_description( "UVC image gain" )
+    options.append( option )
+    option = dds.dds_option( "Gamma", "RGB Camera" )
+    option.set_value( 300 )
+    option_range.min = 100
+    option_range.max = 500
+    option_range.step = 1
+    option_range.default_value = 300
+    option.set_range( option_range )
+    option.set_description( "UVC image gamma setting" )
+    options.append( option )
+    option = dds.dds_option( "Hue", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = -180
+    option_range.max = 180
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "UVC image hue" )
+    options.append( option )
+    option = dds.dds_option( "Saturation", "RGB Camera" )
+    option.set_value( 64 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 64
+    option.set_range( option_range )
+    option.set_description( "UVC image saturation setting" )
+    options.append( option )
+    option = dds.dds_option( "Sharpness", "RGB Camera" )
+    option.set_value( 50 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 50
+    option.set_range( option_range )
+    option.set_description( "UVC image sharpness setting" )
+    options.append( option )
+    option = dds.dds_option( "White Balance", "RGB Camera" )
+    option.set_value( 4600 )
+    option_range.min = 2800
+    option_range.max = 6500
+    option_range.step = 10
+    option_range.default_value = 4600
+    option.set_range( option_range )
+    option.set_description( "Controls white balance of color image. Setting any value will disable auto white balance" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto Exposure", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable / disable auto-exposure" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto White Balance", "RGB Camera" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable / disable auto-white-balance" )
+    options.append( option )
+    option = dds.dds_option( "Frames Queue Size", "RGB Camera" )
+    option.set_value( 16 )
+    option_range.min = 0
+    option_range.max = 32
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Max number of frames you can hold at a given time. Increasing this number will reduce frame drops but increase latency, and vice versa" )
+    options.append( option )
+    option = dds.dds_option( "Power Line Frequency", "RGB Camera" )
+    option.set_value( 3 )
+    option_range.min = 0
+    option_range.max = 3
+    option_range.step = 1
+    option_range.default_value = 3
+    option.set_range( option_range )
+    option.set_description( "Power Line Frequency" )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Priority", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Restrict Auto-Exposure to enforce constant FPS rate. Turn ON to remove the restrictions (may result in FPS drop)" )
+    options.append( option )
+    option = dds.dds_option( "Global Time Enabled", "RGB Camera" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable global timestamp" )
+    options.append( option )
+
+    return options
+
+def motion_module_options():
+    options = []
+    option_range = dds.dds_option_range()
+
+    option = dds.dds_option( "Frames Queue Size", "Motion Module" )
+    option.set_value( 16 )
+    option_range.min = 0
+    option_range.max = 32
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Max number of frames you can hold at a given time. Increasing this number will reduce frame drops but increase latency, and vice versa" )
+    options.append( option )
+    option = dds.dds_option( "Enable Motion Correction", "Motion Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable Automatic Motion Data Correction" )
+    options.append( option )
+    option = dds.dds_option( "Global Time Enabled", "Motion Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable global timestamp" )
+    options.append( option )
+
+    return options
+

--- a/unit-tests/dds/device-init-server.py
+++ b/unit-tests/dds/device-init-server.py
@@ -20,7 +20,7 @@ def test_one_stream():
     log.d( s1.profiles() )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1] )
+    server.init( [s1], [] )
 
 def test_one_motion_stream():
     s1p1 = dds.motion_stream_profile( 30, dds.stream_format("RGB8") )
@@ -30,7 +30,7 @@ def test_one_motion_stream():
     log.d( s1.profiles() )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1] )
+    server.init( [s1], [] )
 
 def test_no_profiles():
     s1profiles = []
@@ -38,12 +38,12 @@ def test_no_profiles():
     s1.init_profiles( s1profiles, 0 )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1] )
+    server.init( [s1], [] )
 
 def test_no_streams():
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [] )
+    server.init( [], [] )
 
 def test_n_profiles( n_profiles ):
     assert n_profiles > 0
@@ -60,7 +60,7 @@ def test_n_profiles( n_profiles ):
     log.d( s1.profiles() )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1] )
+    server.init( [s1], [] )
 
 
 def test_d435i():

--- a/unit-tests/dds/options-server.py
+++ b/unit-tests/dds/options-server.py
@@ -23,44 +23,69 @@ def test_no_options():
     server = dds.device_server( participant, "realdds/device/topic-root" )
     server.init( [s1], dev_opts )
 
-def test_device_options_discovery():
+def test_device_options_discovery( values ):
     # Create one stream with one profile so device init won't fail, no stream options
     s1p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
     s1profiles = [s1p1]
     s1 = dds.depth_stream_server( "s1", "sensor" )
     s1.init_profiles( s1profiles, 0 )
-    do1 = dds.dds_option( "opt1", "device" )
-    do1.set_value( 1 )
-    do2 = dds.dds_option( "opt2", "device" )
-    do2.set_value( 2 )
-    do3 = dds.dds_option( "opt3", "device" )
-    do3.set_value( 3 )
-    dev_opts = [do1, do2, do3]
+    dev_opts = []
+    for index, value in enumerate( values ):
+        option = dds.dds_option( "opt" + str( index ), "device" )
+        option.set_value( value )
+        dev_opts.append( option )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
     server.init( [s1], dev_opts )
 
-def test_stream_options_discovery():
+def test_stream_options_discovery( value, min, max, step, default, description ):
     s1p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
     s1profiles = [s1p1]
     s1 = dds.depth_stream_server( "s1", "sensor" )
     s1.init_profiles( s1profiles, 0 )
     so1 = dds.dds_option( "opt1", "s1" )
-    so1.set_value( 1 )
+    so1.set_value( value )
     so2 = dds.dds_option( "opt2", "s1" )
     range = dds.dds_option_range()
-    range.min = 0 # Using int values because can't test.check_equal floats
-    range.max = 123456
-    range.step = 123
-    range.default_value = 12
+    range.min = min
+    range.max = max
+    range.step = step
+    range.default_value = default
     so2.set_range( range )
     so3 = dds.dds_option( "opt3", "s1" )
-    so3.set_description( "opt3 of s1")
+    so3.set_description( description)
     s1.init_options( [so1, so2, so3] )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
     server.init( [s1], [] )
 
+def test_device_and_multiple_stream_options_discovery( dev_values, stream_values ):
+    dev_options = []
+    for index, value in enumerate( dev_values ):
+        option = dds.dds_option( "opt" + str( index ), "device" )
+        option.set_value( value )
+        dev_options.append( option )
+    stream_options = []
+    for index, value in enumerate( stream_values ):
+        option = dds.dds_option( "opt" + str( index ), "sensor" )
+        option.set_value( value )
+        stream_options.append( option )
+    
+    s1p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
+    s1profiles = [s1p1]
+    s1 = dds.depth_stream_server( "s1", "sensor" )
+    s1.init_profiles( s1profiles, 0 )
+    s1.init_options( stream_options )
+    
+    s2p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
+    s2profiles = [s2p1]
+    s2 = dds.depth_stream_server( "s2", "sensor" )
+    s2.init_profiles( s2profiles, 0 )
+    s2.init_options( stream_options )
+    
+    global server
+    server = dds.device_server( participant, "realdds/device/topic-root" )
+    server.init( [s1, s2], dev_options )
 
 def close_server():
     global server

--- a/unit-tests/dds/options-server.py
+++ b/unit-tests/dds/options-server.py
@@ -1,0 +1,71 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+import pyrealdds as dds
+from rspy import log, test
+
+dds.debug( True, log.nested )
+
+
+participant = dds.participant()
+participant.init( 123, "options-server" )
+
+
+def test_no_options():
+    # Create one stream with one profile so device init won't fail
+    # No device options, no stream options
+    s1p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
+    s1profiles = [s1p1]
+    s1 = dds.depth_stream_server( "s1", "sensor" )
+    s1.init_profiles( s1profiles, 0 )
+    dev_opts = []
+    global server
+    server = dds.device_server( participant, "realdds/device/topic-root" )
+    server.init( [s1], dev_opts )
+
+def test_device_options_discovery():
+    # Create one stream with one profile so device init won't fail, no stream options
+    s1p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
+    s1profiles = [s1p1]
+    s1 = dds.depth_stream_server( "s1", "sensor" )
+    s1.init_profiles( s1profiles, 0 )
+    do1 = dds.dds_option( "opt1", "device" )
+    do1.set_value( 1 )
+    do2 = dds.dds_option( "opt2", "device" )
+    do2.set_value( 2 )
+    do3 = dds.dds_option( "opt3", "device" )
+    do3.set_value( 3 )
+    dev_opts = [do1, do2, do3]
+    global server
+    server = dds.device_server( participant, "realdds/device/topic-root" )
+    server.init( [s1], dev_opts )
+
+def test_stream_options_discovery():
+    s1p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
+    s1profiles = [s1p1]
+    s1 = dds.depth_stream_server( "s1", "sensor" )
+    s1.init_profiles( s1profiles, 0 )
+    so1 = dds.dds_option( "opt1", "s1" )
+    so1.set_value( 1 )
+    so2 = dds.dds_option( "opt2", "s1" )
+    range = dds.dds_option_range()
+    range.min = 0 # Using int values because can't test.check_equal floats
+    range.max = 123456
+    range.step = 123
+    range.default_value = 12
+    so2.set_range( range )
+    so3 = dds.dds_option( "opt3", "s1" )
+    so3.set_description( "opt3 of s1")
+    s1.init_options( [so1, so2, so3] )
+    global server
+    server = dds.device_server( participant, "realdds/device/topic-root" )
+    server.init( [s1], [] )
+
+
+def close_server():
+    global server
+    server = None
+
+
+# From here down, we're in "interactive" mode (see test-device-init.py)
+# ...

--- a/unit-tests/dds/test-options.py
+++ b/unit-tests/dds/test-options.py
@@ -1,0 +1,103 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#test:donotrun:!dds
+
+import pyrealdds as dds
+from rspy import log, test
+
+
+dds.debug( True, 'C  ' )
+log.nested = 'C  '
+
+
+participant = dds.participant()
+participant.init( 123, "test-options" )
+
+info = dds.device_info()
+info.name = "Test Device"
+info.topic_root = "realdds/device/topic-root"
+
+
+import os.path
+cwd = os.path.dirname(os.path.realpath(__file__))
+remote_script = os.path.join( cwd, 'options-server.py' )
+with test.remote( remote_script, nested_indent="  S" ) as remote:
+    remote.wait_until_ready()
+    #
+    #############################################################################################
+    #
+    test.start( "Test no options..." )
+    try:
+        remote.run( 'test_no_options()', timeout=5 )
+        device = dds.device( participant, participant.create_guid(), info )
+        device.run()  # If no device is available in 30 seconds, this will throw
+        test.check( device.is_running() )
+        
+        options = device.options();
+        for option in options:
+            test.unreachable() # Test no device option
+        
+        test.check_equal( device.n_streams(), 1 )
+        for stream in device.streams():
+            options = stream.options();
+            for option in options:
+                test.unreachable() # Test no stream option
+                
+        remote.run( 'close_server()', timeout=5 )
+    except:
+        test.unexpected_exception()
+    device = None
+    test.finish()
+    #
+    #############################################################################################
+    #
+    test.start( "Test device options discovery..." )
+    try:
+        remote.run( 'test_device_options_discovery()', timeout=5 )
+        device = dds.device( participant, participant.create_guid(), info )
+        device.run()  # If no device is available in 30 seconds, this will throw
+        test.check( device.is_running() )
+        
+        options = device.options();
+        test.check_equal( len( options ), 3 )
+        test.check_equal( options[0].get_value(), 1. )
+        test.check_equal( options[1].get_value(), 2. )
+        test.check_equal( options[2].get_value(), 3. )
+        
+        remote.run( 'close_server()', timeout=5 )
+    except:
+        test.unexpected_exception()
+    device = None
+    test.finish()
+    #
+    #############################################################################################
+    #
+    test.start( "Test stream options discovery..." )
+    try:
+        remote.run( 'test_stream_options_discovery()', timeout=5 )
+        device = dds.device( participant, participant.create_guid(), info )
+        device.run()  # If no device is available in 30 seconds, this will throw
+        test.check( device.is_running() )
+        test.check_equal( device.n_streams(), 1 )
+        for stream in device.streams():
+            options = stream.options();
+            test.check_equal( len( options ), 3 )
+            test.check_equal( options[0].get_value(), 1. )
+            test.check_equal( options[1].get_range().min, 0. )
+            test.check_equal( options[1].get_range().max, 123456. )
+            test.check_equal( options[1].get_range().step, 123. )
+            test.check_equal( options[1].get_range().default_value, 12. )
+            test.check_equal( options[2].get_description(), "opt3 of s1" )
+                
+        remote.run( 'close_server()', timeout=5 )
+    except:
+        test.unexpected_exception()
+    device = None
+    test.finish()
+    #
+    #############################################################################################
+
+
+participant = None
+test.print_results_and_exit()


### PR DESCRIPTION
Added dds_option class to handle option objects
rs-dds-server tool gets all supported options and sends them in discovery, currently in stream header message. If we will see that the messages are to big we will split later.
The options are received by dds-device-impl and registered to the software device.

Also disabled shared memory transport as `dds_participant.init()` stuck many times because of it

