### PR TITLE
Fix metadata

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -23,6 +23,18 @@ class depth_sensor;
 typedef std::multimap< rs2_frame_metadata_value, std::shared_ptr< md_attribute_parser_base > >
     metadata_parser_map;
 
+#pragma pack( push, 1 )
+struct metadata_array_value
+{
+    bool is_valid;
+    rs2_metadata_type value;
+};
+#pragma pack( pop )
+
+static_assert( sizeof( metadata_array_value ) == sizeof( rs2_metadata_type ) + 1,
+               "unexpected size for metadata array members" );
+
+
 /*
     Each frame is attached with a static header
     This is a quick and dirty way to manage things like timestamp,
@@ -57,7 +69,7 @@ struct frame_additional_data : frame_header
 {
     uint32_t metadata_size = 0;
     bool fisheye_ae_mode = false;  // TODO: remove in future release
-    std::array< uint8_t, RS2_FRAME_METADATA_ACTUAL_COUNT * sizeof( rs2_metadata_type ) > metadata_blob;
+    std::array< uint8_t, RS2_FRAME_METADATA_ACTUAL_COUNT * sizeof( metadata_array_value ) > metadata_blob;
     rs2_time_t last_timestamp = 0;
     unsigned long long last_frame_number = 0;
     bool is_blocking  = false;  // when running from recording, this bit indicates

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -76,30 +76,32 @@ namespace librealsense
     };
 
 
-    /**\brief metadata parser class - support metadata as array of rs2_metadata_type */
+    /**\brief metadata parser class - support metadata as array of (bool,rs2_metadata_type) */
     class md_array_parser : public md_attribute_parser_base
     {
+        rs2_frame_metadata_value _key;
+
     public:
-        md_array_parser( rs2_frame_metadata_value type )
-            : _type( type )
+        md_array_parser( rs2_frame_metadata_value key )
+            : _key( key )
         {
         }
 
         rs2_metadata_type get( const frame & frm ) const override
         {
-            auto pmd = reinterpret_cast< rs2_metadata_type const * >( frm.additional_data.metadata_blob.data() );
-            rs2_metadata_type const & value = pmd[_type];
-            return value;
+            auto pmd = reinterpret_cast< metadata_array_value const * >( frm.additional_data.metadata_blob.data() );
+            metadata_array_value const & value = pmd[_key];
+            if( ! value.is_valid )
+                throw invalid_value_exception( "Frame does not support this type of metadata" );
+            return value.value;
         }
 
         bool supports(const frame& frm) const override
         {
-            // If there's a parser for the type, it's supported
-            return true;
+            auto pmd = reinterpret_cast< metadata_array_value const * >( frm.additional_data.metadata_blob.data() );
+            metadata_array_value const & value = pmd[_key];
+            return value.is_valid;
         }
-
-    private:
-        rs2_frame_metadata_value _type;
     };
 
 

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -73,12 +73,28 @@ namespace librealsense
         _matcher = matcher;
     }
 
-    software_sensor::software_sensor(std::string name, software_device* owner)
-        : sensor_base(name, owner, &_pbs),
-          _stereo_extension([this]() { return stereo_extension(this); }),
-          _depth_extension([this]() { return depth_extension(this); })
+    static std::shared_ptr< metadata_parser_map > create_software_metadata_parser_map()
     {
-        _metadata_parsers = std::make_shared< metadata_parser_map >();
+        auto md_parser_map = std::make_shared< metadata_parser_map >();
+        for( int i = 0; i < static_cast< int >( rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT ); ++i )
+        {
+            auto key = static_cast< rs2_frame_metadata_value >( i );
+            md_parser_map->emplace( key, std::make_shared< md_array_parser >( key ) );
+        }
+        return md_parser_map;
+    }
+
+    software_sensor::software_sensor(std::string name, software_device* owner)
+        : sensor_base( name, owner, &_pbs )
+        , _stereo_extension( [this]() { return stereo_extension( this ); } )
+        , _depth_extension( [this]() { return depth_extension( this ); } )
+        , _metadata_map{}  // to all 0's
+    {
+        // At this time (and therefore for backwards compatibility) no register_metadata is required for SW sensors,
+        // and metadata persists between frames (!!!!!!!). All SW sensors support ALL metadata. We can therefore
+        // also share their parsers:
+        static auto software_metadata_parser_map = create_software_metadata_parser_map();
+        _metadata_parsers = software_metadata_parser_map;
         _unique_id = unique_id::generate_id();
     }
 
