### PR TITLE
support for Python 3.11 with pybind11 v2.10.3

### DIFF
--- a/CMake/pybind11-download.cmake.in
+++ b/CMake/pybind11-download.cmake.in
@@ -6,7 +6,7 @@ ExternalProject_Add(
     pybind11
     PREFIX .
     GIT_REPOSITORY "https://github.com/pybind/pybind11.git"
-    GIT_TAG        v2.9.0  # 2.10 requires VS 2017+ and Python 3.6+
+    GIT_TAG        v2.10.3
     GIT_CONFIG     advice.detachedHead=false  # otherwise we'll get "You are in 'detached HEAD' state..."
     SOURCE_DIR     "${CMAKE_BINARY_DIR}/third-party/pybind11"
     GIT_SHALLOW    ON        # No history needed (requires cmake 3.6)

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -7,6 +7,8 @@ Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 #include <librealsense2/hpp/rs_record_playback.hpp> // for downcasts
 #include <common/metadata-helper.h>
 
+#include <iostream>
+
 void init_device(py::module &m) {
     /** rs_device.hpp **/
     py::class_<rs2::device> device(m, "device"); // No docstring in C++

--- a/wrappers/python/readme.md
+++ b/wrappers/python/readme.md
@@ -20,7 +20,7 @@ Package is available at https://pypi.python.org/pypi/pyrealsense2
 To install the package, run:
 > `pip install pyrealsense2`
 
-Windows users can install the RealSense SDK 2.0 from the release tab to get pre-compiled binaries of the wrapper, for both x86 and x64 architectures. (Python versions 3.6, 3.7, 3.8, 3.9, 3.10 are supported).
+Windows users can install the RealSense SDK 2.0 from the release tab to get pre-compiled binaries of the wrapper, for both x86 and x64 architectures. (Python versions 3.7, 3.8, 3.9, 3.10, 3.11 are supported).
 
 > **Note:**
 > Python 2.7 distributables can be found for pyrealsense2 versions <= 2.51.1


### PR DESCRIPTION
Goes with https://github.com/IntelRealSense/librealsense-deploy/pull/125 and https://github.com/IntelRealSense/librealsense_win_installer/pull/18.

Adding 3.11 (with new pybind11) causes crashes in 3.6 (in `gil_scoped_acquire`). Certain changes were made to the GIL stuff post-3.6. I tried debugging but any changes on our part would take a lot of testing and I'm not sure are warranted. 3.6 is already EOL.

With the new pybind11, running on 3.7+ passes libCI.

Tracked on [LRS-601]