### PR TITLE
add dds custom on-video-frame to avoid data copy

### DIFF
--- a/src/archive.h
+++ b/src/archive.h
@@ -17,7 +17,7 @@ namespace librealsense
     public:
         virtual callback_invocation_holder begin_callback() = 0;
 
-        virtual frame_interface* alloc_and_track(const size_t size, const frame_additional_data& additional_data, bool requires_memory) = 0;
+        virtual frame_interface* alloc_and_track(const size_t size, frame_additional_data && additional_data, bool requires_memory) = 0;
 
         virtual std::shared_ptr<metadata_parser_map> get_md_parsers() const = 0;
 

--- a/src/frame-archive.h
+++ b/src/frame-archive.h
@@ -26,7 +26,7 @@ namespace librealsense
         std::shared_ptr<sensor_interface> get_sensor() const override { return _sensor.lock(); }
         void set_sensor(std::shared_ptr<sensor_interface> s) override { _sensor = s; }
 
-        T alloc_frame(const size_t size, const frame_additional_data& additional_data, bool requires_memory)
+        T alloc_frame(const size_t size, frame_additional_data && additional_data, bool requires_memory)
         {
             T backbuffer;
             //const size_t size = modes[stream].get_image_size(stream);
@@ -59,7 +59,7 @@ namespace librealsense
             {
                 backbuffer.data.resize(size, 0); // TODO: Allow users to provide a custom allocator for frame buffers
             }
-            backbuffer.additional_data = additional_data;
+            backbuffer.additional_data = std::move( additional_data );
             return backbuffer;
         }
 
@@ -160,9 +160,9 @@ namespace librealsense
             ref->release();
         }
 
-        frame_interface* alloc_and_track(const size_t size, const frame_additional_data& additional_data, bool requires_memory) override
+        frame_interface* alloc_and_track(const size_t size, frame_additional_data && additional_data, bool requires_memory) override
         {
-            auto frame = alloc_frame(size, additional_data, requires_memory);
+            auto frame = alloc_frame( size, std::move( additional_data ), requires_memory );
             return track_frame(frame);
         }
 

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -441,8 +441,11 @@ namespace librealsense
             get_frame_metadata(m_file, info_topic, stream_id, image_data, additional_data);
         }
 
-        frame_interface* frame = m_frame_source->alloc_frame((stream_id.stream_type == RS2_STREAM_DEPTH) ? RS2_EXTENSION_DEPTH_FRAME : RS2_EXTENSION_VIDEO_FRAME,
-            msg->data.size(), additional_data, true);
+        frame_interface * frame = m_frame_source->alloc_frame(
+            ( stream_id.stream_type == RS2_STREAM_DEPTH ) ? RS2_EXTENSION_DEPTH_FRAME : RS2_EXTENSION_VIDEO_FRAME,
+            msg->data.size(),
+            std::move( additional_data ),
+            true );
         if (frame == nullptr)
         {
             LOG_WARNING("Failed to allocate new frame");
@@ -491,7 +494,10 @@ namespace librealsense
             get_frame_metadata(m_file, info_topic, stream_id, motion_data, additional_data);
         }
 
