### PR TITLE
add UT verifying no emitter freq option on legacy devices

### DIFF
--- a/unit-tests/live/d400/test-emitter-frequency-negative.py
+++ b/unit-tests/live/d400/test-emitter-frequency-negative.py
@@ -1,0 +1,19 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#test:donotrun:jetson
+#test:device each(D400*) !D455
+
+import pyrealsense2 as rs
+from rspy import test
+
+ctx = rs.context()
+device = test.find_first_device_or_exit()
+depth_sensor = device.first_depth_sensor()
+
+################################################################################################
+test.start("emitter frequency is not supported on legacy devices")
+test.check_equal(depth_sensor.supports(rs.option.emitter_frequency), False)
+test.finish()
+################################################################################################
+test.print_results_and_exit()

--- a/unit-tests/live/d400/test-emitter-frequency.py
+++ b/unit-tests/live/d400/test-emitter-frequency.py
@@ -13,7 +13,7 @@ device = test.find_first_device_or_exit();
 depth_sensor = device.first_depth_sensor()
 
 fw_version = rsutils.version( device.get_info( rs.camera_info.firmware_version ))
-if fw_version <= rsutils.version(5,13,1,53):
+if fw_version <= rsutils.version(5,14,0,0):
     log.i(f"FW version {fw_version} does not support EMITTER_FREQUENCY option, skipping test...")
     test.print_results_and_exit()
 


### PR DESCRIPTION
Tracked on [DSO-18654]