### PR TITLE
Motion data streaming and fixing dis/re-connections

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -575,24 +575,48 @@ namespace librealsense
                 auto & stream = _streams[sid_index( profile->get_unique_id(), profile->get_stream_index() )];
                 stream->start_streaming( [p = profile, this]( realdds::topics::device::image && dds_frame ) {
                     rs2_stream_profile prof = { p.get() };
-                    rs2_software_video_frame rs2_frame;
-                    
-                    //Copying from dds into LibRS space, same as copy from USB backend.
-                    //TODO - use memory pool or some other frame allocator
-                    rs2_frame.pixels = new uint8_t[dds_frame.size];
-                    if ( !rs2_frame.pixels )
-                        throw std::runtime_error( "Could not allocate memory for new frame" );
-                    memcpy( rs2_frame.pixels, dds_frame.raw_data.data(), dds_frame.size );
-                    
-                    rs2_frame.deleter = []( void * ptr) { delete[] ptr; };
-                    rs2_frame.stride = dds_frame.size / dds_frame.height;
-                    rs2_frame.bpp = rs2_frame.stride / dds_frame.width;
-                    rs2_frame.timestamp = frame_counter * 1000.0 / p->get_framerate(); // TODO - timestamp from dds
-                    rs2_frame.domain = RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK; // TODO - timestamp domain from options?
-                    rs2_frame.frame_number = frame_counter++; // TODO - frame_number from dds
-                    rs2_frame.profile = &prof;
-                    rs2_frame.depth_units = 0.001f; //TODO - depth unit from dds, if needed
-                    on_video_frame( rs2_frame );
+
+                    if( p->get_stream_type() != RS2_STREAM_GYRO  &&
+                        p->get_stream_type() != RS2_STREAM_ACCEL &&
+                        p->get_stream_type() != RS2_STREAM_POSE )
+                    {
+                        rs2_software_video_frame rs2_frame;
+
+                        //Copying from dds into LibRS space, same as copy from USB backend.
+                        //TODO - use memory pool or some other frame allocator
+                        rs2_frame.pixels = new uint8_t[dds_frame.size];
+                        if( !rs2_frame.pixels )
+                            throw std::runtime_error( "Could not allocate memory for new frame" );
+                        memcpy( rs2_frame.pixels, dds_frame.raw_data.data(), dds_frame.size );
+
+                        rs2_frame.deleter = []( void * ptr ) { delete[] ptr; };
+                        rs2_frame.stride = dds_frame.height > 0 ? dds_frame.size / dds_frame.height : dds_frame.size;
+                        rs2_frame.bpp = dds_frame.width > 0 ? rs2_frame.stride / dds_frame.width : rs2_frame.stride;
+                        rs2_frame.timestamp = frame_counter * 1000.0 / p->get_framerate(); // TODO - timestamp from dds
+                        rs2_frame.domain = RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK; // TODO - timestamp domain from options?
+                        rs2_frame.frame_number = frame_counter++; // TODO - frame_number from dds
+                        rs2_frame.profile = &prof;
+                        rs2_frame.depth_units = 0.001f; //TODO - depth unit from dds, if needed
+                        on_video_frame( rs2_frame );
+                    }
+                    else
+                    {
+                        rs2_software_motion_frame rs2_frame;
+
+                        //Copying from dds into LibRS space, same as copy from USB backend.
+                        //TODO - use memory pool or some other frame allocator
+                        rs2_frame.data = new uint8_t[dds_frame.size];
+                        if( !rs2_frame.data )
+                            throw std::runtime_error( "Could not allocate memory for new frame" );
+                        memcpy( rs2_frame.data, dds_frame.raw_data.data(), dds_frame.size );
+
+                        rs2_frame.deleter = []( void * ptr ) { delete[] ptr; };
+                        rs2_frame.timestamp = frame_counter * 1000.0 / p->get_framerate(); // TODO - timestamp from dds
+                        rs2_frame.domain = RS2_TIMESTAMP_DOMAIN_HARDWARE_CLOCK; // TODO - timestamp domain from options?
+                        rs2_frame.frame_number = frame_counter++; // TODO - frame_number from dds
+                        rs2_frame.profile = &prof;
+                        on_motion_frame( rs2_frame );
+                    }
                 } );
             }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -576,9 +576,7 @@ namespace librealsense
                 stream->start_streaming( [p = profile, this]( realdds::topics::device::image && dds_frame ) {
                     rs2_stream_profile prof = { p.get() };
 
-                    if( p->get_stream_type() != RS2_STREAM_GYRO  &&
-                        p->get_stream_type() != RS2_STREAM_ACCEL &&
-                        p->get_stream_type() != RS2_STREAM_POSE )
+                    if( Is< video_stream_profile >(p) )
                     {
                         rs2_software_video_frame rs2_frame;
 
@@ -796,7 +794,7 @@ namespace librealsense
             struct sensor_info
             {
                 std::shared_ptr< dds_sensor_proxy > proxy;
-                int sensor_index;
+                int sensor_index = 0;
             };
             std::map< std::string, sensor_info > sensor_name_to_info;
             // We assign (sid,index) based on the stream type:
@@ -1196,7 +1194,7 @@ namespace librealsense
         auto prev_playback_devices = _playback_devices;
         _playback_devices[file] = dinfo;
         on_device_changed({}, {}, prev_playback_devices, _playback_devices);
-        return std::move(dinfo);
+        return dinfo;
     }
 
     void context::add_software_device(std::shared_ptr<device_info> dev)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -881,7 +881,7 @@ namespace librealsense
 
         platform::backend_device_group get_device_data() const override
         {
-            return platform::backend_device_group{};
+            return platform::backend_device_group{ { platform::playback_device_info{ _dev->device_info().topic_root } } };
         }
     };
 #endif //BUILD_WITH_DDS

--- a/src/context.h
+++ b/src/context.h
@@ -152,6 +152,8 @@ namespace librealsense
                                platform::backend_device_group curr,
                                const std::map<std::string, std::weak_ptr<device_info>>& old_playback_devices,
                                const std::map<std::string, std::weak_ptr<device_info>>& new_playback_devices);