-        frame_interface* frame = m_frame_source->alloc_frame(RS2_EXTENSION_MOTION_FRAME, 3 * sizeof(float), additional_data, true);
+        frame_interface * frame = m_frame_source->alloc_frame( RS2_EXTENSION_MOTION_FRAME,
+                                                               3 * sizeof( float ),
+                                                               std::move( additional_data ),
+                                                               true );
         if (frame == nullptr)
         {
             LOG_WARNING("Failed to allocate new frame");
@@ -637,7 +643,7 @@ namespace librealsense
 
         additional_data.timestamp = timestamp_ms.count();
 
-        frame_interface* new_frame = m_frame_source->alloc_frame(frame_type, frame_size, additional_data, true);
+        frame_interface* new_frame = m_frame_source->alloc_frame(frame_type, frame_size, std::move( additional_data ), true);
         if (new_frame == nullptr)
         {
             LOG_WARNING("Failed to allocate new frame");

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -341,7 +341,11 @@ namespace librealsense
             data.system_time = _actual_source.get_time();
             data.is_blocking = original->is_blocking();
 
-            auto res = _actual_source.alloc_frame(frame_type, vid_stream->get_width() * vid_stream->get_height() * sizeof(float) * 5, data, true);
+            auto res
+                = _actual_source.alloc_frame( frame_type,
+                                              vid_stream->get_width() * vid_stream->get_height() * sizeof( float ) * 5,
+                                              std::move( data ),
+                                              true );
             if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
             res->set_sensor(original->get_sensor());
             res->set_stream(stream);
@@ -402,7 +406,7 @@ namespace librealsense
 
         auto of = dynamic_cast<frame*>(original);
         frame_additional_data data = of->additional_data;
-        auto res = _actual_source.alloc_frame(frame_type, stride * height, data, true);
+        auto res = _actual_source.alloc_frame( frame_type, stride * height, std::move( data ), true );
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = dynamic_cast<video_frame*>(res);
         vf->metadata_parsers = of->metadata_parsers;
@@ -425,7 +429,7 @@ namespace librealsense
     {
         auto of = dynamic_cast<frame*>(original);
         frame_additional_data data = of->additional_data;
-        auto res = _actual_source.alloc_frame(frame_type, of->get_frame_data_size(), data, true);
+        auto res = _actual_source.alloc_frame( frame_type, of->get_frame_data_size(), std::move( data ), true );
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         auto mf = dynamic_cast<motion_frame*>(res);
         mf->metadata_parsers = of->metadata_parsers;
@@ -471,7 +475,10 @@ namespace librealsense
         for (auto&& f : holders)
             req_size += get_embeded_frames_size(f.frame);
 
-        auto res = _actual_source.alloc_frame(RS2_EXTENSION_COMPOSITE_FRAME, req_size * sizeof(rs2_frame*), d, true);
+        auto res = _actual_source.alloc_frame( RS2_EXTENSION_COMPOSITE_FRAME,
+                                               req_size * sizeof( rs2_frame * ),
+                                               std::move( d ),
+                                               true );
         if (!res) return nullptr;
 
         auto cf = static_cast<composite_frame*>(res);

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -457,7 +457,7 @@ void log_callback_end( uint32_t fps,
                     frame_holder fh = _source.alloc_frame(
                         stream_to_frame_types( req_profile_base->get_stream_type() ),
                         expected_size,
-                        fr->additional_data,
+                        std::move( fr->additional_data ),
                         true );
                     auto diff = environment::get_instance().get_time_service()->get_time() - system_time;
                     if( diff > 10 )
@@ -1013,7 +1013,8 @@ void log_callback_end( uint32_t fps,
 
             last_frame_number = frame_counter;
             last_timestamp = timestamp;
-            frame_holder frame = _source.alloc_frame(RS2_EXTENSION_MOTION_FRAME, data_size, fr->additional_data, true);
+            frame_holder frame
+                = _source.alloc_frame( RS2_EXTENSION_MOTION_FRAME, data_size, std::move( fr->additional_data ), true );
             memcpy( (void *)frame->get_frame_data(),
                     sensor_data.fo.pixels,
                     sizeof( byte ) * sensor_data.fo.frame_size );

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -5,7 +5,10 @@
 #include "stream.h"
 
 #include <rsutils/string/from.h>
+#include <rsutils/deferred.h>
 #include <third-party/json.hpp>
+
+using rsutils::deferred;
 
 
 namespace librealsense
@@ -244,13 +247,67 @@ namespace librealsense
         _metadata_parsers->clear();
     }
 
+
+    frame_interface * software_sensor::allocate_new_frame( rs2_extension extension,
+                                                           stream_profile_interface * profile,
+                                                           frame_additional_data && data )
+    {
+        auto frame = _source.alloc_frame( extension, 0, std::move( data ), false );
+        if( ! frame )
+        {
+            LOG_WARNING( "Failed to allocate frame " << data.frame_number << " type " << extension );
+        }
+        else
+        {
+            frame->set_stream( std::dynamic_pointer_cast< stream_profile_interface >( profile->shared_from_this() ) );
+        }
+        return frame;
+    }
+
+
+    frame_interface * software_sensor::allocate_new_video_frame( video_stream_profile_interface * profile,
+                                                                 int stride,
+                                                                 int bpp,
+                                                                 frame_additional_data && data )
+    {
+        auto frame = allocate_new_frame( profile->get_stream_type() == RS2_STREAM_DEPTH ? RS2_EXTENSION_DEPTH_FRAME
+                                                                                        : RS2_EXTENSION_VIDEO_FRAME,
+                                         profile,
+                                         std::move( data ) );
+        if( frame )
+        {
+            auto vid_frame = dynamic_cast< video_frame * >( frame );
+            vid_frame->assign( profile->get_width(), profile->get_height(), stride, bpp * 8 );
+            auto sd = dynamic_cast< software_device * >( _owner );
+            sd->register_extrinsic( *profile );
+        }
+        return frame;
+    }
+
+
+    void software_sensor::invoke_new_frame( frame_interface * frame,
+                                            void const * pixels,
+                                            std::function< void() > on_release )
+    {
+        // The frame pixels/data are stored in the continuation object!
+        if( pixels )
+            frame->attach_continuation( frame_continuation( on_release, pixels ) );
+        _source.invoke_callback( frame );
+    }
+
+
     void software_sensor::on_video_frame( rs2_software_video_frame const & software_frame )
     {
-        if (!_is_streaming) {
-            software_frame.deleter(software_frame.pixels);
-            return;
-        }
+        deferred on_release( [deleter = software_frame.deleter, data = software_frame.pixels]() { deleter( data ); } );
         
+        stream_profile_interface * profile = software_frame.profile->profile;
+        auto vid_profile = dynamic_cast< video_stream_profile_interface * >( profile );
+        if( ! vid_profile )
+            throw invalid_value_exception( "Non-video profile provided to on_video_frame" );
+
+        if( ! _is_streaming )
+            return;
+
         frame_additional_data data;
         data.timestamp = software_frame.timestamp;
         data.timestamp_domain = software_frame.domain;
@@ -260,32 +317,17 @@ namespace librealsense
         data.metadata_size = (uint32_t)( _metadata_map.size() * sizeof( rs2_metadata_type ) );
         memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
-        rs2_extension extension = software_frame.profile->profile->get_stream_type() == RS2_STREAM_DEPTH ?
-            RS2_EXTENSION_DEPTH_FRAME : RS2_EXTENSION_VIDEO_FRAME;
-
-        auto frame = _source.alloc_frame(extension, 0, data, false);
-        if (!frame)
-        {
-            LOG_WARNING("Dropped video frame. alloc_frame(...) returned nullptr");
-            return;
-        }
-        auto vid_profile = dynamic_cast<video_stream_profile_interface*>(software_frame.profile->profile);
-        auto vid_frame = dynamic_cast<video_frame*>(frame);
-        vid_frame->assign(vid_profile->get_width(), vid_profile->get_height(), software_frame.stride, software_frame.bpp * 8);
-
-        frame->set_stream(std::dynamic_pointer_cast<stream_profile_interface>(software_frame.profile->profile->shared_from_this()));
-        frame->attach_continuation(frame_continuation{ [=]() {
-            software_frame.deleter(software_frame.pixels);
-        }, software_frame.pixels });
-
-        auto sd = dynamic_cast<software_device*>(_owner);
-        sd->register_extrinsic(*vid_profile);
-        _source.invoke_callback(frame);
+        auto frame
+            = allocate_new_video_frame( vid_profile, software_frame.stride, software_frame.bpp, std::move( data ) );
+        if( frame )
+            invoke_new_frame( frame, software_frame.pixels, on_release.detach() );
     }
 
     void software_sensor::on_motion_frame( rs2_software_motion_frame const & software_frame )
     {
-        if (!_is_streaming) return;
+        deferred on_release( [deleter = software_frame.deleter, data = software_frame.data]() { deleter( data ); } );
+        if( ! _is_streaming )
+            return;
 
         frame_additional_data data;
         data.timestamp = software_frame.timestamp;
@@ -295,22 +337,17 @@ namespace librealsense
         data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( rs2_metadata_type ));
         memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
-        auto frame = _source.alloc_frame(RS2_EXTENSION_MOTION_FRAME, 0, data, false);
-        if (!frame)
-        {
-            LOG_WARNING("Dropped motion frame. alloc_frame(...) returned nullptr");
-            return;
-        }
-        frame->set_stream(std::dynamic_pointer_cast<stream_profile_interface>(software_frame.profile->profile->shared_from_this()));
-        frame->attach_continuation(frame_continuation{ [=]() {
-            software_frame.deleter(software_frame.data);
-        }, software_frame.data });
-        _source.invoke_callback(frame);
+        auto frame
+            = allocate_new_frame( RS2_EXTENSION_MOTION_FRAME, software_frame.profile->profile, std::move( data ) );
+        if( frame )
+            invoke_new_frame( frame, software_frame.data, on_release.detach() );
     }
 
     void software_sensor::on_pose_frame( rs2_software_pose_frame const & software_frame )
     {
-        if (!_is_streaming) return;
+        deferred on_release( [deleter = software_frame.deleter, data = software_frame.data]() { deleter( data ); } );
+        if( ! _is_streaming )
+            return;
 
         frame_additional_data data;
         data.timestamp = software_frame.timestamp;
@@ -320,17 +357,9 @@ namespace librealsense
         data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( rs2_metadata_type ));
         memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
-        auto frame = _source.alloc_frame(RS2_EXTENSION_POSE_FRAME, 0, data, false);
-        if (!frame)
-        {
-            LOG_WARNING("Dropped pose frame. alloc_frame(...) returned nullptr");
-            return;
-        }
-        frame->set_stream(std::dynamic_pointer_cast<stream_profile_interface>(software_frame.profile->profile->shared_from_this()));
-        frame->attach_continuation(frame_continuation{ [=]() {
-            software_frame.deleter(software_frame.data);
-        }, software_frame.data });
-        _source.invoke_callback(frame);
+        auto frame = allocate_new_frame( RS2_EXTENSION_POSE_FRAME, software_frame.profile->profile, std::move( data ) );
+        if( frame )
+            invoke_new_frame( frame, software_frame.data, on_release.detach() );
     }
 
     void software_sensor::on_notification( rs2_software_notification const & notif )

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -11,6 +11,7 @@ namespace librealsense
 {
     class software_sensor;
     class software_device_info;
+    class video_stream_profile_interface;
 
     class software_device : public device
     {
@@ -117,10 +118,16 @@ namespace librealsense
         void set_metadata(rs2_frame_metadata_value key, rs2_metadata_type value);
         void clear_metadata();
 
+    protected:
+        frame_interface * allocate_new_frame( rs2_extension, stream_profile_interface *, frame_additional_data && );
+        frame_interface * allocate_new_video_frame( video_stream_profile_interface *, int stride, int bpp, frame_additional_data && );
+        void invoke_new_frame( frame_interface * frame, void const * pixels, std::function< void() > on_release );
+
+        std::array< rs2_metadata_type, RS2_FRAME_METADATA_ACTUAL_COUNT > _metadata_map;
+
     private:
         friend class software_device;
         stream_profiles _profiles;
-        std::array< rs2_metadata_type, RS2_FRAME_METADATA_ACTUAL_COUNT > _metadata_map;
         uint64_t _unique_id;
 
         class stereo_extension : public depth_stereo_sensor

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -88,11 +88,15 @@ namespace librealsense
         _metadata_parsers.reset();
     }
 
-    frame_interface* frame_source::alloc_frame(rs2_extension type, size_t size, frame_additional_data additional_data, bool requires_memory) const
+    frame_interface * frame_source::alloc_frame( rs2_extension type,
+                                                 size_t size,
+                                                 frame_additional_data && additional_data,
+                                                 bool requires_memory ) const
     {
         auto it = _archive.find(type);
-        if (it == _archive.end()) throw wrong_api_call_sequence_exception("Requested frame type is not supported!");
-        return it->second->alloc_and_track(size, additional_data, requires_memory);
+        if( it == _archive.end() )
+            throw wrong_api_call_sequence_exception( "Requested frame type is not supported!" );
+        return it->second->alloc_and_track( size, std::move( additional_data ), requires_memory );
     }
 
     void frame_source::set_sensor(const std::shared_ptr<sensor_interface>& s)

--- a/src/source.h
+++ b/src/source.h
@@ -25,7 +25,10 @@ namespace librealsense
 
         std::shared_ptr<option> get_published_size_option();
 
-        frame_interface* alloc_frame(rs2_extension type, size_t size, frame_additional_data additional_data, bool requires_memory) const;
+        frame_interface * alloc_frame( rs2_extension type,
+                                       size_t size,
+                                       frame_additional_data && additional_data,
+                                       bool requires_memory ) const;
 
         void set_callback(frame_callback_ptr callback);
         frame_callback_ptr get_callback() const;

--- a/third-party/rsutils/include/rsutils/deferred.h
+++ b/third-party/rsutils/include/rsutils/deferred.h
@@ -1,0 +1,55 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <functional>
+
+
+namespace rsutils {
+
+
+// RAII for a function: calls it on destruction, allowing automatic calls when going out of scope very similar to a
+// smart pointer that automatically deletes when going out of scope.
+//
+class deferred
+{
+public:
+    typedef std::function< void() > fn;
+
+private:
+    fn _deferred;
+
+    deferred( const deferred & ) = delete;
+    deferred & operator=( const deferred & ) = delete;
+
+public:
+    deferred( fn && f )
+        : _deferred( f )
+    {
+    }
+
+    deferred( deferred && that ) = default;
+
+    bool is_valid() const { return ! ! _deferred; }
+    operator bool() const { return is_valid(); }
+
+    // Destructor forces deferred call to be executed
+    ~deferred()
+    {
+        if( is_valid() )
+            execute();
+    }
+
+    // Prevent the deferred call from ever being invoked
+    void cancel() { _deferred = nullptr; }
+
+    // Returns the deferred function so you can move it somewhere else
+    fn && detach() { return std::move( _deferred ); }
+
+    // Cause the deferred call to be invoked NOW (throws if nothing there!)
+    void execute() { _deferred(); }
+};
+
+
+}  // namespace rsutils


### PR DESCRIPTION
* adds `rsutils::deferred`, which is an easy RAII for functions, kinda like a destructor when you go out of scope
* instead of allocating a new buffer and copying the dds data, we now allocate a vector and just move the data
* we move the data to an already-existing vector (`frame::data`)
* this is a middle step: next step is to not even allocate a new vector and skip over the `rs2_software_video_frame` usage completely
* did some optimizations with `frame_additional_data` being copied and moved around a lot