### PR TITLE
Enumerate video nodes by name

### DIFF
--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -1,24 +1,30 @@
 #!/bin/bash
 # Create symbolic links for video nodes and for metadata nodes - /dev/video-rs-[<sensor>|<sensor>-md]-[camera-index]
-# This script intended for mipi devices on IPU6.
-# Currently it supports only IPU6 platforms, Jetson support will be added later.
+# This script intended for mipi devices on Jetson and IPU6.
 # After running this script in enumeration mode, it will create links as follow for example:
-# $ ls -1l /dev/video-rs-*
-# /dev/video-rs-color-3 -> /dev/video54
-# /dev/video-rs-color-md-3 -> /dev/video55
-# /dev/video-rs-depth-3 -> /dev/video52
-# /dev/video-rs-depth-md-3 -> /dev/video53
-# /dev/video-rs-ir-3 -> /dev/video56
-
 # Example of the output:
+#
+# Jetson:
+# $ ./rs-enum.sh 
+# Bus	  Camera	Sensor	Node Type	Video Node	RS Link
+# mipi	0	      depth	  Streaming	/dev/video0	/dev/video-rs-depth-0
+# mipi	0	      depth	  Metadata	/dev/video1	/dev/video-rs-depth-md-0
+# mipi	0	      color	  Streaming	/dev/video2	/dev/video-rs-color-0
+# mipi	0	      color	  Metadata	/dev/video3	/dev/video-rs-color-md-0
+# mipi	0	      ir	    Streaming	/dev/video4	/dev/video-rs-ir-0
+# mipi	0	      imu	    Streaming	/dev/video5	/dev/video-rs-imu-0
+#
+# Alderlake:
 #$ ./rs-enum.sh 
-#Bus    Camera  Sensor  Node Type  Video Node    RS Link
+# Bus   Camera  Sensor  Node Type  Video Node    RS Link
 # ipu6  3       depth   Streaming  /dev/video52  /dev/video-rs-depth-3
 # ipu6  3       depth   Metadata   /dev/video53  /dev/video-rs-depth-md-3
 # ipu6  3       ir      Streaming  /dev/video56  /dev/video-rs-ir-3
 # ipu6  3       color   Streaming  /dev/video54  /dev/video-rs-color-3
 # ipu6  3       color   Metadata   /dev/video55  /dev/video-rs-color-md-3