+        void invoke_devices_changed_callbacks( std::vector<rs2_device_info> & rs2_devices_info_removed,
+                                               std::vector<rs2_device_info> & rs2_devices_info_added );
         void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
         void start_device_watcher();
         std::shared_ptr<platform::backend> _backend;

--- a/third-party/realdds/include/realdds/dds-device-broadcaster.h
+++ b/third-party/realdds/include/realdds/dds-device-broadcaster.h
@@ -34,7 +34,7 @@ class dds_publisher;
 class dds_topic_writer;
 class dds_topic;
 
-// We're responsible for broadcasting each device on realsense/device-info
+// We're responsible for broadcasting each device to listeners on the DDS network
 //
 class dds_device_broadcaster
 {

--- a/third-party/realdds/include/realdds/topics/dds-topic-names.h
+++ b/third-party/realdds/include/realdds/topics/dds-topic-names.h
@@ -1,0 +1,16 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+namespace realdds {
+namespace topics {
+
+constexpr char * DEVICE_INFO_TOPIC_NAME = "realsense/device-info";
+
+//The next topic names should be concatenated to a topic root
+constexpr char * NOTIFICATION_TOPIC_NAME = "/notification";
+constexpr char * CONTROL_TOPIC_NAME = "/control";
+
+}  // namespace topics
+}  // namespace realdds

--- a/third-party/realdds/include/realdds/topics/dds-topics.h
+++ b/third-party/realdds/include/realdds/topics/dds-topics.h
@@ -1,6 +1,0 @@
-// License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
-#pragma once
-#include "image/image-msg.h"
-#include "flexible/flexible-msg.h"

--- a/third-party/realdds/include/realdds/topics/image/image-msg.h
+++ b/third-party/realdds/include/realdds/topics/image/image-msg.h
@@ -55,8 +55,8 @@ public:
     image & operator=( image && ) = default;
     image & operator=( raw::device::image && );
 
-    bool is_valid() const { return width != 0 && height != 0; }
-    void invalidate() { width = 0; }
+    bool is_valid() const { return width != -1 && height != -1; }
+    void invalidate() { width = -1; }
 
     static std::shared_ptr< dds_topic > create_topic( std::shared_ptr< dds_participant > const & participant,
                                                       char const * topic_name );
@@ -74,8 +74,8 @@ public:
                            eprosima::fastdds::dds::SampleInfo * optional_info = nullptr );
 
     std::vector<uint8_t> raw_data;
-    int width = 0;
-    int height = 0;
+    int width = -1;
+    int height = -1;
     int size;
     int format;
 };

--- a/third-party/realdds/src/dds-device-broadcaster.cpp
+++ b/third-party/realdds/src/dds-device-broadcaster.cpp
@@ -8,6 +8,7 @@
 #include <realdds/dds-topic-writer.h>
 #include <realdds/dds-utilities.h>
 #include <realdds/dds-guid.h>
+#include <realdds/topics/dds-topic-names.h>
 #include <realdds/topics/flexible/flexible-msg.h>
 #include <realdds/topics/flexible/flexiblePubSubTypes.h>
 
