### PR TITLE
remove debug message in global_timestamp_reader

### DIFF
--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -120,7 +120,7 @@ namespace librealsense
         double a, b;
         get_a_b(x, a, b);
         double y(a * (x - _base_sample._x) + b + _base_sample._y);
-        LOG_DEBUG(__FUNCTION__ << ": " << x << " -> " << y << " with coefs:" << a << ", " << b << ", " << _base_sample._x << ", " << _base_sample._y);
+        //LOG_DEBUG(__FUNCTION__ << ": " << x << " -> " << y << " with coefs:" << a << ", " << b << ", " << _base_sample._x << ", " << _base_sample._y);
         return y;
     }
 


### PR DESCRIPTION
This log message is popping up for every frame, and isn't needed unless you're debugging that specific thing.
I commented it out.

We really need to revise our debugging controls: there are better ways to debug and enable "modules" that can be activated at runtime.