### PR TITLE
remove useless code in context.cpp

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -20,25 +20,6 @@
 #include "context.h"
 #include "fw-update/fw-update-factory.h"
 
-template<unsigned... Is> struct seq{};
-template<unsigned N, unsigned... Is>
-struct gen_seq : gen_seq<N-1, N-1, Is...>{};
-template<unsigned... Is>
-struct gen_seq<0, Is...> : seq<Is...>{};
-
-template<unsigned N1, unsigned... I1, unsigned N2, unsigned... I2>
-constexpr std::array<char const, N1+N2-1> concat(char const (&a1)[N1], char const (&a2)[N2], seq<I1...>, seq<I2...>){
-  return {{ a1[I1]..., a2[I2]... }};
-}
-
-template<unsigned N1, unsigned N2>
-constexpr std::array<char const, N1+N2-1> concat(char const (&a1)[N1], char const (&a2)[N2]){
-  return concat(a1, a2, gen_seq<N1-1>{}, gen_seq<N2>{});
-}
-
-// The string is used to retrieve the version embedded into .so file on Linux
-constexpr auto rs2_api_version = concat("VERSION: ",RS2_API_VERSION_STR);
-
 template<>
 bool contains(const std::shared_ptr<librealsense::device_info>& first,
               const std::shared_ptr<librealsense::device_info>& second)
@@ -97,7 +78,7 @@ namespace librealsense
         if (!version_logged)
         {
             version_logged = true;
-            LOG_DEBUG("Librealsense " << std::string(std::begin(rs2_api_version),std::end(rs2_api_version)));
+            LOG_DEBUG( "Librealsense VERSION: " << RS2_API_VERSION_STR );
         }
 
         _backend = platform::create_backend();


### PR DESCRIPTION
Needlessly complicated `concat` just for a constant string...