### PR TITLE
Add device iterator to ImGui ID stack for device selection pop up in RealSense Viewer

### DIFF
--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -455,6 +455,7 @@ int main(int argc, const char** argv) try
                     if (get_device_name(dev_model->dev) == device_names[i]) skip = true;
                 if (skip) continue;
 
+                ImGui::PushID(i);
                 if (ImGui::Selectable(device_names[i].first.c_str(), false, ImGuiSelectableFlags_SpanAllColumns)/* || switch_to_newly_loaded_device*/)
                 {
                     try
@@ -471,6 +472,7 @@ int main(int argc, const char** argv) try
                         error_message = e.what();
                     }
                 }
+                ImGui::PopID();
 
                 if (ImGui::IsItemHovered())
                 {


### PR DESCRIPTION
There is a bug in the device selection pop up in RealSense Viewer.

To reproduce:
1. Connect two or more cameras of the same model
2. Open RealSenseViewer
3. Close the default camera
4. Click on the "Add Source" button
5. Select the second (or third, fourth, ...) camera in the list -> nothing happens

Problem:
The ID of the ImGui::Selectable is based on the label, which in this case is the device name, which is the same for each camera.
Therefore, there will be an ID conflict and only the first Selectable is working.

Solution:
The problem is solved by adding a unique identifier to the [ImGui ID Stack](https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#qa-usage). In the proposed solution this unique identifier is the index of the device in the device_names vector.