@@ -256,23 +272,9 @@ namespace librealsense
 
     void software_sensor::set_metadata( rs2_frame_metadata_value key, rs2_metadata_type value )
     {
-        auto range = _metadata_parsers->equal_range( key );
-        if( range.first == range.second )
-        {
-            if( int( key ) < 0 || int( key ) >= _metadata_map.size() )
-                throw invalid_value_exception( "invalid metadata key " + std::to_string( int( key ) ) );
-            // At this time (and therefore for backwards compatibility) no register_metadata is required for SW sensors,
-            // and metadata persists between frames (!!!!!!!) unless clear_metadata() is used...
-            _metadata_parsers->emplace_hint( range.second, key, std::make_shared< md_array_parser >( key ) );
-        }
-        _metadata_map[key] = value;
+        _metadata_map[key] = { true, value };
     }
 
-
-    void software_sensor::clear_metadata()
-    {
-        _metadata_parsers->clear();
-    }
 
     void software_sensor::on_video_frame( rs2_software_video_frame const & software_frame )
     {
@@ -287,7 +289,7 @@ namespace librealsense
         data.frame_number = software_frame.frame_number;
         data.depth_units = software_frame.depth_units;
 
-        data.metadata_size = (uint32_t)( _metadata_map.size() * sizeof( rs2_metadata_type ) );
+        data.metadata_size = (uint32_t)( _metadata_map.size() * sizeof( metadata_array_value ) );
         memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         rs2_extension extension = software_frame.profile->profile->get_stream_type() == RS2_STREAM_DEPTH ?
@@ -322,7 +324,7 @@ namespace librealsense
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
 
-        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( rs2_metadata_type ));
+        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( metadata_array_value ));
         memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         auto frame = _source.alloc_frame(RS2_EXTENSION_MOTION_FRAME, 0, data, false);
@@ -347,7 +349,7 @@ namespace librealsense
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
 
-        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( rs2_metadata_type ));
+        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( metadata_array_value ));
         memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         auto frame = _source.alloc_frame(RS2_EXTENSION_POSE_FRAME, 0, data, false);

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -114,11 +114,10 @@ namespace librealsense
         void update_read_only_option(rs2_option option, float val);
         void add_option(rs2_option option, option_range range, bool is_writable);
         void set_metadata(rs2_frame_metadata_value key, rs2_metadata_type value);
-        void clear_metadata();
     private:
         friend class software_device;
         stream_profiles _profiles;
-        std::array< rs2_metadata_type, RS2_FRAME_METADATA_ACTUAL_COUNT > _metadata_map;
+        std::array< metadata_array_value, RS2_FRAME_METADATA_ACTUAL_COUNT > _metadata_map;
         uint64_t _unique_id;
 
         class stereo_extension : public depth_stereo_sensor

--- a/unit-tests/sw-dev/sw.py
+++ b/unit-tests/sw-dev/sw.py
@@ -1,0 +1,103 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+import pyrealsense2 as rs
+from rspy import log, test
+from time import time
+
+
+fps = 30
+w = 640
+h = 480
+bpp = 2  # bytes
+pixels = bytearray( b'\x00' * ( w * h * 2 ))  # Dummy data
+domain = rs.timestamp_domain.hardware_clock   # For either depth/color
+
+global_frame_number = 0
+
+
+
+class device:
+    def __init__( self ):
+        self._handle = rs.software_device()
+
+
+class sensor:
+    def __init__( self, sensor_name:str, dev:device = None ):
+        if dev is None:
+            dev = device()
+        self._handle = dev._handle.add_sensor( sensor_name )
+        self._profile = None
+
+    def __enter__( self ):
+        return self
+
+    def __exit__( self, *args ):
+        self.stop()
+
+    def video_stream( self, stream_name:str, type:rs.stream, format:rs.format ):
+        return video_stream( self, stream_name, type, format )
+
+    def start( self, stream ):
+        """
+        """
+        self._profile = rs.video_stream_profile( self._handle.add_video_stream( stream._handle ))
+        self._q = rs.frame_queue( 100 )
+        self._handle.open( self._profile )
+        self._handle.start( self._q )
+
+    def stop( self ):
+        """
+        """
+        if self._profile is not None:
+            self._handle.stop()
+            self._handle.close()
+            del self._q
+            self._profile = None
+
+    def publish( self, frame ):
+        frame.profile = self._profile
+        self._handle.on_video_frame( frame )
+        received_frame = self.receive()
+        test.check_equal( received_frame.get_frame_number(), frame.frame_number )
+        return received_frame
+
+    def receive( self ):
+        """
+        Looks at the syncer queue and gets the next frame from it if available, checking its contents
+        against the expected frame numbers.
+        """
+        f = self._q.poll_for_frame()
+        # NOTE: f will never be None
+        if not f:
+            raise RuntimeError( f'expected a frame but got none' )
+        log.d( "Got", f )
+        return f
+
+
+class video_stream:
+    def __init__( self, sensor:sensor, stream_name:str, type:rs.stream, format:rs.format ):
+        self._sensor = sensor
+        self._handle = rs.video_stream()
+        self._handle.type = type
+        self._handle.uid = 0
+        self._handle.width = w
+        self._handle.height = h
+        self._handle.bpp = bpp
+        self._handle.fmt = format
+        self._handle.fps = fps
+    #
+    def frame( self, frame_number = None, timestamp = None ):
+        f = rs.software_video_frame()
+        f.pixels = pixels
+        f.stride = w * bpp
+        f.bpp = bpp
+        if frame_number is not None:
+            f.frame_number = frame_number
+        else:
+            global global_frame_number
+            global_frame_number += 1
+            f.frame_number = global_frame_number
+        f.timestamp = timestamp or time()
+        f.domain = domain
+        return f

