### PR TITLE
Add device extrinsics data

### DIFF
--- a/third-party/realdds/include/realdds/dds-defines.h
+++ b/third-party/realdds/include/realdds/dds-defines.h
@@ -72,4 +72,19 @@ struct motion_intrinsics
 };
 
 
+// Cross-stream extrinsics: encodes the topology describing how the different devices are oriented.
+struct extrinsics
+{
+    float rotation[9];    // Column-major 3x3 rotation matrix
+    float translation[3]; // Three-element translation vector, in meters
+
+    nlohmann::json to_json() const;
+    static extrinsics from_json( nlohmann::json const & j );
+};
+
+
+// Maps < from stream_name, to stream_name > pairs to extrinsics
+typedef std::map< std::pair< std::string, std::string >, std::shared_ptr< extrinsics > > extrinsics_map;
+
+
 }  // namespace realdds

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include <realdds/dds-option.h>
+#include <realdds/dds-defines.h>
+
 #include <librealsense2/utilities/concurrency/concurrency.h>
 #include <third-party/json_fwd.hpp>
 
@@ -59,7 +61,7 @@ public:
     // On successful return from init(), each of the streams will be alive so clients will be able
     // to subscribe.
     void init( const std::vector< std::shared_ptr< dds_stream_server > > & streams,
-               const dds_options & options );
+               const dds_options & options, const extrinsics_map & extr );
 
     bool is_valid() const { return( nullptr != _notification_server.get() ); }
     bool operator!() const { return ! is_valid(); }
@@ -102,6 +104,8 @@ private:
     control_callback _close_streams_callback = nullptr;
     set_option_callback _set_option_callback = nullptr;
     query_option_callback _query_option_callback = nullptr;
+
+    extrinsics_map _extrinsics_map; // <from stream, to stream> to extrinsics
 };  // class dds_device_server
 
 

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -59,6 +59,8 @@ public:
     void set_option_value( const std::shared_ptr< dds_option > & option, float new_value );
     float query_option_value( const std::shared_ptr< dds_option > & option );
 
+    std::shared_ptr< extrinsics > get_extrinsics( std::string from, std::string to ) const;
+
 private:
     class impl;
     std::shared_ptr< impl > _impl;

--- a/third-party/realdds/src/dds-defines.cpp
+++ b/third-party/realdds/src/dds-defines.cpp
@@ -82,5 +82,39 @@ nlohmann::json motion_intrinsics::to_json() const
     return ret;
 }
 
+nlohmann::json extrinsics::to_json() const
+{
+    return nlohmann::json::array( {
+        rotation[0], rotation[1], rotation[2],
+        rotation[3], rotation[4], rotation[5],
+        rotation[6], rotation[7], rotation[8],
+        translation[0], translation[1], translation[2]
+    } );
+}
+
+/* static  */ extrinsics extrinsics::from_json( nlohmann::json const & j )
+{
+    extrinsics ret;
+    int index = 0;
+
+    ret.rotation[0] = utilities::json::get< float >( j, index++ );
+    ret.rotation[1] = utilities::json::get< float >( j, index++ );
+    ret.rotation[2] = utilities::json::get< float >( j, index++ );
+    ret.rotation[3] = utilities::json::get< float >( j, index++ );
+    ret.rotation[4] = utilities::json::get< float >( j, index++ );
+    ret.rotation[5] = utilities::json::get< float >( j, index++ );
+    ret.rotation[6] = utilities::json::get< float >( j, index++ );
+    ret.rotation[7] = utilities::json::get< float >( j, index++ );
+    ret.rotation[8] = utilities::json::get< float >( j, index++ );
+    ret.translation[0] = utilities::json::get< float >( j, index++ );
+    ret.translation[1] = utilities::json::get< float >( j, index++ );
+    ret.translation[2] = utilities::json::get< float >( j, index++ );
+
+    if( index != j.size() )
+        DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
+
+    return ret;
+}
+
 
 }  // namespace realdds

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -286,6 +286,17 @@ bool dds_device::impl::init()
                     n_streams_expected = utilities::json::get< size_t >( j, "n-streams" );
                     LOG_DEBUG( "... device-header: " << n_streams_expected << " streams expected" );
 
+                    if( utilities::json::has( j, "extrinsics" ) )
+                    {
+                        for( auto & ex : j["extrinsics"] )
+                        {
+                            std::string to_name = utilities::json::get< std::string >( ex, 0 );
+                            std::string from_name = utilities::json::get< std::string >( ex, 1 );
+                            extrinsics extr = extrinsics::from_json( utilities::json::get< json >( ex, 2 ) );
+                            _extrinsics_map[std::make_pair( to_name, from_name )] = std::make_shared< extrinsics >( extr );
+                        }
+                    }
+
                     state = state_type::WAIT_FOR_DEVICE_OPTIONS;
                 }
                 else if( state_type::WAIT_FOR_DEVICE_OPTIONS == state && id == "device-options" )

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -55,6 +55,8 @@ public:
 
     dds_options _options;
 
+    extrinsics_map _extrinsics_map; // <from stream, to stream> to extrinsics
+
     impl( std::shared_ptr< dds_participant > const & participant,
           dds_guid const & guid,
           topics::device_info const & info );

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -143,4 +143,14 @@ float dds_device::query_option_value( const std::shared_ptr< dds_option > & opti
     return _impl->query_option_value( option );
 }
 
