### PR TITLE
C++ unit-tests now on C++14

### DIFF
--- a/unit-tests/LRS_jetson_compile_pipeline.stats
+++ b/unit-tests/LRS_jetson_compile_pipeline.stats
@@ -1,2 +1,2 @@
-warnings 3
+warnings 1
 

--- a/unit-tests/LRS_linux_compile_pipeline.stats
+++ b/unit-tests/LRS_linux_compile_pipeline.stats
@@ -1,2 +1,2 @@
-warnings 2
+warnings 0
 

--- a/unit-tests/unit-test-config.py
+++ b/unit-tests/unit-test-config.py
@@ -94,7 +94,6 @@ source_group( "Common Files" FILES ${CATCH_FILES} ''' + dir + '''/test.cpp''' )
     if not custom_main:
         handle.write( ' ' + dir + '/unit-test-default-main.cpp' )
     handle.write( ''' )
-set_property(TARGET ''' + testname + ''' PROPERTY CXX_STANDARD 11)
 target_link_libraries( ''' + testname + ''' ${DEPENDENCIES} )
 
 set_target_properties( ''' + testname + ''' PROPERTIES FOLDER "Unit-Tests/''' + os.path.dirname( testdir ) + '''" )


### PR DESCRIPTION
Should remove 2 warnings in Linux...