### PR TITLE
fix bugs due to operator bool in dds-stream-format

### DIFF
--- a/third-party/realdds/include/realdds/dds-stream-profile.h
+++ b/third-party/realdds/include/realdds/dds-stream-profile.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <string>
+#include <cstring>
 #include <vector>
 #include <memory>
 #include <iosfwd>
@@ -32,7 +33,8 @@ struct dds_stream_format
     dds_stream_format( std::string const & s );
 
     bool is_valid() const { return data[0] != 0; }
-    operator bool() const { return is_valid(); }
+    bool operator==( dds_stream_format const & rhs ) const { return std::strncmp( data, rhs.data, size ) == 0; }
+    bool operator!=( dds_stream_format const & rhs ) const { return ! operator==( rhs ); }
 
     std::string to_string() const { return std::string( data ); }
     operator std::string() const { return to_string(); }
@@ -68,7 +70,7 @@ public:
     // This is for initialization and is called from dds_stream_base only!
     void init_stream( std::weak_ptr< dds_stream_base > const & stream );
 
-    dds_stream_format format() const { return _format; }
+    dds_stream_format const & format() const { return _format; }
     int16_t frequency() const { return _frequency; }
 
     // These are for debugging - not functional

--- a/third-party/realdds/src/dds-stream-sensor-bridge.cpp
+++ b/third-party/realdds/src/dds-stream-sensor-bridge.cpp
@@ -181,7 +181,9 @@ void dds_stream_sensor_bridge::sensor_bridge::verify_compatible_profile(
         if( already_streaming.is_explicit || already_streaming.is_implicit )
         {
             // Profiles are compatible if they match resolution, FPS
-            if( !profiles_are_compatible( profile, already_streaming.profile ) )
+            // If they're of different types (e.g., depth vs ir), we don't care about the format
+            bool const different_types = profile->stream()->type_string() != already_streaming.server->type_string();
+            if( ! profiles_are_compatible( profile, already_streaming.profile, different_types ) )
                 DDS_THROW( runtime_error,
                            "profile " + profile->to_string() + " is incompatible with already-open "
                            + already_streaming.profile->to_string() );


### PR DESCRIPTION
Format comparison was using operator bool, meaning if two formats were not the same all it compared was whether both were valid.
