### PR TITLE
Threading optimizations in DDS

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1431,10 +1431,6 @@ namespace librealsense
         if (_devices_changed_callback == nullptr && _devices_changed_callbacks.size() == 0) // There are no register callbacks any more _device_watcher can be stopped
         {
             _device_watcher->stop();
-#ifdef BUILD_WITH_DDS
-            if( _dds_watcher )
-                _dds_watcher->stop();
-#endif //BUILD_WITH_DDS
         }
     }
 

--- a/third-party/realdds/include/realdds/dds-device-watcher.h
+++ b/third-party/realdds/include/realdds/dds-device-watcher.h
@@ -5,10 +5,9 @@
 
 #include "dds-participant.h"
 
-#include <rsutils/concurrency/concurrency.h>
-
 #include <map>
 #include <memory>
+#include <mutex>
 
 
 namespace realdds {
@@ -43,7 +42,7 @@ public:
 
     void start();
     void stop();
-    bool is_stopped() const { return ! _active_object.is_active(); }
+    bool is_stopped() const;
 
     bool foreach_device( std::function< bool( std::shared_ptr< dds_device > const & ) > ) const;
 
@@ -59,7 +58,6 @@ private:
     std::shared_ptr< dds_participant::listener > _listener;
     std::shared_ptr< dds_topic_reader > _device_info_topic;
 
-    active_object<> _active_object;
     on_device_change_callback _on_device_added;
     on_device_change_callback _on_device_removed;
     std::map< dds_guid, std::shared_ptr< dds_device > > _dds_devices;

--- a/third-party/realdds/include/realdds/dds-topic-reader-thread.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader-thread.h
@@ -33,10 +33,13 @@ class dds_topic_reader_thread : public dds_topic_reader
     typedef dds_topic_reader super;
 
 public:
+    dds_topic_reader_thread( std::shared_ptr< dds_topic > const & topic );
     dds_topic_reader_thread( std::shared_ptr< dds_topic > const & topic,
                              std::shared_ptr< dds_subscriber > const & subscriber );
+    ~dds_topic_reader_thread();
 
     void run( qos const & ) override;
+    void stop() override;
 };
 
 

--- a/third-party/realdds/include/realdds/dds-topic-reader-thread.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader-thread.h
@@ -5,7 +5,8 @@
 
 #include "dds-topic-reader.h"
 
