### PR TITLE
DDS testing - Add camera models and disconnection test

### DIFF
--- a/unit-tests/dds/d405.py
+++ b/unit-tests/dds/d405.py
@@ -1,0 +1,701 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+import pyrealdds as dds
+from rspy import log, test
+
+
+device_info = dds.device_info()
+device_info.name = "Intel RealSense D405"
+device_info.serial = "123622270732"
+device_info.product_line = "D400"
+device_info.topic_root = "realdds/D405/" + device_info.serial
+
+
+def build( participant ):
+    """
+    Build a D405 device server for use in DDS
+    """
+    depth = depth_stream()
+    ir0 = colored_infrared_stream()
+    ir1 = ir_stream( 1 )
+    ir2 = ir_stream( 2 )
+    color = color_stream()
+    #
+    d405 = dds.device_server( participant, device_info.topic_root )
+    d405.init( [ir0, ir1, ir2, color, depth], [] )
+    return d405
+
+
+def colored_infrared_stream():
+    stream = dds.ir_stream_server( "Infrared", "Stereo Module" )
+    stream.init_profiles( colored_infrared_stream_profiles(), 0 )
+    stream.init_options( stereo_module_options() )
+    return stream
+
+
+def colored_infrared_stream_profiles():
+    return [
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 5,  dds.stream_format("UYVY"), 1280, 720 ),
+        dds.video_stream_profile( 5,  dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 5,  dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 5,  dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 5,  dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 5,  dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 5,  dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 5,  dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 5,  dds.stream_format("RGB8"), 424, 240 )
+        ]                                                  
+
+
+def depth_stream_profiles():
+    return [
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 1280, 720 ),
+        dds.video_stream_profile( 5,  dds.stream_format("Z16"), 1280, 720 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 5,  dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 5,  dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 5,  dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 256, 144 )
+        ]
+
+
+def depth_stream():
+    stream = dds.depth_stream_server( "Depth", "Stereo Module" )
+    stream.init_profiles( depth_stream_profiles(), 5 )
+    stream.init_options( stereo_module_options() )
+    return stream
+
+
+def ir_stream_profiles():
+    return [
+        dds.video_stream_profile( 25, dds.stream_format("Y16"),  1288, 808 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"),  1288, 808 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 1280, 720 ),
+        dds.video_stream_profile( 5,  dds.stream_format("GREY"), 1280, 720 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 5,  dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 5,  dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 5,  dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 5,  dds.stream_format("GREY"), 424, 240 )
+        ]
+
+
+def ir_stream( number ):
+    stream = dds.ir_stream_server( "Infrared " + str(number), "Stereo Module" )
+    stream.init_profiles( ir_stream_profiles(), 0 )
+    stream.init_options( stereo_module_options() )
+    return stream
+
+
+def color_stream_profiles():
+    return [
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"),  1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"),  1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"),  1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 1280, 720 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"),  848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"),  848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"),  848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"),  848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"),  848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"),  640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"),  640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"),  640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"),  640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"),  640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"),  640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"),  640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"),  640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"),  640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"),  640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"),  480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"),  480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"),  480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"),  480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"),  480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"),  424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"),  424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"),  424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"),  424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"),  424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 424, 240 )
+        ]
+
+
+def color_stream():
+    stream = dds.color_stream_server( "Color",  "Stereo Module" )
+    stream.init_profiles( color_stream_profiles(), 30 )
+    stream.init_options( stereo_module_options() )
+    return stream
+
+def stereo_module_options():
+    options = []
+    option_range = dds.dds_option_range()
+
+    option = dds.dds_option( "Backlight Compensation", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Enable / disable backlight compensation" )
+    options.append( option )
+    option = dds.dds_option( "Brightness", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = -64
+    option_range.max = 64
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "UVC image brightness" )
+    options.append( option )
+    option = dds.dds_option( "Contrast", "Stereo Module" )
+    option.set_value( 50 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 50
+    option.set_range( option_range )
+    option.set_description( "UVC image contrast" )
+    options.append( option )
+    option = dds.dds_option( "Exposure", "Stereo Module" )
+    option.set_value( 33000 )
+    option_range.min = 1
+    option_range.max = 165000
+    option_range.step = 1
+    option_range.default_value = 33000
+    option.set_range( option_range )
+    option.set_description( "Depth Exposure (usec)" )
+    options.append( option )
+    option = dds.dds_option( "Gain", "Stereo Module" )
+    option.set_value( 16 )
+    option_range.min = 16
+    option_range.max = 248
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "UVC image gain" )
+    options.append( option )
+    option = dds.dds_option( "Gamma", "Stereo Module" )
+    option.set_value( 300 )
+    option_range.min = 100
+    option_range.max = 500
+    option_range.step = 1
+    option_range.default_value = 300
+    option.set_range( option_range )
+    option.set_description( "UVC image gamma setting" )
+    options.append( option )
+    option = dds.dds_option( "Hue", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = -180
+    option_range.max = 180
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "UVC image hue" )
+    options.append( option )
+    option = dds.dds_option( "Saturation", "Stereo Module" )
+    option.set_value( 64 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 64
+    option.set_range( option_range )
+    option.set_description( "UVC image saturation setting" )
+    options.append( option )
+    option = dds.dds_option( "Sharpness", "Stereo Module" )
+    option.set_value( 50 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 50
+    option.set_range( option_range )
+    option.set_description( "UVC image sharpness setting" )
+    options.append( option )
+    option = dds.dds_option( "White Balance", "Stereo Module" )
+    option.set_value( 4600 )
+    option_range.min = 2800
+    option_range.max = 6500
+    option_range.step = 10
+    option_range.default_value = 4600
+    option.set_range( option_range )
+    option.set_description( "Controls white balance of color image. Setting any value will disable auto white balance" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto Exposure", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable Auto Exposure" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto White Balance", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable / disable auto-white-balance" )
+    options.append( option )
+    option = dds.dds_option( "Visual Preset", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 5
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Advanced-Mode Preset" )
+    options.append( option )
+    option = dds.dds_option( "Frames Queue Size", "Stereo Module" )
+    option.set_value( 16 )
+    option_range.min = 0
+    option_range.max = 32
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Max number of frames you can hold at a given time. Increasing this number will reduce frame drops but increase latency, and vice versa" )
+    options.append( option )
+    option = dds.dds_option( "Power Line Frequency", "Stereo Module" )
+    option.set_value( 3 )
+    option_range.min = 0
+    option_range.max = 3
+    option_range.step = 1
+    option_range.default_value = 3
+    option.set_range( option_range )
+    option.set_description( "Power Line Frequency" )
+    options.append( option )
+    option = dds.dds_option( "Error Polling Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Enable / disable polling of camera internal errors" )
+    options.append( option )
+    option = dds.dds_option( "Output Trigger Enabled", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Generate trigger from the camera to external device once per frame" )
+    options.append( option )
+    option = dds.dds_option( "Depth Units", "Stereo Module" )
+    option.set_value( 0.0001 )
+    option_range.min = 1e-06
+    option_range.max = 0.01
+    option_range.step = 1e-06
+    option_range.default_value = 0.001
+    option.set_range( option_range )
+    option.set_description( "Number of meters represented by a single depth unit" )
+    options.append( option )
+    option = dds.dds_option( "Stereo Baseline", "Stereo Module" )
+    option.set_value( 17.9998 )
+    option_range.min = 17.9998
+    option_range.max = 17.9998
+    option_range.step = 0
+    option_range.default_value = 17.9998
+    option.set_range( option_range )
+    option.set_description( "Distance in mm between the stereo imagers" )
+    options.append( option )
+    option = dds.dds_option( "Global Time Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable global timestamp" )
+    options.append( option )
+    option = dds.dds_option( "Hdr Enabled", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Name", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 3
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Size", "Stereo Module" )
+    option.set_value( 2 )
+    option_range.min = 2
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 2
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Id", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Limit", "Stereo Module" )
+    option.set_value( 165000 )
+    option_range.min = 1
+    option_range.max = 165000
+    option_range.step = 1
+    option_range.default_value = 33000
+    option.set_range( option_range )
+    option.set_description( "Exposure limit is in microseconds. If the requested exposure limit is greater than frame time, it will be set to frame time at runtime. Setting will not take effect until next streaming session." )
+    options.append( option )
+    option = dds.dds_option( "Auto Gain Limit", "Stereo Module" )
+    option.set_value( 248 )
+    option_range.min = 16
+    option_range.max = 248
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Gain limits ranges from 16 to 248. If the requested gain limit is less than 16, it will be set to 16. If the requested gain limit is greater than 248, it will be set to 248. Setting will not take effect until next streaming session." )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Limit Toggle", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Toggle Auto-Exposure Limit" )
+    options.append( option )
+    option = dds.dds_option( "Auto Gain Limit Toggle", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Toggle Auto-Gain Limit" )
+    options.append( option )
+
+    return options

--- a/unit-tests/dds/d455.py
+++ b/unit-tests/dds/d455.py
@@ -1,0 +1,913 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+import pyrealdds as dds
+from rspy import log, test
+
+
+device_info = dds.device_info()
+device_info.name = "Intel RealSense D455"
+device_info.serial = "114222251267"
+device_info.product_line = "D400"
+device_info.topic_root = "realdds/D455/" + device_info.serial
+
+
+def build( participant ):
+    """
+    Build a D455 device server for use in DDS
+    """
+    accel = accel_stream()
+    gyro = gyro_stream()
+    depth = depth_stream()
+    ir0 = colored_infrared_stream()
+    ir1 = ir_stream( 1 )
+    ir2 = ir_stream( 2 )
+    color = color_stream()
+    #
+    d455 = dds.device_server( participant, device_info.topic_root )
+    d455.init( [accel, gyro, depth, ir0, ir1, ir2, color], [] )
+    return d455
+
+
+def accel_stream_profiles():
+    return [
+        dds.motion_stream_profile( 63, dds.stream_format("MXYZ") ),
+        dds.motion_stream_profile( 250, dds.stream_format("MXYZ") )
+        ]
+
+
+def accel_stream():
+    stream = dds.accel_stream_server( "Accel", "Motion Module" )
+    stream.init_profiles( accel_stream_profiles(), 0 )
+    stream.init_options( motion_module_options() )
+    return stream
+
+
+def gyro_stream_profiles():
+    return [
+        dds.motion_stream_profile( 200, dds.stream_format("MXYZ") ),
+        dds.motion_stream_profile( 400, dds.stream_format("MXYZ") )
+        ]
+
+
+def gyro_stream():
+    stream = dds.gyro_stream_server( "Gyro", "Motion Module" )
+    stream.init_profiles( gyro_stream_profiles(), 0 )
+    stream.init_options( motion_module_options() )
+    return stream
+
+
+def colored_infrared_stream():
+    stream = dds.ir_stream_server( "Infrared", "Stereo Module" )
+    stream.init_profiles( colored_infrared_stream_profiles(), 0 )
+    stream.init_options( stereo_module_options() )
+    return stream
+
+
+def colored_infrared_stream_profiles():
+    return [
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("UYVY"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("UYVY"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 100, dds.stream_format("UYVY"), 848, 100 ),
+        dds.video_stream_profile( 100, dds.stream_format("BGRA"), 848, 100 ),
+        dds.video_stream_profile( 100, dds.stream_format("RGBA"), 848, 100 ),
+        dds.video_stream_profile( 100, dds.stream_format("RGB2"), 848, 100 ),
+        dds.video_stream_profile( 100, dds.stream_format("RGB8"), 848, 100 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("UYVY"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("UYVY"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("UYVY"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("UYVY"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 424, 240 )
+        ]  
+
+
+def depth_stream_profiles():
+    return [
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Z16"), 1280, 720 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Z16"), 848, 480 ),
+        dds.video_stream_profile( 100, dds.stream_format("Z16"), 848, 100 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Z16"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Z16"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Z16"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Z16"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("Z16"), 256, 144 )
+        ]
+
+
+def depth_stream():
+    stream = dds.depth_stream_server( "Depth", "Stereo Module" )
+    stream.init_profiles( depth_stream_profiles(), 5 )
+    stream.init_options( stereo_module_options() )
+    return stream
+
+
+def ir_stream_profiles():
+    return [
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 1280, 800 ),
+        dds.video_stream_profile( 25, dds.stream_format("Y16"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("GREY"), 1280, 720 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("GREY"), 848, 480 ),
+        dds.video_stream_profile( 100, dds.stream_format("GREY"), 848, 100 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("GREY"), 640, 480 ),
+        dds.video_stream_profile( 25, dds.stream_format("Y16"), 640, 400 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 640, 400 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("GREY"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("GREY"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("GREY"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("GREY"), 424, 240 )
+        ]
+
+
+def ir_stream( number ):
+    stream = dds.ir_stream_server( "Infrared " + str(number), "Stereo Module" )
+    stream.init_profiles( ir_stream_profiles(), 0 )
+    stream.init_options( stereo_module_options() )
+    return stream
+
+
+def color_stream_profiles():
+    return [
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("BYR2"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 1280, 800 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 1280, 800 ),
+        dds.video_stream_profile( 10, dds.stream_format("RGB8"), 1280, 800 ),
+        dds.video_stream_profile( 10, dds.stream_format("Y16"), 1280, 800 ),
+        dds.video_stream_profile( 10, dds.stream_format("BGRA"), 1280, 800 ),
+        dds.video_stream_profile( 10, dds.stream_format("RGBA"), 1280, 800 ),
+        dds.video_stream_profile( 10, dds.stream_format("RGB2"), 1280, 800 ),
+        dds.video_stream_profile( 10, dds.stream_format("YUYV"), 1280, 800 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 1280, 800 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"), 1280, 800 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 1280, 800 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 1280, 800 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 1280, 800 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 1280, 800 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 1280, 720 ),
+        dds.video_stream_profile( 10, dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 10, dds.stream_format("Y16"), 1280, 720 ),
+        dds.video_stream_profile( 10, dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 10, dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 10, dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 10, dds.stream_format("YUYV"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 1280, 720 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 1280, 720 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 848, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 848, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 640, 480 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 640, 480 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 640, 360 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 640, 360 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 480, 270 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 480, 270 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("Y16"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 90, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("Y16"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 60, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("Y16"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 30, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("Y16"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 15, dds.stream_format("YUYV"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB8"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("Y16"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("BGRA"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGBA"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("RGB2"), 424, 240 ),
+        dds.video_stream_profile( 5 , dds.stream_format("YUYV"), 424, 240 )
+        ]
+
+
+def color_stream():
+    stream = dds.color_stream_server( "Color",  "RGB Camera" )
+    stream.init_profiles( color_stream_profiles(), 25 )
+    stream.init_options( rgb_camera_options() )
+    return stream
+
+
+def stereo_module_options():
+    options = []
+    option_range = dds.dds_option_range()
+
+    option = dds.dds_option( "Exposure", "Stereo Module" )
+    option.set_value( 33000 )
+    option_range.min = 1
+    option_range.max = 200000
+    option_range.step = 1
+    option_range.default_value = 33000
+    option.set_range( option_range )
+    option.set_description( "Depth Exposure (usec)" )
+    options.append( option )
+    option = dds.dds_option( "Gain", "Stereo Module" )
+    option.set_value( 16 )
+    option_range.min = 16
+    option_range.max = 248
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "UVC image gain" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto Exposure", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable Auto Exposure" )
+    options.append( option )
+    option = dds.dds_option( "Visual Preset", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 5
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Advanced-Mode Preset" )
+    options.append( option )
+    option = dds.dds_option( "Laser Power", "Stereo Module" )
+    option.set_value( 150 )
+    option_range.min = 0
+    option_range.max = 360
+    option_range.step = 30
+    option_range.default_value = 150
+    option.set_range( option_range )
+    option.set_description( "Manual laser power in mw. applicable only when laser power mode is set to Manual" )
+    options.append( option )
+    option = dds.dds_option( "Emitter Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Emitter select, 0-disable all emitters, 1-enable laser, 2-enable laser auto (opt), 3-enable LED (opt)" )
+    options.append( option )
+    option = dds.dds_option( "Frames Queue Size", "Stereo Module" )
+    option.set_value( 16 )
+    option_range.min = 0
+    option_range.max = 32
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Max number of frames you can hold at a given time. Increasing this number will reduce frame drops but increase latency, and vice versa" )
+    options.append( option )
+    option = dds.dds_option( "Error Polling Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Enable / disable polling of camera internal errors" )
+    options.append( option )
+    option = dds.dds_option( "Output Trigger Enabled", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Generate trigger from the camera to external device once per frame" )
+    options.append( option )
+    option = dds.dds_option( "Depth Units", "Stereo Module" )
+    option.set_value( 0.001 )
+    option_range.min = 1e-06
+    option_range.max = 0.01
+    option_range.step = 1e-06
+    option_range.default_value = 0.001
+    option.set_range( option_range )
+    option.set_description( "Number of meters represented by a single depth unit" )
+    options.append( option )
+    option = dds.dds_option( "Stereo Baseline", "Stereo Module" )
+    option.set_value( 94.9609 )
+    option_range.min = 94.9609
+    option_range.max = 94.9609
+    option_range.step = 0
+    option_range.default_value = 94.9609
+    option.set_range( option_range )
+    option.set_description( "Distance in mm between the stereo imagers" )
+    options.append( option )
+    option = dds.dds_option( "Inter Cam Sync Mode", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 260
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Inter-camera synchronization mode: 0:Default, 1:Master, 2:Slave, 3:Full Salve, 4-258:Genlock with burst count of 1-255 frames for each trigger, 259 and 260 for two frames per trigger with laser ON-OFF and OFF-ON." )
+    options.append( option )
+    option = dds.dds_option( "Emitter On Off", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Alternating emitter pattern, toggled on/off on per-frame basis" )
+    options.append( option )
+    option = dds.dds_option( "Global Time Enabled", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable global timestamp" )
+    options.append( option )
+    option = dds.dds_option( "Emitter Always On", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Emitter always on mode: 0:disabled(default), 1:enabled" )
+    options.append( option )
+    option = dds.dds_option( "Thermal Compensation", "Stereo Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Toggle thermal compensation adjustments mechanism" )
+    options.append( option )
+    option = dds.dds_option( "Hdr Enabled", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Name", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 3
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Size", "Stereo Module" )
+    option.set_value( 2 )
+    option_range.min = 2
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 2
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Sequence Id", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 2
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "HDR Option" )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Limit", "Stereo Module" )
+    option.set_value( 200000 )
+    option_range.min = 1
+    option_range.max = 200000
+    option_range.step = 1
+    option_range.default_value = 33000
+    option.set_range( option_range )
+    option.set_description( "Exposure limit is in microseconds. If the requested exposure limit is greater than frame time, it will be set to frame time at runtime. Setting will not take effect until next streaming session." )
+    options.append( option )
+    option = dds.dds_option( "Auto Gain Limit", "Stereo Module" )
+    option.set_value( 248 )
+    option_range.min = 16
+    option_range.max = 248
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Gain limits ranges from 16 to 248. If the requested gain limit is less than 16, it will be set to 16. If the requested gain limit is greater than 248, it will be set to 248. Setting will not take effect until next streaming session." )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Limit Toggle", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Toggle Auto-Exposure Limit" )
+    options.append( option )
+    option = dds.dds_option( "Auto Gain Limit Toggle", "Stereo Module" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Toggle Auto-Gain Limit" )
+    options.append( option )
+
+    return options
+
+
+def rgb_camera_options():
+    options = []
+    option_range = dds.dds_option_range()
+
+    option = dds.dds_option( "Backlight Compensation", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Enable / disable backlight compensation" )
+    options.append( option )
+    option = dds.dds_option( "Brightness", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = -64
+    option_range.max = 64
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "UVC image brightness" )
+    options.append( option )
+    option = dds.dds_option( "Contrast", "RGB Camera" )
+    option.set_value( 50 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 50
+    option.set_range( option_range )
+    option.set_description( "UVC image contrast" )
+    options.append( option )
+    option = dds.dds_option( "Exposure", "RGB Camera" )
+    option.set_value( 156 )
+    option_range.min = 1
+    option_range.max = 10000
+    option_range.step = 1
+    option_range.default_value = 156
+    option.set_range( option_range )
+    option.set_description( "Controls exposure time of color camera. Setting any value will disable auto exposure" )
+    options.append( option )
+    option = dds.dds_option( "Gain", "RGB Camera" )
+    option.set_value( 64 )
+    option_range.min = 0
+    option_range.max = 128
+    option_range.step = 1
+    option_range.default_value = 64
+    option.set_range( option_range )
+    option.set_description( "UVC image gain" )
+    options.append( option )
+    option = dds.dds_option( "Gamma", "RGB Camera" )
+    option.set_value( 300 )
+    option_range.min = 100
+    option_range.max = 500
+    option_range.step = 1
+    option_range.default_value = 300
+    option.set_range( option_range )
+    option.set_description( "UVC image gamma setting" )
+    options.append( option )
+    option = dds.dds_option( "Hue", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = -180
+    option_range.max = 180
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "UVC image hue" )
+    options.append( option )
+    option = dds.dds_option( "Saturation", "RGB Camera" )
+    option.set_value( 64 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 64
+    option.set_range( option_range )
+    option.set_description( "UVC image saturation setting" )
+    options.append( option )
+    option = dds.dds_option( "Sharpness", "RGB Camera" )
+    option.set_value( 50 )
+    option_range.min = 0
+    option_range.max = 100
+    option_range.step = 1
+    option_range.default_value = 50
+    option.set_range( option_range )
+    option.set_description( "UVC image sharpness setting" )
+    options.append( option )
+    option = dds.dds_option( "White Balance", "RGB Camera" )
+    option.set_value( 4600 )
+    option_range.min = 2800
+    option_range.max = 6500
+    option_range.step = 10
+    option_range.default_value = 4600
+    option.set_range( option_range )
+    option.set_description( "Controls white balance of color image. Setting any value will disable auto white balance" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto Exposure", "RGB Camera" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable / disable auto-exposure" )
+    options.append( option )
+    option = dds.dds_option( "Enable Auto White Balance", "RGB Camera" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable / disable auto-white-balance" )
+    options.append( option )
+    option = dds.dds_option( "Frames Queue Size", "RGB Camera" )
+    option.set_value( 16 )
+    option_range.min = 0
+    option_range.max = 32
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Max number of frames you can hold at a given time. Increasing this number will reduce frame drops but increase latency, and vice versa" )
+    options.append( option )
+    option = dds.dds_option( "Power Line Frequency", "RGB Camera" )
+    option.set_value( 3 )
+    option_range.min = 0
+    option_range.max = 3
+    option_range.step = 1
+    option_range.default_value = 3
+    option.set_range( option_range )
+    option.set_description( "Power Line Frequency" )
+    options.append( option )
+    option = dds.dds_option( "Auto Exposure Priority", "RGB Camera" )
+    option.set_value( 0 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 0
+    option.set_range( option_range )
+    option.set_description( "Restrict Auto-Exposure to enforce constant FPS rate. Turn ON to remove the restrictions (may result in FPS drop)" )
+    options.append( option )
+    option = dds.dds_option( "Global Time Enabled", "RGB Camera" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable global timestamp" )
+    options.append( option )
+
+    return options
+
+
+def motion_module_options():
+    options = []
+    option_range = dds.dds_option_range()
+
+    option = dds.dds_option( "Frames Queue Size", "Motion Module" )
+    option.set_value( 16 )
+    option_range.min = 0
+    option_range.max = 32
+    option_range.step = 1
+    option_range.default_value = 16
+    option.set_range( option_range )
+    option.set_description( "Max number of frames you can hold at a given time. Increasing this number will reduce frame drops but increase latency, and vice versa" )
+    options.append( option )
+    option = dds.dds_option( "Enable Motion Correction", "Motion Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable Automatic Motion Data Correction" )
+    options.append( option )
+    option = dds.dds_option( "Global Time Enabled", "Motion Module" )
+    option.set_value( 1 )
+    option_range.min = 0
+    option_range.max = 1
+    option_range.step = 1
+    option_range.default_value = 1
+    option.set_range( option_range )
+    option.set_description( "Enable/Disable global timestamp" )
+    options.append( option )
+
+    return options

--- a/unit-tests/dds/dds.py
+++ b/unit-tests/dds/dds.py
@@ -3,7 +3,7 @@
 
 import pyrealdds
 from rspy import log, test
-
+from time import sleep
 
 def run_server( server_script, nested_indent = 'svr' ):
     import os.path
@@ -30,3 +30,14 @@ def run_server( server_script, nested_indent = 'svr' ):
         run_time = time.time() - start_time
         log.d( "server took", run_time, "seconds" )
 
+
+def wait_for_devices( context, mask, tries = 3 ):
+    """
+    Since DDS devices may take time to be recognized and then initialized, we try over time:
+    """
+    while tries:
+        devices = context.query_devices( mask )
+        if len(devices) > 0:
+            return devices
+        tries -= 1
+        sleep( 1 )

--- a/unit-tests/dds/device-broadcaster.py
+++ b/unit-tests/dds/device-broadcaster.py
@@ -4,6 +4,7 @@
 import pyrealdds as dds
 from rspy import log, test
 import d435i
+import d405
 
 dds.debug( True, log.nested )
 

--- a/unit-tests/dds/device-broadcaster.py
+++ b/unit-tests/dds/device-broadcaster.py
@@ -5,6 +5,7 @@ import pyrealdds as dds
 from rspy import log, test
 import d435i
 import d405
+import d455
 
 dds.debug( True, log.nested )
 

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -9,6 +9,7 @@ log.nested = 'C  '
 import d435i
 import d405
 import d455
+import dds
 
 import pyrealsense2 as rs
 rs.log_to_console( rs.log_severity.debug )
@@ -16,18 +17,6 @@ from time import sleep
 
 context = rs.context( '{"dds-domain":123}' )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
-
-
-def wait_for_devices( tries = 3 ):
-    """
-    Since DDS devices may take time to be recognized and then initialized, we try over time:
-    """
-    while tries:
-        devices = context.query_devices( only_sw_devices )
-        if len(devices) > 0:
-            return devices
-        tries -= 1
-        sleep( 1 )
 
 
 import os.path
@@ -42,7 +31,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     try:
         remote.run( 'instance = broadcast_device( d435i, d435i.device_info )', timeout=5 )
         n_devs = 0
-        for dev in wait_for_devices():
+        for dev in dds.wait_for_devices( context, only_sw_devices ):
             n_devs += 1
         test.check_equal( n_devs, 1 )
         test.check_equal( dev.get_info( rs.camera_info.name ), d435i.device_info.name )
@@ -71,7 +60,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     try:
         remote.run( 'instance = broadcast_device( d405, d405.device_info )', timeout=5 )
         n_devs = 0
-        for dev in wait_for_devices():
+        for dev in dds.wait_for_devices( context, only_sw_devices ):
             n_devs += 1
         test.check_equal( n_devs, 1 )
         test.check_equal( dev.get_info( rs.camera_info.name ), d405.device_info.name )
@@ -95,7 +84,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     try:
         remote.run( 'instance = broadcast_device( d455, d455.device_info )', timeout=5 )
         n_devs = 0
-        for dev in wait_for_devices():
+        for dev in dds.wait_for_devices( context, only_sw_devices ):
             n_devs += 1
         test.check_equal( n_devs, 1 )
         test.check_equal( dev.get_info( rs.camera_info.name ), d455.device_info.name )

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -1,0 +1,95 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+#test:donotrun:!dds
+
+from rspy import log, test
+log.nested = 'C  '
+
+import d435i
+import d405
+import pyrealsense2 as rs
+rs.log_to_console( rs.log_severity.debug )
+from time import sleep
+
+context = rs.context( '{"dds-domain":123}' )
+only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
+
+
+def wait_for_devices( tries = 3 ):
+    """
+    Since DDS devices may take time to be recognized and then initialized, we try over time:
+    """
+    while tries:
+        devices = context.query_devices( only_sw_devices )
+        if len(devices) > 0:
+            return devices
+        tries -= 1
+        sleep( 1 )
+    
+
+
+import os.path
+cwd = os.path.dirname(os.path.realpath(__file__))
+remote_script = os.path.join( cwd, 'device-broadcaster.py' )
+with test.remote( remote_script, nested_indent="  S" ) as remote:
+    remote.wait_until_ready()
+    #
+    #############################################################################################
+    #
+    test.start( "Test D435i" )
+    try:
+        remote.run( 'instance = broadcast_device( d435i, d435i.device_info )', timeout=5 )
+        n_devs = 0
+        for dev in wait_for_devices():
+            n_devs += 1
+        test.check_equal( n_devs, 1 )
+        test.check_equal( dev.get_info( rs.camera_info.name ), d435i.device_info.name )
+        test.check_equal( dev.get_info( rs.camera_info.serial_number ), d435i.device_info.serial )
+        test.check_equal( dev.get_info( rs.camera_info.physical_port ), d435i.device_info.topic_root )
+        sensors = {sensor.get_info( rs.camera_info.name ) : sensor for sensor in dev.query_sensors()}
+        test.check_equal( len(sensors), 3 )
+        if test.check( 'Stereo Module' in sensors ):
+            sensor = sensors.get('Stereo Module')
+            test.check_equal( len(sensor.get_stream_profiles()), len(d435i.depth_stream_profiles())+2*len(d435i.ir_stream_profiles()) )
+        if test.check( 'RGB Camera' in sensors ):
+            sensor = sensors['RGB Camera']
+            test.check_equal( len(sensor.get_stream_profiles()), len(d435i.color_stream_profiles()) )
+        if test.check( 'Motion Module' in sensors ):
+            sensor = sensors['Motion Module']
+            test.check_equal( len(sensor.get_stream_profiles()), len(d435i.accel_stream_profiles())+len(d435i.gyro_stream_profiles()) )
+        remote.run( 'close_server( instance )', timeout=5 )
+    except:
+        test.unexpected_exception()
+    dev = None
+    test.finish()
+    #
+    #############################################################################################
+    #
+    test.start( "Test D405" )
+    try:
+        remote.run( 'instance = broadcast_device( d405, d405.device_info )', timeout=5 )
+        n_devs = 0
+        for dev in wait_for_devices():
+            n_devs += 1
+        test.check_equal( n_devs, 1 )
+        test.check_equal( dev.get_info( rs.camera_info.name ), d405.device_info.name )
+        test.check_equal( dev.get_info( rs.camera_info.serial_number ), d405.device_info.serial )
+        test.check_equal( dev.get_info( rs.camera_info.physical_port ), d405.device_info.topic_root )
+        sensors = {sensor.get_info( rs.camera_info.name ) : sensor for sensor in dev.query_sensors()}
+        test.check_equal( len(sensors), 1 )
+        if test.check( 'Stereo Module' in sensors ):
+            sensor = sensors.get('Stereo Module')
+            test.check_equal( len(sensor.get_stream_profiles()),
+                              len(d405.depth_stream_profiles())+2*len(d405.ir_stream_profiles())+len(d405.color_stream_profiles())+len(d405.colored_infrared_stream_profiles()) )
+        remote.run( 'close_server( instance )', timeout=5 )
+    except:
+        test.unexpected_exception()
+    dev = None
+    test.finish()
+    #
+    #############################################################################################
+
+
+context = None
+test.print_results_and_exit()

--- a/unit-tests/dds/test-librs-logic.py
+++ b/unit-tests/dds/test-librs-logic.py
@@ -43,29 +43,40 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         test.check_equal( len(n_devs), 1 )
         
         remote.run( 'instance2 = broadcast_device( d405, d405.device_info )', timeout=5 )
-        sleep( 2 ) # Wait for device to be received and built, otherwise wait_for_devices will return immediately with d435i only
+        sleep( 1 ) # Wait for device to be received and built, otherwise wait_for_devices will return immediately with previous devices
         n_devs = wait_for_devices()
         test.check_equal( len(n_devs), 2 )
+        
+        remote.run( 'instance3 = broadcast_device( d455, d455.device_info )', timeout=5 )
+        sleep( 1 ) # Wait for device to be received and built, otherwise wait_for_devices will return immediately with previous devices
+        n_devs = wait_for_devices()
+        test.check_equal( len(n_devs), 3 )
         
         remote.run( 'close_server( instance )', timeout=5 )
         remote.run( 'instance = None', timeout=1 )
-        sleep( 1 ) # Give client device time to close
-        n_devs = wait_for_devices()
-        test.check_equal( len(n_devs), 1 )
-        
-        remote.run( 'instance3 = broadcast_device( d435i, d435i.device_info )', timeout=5 )
-        sleep( 2 ) # Wait for device to be received and built, otherwise wait_for_devices will return immediately with d405 only
+        sleep( 0.5 ) # Give client device time to close
         n_devs = wait_for_devices()
         test.check_equal( len(n_devs), 2 )
         
+        remote.run( 'instance4 = broadcast_device( d435i, d435i.device_info )', timeout=5 )
+        sleep( 1 ) # Wait for device to be received and built, otherwise wait_for_devices will return immediately with previous devices
+        n_devs = wait_for_devices()
+        test.check_equal( len(n_devs), 3 )
+        
         remote.run( 'close_server( instance2 )', timeout=5 )
         remote.run( 'instance2 = None', timeout=1 )
-        sleep( 1 ) # Give client device time to close
+        sleep( 0.5 ) # Give client device time to close
+        n_devs = wait_for_devices()
+        test.check_equal( len(n_devs), 2 )
+        
+        remote.run( 'close_server( instance3 )', timeout=5 )
+        remote.run( 'instance2 = None', timeout=1 )
+        sleep( 0.5 ) # Give client device time to close
         n_devs = wait_for_devices()
         test.check_equal( len(n_devs), 1 )
         
-        remote.run( 'close_server( instance3 )', timeout=5 )
-        sleep( 1 ) # Give client device time to close
+        remote.run( 'close_server( instance4 )', timeout=5 )
+        sleep( 0.5 ) # Give client device time to close
         n_devs = wait_for_devices()
         test.check_equal( n_devs, None )
     except:


### PR DESCRIPTION
Added D405 and D455 models

Renamed `test-librs` to `test-librs-device-properties` and added tests for D405+D455 (Currently this file only tests correct discovery of the device and it's streams)

Created `test-librs-logic` and added a test that connects multiple cameras, disconnect and reconnect to verify all activities are received correctly by the client

