### PR TITLE
change metadata_blob to fit ALL metadata; software_sensor now uses array indexing

### DIFF
--- a/src/ds/ds-timestamp.cpp
+++ b/src/ds/ds-timestamp.cpp
@@ -31,9 +31,7 @@ namespace librealsense
             LOG_ERROR("Frame is not valid. Failed to downcast to librealsense::frame.");
             return false;
         }
-        auto md = f->additional_data.metadata_blob;
         auto mds = f->additional_data.metadata_size;
-
         if (mds)
             return true;
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -57,7 +57,7 @@ struct frame_additional_data : frame_header
 {
     uint32_t metadata_size = 0;
     bool fisheye_ae_mode = false;  // TODO: remove in future release
-    std::array< uint8_t, MAX_META_DATA_SIZE > metadata_blob;
+    std::array< uint8_t, RS2_FRAME_METADATA_ACTUAL_COUNT * sizeof( rs2_metadata_type ) > metadata_blob;
     rs2_time_t last_timestamp = 0;
     unsigned long long last_frame_number = 0;
     bool is_blocking  = false;  // when running from recording, this bit indicates
@@ -74,7 +74,7 @@ struct frame_additional_data : frame_header
     frame_additional_data( rs2_time_t in_timestamp,
                            unsigned long long in_frame_number,
                            rs2_time_t in_system_time,
-                           uint8_t md_size,
+                           uint32_t md_size,
                            const uint8_t * md_buf,
                            rs2_time_t backend_time,
                            rs2_time_t last_timestamp,
@@ -90,9 +90,8 @@ struct frame_additional_data : frame_header
         , depth_units( in_depth_units )
         , raw_size( transmitted_size )
     {
-        // Copy up to 255 bytes to preserve metadata as raw data
         if( metadata_size )
-            std::copy( md_buf, md_buf + std::min( md_size, MAX_META_DATA_SIZE ), metadata_blob.begin() );
+            std::copy( md_buf, md_buf + std::min( size_t( md_size ), metadata_blob.size() ), metadata_blob.begin() );
     }
 };
 

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -14,18 +14,6 @@
 
 namespace librealsense
 {
-/** \brief Metadata fields that are utilized internally by librealsense
-    Provides extention to the r2_frame_metadata list of attributes*/
-    enum frame_metadata_internal
-    {
-        RS2_FRAME_METADATA_HW_TYPE  =   RS2_FRAME_METADATA_COUNT +1 , /**< 8-bit Module type: RS4xx, IVCAM*/
-        RS2_FRAME_METADATA_SKU_ID                                   , /**< 8-bit SKU Id*/
-        RS2_FRAME_METADATA_FORMAT                                   , /**< 16-bit Frame format*/
-        RS2_FRAME_METADATA_WIDTH                                    , /**< 16-bit Frame width. pixels*/
-        RS2_FRAME_METADATA_HEIGHT                                   , /**< 16-bit Frame height. pixels*/
-        RS2_FRAME_METADATA_COUNT
-    };
-
     /**\brief Base class that establishes the interface for retrieving metadata attributes*/
     class md_attribute_parser_base
     {
@@ -84,6 +72,33 @@ namespace librealsense
             }
             return false;
         }
+        rs2_frame_metadata_value _type;
+    };
+
+
+    /**\brief metadata parser class - support metadata as array of rs2_metadata_type */
+    class md_array_parser : public md_attribute_parser_base
+    {
+    public:
+        md_array_parser( rs2_frame_metadata_value type )
+            : _type( type )
+        {
+        }
+
+        rs2_metadata_type get( const frame & frm ) const override
+        {
+            auto pmd = reinterpret_cast< rs2_metadata_type const * >( frm.additional_data.metadata_blob.data() );
+            rs2_metadata_type const & value = pmd[_type];
+            return value;
+        }
+
+        bool supports(const frame& frm) const override
+        {
+            // If there's a parser for the type, it's supported
+            return true;
+        }
+
+    private:
         rs2_frame_metadata_value _type;
     };
 

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -78,7 +78,7 @@ namespace librealsense
           _stereo_extension([this]() { return stereo_extension(this); }),
           _depth_extension([this]() { return depth_extension(this); })
     {
-        _metadata_parsers = md_constant_parser::create_metadata_parser_map();
+        _metadata_parsers = std::make_shared< metadata_parser_map >();
         _unique_id = unique_id::generate_id();
     }
 
