### PR TITLE
change default dds participant name in context to the executable name

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -30,6 +30,7 @@
 #include <realdds/topics/device-info-msg.h>
 #include <realdds/topics/image/image-msg.h>
 #include <rsutils/shared-ptr-singleton.h>
+#include <rsutils/os/executable-name.h>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 
 // We manage one participant and device-watcher per domain:
@@ -168,7 +169,7 @@ namespace librealsense
             auto & domain = dds_domain_context_by_id[domain_id];
             _dds_participant = domain.participant.instance();
             if( ! _dds_participant->is_valid() )
-                _dds_participant->init( domain_id, "librealsense" );
+                _dds_participant->init( domain_id, rsutils::os::executable_name() );
             _dds_watcher = domain.device_watcher.instance( _dds_participant );
         }
 #endif //BUILD_WITH_DDS
@@ -194,7 +195,8 @@ namespace librealsense
         if( rsutils::json::get< bool >( settings, "dds-discovery", true ) )
         {
             realdds::dds_domain_id domain_id = rsutils::json::get< int >( settings, "dds-domain", 0 );
-            std::string participant_name = rsutils::json::get< std::string >( settings, "dds-participant-name", "librealsense" );
+            std::string participant_name
+                = rsutils::json::get< std::string >( settings, "dds-participant-name", rsutils::os::executable_name() );
 
             auto & domain = dds_domain_context_by_id[domain_id];
             _dds_participant = domain.participant.instance();

--- a/third-party/rsutils/include/rsutils/os/executable-name.h
+++ b/third-party/rsutils/include/rsutils/os/executable-name.h
@@ -1,0 +1,20 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <string>
+
+
+namespace rsutils {
+namespace os {
+
+
+// Returns the path to the executable currently running
+std::string executable_path();
+// Returns the filename component of the executable currently running
+std::string executable_name( bool with_extension = false );
+
+
+}
+}

--- a/third-party/rsutils/py/pyrsutils.cpp
+++ b/third-party/rsutils/py/pyrsutils.cpp
@@ -8,6 +8,7 @@
 #include <rsutils/version.h>
 #include <rsutils/number/running-average.h>
 #include <rsutils/number/stabilized-value.h>
+#include <rsutils/os/executable-name.h>
 
 
 #define NAME pyrsutils
@@ -29,6 +30,8 @@ PYBIND11_MODULE(NAME, m) {
            py::arg( "logger" ) = LIBREALSENSE_ELPP_ID );
 
     m.def( "split", &rsutils::string::split );
+    m.def( "executable_path", &rsutils::os::executable_path );
+    m.def( "executable_name", &rsutils::os::executable_name, py::arg( "with_extension" ) = false );
 
     using rsutils::version;
     py::class_< version >( m, "version" )

--- a/third-party/rsutils/src/executable-name.cpp
+++ b/third-party/rsutils/src/executable-name.cpp
@@ -9,6 +9,7 @@
 #include <Windows.h>
 #elif defined( __APPLE__ )
 #include <mach-o/dyld.h>
+#include <limits.h>  // PATH_MAX is POSIX, rather than MAXPATHLEN
 #endif
 
 
@@ -33,7 +34,7 @@ std::string executable_path()
 #elif defined( __APPLE__ )
 
     // "With deep directories the total bufsize needed could be more than MAXPATHLEN."
-    uint32_t const max_size = MAXPATHLEN + 1;
+    uint32_t const max_size = PATH_MAX + 1;
     char buf[max_size];
     uint32_t size = max_size;
     _NSGetExecutablePath( buf, &size );

--- a/third-party/rsutils/src/executable-name.cpp
+++ b/third-party/rsutils/src/executable-name.cpp
@@ -1,0 +1,56 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include <rsutils/os/executable-name.h>
+
+#if defined( PLATFORM_POSIX ) || defined( __linux__ )
+#include <iostream>
+#elif defined( _WIN32 )
+#include <Windows.h>
+#endif
+
+
+namespace rsutils {
+namespace os {
+
+
+std::string executable_path()
+{
+#if defined( PLATFORM_POSIX ) || defined( __linux__ )
+
+    std::string sp;
+    std::ifstream( "/proc/self/comm" ) >> sp;
+    return sp;
+
+#elif defined( _WIN32 )
+
+    char buf[MAX_PATH];
+    GetModuleFileNameA( nullptr, buf, MAX_PATH );
+    return buf;
+
+#else
+
+    static_assert(false, "unrecognized platform");
+
+#endif
+}
+
+
+std::string executable_name( bool with_extension )
+{
+    auto path = executable_path();
+    auto sep = path.find_last_of( "/\\" );
+    if( sep != std::string::npos )
+        path = path.substr( sep + 1 );
+    if( ! with_extension )
+    {
+        auto period = path.find_last_of( '.' );
+        if( period != std::string::npos )
+            path.resize( period );
+    }
+    return path;
+}
+
+
+}  // namespace os
+}  // namespace rsutils

--- a/third-party/rsutils/src/executable-name.cpp
+++ b/third-party/rsutils/src/executable-name.cpp
@@ -4,7 +4,7 @@
 #include <rsutils/os/executable-name.h>
 
 #if defined( PLATFORM_POSIX ) || defined( __linux__ )
-#include <iostream>
+#include <fstream>
 #elif defined( _WIN32 )
 #include <Windows.h>
 #endif

--- a/third-party/rsutils/src/executable-name.cpp
+++ b/third-party/rsutils/src/executable-name.cpp
@@ -7,6 +7,8 @@
 #include <fstream>
 #elif defined( _WIN32 )
 #include <Windows.h>
+#elif defined( __APPLE__ )
+#include <mach-o/dyld.h>
 #endif
 
 
@@ -28,9 +30,18 @@ std::string executable_path()
     GetModuleFileNameA( nullptr, buf, MAX_PATH );
     return buf;
 
+#elif defined( __APPLE__ )
+
+    // "With deep directories the total bufsize needed could be more than MAXPATHLEN."
+    uint32_t const max_size = MAXPATHLEN + 1;
+    char buf[max_size];
+    uint32_t size = max_size;
+    _NSGetExecutablePath( buf, &size );
+    return buf;
+
 #else
 
-    static_assert(false, "unrecognized platform");
+    static_assert( false, "unrecognized platform" );
 
 #endif
 }


### PR DESCRIPTION
Before, all instances of librealsense programs were identified with `librealsense` and you couldn't really distinguish unless the coder specified the participant name in the json.

Now it gets the executable name by default and uses it.

Tested under Windows and Linux.