### PR TITLE
Force Ubuntu 22 for CppCheck run

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -22,6 +22,7 @@ jobs:
         run: |
           sudo apt-get update;
           sudo apt-get install -qq cppcheck;
+          cppcheck --version
 
       - name: pwd
         shell: bash

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -65,6 +65,6 @@ jobs:
             echo "cppcheck_run succeeded, found" $ERROR_COUNT "errors, as expected";
             exit 0;
           else
-            echo "cppcheck_run failed, found" $ERROR_COUNT "errors, see log for details";
+            echo "cppcheck_run failed, found" $ERROR_COUNT "errors, expected " ${{env.CPPCHECK_EXPECTED_ERROR_COUNT}} " see log for details";
             exit 1;
           fi

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -22,7 +22,11 @@ jobs:
         run: |
           sudo apt-get update;
           sudo apt-get install -qq cppcheck;
-      
+
+      - name: pwd
+        shell: bash
+        run: pwd
+        
       - name: Run
         shell: bash
         #Selected run options:

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   cppcheck:
     name: cppcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Expected error count should decrease as we handle the errors. Update accordingly.
-  CPPCHECK_EXPECTED_ERROR_COUNT: 10
+  CPPCHECK_EXPECTED_ERROR_COUNT: 3903
 
 jobs:
   cppcheck:
@@ -22,11 +22,6 @@ jobs:
         run: |
           sudo apt-get update;
           sudo apt-get install -qq cppcheck;
-          cppcheck --version
-
-      - name: pwd
-        shell: bash
-        run: pwd
         
       - name: Run
         shell: bash


### PR DESCRIPTION
There might be a difference when running from the fork and the origin.
Want to test it...