### PR TITLE
Build_CI restructure with live-tests on Linux only

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -15,19 +15,17 @@ env:
   # GH-Actions Windows VM currently supply ~14 GB available on D drive, and ~80 GB on drive C.
   # Building LRS statically with third parties is too much for drive D so we clone to drive 'D' and build on drive 'C'
   WIN_BUILD_DIR: C:/lrs_build
-  
-jobs:    
-  Windows_testing_cpp_USB_Win7:
+
+
+jobs:
+
+
+  #--------------------------------------------------------------------------------
+  Win_SH_EX_CfU:  # Windows, shared, with Examples & Tools, and Check for Updates
     runs-on: windows-2019
     timeout-minutes: 60
-    env:
-      VS15: false
-      RS_CPP_TEST: true
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-       python-version: '3.8.1'
 
     - name: Enable Long Paths
       shell: powershell
@@ -47,60 +45,33 @@ jobs:
        mkdir ${{env.WIN_BUILD_DIR}}
     
     - name: Configure CMake
-    # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-    # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       shell: bash
       run: |        
-        LRS_SRC_DIR=$(pwd)   
+        LRS_SRC_DIR=$(pwd)
         cd ${{env.WIN_BUILD_DIR}}
         pwd
         ls        
-        cmake ${LRS_SRC_DIR} -G "Visual Studio 16 2019" -DPYTHON_EXECUTABLE=${{env.PYTHON_PATH}} -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.8 -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_WITH_TM2=false -DFORCE_RSUSB_BACKEND=true -DBUILD_WITH_DDS=true
+        cmake ${LRS_SRC_DIR} -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=true -DBUILD_TOOLS=true -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true
 
     - name: Build
       # Build your program with the given configuration
       shell: bash
       run: |
         cd ${{env.WIN_BUILD_DIR}}
-        pwd
-        ls
         cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -m    