@@ -183,7 +184,7 @@ bool dds_device_broadcaster::add_dds_device( const device_info & dev_info )
 bool dds_device_broadcaster::create_device_writer( const device_info & dev_info )
 {
     if( ! _topic )
-        _topic = topics::flexible_msg::create_topic( _publisher->get_participant(), "realsense/device-info" );
+        _topic = topics::flexible_msg::create_topic( _publisher->get_participant(), topics::DEVICE_INFO_TOPIC_NAME );
 
     // Create a data writer for the topic
     auto writer = std::make_shared< dds_client_listener >( _topic, _publisher, this );

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -8,6 +8,7 @@
 #include <realdds/dds-topic-writer.h>
 #include <realdds/dds-subscriber.h>
 #include <realdds/dds-option.h>
+#include <realdds/topics/dds-topic-names.h>
 #include <realdds/topics/flexible/flexible-msg.h>
 
 #include <fastdds/dds/publisher/DataWriter.hpp>
@@ -235,7 +236,7 @@ void dds_device::impl::create_notifications_reader()
     if( _notifications_reader )
         return;
 
-    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + "/notification" );
+    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + topics::NOTIFICATION_TOPIC_NAME );
 
     _notifications_reader = std::make_shared< dds_topic_reader >( topic );
 
@@ -251,7 +252,7 @@ void dds_device::impl::create_control_writer()
     if( _control_writer )
         return;
 
-    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + "/control" );
+    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + topics::CONTROL_TOPIC_NAME );
     _control_writer = std::make_shared< dds_topic_writer >( topic );
     dds_topic_writer::qos wqos( eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS );
     wqos.history().depth = 10;  // default is 1

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -11,6 +11,7 @@
 #include <realdds/dds-notification-server.h>
 #include <realdds/dds-topic-reader.h>
 #include <realdds/dds-utilities.h>
+#include <realdds/topics/dds-topic-names.h>
 #include <realdds/topics/image/image-msg.h>
 #include <realdds/topics/flexible/flexible-msg.h>
 #include <realdds/dds-topic.h>