@@ -254,12 +254,26 @@ namespace librealsense
     }
 
 
-    void software_sensor::set_metadata(rs2_frame_metadata_value key, rs2_metadata_type value)
+    void software_sensor::set_metadata( rs2_frame_metadata_value key, rs2_metadata_type value )
     {
+        if( ! _metadata_parsers->count( key ) )
+        {
+            if( int( key ) < 0 || int( key ) >= _metadata_map.size() )
+                throw invalid_value_exception( "invalid metadata key " + std::to_string( int( key ) ) );
+            // At this time (and therefore for backwards compatibility) no register_metadata is required for SW sensors,
+            // and metadata persists between frames (!!!!!!!) unless clear_metadata() is used...
+            _metadata_parsers->emplace( key, std::make_shared< md_array_parser >( key ) );
+        }
         _metadata_map[key] = value;
     }
 
-    void software_sensor::on_video_frame(rs2_software_video_frame software_frame)
+
+    void software_sensor::clear_metadata()
+    {
+        _metadata_parsers->clear();
+    }
+
+    void software_sensor::on_video_frame( rs2_software_video_frame const & software_frame )
     {
         if (!_is_streaming) {
             software_frame.deleter(software_frame.pixels);
@@ -272,20 +286,8 @@ namespace librealsense
         data.frame_number = software_frame.frame_number;
         data.depth_units = software_frame.depth_units;
 
-        data.metadata_size = 0;
-        for (auto i : _metadata_map)
-        {
-            auto size_of_enum = sizeof(rs2_frame_metadata_value);
-            auto size_of_data = sizeof(rs2_metadata_type);
-            if (data.metadata_size + size_of_enum + size_of_data > 255)
-            {
-                continue; //stop adding metadata to frame
-            }
-            memcpy(data.metadata_blob.data() + data.metadata_size, &i.first, size_of_enum);
-            data.metadata_size += static_cast<uint32_t>(size_of_enum);
-            memcpy(data.metadata_blob.data() + data.metadata_size, &i.second, size_of_data);
-            data.metadata_size += static_cast<uint32_t>(size_of_data);
-        }
+        data.metadata_size = (uint32_t)( _metadata_map.size() * sizeof( rs2_metadata_type ) );
+        memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         rs2_extension extension = software_frame.profile->profile->get_stream_type() == RS2_STREAM_DEPTH ?
             RS2_EXTENSION_DEPTH_FRAME : RS2_EXTENSION_VIDEO_FRAME;
@@ -310,7 +312,7 @@ namespace librealsense
         _source.invoke_callback(frame);
     }
 
-    void software_sensor::on_motion_frame(rs2_software_motion_frame software_frame)
+    void software_sensor::on_motion_frame( rs2_software_motion_frame const & software_frame )
     {
         if (!_is_streaming) return;
 
@@ -319,16 +321,8 @@ namespace librealsense
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
 
-        data.metadata_size = 0;
-        for (auto i : _metadata_map)
-        {
-            auto size_of_enum = sizeof(rs2_frame_metadata_value);
-            auto size_of_data = sizeof(rs2_metadata_type);
-            memcpy(data.metadata_blob.data() + data.metadata_size, &i.first, size_of_enum);
-            data.metadata_size += static_cast<uint32_t>(size_of_enum);
-            memcpy(data.metadata_blob.data() + data.metadata_size, &i.second, size_of_data);
-            data.metadata_size += static_cast<uint32_t>(size_of_data);
-        }
+        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( rs2_metadata_type ));
+        memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         auto frame = _source.alloc_frame(RS2_EXTENSION_MOTION_FRAME, 0, data, false);
         if (!frame)
@@ -343,7 +337,7 @@ namespace librealsense
         _source.invoke_callback(frame);
     }
 
-    void software_sensor::on_pose_frame(rs2_software_pose_frame software_frame)
+    void software_sensor::on_pose_frame( rs2_software_pose_frame const & software_frame )
     {
         if (!_is_streaming) return;
 
@@ -352,16 +346,8 @@ namespace librealsense
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
 
-        data.metadata_size = 0;
-        for (auto i : _metadata_map)
-        {
-            auto size_of_enum = sizeof(rs2_frame_metadata_value);
-            auto size_of_data = sizeof(rs2_metadata_type);
-            memcpy(data.metadata_blob.data() + data.metadata_size, &i.first, size_of_enum);
-            data.metadata_size += static_cast<uint32_t>(size_of_enum);
-            memcpy(data.metadata_blob.data() + data.metadata_size, &i.second, size_of_data);
-            data.metadata_size += static_cast<uint32_t>(size_of_data);
-        }
+        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( rs2_metadata_type ));
+        memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         auto frame = _source.alloc_frame(RS2_EXTENSION_POSE_FRAME, 0, data, false);
         if (!frame)