-     
-    - name: Test
-      shell: bash
-      id: test-step
-      # We set continue-on-error: true as a workaround for not skipping the upload log step on failure,
-      # The final step will check the return value from the test step and decide if to fail/pass the job
-      continue-on-error: true 
-      run: |
-       export LRS_LOG_LEVEL="DEBUG";
-       cd  ${{env.WIN_BUILD_DIR}}/${{env.LRS_RUN_CONFIG}}
-       ls
-       ./live-test.exe -d yes -i [software-device]  
-       
-    - name: Upload RS log artifact
-      uses: actions/upload-artifact@v2
-      with: 
-        name: Log file - Windows_testing_cpp_USB_Win7
-        path:  ${{env.WIN_BUILD_DIR}}/${{env.LRS_RUN_CONFIG}}/*.log
-        
-    - name: Provide correct exit status for job 
-      shell: bash
-      run: |
-        if [ ${{steps.test-step.outcome}} = "failure" ];then
-           echo "Test step failed, please open it to view the reported issue"
-           exit 1
-        else
-           exit 0
-        fi
-  
-  Windows_cpp:
+
+
+  #--------------------------------------------------------------------------------
+  Win_ST_Py_DDS:  # Windows, Static, Python, Tools, DDS
     runs-on: windows-2019
     timeout-minutes: 60
-    env:
-      VS15: true
     steps:
     - uses: actions/checkout@v2    
+    - uses: actions/setup-python@v2
+      with:
+       python-version: '3.8.1'
 
     - name: Enable Long Paths
       shell: powershell
@@ -120,15 +91,13 @@ jobs:
        mkdir ${{env.WIN_BUILD_DIR}}
 
     - name: Configure CMake
-    # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-    # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       shell: bash
       run: |        
         LRS_SRC_DIR=$(pwd)   
         cd ${{env.WIN_BUILD_DIR}}
-        pwd
-        ls
-        cmake ${LRS_SRC_DIR} -G "Visual Studio 16 2019" -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DCHECK_FOR_UPDATES=true
+        cmake ${LRS_SRC_DIR} -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=false -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=true -DPYTHON_EXECUTABLE=${{env.PYTHON_PATH}} -DBUILD_PYTHON_BINDINGS=true 
 
     - name: Build
       # Build your program with the given configuration
@@ -136,55 +105,18 @@ jobs:
       run: |
         cd ${{env.WIN_BUILD_DIR}}
         cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -m    
-        
-  Windows_cpp_static:
+
+
+  #--------------------------------------------------------------------------------
+  Win_SH_Py_RSUSB_Csharp:  # Windows, Shared, Python, RSUSB backend, C# bindings
     runs-on: windows-2019
     timeout-minutes: 60
-    env:
-      VS15: true
       
     steps:
     - uses: actions/checkout@v2    
-
-    - name: Enable Long Paths
-      shell: powershell
-      run: |
-       New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
-
-    - name: PreBuild
-      shell: bash
-      run: |
-       cd scripts && ./api_check.sh && cd ..
-       mkdir ${{env.WIN_BUILD_DIR}}
-
-    - name: Configure CMake
-    # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-    # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      shell: bash
-      run: |   
-        pwd 
-        LRS_SRC_DIR=$(pwd)        
-        cd ${{env.WIN_BUILD_DIR}}
-        cmake ${LRS_SRC_DIR} -G "Visual Studio 16 2019" -DBUILD_WITH_TM2=true -DCHECK_FOR_UPDATES=true -DBUILD_SHARED_LIBS=false -DBUILD_TOOLS=true -DBUILD_WITH_DDS=true
-
-    - name: Build
-      # Build your program with the given configuration
-      shell: bash
-      run: |
-        cd ${{env.WIN_BUILD_DIR}}
-        cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -m    
-       
-  Windows_CSharp:
-    # The CMake configure and build commands are platform agnostic and should work equally
-    # well on Windows or Mac.  You can convert this to a matrix build if you need
-    # cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-2019   
-    timeout-minutes: 60
-    env:
-      VS15: true  
-    steps:
-    - uses: actions/checkout@v2       
+    - uses: actions/setup-python@v2
+      with:
+       python-version: '3.8.1'
 
     - name: Enable Long Paths
       shell: powershell
@@ -196,7 +128,7 @@ jobs:
       run: |
         cd scripts
         ./api_check.sh
-        cd ..
+        cd ..   
 
     - name: PreBuild
       shell: bash
@@ -207,25 +139,23 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       shell: bash
-      run: |        
-        LRS_SRC_DIR=$(pwd)   
+      run: |   
+        LRS_SRC_DIR=$(pwd)
         cd ${{env.WIN_BUILD_DIR}}
-        pwd
-        ls
-        cmake ${LRS_SRC_DIR} -G "Visual Studio 16 2019" -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_CSHARP_BINDINGS=true -DDOTNET_VERSION_LIBRARY="4.5" -DDOTNET_VERSION_EXAMPLES="4.5" -DCHECK_FOR_UPDATES=true    
+        cmake ${LRS_SRC_DIR} -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=false -DPYTHON_EXECUTABLE=${{env.PYTHON_PATH}} -DBUILD_PYTHON_BINDINGS=true -DFORCE_RSUSB_BACKEND=true -DBUILD_CSHARP_BINDINGS=true -DDOTNET_VERSION_LIBRARY="4.5" -DDOTNET_VERSION_EXAMPLES="4.5"
 
     - name: Build
       # Build your program with the given configuration
       shell: bash
       run: |
         cd ${{env.WIN_BUILD_DIR}}
-        cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -m     
+        cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -m    
 
-  Linux_testing_cpp:
+
+  #--------------------------------------------------------------------------------
+  U18_ST_Py_EX_CfU_LiveTest:  # Ubuntu 2018, Static, Python, Examples & Tools, Check for Updates, Legacy Live-Tests
     runs-on: ubuntu-18.04    
     timeout-minutes: 60
-    env: 
-      RS_CPP_TEST: true
     steps:
     - uses: actions/checkout@v2
     
@@ -248,7 +178,7 @@ jobs:
       shell: bash
       run: | 
         cd build
-        cmake .. -DBUILD_UNIT_TESTS=false -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true -DBUILD_WITH_DDS=true
+        cmake .. -DBUILD_SHARED_LIBS=false -DBUILD_EXAMPLES=true -DBUILD_TOOLS=true -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=true -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
         cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4
         
     - name: Test
@@ -265,7 +195,7 @@ jobs:
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v2
       with: 
-        name: Log file - Linux_testing_cpp
+        name: Log file - U20_SH_Py_LiveTest_DDS
         path: build/*.log
         
         
@@ -279,8 +209,10 @@ jobs:
            exit 0
         fi
 
-  Linux_static_cpp:
-    runs-on: ubuntu-18.04    
+
+  #--------------------------------------------------------------------------------
+  U20_SH_Py_DDS:  # Ubuntu 2020, Shared, Python, DDS
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
@@ -306,76 +238,98 @@ jobs:
         cd ..
         mkdir build
 
-    - name: Build Debug
+    - name: Build
       shell: bash
       run: |
         cd build
-        cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_TOOLS=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5 -DBUILD_WITH_DDS=true
-        cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4  
-
-    - name: Build RelWithDebInfo
-      shell: bash
-      run: |
-        cd build
-        cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_TM2=true -DBUILD_SHARED_LIBS=false -DCHECK_FOR_UPDATES=true -DBUILD_TOOLS=true -DBUILD_PYTHON_BINDINGS=true -DPYBIND11_PYTHON_VERSION=3.5 -DBUILD_WITH_DDS=true
-        cmake --build . --config ${{env.LRS_RUN_WITH_DEB_CONFIG}} -- -j4  
+        cmake .. -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
+        cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4  
   
-  Linux_python_nodejs:
-      runs-on: ubuntu-18.04     
-      timeout-minutes: 60
-      env: 
-        LRS_BUILD_NODEJS: true
-      steps:
-      - uses: actions/checkout@v2   
+
+  #--------------------------------------------------------------------------------
+  U18_SH_RSUSB_LiveTest_NodeJS:  # Ubuntu 2018, Shared, Legacy live-tests, NodeJS wrapper
+    runs-on: ubuntu-18.04     
+    timeout-minutes: 60
+    env: 
+      LRS_BUILD_NODEJS: true
+    steps:
+    - uses: actions/checkout@v2   
           
+    - name: Check_API
+      shell: bash
+      run: |
+        cd scripts
+        ./api_check.sh
+        cd ..  
         
-      - name: Check_API
-        shell: bash
-        run: |
-          cd scripts
-          ./api_check.sh
-          cd ..  
-        
-      - name: Prebuild
-        shell: bash
-        run: |
-          set -x
-          # Workaround for nvm failure: https://github.com/appleboy/ssh-action/issues/70
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-          nvm install 10.15.3;
-          nvm use 10.15.3;
-          npm install -g node-gyp;
-          npm install -g mocha;
-          git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git;
-          export OLDPATH=$PATH  
-          echo OLDPATH=$OLDPATH
-          export PATH=$PATH:$(pwd)/depot_tools;
-          echo PATH=$PATH
-          cd wrappers/nodejs/tools && npm install && cd ..;
-          node ./tools/linter.js;
-          python ./tools/enums.py -i ../../include/librealsense2 -a ./src -v
-          export PATH=$OLDPATH && unset OLDPATH && cd ../../;
-          mkdir build
-          sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
-          sudo apt-get update;
-          sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
-          sudo apt-get install -qq libusb-1.0-0-dev;
-          sudo apt-get install -qq libgtk-3-dev;
-          sudo apt-get install gcc-5 g++-5;
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
-          sudo apt-get install libglfw3-dev libglfw3;
-      
-      - name: Build
-        shell: bash
-        run: | 
-          python ./wrappers/nodejs/tools/enums.py -i ./include/librealsense2 -a ./wrappers/nodejs/src -v
-          cd build
-          cmake .. -DBUILD_PYTHON_BINDINGS=true -DBUILD_NODEJS_BINDINGS=true -DPYBIND11_PYTHON_VERSION=2.7 -DCHECK_FOR_UPDATES=true
-          cmake --build . --config $LRS_BUILD_CONFIG -- -j4
-          cd ../wrappers/nodejs/ && npm install && cd -
+    - name: Prebuild
+      shell: bash
+      run: |
+        set -x
+        # Workaround for nvm failure: https://github.com/appleboy/ssh-action/issues/70
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+        nvm install 10.15.3;
+        nvm use 10.15.3;
+        npm install -g node-gyp;
+        npm install -g mocha;
+        git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git;
+        export OLDPATH=$PATH  
+        echo OLDPATH=$OLDPATH
+        export PATH=$PATH:$(pwd)/depot_tools;
+        echo PATH=$PATH
+        cd wrappers/nodejs/tools && npm install && cd ..;
+        node ./tools/linter.js;
+        python ./tools/enums.py -i ../../include/librealsense2 -a ./src -v
+        export PATH=$OLDPATH && unset OLDPATH && cd ../../;
+        mkdir build
+        sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
+        sudo apt-get update;
+        sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
+        sudo apt-get install -qq libusb-1.0-0-dev;
+        sudo apt-get install -qq libgtk-3-dev;
+        sudo apt-get install gcc-5 g++-5;
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
+        sudo apt-get install libglfw3-dev libglfw3;
+
+    - name: Build
+      shell: bash
+      run: | 
+        python ./wrappers/nodejs/tools/enums.py -i ./include/librealsense2 -a ./wrappers/nodejs/src -v
+        cd build
+        cmake .. -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_WITH_TM2=false -DCHECK_FOR_UPDATES=false -DFORCE_RSUSB_BACKEND=true -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_NODEJS_BINDINGS=true
+        cmake --build . --config $LRS_BUILD_CONFIG -- -j4
+        cd ../wrappers/nodejs/ && npm install && cd -
+
+    - name: Test
+      shell: bash
+      id: test-step
+      # We set continue-on-error: true as a workaround for not skipping the upload log step on failure,
+      # The final step will check the return value from the test step and decide if to fail/pass the job
+      continue-on-error: true 
+      run: | 
+        export LRS_LOG_LEVEL="DEBUG";
+        cd build   
+        ./unit-tests/live-test -d yes -i [software-device]        
+
+    - name: Upload RS log artifact
+      uses: actions/upload-artifact@v2
+      with: 
+        name: Log file - U18_SH_LiveTest_NodeJS
+        path: build/*.log
+
+    - name: Provide correct exit status for job 
+      shell: bash
+      run: |
+        if [ ${{steps.test-step.outcome}} = "failure" ];then
+           echo "Test step failed, please open it to view the reported issue"
+           exit 1
+        else
+           exit 0
+        fi
 
 
+  #--------------------------------------------------------------------------------
   Mac_cpp:
     runs-on: macos-10.15
     timeout-minutes: 60
@@ -408,7 +362,9 @@ jobs:
         cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCHECK_FOR_UPDATES=true
         cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4
         ls
-  
+
+
+  #--------------------------------------------------------------------------------
   Android_cpp:
     runs-on: ubuntu-18.04   
     timeout-minutes: 60
@@ -442,5 +398,4 @@ jobs:
        cmake .. -DCMAKE_TOOLCHAIN_FILE=../android-ndk-r20b/build/cmake/android.toolchain.cmake -DFORCE_RSUSB_BACKEND=true
        cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4
        ls
-  
-  
+

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -188,7 +188,6 @@ jobs:
       # The final step will check the return value from the test step and decide if to fail/pass the job
       continue-on-error: true 
       run: | 
-        echo "Job name= ${{ jobs.${{ github.job }}.name }}"
         export LRS_LOG_LEVEL="DEBUG";
         cd build   
         ./unit-tests/live-test -d yes -i [software-device]        
@@ -196,7 +195,7 @@ jobs:
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v2
       with: 
-        name: Log file - ${{ jobs.${{ github.job }}.name }}
+        name: Log file - U18_ST_Py_EX_CfU_LiveTest
         path: build/*.log
         
         
@@ -316,7 +315,7 @@ jobs:
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v2
       with: 
-        name: Log file - ${{ jobs.${{ github.job }}.name }}
+        name: Log file - U18_SH_RSUSB_LiveTest_NodeJS
         path: build/*.log
 
     - name: Provide correct exit status for job 

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -188,6 +188,7 @@ jobs:
       # The final step will check the return value from the test step and decide if to fail/pass the job
       continue-on-error: true 
       run: | 
+        echo "Job name= ${{ jobs.${{ github.job }}.name }}"
         export LRS_LOG_LEVEL="DEBUG";
         cd build   
         ./unit-tests/live-test -d yes -i [software-device]        
@@ -195,7 +196,7 @@ jobs:
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v2
       with: 
-        name: Log file - U20_SH_Py_LiveTest_DDS
+        name: Log file - ${{ jobs.${{ github.job }}.name }}
         path: build/*.log
         
         
@@ -315,7 +316,7 @@ jobs:
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v2
       with: 
-        name: Log file - U18_SH_LiveTest_NodeJS
+        name: Log file - ${{ jobs.${{ github.job }}.name }}
         path: build/*.log
 
     - name: Provide correct exit status for job 


### PR DESCRIPTION
This solves the problem with recent change on the DDS branch: the server image of Windows-2019 has [changed](https://github.com/actions/runner-images/commit/c42d235336ece98c0599b53a0c25bd0e5a77a219) and the `Windows_testing_cpp_USB_Win7` job no longer passes for an unknown reason.

The CI rework achieves better runtime on average:
* Moves live-tests to be all on the Linux side until the Windows build has no issues in it
* No more `BUILD_WITH_TM2` builds
* Job names reflect what they actually run
* DDS on Ubuntu 20