### PR TITLE
add sample.preset to avoid install problems

### DIFF
--- a/tools/realsense-viewer/presets/sample.preset
+++ b/tools/realsense-viewer/presets/sample.preset
@@ -1,0 +1,26 @@
+{
+    "READ-ME": [
+        "This is a sample preset file, and should not (in fact, cannot) be loaded.",
+        "",
+        "Presets are JSON files that were exported from the RealSense Viewer. For the Viewer to automatically show",
+        "these in the Preset combo-box for a particular camera:",
+        "    * place it into ~/librealsense2/presets (in Windows, under your Documents folder)",
+        "    * name it '<model> <name>.preset', where <model> is the camera name, e.g. 'D435I Max Range.preset'",
+        "",
+        "Is is best not to generate these manually, but rather export one from the Viewer and then maybe change its",
+        "values."
+    ],
+    "device": {
+        "name": "Intel RealSense D435I",
+        "product line": "D400"
+    },
+    "parameters": {
+        "key": "value..."
+    },
+    "schema version": 1,
+    "viewer": {
+        "stream-fps": "60",
+        "stream-height": "480",
+        "stream-width": "640"
+    }
+}


### PR DESCRIPTION
To fix issue introduced in #11265 .
Introduces a `sample.preset` file with comments inside, installed under ~/librealsense2/presets (same as before; Documents/... in Windows). The file itself is not an actual preset and will error when loaded into the Viewer.