-#include <rsutils/concurrency/concurrency.h>
+#include <fastdds/dds/core/condition/GuardCondition.hpp>
+#include <thread>
 
 
 namespace realdds {
@@ -28,7 +29,10 @@ namespace realdds {
 //
 class dds_topic_reader_thread : public dds_topic_reader
 {
-    active_object<> _th;
+    eprosima::fastdds::dds::GuardCondition _stopped;
+    std::thread _th;
+
+
 
     typedef dds_topic_reader super;
 

--- a/third-party/realdds/include/realdds/dds-topic-reader.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader.h
@@ -75,6 +75,9 @@ public:
     // The callbacks should be set before we actually create the underlying DDS objects, so the reader does not
     virtual void run( qos const & );
 
+    // Go back to a pre-run() state, such that is_running() returns false
+    virtual void stop();
+
     // DataReaderListener
 protected:
     void on_subscription_matched( eprosima::fastdds::dds::DataReader *,

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -24,7 +24,7 @@
 namespace realdds {
 
 
-class dds_topic_reader_thread;
+class dds_topic_reader;
 class dds_topic_writer;
 class dds_subscriber;
 
@@ -51,7 +51,7 @@ public:
     std::queue< nlohmann::json > _option_response_queue;
 
     std::shared_ptr< dds_topic_reader > _notifications_reader;
-    std::shared_ptr< dds_topic_reader_thread > _metadata_reader;
+    std::shared_ptr< dds_topic_reader > _metadata_reader;
     std::shared_ptr< dds_topic_writer > _control_writer;
 
     dds_options _options;

--- a/third-party/realdds/src/dds-topic-reader-thread.cpp
+++ b/third-party/realdds/src/dds-topic-reader-thread.cpp
@@ -6,10 +6,13 @@
 #include <realdds/dds-subscriber.h>
 #include <realdds/dds-utilities.h>
 
+#include <rsutils/time/stopwatch.h>
+
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 
+#include <fastdds/dds/core/condition/WaitSet.hpp>
 
 namespace realdds {
 
@@ -23,27 +26,13 @@ dds_topic_reader_thread::dds_topic_reader_thread( std::shared_ptr< dds_topic > c
 dds_topic_reader_thread::dds_topic_reader_thread( std::shared_ptr< dds_topic > const & topic,
                                                   std::shared_ptr< dds_subscriber > const & subscriber )
     : super( topic, subscriber )
-    , _th(
-          [this, name = topic->get()->get_name()]( dispatcher::cancellable_timer )
-          {
-              if( ! _reader )
-                  return;
-              eprosima::fastrtps::Duration_t const one_second = { 1, 0 };
-              LOG_DEBUG( "----> '" << name << "' waiting for message" );
-              if( _reader->wait_for_unread_message( one_second ) )
-              {
-                  LOG_DEBUG( "----> '" << name << "' callback" );
-                  _on_data_available();
-                  LOG_DEBUG( "<---- '" << name << "' callback" );
-              }
-          } )
 {
 }
 
 
 dds_topic_reader_thread::~dds_topic_reader_thread()
 {
-    LOG_DEBUG( "xxxxx '" << ( _reader ? _reader->get_topicdescription()->get_name() : "unknown" ) << "' dtor" );
+    stop();  // Make sure thread is stopped!
 }
 
 
@@ -56,13 +45,43 @@ void dds_topic_reader_thread::run( qos const & rqos )
     status_mask << eprosima::fastdds::dds::StatusMask::subscription_matched();
     //status_mask << eprosima::fastdds::dds::StatusMask::data_available();
     _reader = DDS_API_CALL( _subscriber->get()->create_datareader( _topic->get(), rqos, this, status_mask ) );
-    _th.start();
+    
+    _th = std::thread(
+        [this, name = _topic->get()->get_name()]()
+        {
+            eprosima::fastdds::dds::WaitSet wait_set;
+            auto & condition = _reader->get_statuscondition();
+            condition.set_enabled_statuses( eprosima::fastdds::dds::StatusMask::data_available() );
+            wait_set.attach_condition( condition );
+
+            wait_set.attach_condition( _stopped );
+
+            while( ! _stopped.get_trigger_value() )
+            {
+                _stopped.set_trigger_value( false );
+
+                eprosima::fastdds::dds::ConditionSeq active_conditions;
+                wait_set.wait( active_conditions, eprosima::fastrtps::c_TimeInfinite );
+
+                if( _stopped.get_trigger_value() )
+                    break;
+
+                rsutils::time::stopwatch stopwatch;
+                _on_data_available();
+                if( stopwatch.get_elapsed() > std::chrono::milliseconds( 500 ) )
+                    LOG_WARNING( "<---- '" << name << "' callback took too long!" );
+            }
+        } );
 }
 
 
 void dds_topic_reader_thread::stop()
 {
-    _th.stop();
+    if( _th.joinable() )
+    {
+        _stopped.set_trigger_value( true );
+        _th.join();
+    }
     super::stop();
 }
 

--- a/third-party/realdds/src/dds-topic-reader.cpp
+++ b/third-party/realdds/src/dds-topic-reader.cpp
@@ -94,6 +94,20 @@ void dds_topic_reader::run( qos const & rqos )
 }
 
 
+void dds_topic_reader::stop()
+{
+    if( _subscriber )
+    {
+        if( _reader )
+        {
+            DDS_API_CALL_NO_THROW( _subscriber->get()->delete_datareader( _reader ) );
+            _reader = nullptr;
+        }
+    }
+    assert( ! is_running() );
+}
+
+
 void dds_topic_reader::on_subscription_matched(
     eprosima::fastdds::dds::DataReader *, eprosima::fastdds::dds::SubscriptionMatchedStatus const & info )
 {

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -221,7 +221,7 @@ def query( monitor_changes = True ):
     #
     # Get all devices, and store by serial-number
     global _device_by_sn, _context, _port_to_sn
-    _context = rs.context()
+    _context = rs.context( '{"dds-discovery":false}' )
     _device_by_sn = dict()
     try:
         log.d( 'discovering devices ...' )

--- a/wrappers/python/pyrs_context.cpp
+++ b/wrappers/python/pyrs_context.cpp
@@ -16,9 +16,9 @@ void init_context(py::module &m) {
 
     // Not binding devices_changed_callback, templated
 
-    py::class_<rs2::context> context(m, "context", "Librealsense context class. Includes realsense API version.");
-    context.def( py::init<>() )
-        .def( py::init< char const * >() )
+    py::class_< rs2::context >( m, "context", "Librealsense context class. Includes realsense API version." )
+        .def( py::init< char const * >(),
+              py::arg( "json-settings" ) = nullptr )
         .def("query_devices", (rs2::device_list(rs2::context::*)() const) &rs2::context::query_devices, "Create a static"
              " snapshot of all connected devices at the time of the call.")
         .def( "query_devices", ( rs2::device_list( rs2::context::* )(int) const ) & rs2::context::query_devices, "Create a static"


### PR DESCRIPTION
LibCI was hanging on some tests, mainly non-dds-related ones, because of timeouts. There were infinite waits somehow on the closing of resources.

This cleans up a lot and makes things much better.

* refactored the reader-thread code to use all eprosima synchronization instead of the previous concurrency classes (dispatcher etc.)
* made the device-watcher use a reader-thread
* don't stop the dds watcher when a device is destroyed (we won't be able to pick up new devices!)
* disable dds in run-unit-tests (the libCI wrapper)

This should fix libCI so I'll merge this first and then the other PRs...