+std::shared_ptr< extrinsics > dds_device::get_extrinsics( std::string from, std::string to ) const
+{
+    auto iter = _impl->_extrinsics_map.find( std::make_pair( from, to ) );
+    if( iter != _impl->_extrinsics_map.end() )
+        return iter->second;
+
+    std::shared_ptr< extrinsics > empty;
+    return empty;
+}
+
 }  // namespace realdds

--- a/unit-tests/dds/d405.py
+++ b/unit-tests/dds/d405.py
@@ -23,7 +23,7 @@ def build( participant ):
     color = color_stream()
     #
     d405 = dds.device_server( participant, device_info.topic_root )
-    d405.init( [ir0, ir1, ir2, color, depth], [] )
+    d405.init( [ir0, ir1, ir2, color, depth], [], {} )
     return d405
 
 

--- a/unit-tests/dds/d435i.py
+++ b/unit-tests/dds/d435i.py
@@ -24,7 +24,7 @@ def build( participant ):
     color = color_stream()
     #
     d435i = dds.device_server( participant, device_info.topic_root )
-    d435i.init( [accel, color, depth, gyro, ir1, ir2], [] )
+    d435i.init( [accel, color, depth, gyro, ir1, ir2], [], {} )
     return d435i
 
 

--- a/unit-tests/dds/d455.py
+++ b/unit-tests/dds/d455.py
@@ -25,7 +25,7 @@ def build( participant ):
     color = color_stream()
     #
     d455 = dds.device_server( participant, device_info.topic_root )
-    d455.init( [accel, gyro, depth, ir0, ir1, ir2, color], [] )
+    d455.init( [accel, gyro, depth, ir0, ir1, ir2, color], [], {} )
     return d455
 
 

--- a/unit-tests/dds/device-init-server.py
+++ b/unit-tests/dds/device-init-server.py
@@ -20,7 +20,7 @@ def test_one_stream():
     log.d( s1.profiles() )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1], [] )
+    server.init( [s1], [], {} )
 
 def test_one_motion_stream():
     s1p1 = dds.motion_stream_profile( 30, dds.stream_format("RGB8") )
@@ -30,7 +30,7 @@ def test_one_motion_stream():
     log.d( s1.profiles() )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1], [] )
+    server.init( [s1], [], {} )
 
 def test_no_profiles():
     s1profiles = []
@@ -38,12 +38,12 @@ def test_no_profiles():
     s1.init_profiles( s1profiles, 0 )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1], [] )
+    server.init( [s1], [], {} )
 
 def test_no_streams():
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [], [] )
+    server.init( [], [], {} )
 
 def test_n_profiles( n_profiles ):
     assert n_profiles > 0
@@ -60,7 +60,7 @@ def test_n_profiles( n_profiles ):
     log.d( s1.profiles() )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1], [] )
+    server.init( [s1], [], {} )
 
 
 def test_d435i():

--- a/unit-tests/dds/options-server.py
+++ b/unit-tests/dds/options-server.py
@@ -21,7 +21,7 @@ def test_no_options():
     dev_opts = []
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1], dev_opts )
+    server.init( [s1], dev_opts, {} )
 
 def test_device_options_discovery( values ):
     # Create one stream with one profile so device init won't fail, no stream options
@@ -36,7 +36,7 @@ def test_device_options_discovery( values ):
         dev_opts.append( option )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1], dev_opts )
+    server.init( [s1], dev_opts, {})
 
 def test_stream_options_discovery( value, min, max, step, default, description ):
     s1p1 = dds.video_stream_profile( 9, dds.stream_format("RGB8"), 10, 10 )
@@ -57,7 +57,7 @@ def test_stream_options_discovery( value, min, max, step, default, description )
     s1.init_options( [so1, so2, so3] )
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1], [] )
+    server.init( [s1], [], {} )
 
 def test_device_and_multiple_stream_options_discovery( dev_values, stream_values ):
     dev_options = []
@@ -85,7 +85,7 @@ def test_device_and_multiple_stream_options_discovery( dev_values, stream_values
     
     global server
     server = dds.device_server( participant, "realdds/device/topic-root" )
-    server.init( [s1, s2], dev_options )
+    server.init( [s1, s2], dev_options, {} )
 
 def close_server():
     global server


### PR DESCRIPTION
Adding extrinsics data to device information (using device-header topic)

1. While collecting the data, all profiles combinations are checked for extrinsics data. The connection graph that is built in the camera user side might be different then the one in the server, containing more connections between vertices.
Example graphs for D435i are attached. Because of the large number of profiles and connections only some of the video profiles are shown (those with resolution 1280x720 pixels)

Server side:
![server side only 1280x720 profiles](https://user-images.githubusercontent.com/100071798/211288924-ff63289f-58cf-4fec-9eb7-6a6d80c57dfc.png)
No connection between `IR1` and `IR2`, or `IR1` to `Color`, etc...

Client side:
![client side only 1280x720 profiles](https://user-images.githubusercontent.com/100071798/211288929-dbf977dc-4445-4026-859f-5370b69f0ce4.png)
All streams are connected.

2. Because graph search yields different path between profiles (extrinsics data is the edges in the graph), and the fact that extrinsics data fields are of type `float`, some extrinsics data calculation can yield different result in the client then in the server, but the difference is smaller than `float` precision. Example for extrinsics from `Infrared 2` to `Infrared 1`
Server side:
Translation Vector :
[0.049864, 0, 0]
Rotation Matrix :
[1, 0, 0]
[0, 1, 0]
[0, 0, 1]

Client side:
Translation Vector :
[0.049864, -9.31323e-10, 0]
Rotation Matrix :
[1, -5.34328e-12, 0]
[-5.34328e-12, 1, 2.91038e-11]
[0, 2.91038e-11, 1]