### PR TITLE
[D457] marking device nodes according to device capability.

### DIFF
--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -323,7 +323,7 @@ namespace librealsense
 
             static uvc_device_info get_info_from_usb_device_path(const std::string& video_path, const std::string& name);
 
-            static uvc_device_info get_info_from_mipi_device_path(const std::string& video_path, const std::string& name);
+            static uvc_device_info get_info_from_mipi_device_path(const std::string& video_path, const std::string& name, int& depth_node);
 
             static void get_mipi_device_info(const std::string& dev_name,
                                              std::string& bus_info, std::string& card);


### PR DESCRIPTION
Marking device nodes according to device capability.
(as a comparison, the "mi" member of USB device nodes is read from the interface number.)

SUPPOSE, the DEPTH is the first sensor for each camera device.
    if there is more than one device but not all sensors are enumerated,
       the same number of DEPTH sensors can be found.
the old method is marking the nodes by index.