--- a/unit-tests/sw-dev/test-metadata.py
+++ b/unit-tests/sw-dev/test-metadata.py
@@ -165,7 +165,7 @@ try:
             rgb.set( rs.frame_metadata_value.actual_fps, 0xf00d )
             stereo.set( rs.frame_metadata_value.actual_fps, 0xbaad )
             c1 = rgb.publish( color.frame() )
-            test.check_false( f1.supports_frame_metadata( rs.frame_metadata_value.actual_fps ))
+            test.check_false( d1.supports_frame_metadata( rs.frame_metadata_value.actual_fps ))
             test.check_false( c1.supports_frame_metadata( rs.frame_metadata_value.white_balance ))
             test.check_equal( c1.get_frame_metadata( rs.frame_metadata_value.actual_fps ), 0xf00d )
 

--- a/unit-tests/sw-dev/test-metadata.py
+++ b/unit-tests/sw-dev/test-metadata.py
@@ -164,7 +164,7 @@ try:
 
             rgb.set( rs.frame_metadata_value.actual_fps, 0xf00d )
             stereo.set( rs.frame_metadata_value.actual_fps, 0xbaad )
-            c1 = rgb.publish( ir.frame() )
+            c1 = rgb.publish( color.frame() )
             test.check_false( f1.supports_frame_metadata( rs.frame_metadata_value.actual_fps ))
             test.check_false( c1.supports_frame_metadata( rs.frame_metadata_value.white_balance ))
             test.check_equal( c1.get_frame_metadata( rs.frame_metadata_value.actual_fps ), 0xf00d )
@@ -174,6 +174,13 @@ try:
             d2 = stereo.publish( depth.frame() )
             test.check_false( c1.supports_frame_metadata( rs.frame_metadata_value.saturation ))
             test.check_equal( d2.get_frame_metadata( rs.frame_metadata_value.saturation ), 0x1eaf )
+
+            stereo.set( rs.frame_metadata_value.contrast, 0xdeaf )
+            rgb.set( rs.frame_metadata_value.sharpness, 0xface )
+            d3 = stereo.publish( depth.frame() )
+            c2 = rgb.publish( color.frame() )
+            test.check_false( c2.supports_frame_metadata( rs.frame_metadata_value.contrast ))
+            test.check_false( d3.supports_frame_metadata( rs.frame_metadata_value.sharpness ))
 except:
     test.unexpected_exception()
 test.finish()

--- a/unit-tests/sw-dev/test-metadata.py
+++ b/unit-tests/sw-dev/test-metadata.py
@@ -6,9 +6,33 @@ from rspy import log, test
 import sw
 
 
+def frame_metadata_values():
+    return [rs.frame_metadata_value.__getattribute__( rs.frame_metadata_value, k )
+            for k, v in rs.frame_metadata_value.__dict__.items()
+            if str(v).startswith('frame_metadata_value.')]
+
+
 #############################################################################################
 #
-test.start( "Basic sanity" )
+test.start( "Nothing supported by default" )
+try:
+    with sw.sensor( "Stereo Module" ) as sensor:
+        depth = sensor.video_stream( "Depth", rs.stream.depth, rs.format.z16 )
+        #ir = sensor.video_stream( "Infrared", rs.stream.infrared, rs.format.y8 )
+        sensor.start( depth )
+
+        # Publish a frame
+        f = sensor.publish( depth.frame() )
+
+        for md in frame_metadata_values():
+            test.check_false( f.supports_frame_metadata( md ))
+except:
+    test.unexpected_exception()
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Set one value" )
 try:
     with sw.sensor( "Stereo Module" ) as sensor:
         depth = sensor.video_stream( "Depth", rs.stream.depth, rs.format.z16 )