@@ -376,7 +362,7 @@ namespace librealsense
         _source.invoke_callback(frame);
     }
 
-    void software_sensor::on_notification(rs2_software_notification notif)
+    void software_sensor::on_notification( rs2_software_notification const & notif )
     {
         notification n{ notif.category, notif.type, notif.severity, notif.description };
         n.serialized_data = notif.serialized_data;

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -256,13 +256,14 @@ namespace librealsense
 
     void software_sensor::set_metadata( rs2_frame_metadata_value key, rs2_metadata_type value )
     {
-        if( ! _metadata_parsers->count( key ) )
+        auto range = _metadata_parsers->equal_range( key );
+        if( range.first == range.second )
         {
             if( int( key ) < 0 || int( key ) >= _metadata_map.size() )
                 throw invalid_value_exception( "invalid metadata key " + std::to_string( int( key ) ) );
             // At this time (and therefore for backwards compatibility) no register_metadata is required for SW sensors,
             // and metadata persists between frames (!!!!!!!) unless clear_metadata() is used...
-            _metadata_parsers->emplace( key, std::make_shared< md_array_parser >( key ) );
+            _metadata_parsers->emplace_hint( range.second, key, std::make_shared< md_array_parser >( key ) );
         }
         _metadata_map[key] = value;
     }

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -106,18 +106,19 @@ namespace librealsense
         void start(frame_callback_ptr callback) override;
         void stop() override;
 
-        void on_video_frame(rs2_software_video_frame frame);
-        void on_motion_frame(rs2_software_motion_frame frame);
-        void on_pose_frame(rs2_software_pose_frame frame);
-        void on_notification(rs2_software_notification notif);
+        void on_video_frame( rs2_software_video_frame const & );
+        void on_motion_frame( rs2_software_motion_frame const & );
+        void on_pose_frame( rs2_software_pose_frame const & );
+        void on_notification( rs2_software_notification const & );
         void add_read_only_option(rs2_option option, float val);
         void update_read_only_option(rs2_option option, float val);
         void add_option(rs2_option option, option_range range, bool is_writable);
         void set_metadata(rs2_frame_metadata_value key, rs2_metadata_type value);
+        void clear_metadata();
     private:
         friend class software_device;
         stream_profiles _profiles;
-        std::map<rs2_frame_metadata_value, rs2_metadata_type> _metadata_map;
+        std::array< rs2_metadata_type, RS2_FRAME_METADATA_ACTUAL_COUNT > _metadata_map;
         uint64_t _unique_id;
 
         class stereo_extension : public depth_stereo_sensor

--- a/src/types.h
+++ b/src/types.h
@@ -338,6 +338,18 @@ namespace librealsense
 
     typedef float float_4[4];
 
+    /** \brief Metadata fields that are utilized internally by librealsense
+    Provides extention to the r2_frame_metadata list of attributes*/
+    enum frame_metadata_internal
+    {
+        RS2_FRAME_METADATA_HW_TYPE = RS2_FRAME_METADATA_COUNT + 1, /**< 8-bit Module type: RS4xx, IVCAM*/
+        RS2_FRAME_METADATA_SKU_ID, /**< 8-bit SKU Id*/
+        RS2_FRAME_METADATA_FORMAT, /**< 16-bit Frame format*/
+        RS2_FRAME_METADATA_WIDTH, /**< 16-bit Frame width. pixels*/
+        RS2_FRAME_METADATA_HEIGHT, /**< 16-bit Frame height. pixels*/
+        RS2_FRAME_METADATA_ACTUAL_COUNT
+    };
+
     /////////////////////////////
     // Enumerated type support //
     /////////////////////////////


### PR DESCRIPTION
* blob no longer limited to 255 bytes, so can fit all metadata
* meaning we can remove the extra metadata map
* added an array-based (the constant type is still used but only in the ros reader, which I didn't want to touch) metadata parser
* made use of it in the software sensor
* this should also speed up metadata access (set/get) with software sensors
* fix HUGE issue with the metadata count
* added clear_metadata()
* software structs are now passed by reference