-
+#
+# Dependency: v4l-utils
+#
 # parse command line parameters
 # for '-i' parameter, print links only
 while [[ $# -gt 0 ]]; do
@@ -119,4 +125,3 @@ for camera in a b c d; do
 done
 
 # end of file
-

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Create symbolic links for video nodes and for metadata nodes - /dev/video-rs-[<sensor>|<sensor>-md]-[camera-index]
+# This script intended for mipi devices on IPU6.
+# Currently it supports only IPU6 platforms, Jetson support will be added later.
+# After running this script in enumeration mode, it will create links as follow for example:
+# $ ls -1l /dev/video-rs-*
+# /dev/video-rs-color-3 -> /dev/video54
+# /dev/video-rs-color-md-3 -> /dev/video55
+# /dev/video-rs-depth-3 -> /dev/video52
+# /dev/video-rs-depth-md-3 -> /dev/video53
+# /dev/video-rs-ir-3 -> /dev/video56
+
+# Example of the output:
+#$ ./rs-enum.sh 
+#Bus    Camera  Sensor  Node Type  Video Node    RS Link
+# ipu6  3       depth   Streaming  /dev/video52  /dev/video-rs-depth-3
+# ipu6  3       depth   Metadata   /dev/video53  /dev/video-rs-depth-md-3
+# ipu6  3       ir      Streaming  /dev/video56  /dev/video-rs-ir-3
+# ipu6  3       color   Streaming  /dev/video54  /dev/video-rs-color-3
+# ipu6  3       color   Metadata   /dev/video55  /dev/video-rs-color-md-3
+
+# parse command line parameters
+# for '-i' parameter, print links only
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -i|--info)
+      info=1
+      shift
+    ;;
+    *)
+      info=0
+      shift
+    ;;
+    esac
+done
+#set -x
+
+declare -A camera_idx=( [a]=0 [b]=1 [c]=2 [d]=3 )
+declare -A d4xx_vc=([1]=1 [2]=3 [4]=5)
+declare -A d4xx_vc_named=([depth]=1 [rgb]=3 ["motion detection"]=5 [imu]=7)
+declare -A camera_names=( [depth]=depth [rgb]=color ["motion detection"]=ir [imu]=imu )
+
+camera_vid=("depth" "depth-md" "color" "color-md" "ir" "imu")
+
+printf "Bus\tCamera\tSensor\tNode Type\tVideo Node\tRS Link\n"
+
+# For Jetson we have simple method
+if [ -n "$(v4l2-ctl --list-devices | grep tegra)" ]; then
+  for ((i = 0; i < 127; i++)); do
+    if [ ! -c /dev/video${i} ]; then
+      break;
+    fi
+    cam_id=$((i/6))
+    sens_id=$((i%6))
+    vid="/dev/video${i}"
+    dev_name=$(v4l2-ctl -d ${vid} -D | grep 'Driver name' | head -n1 | awk -F' : ' '{print $2}')
+    dev_ln="/dev/video-rs-${camera_vid[${sens_id}]}-${cam_id}"
+    bus="mipi"
+    if [ "$dev_name" = "uvcvideo" ]; then
+      dev_ln=$vid
+      bus="usb"
+    fi
+    if [ -n "$(echo ${camera_vid[${sens_id}]} | awk /md/)" ]; then
+	    type="Metadata"
+    else
+	    type="Streaming"
+    fi
+    sensor_name=$(echo "${camera_vid[${sens_id}]}" | awk -F'-' '{print $1}')
+    printf '%s\t%d\t%s\t%s\t%s\t%s\n' ${bus} ${cam_id} ${sensor_name} ${type} ${vid} ${dev_ln}
+    # create link only in case we choose not only to show it
+    if [[ $info -eq 0 ]] && [[ $bus != "usb" ]]; then
+      [[ -e $dev_ln ]] && sudo unlink $dev_ln
+      sudo ln -s $vid $dev_ln
+    fi
+  done
+exit 0
+fi
+
+#ADL-P IPU6
+# cache media-ctl output
+dot=$(media-ctl --print-dot)
+# for all d457 muxes a, b, c and d
+for camera in a b c d; do
+  for sens in "${!d4xx_vc_named[@]}"; do
+    # get sensor binding from media controller
+    d4xx_sens=$(echo "${dot}" | grep "D4XX $sens $camera" | awk '{print $1}')
+    [[ -z $d4xx_sens ]] && continue; # echo "SENS $sens NOT FOUND" && continue
+    d4xx_sens_mux=$(echo "${dot}" | grep $d4xx_sens:port0 | awk '{print $3}' | awk -F':' '{print $1}')
+    csi2=$(echo "${dot}" | grep $d4xx_sens_mux:port0 | awk '{print $3}' | awk -F':' '{print $1}')
+    be_soc=$(echo "${dot}" | grep $csi2:port1 | grep -v dashed | awk '{print $3}' | awk -F':' '{print $1}')
+    vid_nd=$(echo "${dot}" | grep "$be_soc:port${d4xx_vc_named[${sens}]}" | grep -v dashed | awk '{print $3}' | awk -F':' '{print $1}')
+    [[ -z $vid_nd ]] && continue; # echo "SENS $sens NOT FOUND" && continue
+    vid=$(echo "${dot}" | grep "${vid_nd}" | grep video | tr '\\n' '\n' | grep video | awk -F'"' '{print $1}')
+    dev_ln="/dev/video-rs-${camera_names["${sens}"]}-${camera_idx[${camera}]}"
+    dev_name=$(v4l2-ctl -d $vid -D | grep Model | awk -F':' '{print $2}')
+    # echo Sensor: $sens,\t Device: $vid,\t Link $dev_ln
+    printf '%s\t%d\t%s\tStreaming\t%s\t%s\n' "$dev_name" ${camera_idx[${camera}]} ${camera_names["${sens}"]} $vid $dev_ln
+    # create link only in case we choose not only to show it
+    if [[ $info -eq 0 ]]; then
+      [[ -e $dev_ln ]] && sudo unlink $dev_ln
+      sudo ln -s $vid $dev_ln
+      # activate ipu6 link enumeration feature
+      v4l2-ctl -d $dev_ln -c enumerate_graph_link=1
+    fi
+    # metadata link
+    # skip IR metadata node for now.
+    [[ ${camera_names["${sens}"]} == 'ir' ]] && continue
+    vid_num=$(echo $vid | grep -o '[0-9]\+')
+    dev_md_ln="/dev/video-rs-${camera_names["${sens}"]}-md-${camera_idx[${camera}]}"
+    dev_name=$(v4l2-ctl -d "/dev/video$(($vid_num+1))" -D | grep Model | awk -F':' '{print $2}')
+    # echo Metadata: $sens,\t Device: "/dev/video$(($vid_num+1))",\t Link: $dev_md_ln
+    printf '%s\t%d\t%s\tMetadata\t/dev/video%s\t%s\n' "$dev_name" ${camera_idx[${camera}]} ${camera_names["${sens}"]} $(($vid_num+1)) $dev_md_ln
+    # create link only in case we choose not only to show it
+    if [[ $info -eq 0 ]]; then
+      [[ -e $dev_md_ln ]] && sudo unlink $dev_md_ln
+      sudo ln -s "/dev/video$(($vid_num+1))" $dev_md_ln
+    fi
+  done
+done
+
+# end of file
+

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -804,10 +804,75 @@ namespace librealsense
                                    const std::string&)> action)
         {
             std::vector<std::string> video_paths = get_video_paths();
-
-            // Collect UVC nodes info to bundle metadata and video
             typedef std::pair<uvc_device_info,std::string> node_info;
             std::vector<node_info> uvc_nodes,uvc_devices;
+            std::vector<node_info> mipi_rs_enum_nodes;
+            /* Enumerate mipi nodes by links with usage of rs-enum script */
+            std::vector<std::string> video_sensors = {"depth", "color", "ir", "imu"};
+            const int MAX_V4L2_DEVICES = 8; // assume maximum 8 mipi devices
+
+            for ( int i = 0; i < MAX_V4L2_DEVICES; i++ ) {
+                for (const auto &vs: video_sensors) {
+                    int vfd = -1;
+                    std::string device_path = "video-rs-" + vs + "-" + std::to_string(i);
+                    std::string device_md_path = "video-rs-" + vs + "-md-" + std::to_string(i);
+                    std::string video_path = "/dev/" + device_path;
+                    std::string video_md_path = "/dev/" + device_md_path;
+                    uvc_device_info info{};
+
+                    // Get Video node
+                    // Check if file on video_path is exists
+                    vfd = open(video_path.c_str(), O_RDONLY | O_NONBLOCK);
+
+                    if (vfd < 0) // file does not exists, continue to the next one
+                        continue;
+                    else
+                        ::close(vfd); // file exists, close file and continue to assign it
+                    try
+                    {
+                        info = get_info_from_mipi_device_path(video_path, device_path);
+                    }
+                    catch(const std::exception & e)
+                    {
+                        LOG_WARNING("MIPI video device issue: " << e.what());
+                        continue;
+                    }
+
+                    info.mi = vs.compare("imu") ? 0 : 4;
+                    info.unique_id += "-" + std::to_string(i);
+                    mipi_rs_enum_nodes.emplace_back(info, video_path);
+
+                    // Get metadata node
+                    // Check if file on video_md_path is exists
+                    vfd = open(video_md_path.c_str(), O_RDONLY | O_NONBLOCK);
+
+                    if (vfd < 0) // file does not exists, continue to the next one
+                        continue;
+                    else
+                        ::close(vfd); // file exists, close file and continue to assign it
+
+                    try
+                    {
+                        info = get_info_from_mipi_device_path(video_md_path, device_md_path);
+                    }
+                    catch(const std::exception & e)
+                    {
+                        LOG_WARNING("MIPI video metadata device issue: " << e.what());
+                        continue;
+                    }
+                    info.mi = 3;
+                    info.unique_id += "-" + std::to_string(i);
+                    mipi_rs_enum_nodes.emplace_back(info, video_md_path);
+                }
+            }
+
+            // Append mipi nodes to uvc nodes list
+            if(mipi_rs_enum_nodes.size())
+            {
+                uvc_nodes.insert(uvc_nodes.end(), mipi_rs_enum_nodes.begin(), mipi_rs_enum_nodes.end());
+            }
+
+            // Collect UVC nodes info to bundle metadata and video
 
             for(auto&& video_path : video_paths)
             {
@@ -821,11 +886,14 @@ namespace librealsense
                     {
                         info = get_info_from_usb_device_path(video_path, name);
                     }
-                    else //video4linux devices that are not USB devices
+                    else if(mipi_rs_enum_nodes.empty()) //video4linux devices that are not USB devices and not previously enumerated by rs links
                     {
                         info = get_info_from_mipi_device_path(video_path, name);
                     }
-
+                    else // continue as we already have mipi nodes enumerated by rs links in uvc_nodes
+                    {
+                        continue;
+                    }
                     auto dev_name = "/dev/" + name;
                     uvc_nodes.emplace_back(info, dev_name);
                 }


### PR DESCRIPTION
LRS V4L2 Backend Enumerate video nodes by name [LRS-573] 
rs-enum.sh:
 - Create symbolic links for video nodes and for metadata nodes - /dev/video-rs-[|-md]-[camera-index] 
 backend-v4l2.cpp:
 - scan for rs-enum links

Follow-by: #11319

Signed-off-by: Dmitry Perchanov <dmitry.perchanov@intel.com>