### PR TITLE
Fully qualify `std::move` invocations to fix -Wunqualified-std-cast-call

### DIFF
--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -955,7 +955,7 @@ namespace rs2
     {
     public:
         explicit device_list(std::shared_ptr<rs2_device_list> list)
-            : _list(move(list)) {}
+            : _list(std::move(list)) {}
 
         device_list()
             : _list(nullptr) {}
@@ -977,7 +977,7 @@ namespace rs2
 
         device_list& operator=(std::shared_ptr<rs2_device_list> list)
         {
-            _list = move(list);
+            _list = std::move(list);
             return *this;
         }
 

--- a/src/context.h
+++ b/src/context.h
@@ -58,7 +58,7 @@ namespace librealsense
 
     protected:
         explicit device_info(std::shared_ptr<context> backend)
-            : _ctx(move(backend))
+            : _ctx(std::move(backend))
         {}
 
         virtual std::shared_ptr<device_interface> create(std::shared_ptr<context> ctx,

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -36,7 +36,7 @@ frame::frame( frame && r )
 
 frame & frame::operator=( frame && r )
 {
-    data = move( r.data );
+    data = std::move( r.data );
     owner = r.owner;
     ref_count = r.ref_count.exchange( 0 );
     _kept = r._kept.exchange( false );

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -774,7 +774,7 @@ void rs2_start(const rs2_sensor* sensor, rs2_frame_callback_ptr on_frame, void* 
     VALIDATE_NOT_NULL(on_frame);
     librealsense::frame_callback_ptr callback(
         new librealsense::frame_callback(on_frame, user));
-    sensor->sensor->start(move(callback));
+    sensor->sensor->start(std::move(callback));
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, sensor, on_frame, user)
 
@@ -784,7 +784,7 @@ void rs2_start_queue(const rs2_sensor* sensor, rs2_frame_queue* queue, rs2_error
     VALIDATE_NOT_NULL(queue);
     librealsense::frame_callback_ptr callback(
         new librealsense::frame_callback(rs2_enqueue_frame, queue));
-    sensor->sensor->start(move(callback));
+    sensor->sensor->start(std::move(callback));
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, sensor, queue)
 
@@ -1873,7 +1873,7 @@ rs2_pipeline_profile* rs2_pipeline_start_with_callback(rs2_pipeline* pipe, rs2_f
     VALIDATE_NOT_NULL(pipe);
     librealsense::frame_callback_ptr callback( new librealsense::frame_callback( on_frame, user ),
                                                []( rs2_frame_callback * p ) { p->release(); } );
-    return new rs2_pipeline_profile{ pipe->pipeline->start(std::make_shared<pipeline::config>(), move(callback)) };
+    return new rs2_pipeline_profile{ pipe->pipeline->start(std::make_shared<pipeline::config>(), std::move(callback)) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, pipe, on_frame, user)
 
@@ -2140,7 +2140,7 @@ void rs2_start_processing_queue(rs2_processing_block* block, rs2_frame_queue* qu
     VALIDATE_NOT_NULL(queue);
     librealsense::frame_callback_ptr callback(
         new librealsense::frame_callback(rs2_enqueue_frame, queue));
-    block->block->set_output_callback(move(callback));
+    block->block->set_output_callback(std::move(callback));
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, block, queue)
 

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -547,7 +547,7 @@ void log_callback_end( uint32_t fps,
         if (_on_open)
             _on_open(_internal_config);
 
-        _power = move(on);
+        _power = std::move(on);
         _is_opened = true;
 
         try {
@@ -824,8 +824,8 @@ void log_callback_end( uint32_t fps,
         _fps_and_sampling_frequency_per_rs2_stream(fps_and_sampling_frequency_per_rs2_stream),
         _hid_device(hid_device),
         _is_configured_stream(RS2_STREAM_COUNT),
-        _hid_iio_timestamp_reader(move(hid_iio_timestamp_reader)),
-        _custom_hid_timestamp_reader(move(custom_hid_timestamp_reader))
+        _hid_iio_timestamp_reader(std::move(hid_iio_timestamp_reader)),
+        _custom_hid_timestamp_reader(std::move(custom_hid_timestamp_reader))
     {
         register_metadata(RS2_FRAME_METADATA_BACKEND_TIMESTAMP, make_additional_data_parser(&frame_additional_data::backend_timestamp));
 
@@ -1113,7 +1113,7 @@ void log_callback_end( uint32_t fps,
         std::unique_ptr<frame_timestamp_reader> timestamp_reader,
         device* dev)
         : sensor_base(name, dev, (recommended_proccesing_blocks_interface*)this),
-        _device(move(uvc_device)),
+        _device(std::move(uvc_device)),
         _user_count(0),
         _timestamp_reader(std::move(timestamp_reader))
     {

--- a/src/types.h
+++ b/src/types.h
@@ -260,14 +260,14 @@ namespace librealsense
             std::lock_guard<std::mutex> lock(other._mtx);
             if (!other._was_init)
             {
-                _init = move(other._init);
+                _init = std::move(other._init);
                 _was_init = false;
             }
             else
             {
-                _init = move(other._init);
+                _init = std::move(other._init);
                 _was_init = true;
-                _ptr = move(other._ptr);
+                _ptr = std::move(other._ptr);
             }
         }
 
@@ -282,14 +282,14 @@ namespace librealsense
             std::lock_guard<std::mutex> lock2(other._mtx);
             if (!other._was_init)
             {
-                _init = move(other._init);
+                _init = std::move(other._init);
                 _was_init = false;
             }
             else
             {
-                _init = move(other._init);
+                _init = std::move(other._init);
                 _was_init = true;
-                _ptr = move(other._ptr);
+                _ptr = std::move(other._ptr);
             }
 
             return *this;

--- a/unit-tests/unit-tests-common.h
+++ b/unit-tests/unit-tests-common.h
@@ -330,7 +330,7 @@ class require_error
     bool validate_error_message;      // Messages content may vary , subject to backend selection
     rs2_error * err;
 public:
-    require_error(std::string message, bool message_validation = true) : message(move(message)), validate_error_message(message_validation), err() {}
+    require_error(std::string message, bool message_validation = true) : message(std::move(message)), validate_error_message(message_validation), err() {}
     require_error(const require_error &) = delete;
     ~require_error() NOEXCEPT_FALSE
     {


### PR DESCRIPTION
Clang implemented a warning last year to detect bare `move` and `forward` calls, as they have the potential to be error prone: https://github.com/llvm/llvm-project/commit/70b1f6de539867353940d3dcb8b25786d5082d63. This warning should be available in clang-15.

This warning also applies to `std::forward`, but the few uses of `std::forward` in librealsense are all fully qualified.

Verified locally by using a recent version of clang and building with `-Werror=unqualified-std-cast-call`.