@@ -22,6 +46,7 @@ try:
         f = sensor.publish( depth.frame() )
 
         # Frame should have received the metadata from the sensor
+        test.check( f.supports_frame_metadata( rs.frame_metadata_value.white_balance ))
         test.check_equal( f.get_frame_metadata( rs.frame_metadata_value.white_balance ), 0xbaad )
 except:
     test.unexpected_exception()

--- a/unit-tests/sw-dev/test-metadata.py
+++ b/unit-tests/sw-dev/test-metadata.py
@@ -1,0 +1,92 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+import pyrealsense2 as rs
+from rspy import log, test
+import sw
+
+
+#############################################################################################
+#
+test.start( "Basic sanity" )
+try:
+    with sw.sensor( "Stereo Module" ) as sensor:
+        depth = sensor.video_stream( "Depth", rs.stream.depth, rs.format.z16 )
+        #ir = sensor.video_stream( "Infrared", rs.stream.infrared, rs.format.y8 )
+        sensor.start( depth )
+
+        # Metadata is set on the sensor, not the software frame
+        sensor._handle.set_metadata( rs.frame_metadata_value.white_balance, 0xbaad )
+    
+        # Publish the frame
+        f = sensor.publish( depth.frame() )
+
+        # Frame should have received the metadata from the sensor
+        test.check_equal( f.get_frame_metadata( rs.frame_metadata_value.white_balance ), 0xbaad )
+except:
+    test.unexpected_exception()
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Post-frame metadata does not affect frame" )
+try:
+    with sw.sensor( "Stereo Module" ) as sensor:
+        depth = sensor.video_stream( "Depth", rs.stream.depth, rs.format.z16 )
+        sensor.start( depth )
+
+        sensor._handle.set_metadata( rs.frame_metadata_value.white_balance, 0xbaad )
+    
+        f = sensor.publish( depth.frame() )
+
+        sensor._handle.set_metadata( rs.frame_metadata_value.white_balance, 0xf00d )
+
+        test.check_equal( f.get_frame_metadata( rs.frame_metadata_value.white_balance ), 0xbaad )
+except:
+    test.unexpected_exception()
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Metadata is kept from frame to frame" )
+try:
+    with sw.sensor( "Stereo Module" ) as sensor:
+        depth = sensor.video_stream( "Depth", rs.stream.depth, rs.format.z16 )
+        sensor.start( depth )
+
+        sensor._handle.set_metadata( rs.frame_metadata_value.white_balance, 0xbaad )
+        f1 = sensor.publish( depth.frame() )
+        test.check_equal( f1.get_frame_metadata( rs.frame_metadata_value.white_balance ), 0xbaad )
+
+        f2 = sensor.publish( depth.frame() )
+        test.check_equal( f2.get_frame_metadata( rs.frame_metadata_value.white_balance ), 0xbaad )
+
+except:
+    test.unexpected_exception()
+test.finish()
+#
+#############################################################################################
+#
+test.start( "Prev frame does not pick up new data from new frame" )
+try:
+    with sw.sensor( "Stereo Module" ) as sensor:
+        depth = sensor.video_stream( "Depth", rs.stream.depth, rs.format.z16 )
+        sensor.start( depth )
+
+        sensor._handle.set_metadata( rs.frame_metadata_value.white_balance, 0xbaad )
+        f1 = sensor.publish( depth.frame() )
+
+        sensor._handle.set_metadata( rs.frame_metadata_value.actual_fps, 0xf00d )
+        f2 = sensor.publish( depth.frame() )
+
+        test.check_equal( f2.get_frame_metadata( rs.frame_metadata_value.white_balance ), 0xbaad )
+        test.check_equal( f2.get_frame_metadata( rs.frame_metadata_value.actual_fps ), 0xf00d )
+
+        test.check_equal( f1.supports_frame_metadata( rs.frame_metadata_value.actual_fps ), False )
+except:
+    test.unexpected_exception()
+test.finish()
+#
+#############################################################################################
+test.print_results_and_exit()
+


### PR DESCRIPTION
So it turns out that we cannot count on sensor-based parsers to keep validity of frame-based metadata (obviously), which is what happened after https://github.com/IntelRealSense/librealsense/pull/11551.
So this brings in the validity back into the `metadata_blob`. It's still all array-based and fast, at the cost of a slightly bigger blob.
Add unit-tests for it. The last test failed before the fix; now passes.