### PR TITLE
fix libci with device directive and !

### DIFF
--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -205,7 +205,7 @@ class TestConfigFromText( TestConfig ):
                                 log.e(source + '+' + str(line['index']) + ': invalid syntax:', params,
                                       '. All device names after \'' + params[0] +
                                       '\' must start with \'!\' in order to skip them')
-                            break
+                                break
                         else:
                             self._configurations.append( params )
                 else:


### PR DESCRIPTION
LibCI was not running FW update for D400 cameras in tests that had the `!D457` directive in them...