@@ -150,7 +151,7 @@ void dds_device_server::init( std::vector< std::shared_ptr< dds_stream_server > 
     try
     {
         // Create a notifications server and set discovery notifications
-        _notification_server = std::make_shared< dds_notification_server >( _publisher, _topic_root + "/notification" );
+        _notification_server = std::make_shared< dds_notification_server >( _publisher, _topic_root + topics::NOTIFICATION_TOPIC_NAME );
 
         // If a previous init failed (e.g., one of the streams has no profiles):
         _stream_name_to_server.clear();
@@ -167,7 +168,7 @@ void dds_device_server::init( std::vector< std::shared_ptr< dds_stream_server > 
         _notification_server->run();
 
         // Create a control reader and set callback
-        auto topic = topics::flexible_msg::create_topic( _subscriber->get_participant(), _topic_root + "/control" );
+        auto topic = topics::flexible_msg::create_topic( _subscriber->get_participant(), _topic_root + topics::CONTROL_TOPIC_NAME );
         _control_reader = std::make_shared< dds_topic_reader >( topic, _subscriber );
 
         _control_reader->on_data_available( [&]() { on_control_message_received(); } );

--- a/third-party/realdds/src/dds-device-watcher.cpp
+++ b/third-party/realdds/src/dds-device-watcher.cpp
@@ -7,6 +7,7 @@
 #include <realdds/dds-device.h>
 #include <realdds/dds-utilities.h>
 #include <realdds/dds-guid.h>
+#include <realdds/topics/dds-topic-names.h>
 #include <realdds/topics/flexible/flexible-msg.h>
 #include <realdds/topics/device-info-msg.h>
 
@@ -21,7 +22,7 @@ using namespace realdds;
 
 dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const & participant )
     : _device_info_topic(
-        new dds_topic_reader( topics::flexible_msg::create_topic( participant, "realsense/device-info" ) ) )
+        new dds_topic_reader( topics::flexible_msg::create_topic( participant, topics::DEVICE_INFO_TOPIC_NAME ) ) )
     , _participant( participant )
     , _active_object( [this]( dispatcher::cancellable_timer timer ) {
 

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -7,7 +7,6 @@
 #include <realdds/dds-publisher.h>
 #include <realdds/dds-stream-server.h>
 #include <realdds/dds-utilities.h>
-#include <realdds/topics/dds-topics.h>
 #include <realdds/dds-topic.h>
 #include <realdds/dds-topic-writer.h>
 

--- a/tools/dds/dds-server/lrs-device-controller.cpp
+++ b/tools/dds/dds-server/lrs-device-controller.cpp
@@ -182,7 +182,16 @@ void lrs_device_controller::start_streaming( const json & msg )
     _sensors[sensor_index].start( [&]( rs2::frame f ) {
         _dds_device_server->publish_image( f.get_profile().stream_name(), static_cast< const uint8_t * >( f.get_data() ), f.get_data_size() );
     } );
-    std::cout << realdds_streams_to_start[0].first << " stream started" << std::endl;
+    if( realdds_streams_to_start.size() == 1 )
+        std::cout << realdds_streams_to_start[0].first << " stream started" << std::endl;
+    else
+    {
+        std::cout << "[\"";
+        size_t i = 0;
+        for( ; i < realdds_streams_to_start.size() - 1; ++i )
+            std::cout << realdds_streams_to_start[i].first << "\", \"";
+        std::cout << realdds_streams_to_start[i].first << "\"] streams started" << std::endl;
+    }
 }
 
 void lrs_device_controller::stop_streaming( const json & msg )

--- a/tools/dds/dds-server/lrs-device-watcher.cpp
+++ b/tools/dds/dds-server/lrs-device-watcher.cpp
@@ -13,7 +13,6 @@ lrs_device_watcher::lrs_device_watcher( rs2::context &ctx )
 {
 }
 
-
 lrs_device_watcher::~lrs_device_watcher() 
 {
 }
@@ -43,20 +42,25 @@ void lrs_device_watcher::run( std::function< void( rs2::device ) > add_device_cb
 
                 for( auto device_to_remove : devices_to_remove )
                 {
-                    remove_device_cb( device_to_remove );
-                    std::cout << "Device '" << device_to_remove.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - removed" << std::endl;
-                    strong_rs_device_list->erase( std::remove_if( strong_rs_device_list->begin(),
-                                                           strong_rs_device_list->end(),
-                                                           [&]( const rs2::device & dev ) {
-                                                               return dev == device_to_remove;
-                                                           } ),
-                                           strong_rs_device_list->end() );
+                    try
+                    {
+                        remove_device_cb( device_to_remove );
+                        std::cout << "Device '" << device_to_remove.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ) << "' - removed" << std::endl;
+                        auto it = std::find_if( strong_rs_device_list->begin(), strong_rs_device_list->end(),
+                            [&]( const rs2::device & dev ) {
+                                return strcmp( dev.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ), device_to_remove.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ) ) == 0;
+                        } );
+                        strong_rs_device_list->erase( it );
+                    }
+                    catch( std::exception e )
+                    {
+                        std::cout << "Exception durin remove_device_cb: " << e.what() << std::endl;
+                    }
                 }
  
-
                 for( auto && rs_device : info.get_new_devices() )
                 {
-                    std::cout << "Device '" << rs_device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - detected" << std::endl;
+                    std::cout << "Device '" << rs_device.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ) << "' - detected" << std::endl;
                     add_device_cb( rs_device );
                     strong_rs_device_list->push_back(rs_device);
                 }
@@ -64,8 +68,7 @@ void lrs_device_watcher::run( std::function< void( rs2::device ) > add_device_cb
         } );
 }
 
-void tools::lrs_device_watcher::notify_connected_devices_on_wake_up(
-    std::function< void( rs2::device ) > add_device_cb )
+void lrs_device_watcher::notify_connected_devices_on_wake_up( std::function< void( rs2::device ) > add_device_cb )
 {
     auto connected_dev_list = _ctx.query_devices();
     for( auto connected_dev : connected_dev_list )

--- a/tools/dds/realdds-py/python.cpp
+++ b/tools/dds/realdds-py/python.cpp
@@ -4,7 +4,7 @@ Copyright(c) 2022 Intel Corporation. All Rights Reserved. */
 #include "python.hpp"
 
 #include <realdds/dds-participant.h>
-#include <realdds/topics/dds-topics.h>
+#include <realdds/topics/flexible/flexible-msg.h>
 #include <realdds/topics/flexible/flexiblePubSubTypes.h>
 #include <realdds/dds-device-broadcaster.h>
 #include <realdds/dds-device-server.h>


### PR DESCRIPTION
Added handling for motion streams, calling `software_device::on_motion_frame`

Implemented callbacks for `dds_device_watcher` to add or remove devices.
Fixed some bugs in the way devices are identified and searched in context.cpp and lrs_device_watcher

Topic names are now listed in a single location, as requested in a previous PR.

Tracked on [LRS-592](https://rsjira.intel.com/browse/LRS-592)