### PR TITLE
add slice and shorten_json_string

### DIFF
--- a/third-party/rsutils/include/rsutils/string/ellipsis.h
+++ b/third-party/rsutils/include/rsutils/string/ellipsis.h
@@ -1,0 +1,95 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "slice.h"
+#include <sstream>
+
+
+namespace rsutils {
+namespace string {
+
+
+// Pair of slices, from one or two different sources.
+// These can be put together using constructs like ellipsis...
+//
+struct twoslice
+{
+    typedef slice::size_type size_type;
+
+    slice first, second;
+
+    twoslice( slice const & f, slice const & s )
+        : first( f )
+        , second( s )
+    {
+    }
+    twoslice() {}
+
+    size_type length() const { return first.length() + second.length(); }
+
+    // We're empty if both parts are empty
+    bool empty() const { return ! length(); }
+
+    // By changing which part is empty, meaning is conveyed: we're invalid only if left is empty.
+    // I.e., empty implies invalid but invalid does not imply empty!
+    bool is_valid() const { return !! first; }
+    operator bool() const { return is_valid(); }
+};
+
+
+// Output to ostream two strings separated by " ... ". E.g.:
+//      This is part ... of a string.
+// With:
+//      os << ellipsis( part1, part2 );
+// 
+// If either part is empty, no ellipsis is output. Depending on which part is empty, meaning can be
+// conveyed:
+//      - if left is empty, operator bool() will return false - i.e., we're invalid
+//      - if right is empty, we're valid
+// So, returning an empty ellipsis is like returning an invalid state.
+//
+struct ellipsis : twoslice
+{
+    static constexpr size_type const extra_length = 5;  // " ... "
+
+    ellipsis( slice const & f, slice const & s ) : twoslice( f, s ) {}
+    ellipsis() = default;
+
+    size_type length() const
+    {
+        size_type l = twoslice::length();
+        if( l )
+            l += extra_length;
+        return l;
+    }
+
+    std::string to_string() const;
+};
+
+
+inline std::ostream & operator<<( std::ostream & os, ellipsis const & el )
+{
+    if( el.first )
+    {
+        os << el.first;
+        if( el.second )
+            os << " ... " << el.second;
+    }
+    else if( el.second )
+        os << el.second;
+    return os;
+}
+
+
+inline std::string ellipsis::to_string() const
+{
+    std::ostringstream os;
+    os << *this;
+    return os.str();
+}
+
+
+}  // namespace string
+}  // namespace rsutils

--- a/third-party/rsutils/include/rsutils/string/shorten-json-string.h
+++ b/third-party/rsutils/include/rsutils/string/shorten-json-string.h
@@ -1,0 +1,35 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "ellipsis.h"
+
+
+namespace rsutils {
+namespace string {
+
+
+// Shorten the given json string representation so it does not exceed a maximum length.
+//
+// This is a formatting function - mostly used in reports, debugging output, etc.
+// E.g.:
+//      {"one":1,"two":2,"three":3,"four":4} -> {"one":1,"two":2,"thr ... }
+//      {"one":1,"two":[1,2,3],"three":{"longassblock":{"insideblock":89012}},"four":4}
+//          -> {"one":1,"two":[1,2,3],"three":{"longassblock":{ ... }},"four":4}
+//          -> {"one":1,"two":[1,2,3],"three":{ ... },"four":4}
+// 
+// Both [] and {} blocks are considered for shortening.
+//
+// When more than one inside block exists, all are evaluated recursively to find the longest
+// representation possible.
+// 
+// @param max_length
+//      must be reasonably long (at least enough characters to encompass '{ ... }' or 7 characters) or the original
+//      string will be returned
+//
+ellipsis shorten_json_string( slice const & str, size_t max_length = 96 );
+
+
+}  // namespace string
+}  // namespace rsutils

--- a/third-party/rsutils/include/rsutils/string/slice.h
+++ b/third-party/rsutils/include/rsutils/string/slice.h
@@ -1,0 +1,86 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <string>
+#include <ostream>
+#include <cassert>
+#include <cstring>  // std::strlen
+
+
+namespace rsutils {
+namespace string {
+
+
+// Same as std::string, except not null-terminated, and does not manage its own memory! Similar to the C++17
+// std::string_view, except it can be expanded to be non-const, too.
+//
+// This is meant to point into an existing string and have a short life-time. If the underlying memory is removed, e.g.:
+//      slice foo()
+//      {
+//          std::string bar = "haha";
+//          return slice(bar);
+//      }
+// Not good!
+//
+// This can come in very useful when wanting to break a string into parts but without incurring allocations or copying,
+// or changing of the original string contents (like strtok does), or when the original memory is not null-terminated.
+//
+class slice
+{
+public:
+    typedef char const * const_iterator;
+    typedef std::string::size_type size_type;
+    typedef std::string::value_type value_type;
+
+private:
+    const_iterator _begin, _end;
+
+public:
+    slice( const_iterator begin, const_iterator end )
+        : _begin( begin )
+        , _end( end )
+    {
+        assert( begin <= end );
+    }
+    slice( char const * str, size_type length )
+        : slice( str, str + length )
+    {
+    }
+    explicit slice( char const * str )
+        : slice( str, std::strlen( str ) )
+    {
+    }
+    slice( std::string const & str )
+        : slice( str.data(), str.length() )
+    {
+    }
+    slice()
+        : _begin( nullptr )
+        , _end( nullptr )
+    {
+    }
+
+    bool empty() const { return begin() == end(); }
+    size_type length() const { return end() - begin(); }
+    operator bool() const { return ! empty(); }
+
+    void clear() { _end = _begin; }
+
+    const_iterator begin() const { return _begin; }
+    const_iterator end() const { return _end; }
+
+    value_type front() const { return *begin(); }
+    value_type back() const { return end()[-1]; }
+};
+
+
+inline std::ostream & operator<<( std::ostream & os, slice const & str )
+{
+    return os.write( str.begin(), str.length() );
+}
+
+
+}  // namespace string
+}  // namespace rsutils

--- a/third-party/rsutils/py/pyrsutils.cpp
+++ b/third-party/rsutils/py/pyrsutils.cpp
@@ -5,6 +5,7 @@
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/string/split.h>
 #include <rsutils/string/from.h>
+#include <rsutils/string/shorten-json-string.h>
 #include <rsutils/version.h>
 #include <rsutils/number/running-average.h>
 #include <rsutils/number/stabilized-value.h>
@@ -30,6 +31,18 @@ PYBIND11_MODULE(NAME, m) {
            py::arg( "logger" ) = LIBREALSENSE_ELPP_ID );
 
     m.def( "split", &rsutils::string::split );
+    m.def(
+        "shorten_json_string",
+        []( std::string const & str, size_t max_length )
+        { return rsutils::string::shorten_json_string( str, max_length ).to_string(); },
+        py::arg( "string" ),
+        py::arg( "max-length" ) = 96 );
+    m.def(
+        "shorten_json_string",
+        []( nlohmann::json const & j, size_t max_length )
+        { return rsutils::string::shorten_json_string( j.dump(), max_length ).to_string(); },
+        py::arg( "json" ),
+        py::arg( "max-length" ) = 96 );
     m.def( "executable_path", &rsutils::os::executable_path );
     m.def( "executable_name", &rsutils::os::executable_name, py::arg( "with_extension" ) = false );
 

--- a/third-party/rsutils/src/shorten-json-string.cpp
+++ b/third-party/rsutils/src/shorten-json-string.cpp
@@ -1,0 +1,128 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include <rsutils/string/shorten-json-string.h>
+
+
+namespace rsutils {
+namespace string {
+
+
+// Given an outside block, e.g.:
+//        012345678901234567890123456789012345678901234567890123456789012345678901234567890
+//        0         1         2         3         4         5         6         7         8
+//        {"one":1,"two":[1,2,3],"three":{"longassblock":{"insideblock":89012}},"four":4}
+// Find the first inside block, including the enclosing delimiters (parenthesis or square brackets):
+//                       ^______^        ^_____________________________________^
+//
+static slice find_inside_block( slice const & outside )
+{
+    // find an opening
+    slice::const_iterator it = outside.begin() + 1;  // opening {, separating comma, etc.
+    bool in_quote = false;
+    while( it < outside.end() && ( in_quote || *it != '[' && *it != '{' ) )
+    {
+        if( *it == '"' )
+            in_quote = ! in_quote;
+        ++it;
+    }
+    if( it >= outside.end() )
+        return slice();
+    assert( ! in_quote );
+    auto const begin = it;
+    char const open = *begin;
+
+    // find the closing
+    char const close = ( *it == '[' ) ? ']' : '}';
+    int nesting = 0;
+    while( 1 )
+    {
+        if( ++it == outside.end() )
+            // Something is invalid
+            return slice();
+
+        if( *it == '"' )
+            in_quote = ! in_quote;
+        else if( ! in_quote )
+        {
+            if( *it == close )
+            {
+                if( 0 == nesting )
+                    break;
+                --nesting;
+            }
+            else if( *it == open )
+                ++nesting;
+        }
+    }
+    return slice( begin, it + 1 );  // including the enclosing {} or []
+}
+
+
+// max-length output
+// ---------- ---------------------------------------------------
+//          7 { ... }
+//          8 {" ... }
+//          9 {"a ... }
+//         22 {"a[1]":1,"b[2": ... }
+//         29 {"a[1]":1,"b[2":3,"d":[ ... }
+//         41 {"a[1]":1,"b[2":3,"d":[1,2,{3,4,5, ... ]}
+//         42 {"a[1]":1,"b[2":3,"d":[1,2,{ ... },6,7,8]}
+//         43 {"a[1]":1,"b[2":3,"d":[1,2,{3 ... },6,7,8]}
+//         49 {"a[1]":1,"b[2":3,"d":[1,2,{3,4,5,6 ... },6,7,8]}
+//         50 {"a[1]":1,"b[2":3,"d":[1,2,{3,4,5,6,7,8,9},6,7,8]}   <--   original json string
+//
+ellipsis shorten_json_string( slice const & str, size_t max_length )
+{
+    if( str.length() <= max_length )
+        // Already short enough
+        return ellipsis( str, slice() );
+    if( max_length < 7 )
+        return ellipsis( slice(), str );  // impossible: "{ ... }" is the minimum
+
+    // Try to find an inside block that can be taken out
+    ellipsis final;
+    slice range = str;
+    while( slice block = find_inside_block( range ) )
+    {
+        // Removing the whole block is one option:
+        //        0123456789012345678901234567890123456789012345678
+        //        0         1         2         3         4
+        //        {"one":1,"two":[1,2,3],"three":{ ... },"four":4}
+        //        ^_______________________________^    ^__________^
+        ellipsis candidate( slice( str.begin(), block.begin() + 1 ), slice( block.end() - 1, str.end() ) );
+        if( candidate.length() <= max_length && candidate.length() > final.length() )
+            final = candidate;
+
+        // But we might be able to remove only an inside block and get a better result:
+        auto inside_max_length = int(max_length) - ( block.begin() - str.begin() ) - ( str.end() - block.end() );
+        if( inside_max_length > 6 )
+        {
+            auto inside = shorten_json_string( block, inside_max_length );
+            if( inside )
+            {
+                // See if shortening the inside block gives a better result than shortening
+                // the outside...
+                //        {"one":1,"two":[1,2,3],"three":{"longassblock":{ ... }},"four":4}
+                //                                       ^________________^    ^_^
+                ellipsis inside_candidate( slice( str.begin(), inside.first.end() ),
+                                           slice( inside.second.begin(), str.end() ) );
+                if( inside_candidate.length() <= max_length  &&  inside_candidate.length() > final.length() )
+                    final = inside_candidate;
+            }
+        }
+
+        // Next iteration, continue right after this block
+        range = slice( block.end(), str.end() );
+    }
+
+    // The minimal solution is to shorten the current block at the end (if we can't find anything else)
+    if( ! final )
+        final = ellipsis( slice( str.begin(), str.begin() + max_length - 6 ),
+                          slice( str.end() - 1, str.end() ) );
+    return final;
+}
+
+
+}  // namespace string
+}  // namespace rsutils

--- a/unit-tests/rsutils/string/test-shorten-json.py
+++ b/unit-tests/rsutils/string/test-shorten-json.py
@@ -1,0 +1,110 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+from rspy import log, test
+from pyrsutils import shorten_json_string as short
+
+
+# This tests shorten_json_string, but indirectly also json conversion from python objects
+
+
+#############################################################################################
+#
+test.start( "shorten_json_string (string)" )
+#
+# strings are not enforced as valid json objects
+test.check_equal( short( '' ), '' )
+test.check_equal( short( '{' ), '{' )
+test.check_equal( short( '{}' ), '{}' )
+test.check_equal( short( '[' ), '[' )
+test.check_equal( short( '[]' ), '[]' )
+test.check_equal( short( '[{}]' ), '[{}]' )
+test.check_equal( short( '{[{}]}' ), '{[{}]}' )  # note: invalid dict/json, but OK as a string!
+test.check_equal( short( '[1,2,3]' ), '[1,2,3]' )
+test.check_equal( short( '{"some":"one"}' ), '{"some":"one"}' )
+#
+test.finish()
+#
+#############################################################################################
+#
+test.start( "shorten_json_string (string, max-length)" )
+#
+# max-length must be reasonably long (at least enough characters to encompass '{ ... }' or 7
+# characters) or the original string will be returned:
+#
+s = '{"some":"one"}'
+test.check_equal( short( s, 0 ), s )  # invalid
+test.check_equal( short( s, 1 ), s )  # invalid
+test.check_equal( short( s, 2 ), s )  # invalid
+test.check_equal( short( s, 3 ), s )  # invalid
+test.check_equal( short( s, 4 ), s )  # invalid
+test.check_equal( short( s, 5 ), s )  # invalid
+test.check_equal( short( s, 6 ), s )  # invalid
+test.check_equal( short( s, 7 ), '{ ... }' )
+test.check_equal( short( s, 10 ), '{"so ... }' )
+#
+s = '[1,2,3,4,5,6,7,8]'
+test.check_equal( short( s, 6 ), s )
+test.check_equal( short( s, 7 ), '[ ... ]' )
+test.check_equal( short( s, 8 ), '[1 ... ]' )
+test.check_equal( short( s, 16 ), '[1,2,3,4,5 ... ]' )
+test.check_equal( short( s, 17 ), s )
+test.check_equal( short( s, 18 ), s )
+#
+test.finish()
+#
+#############################################################################################
+#
+test.start( "shorten_json_string with ellipsis deep inside" )
+#
+s = '{"a[1]":1,"b[2":3,"d":[1,2,{3,4,5,6,7,8,9},6,7,8]}'  # more complicated
+test.check_equal( short( s ), s )
+test.check_equal( short( s, len(s) ), s )
+test.check_equal( short( s, len(s)-1 ), '{"a[1]":1,"b[2":3,"d":[1,2,{3,4,5,6 ... },6,7,8]}' )
+test.check_equal( short( s, len(s)-2 ), '{"a[1]":1,"b[2":3,"d":[1,2,{3,4,5, ... },6,7,8]}' )
+test.check_equal( short( s, len(s)-8 ), '{"a[1]":1,"b[2":3,"d":[1,2,{ ... },6,7,8]}' )
+test.check_equal( short( s, len(s)-9 ), '{"a[1]":1,"b[2":3,"d":[1,2,{3,4,5, ... ]}' )
+#
+test.finish()
+#
+#############################################################################################
+#
+test.start( "shorten_json_string (None)" )
+#
+# None translates to json 'null', so is entirely valid
+test.check_equal( short( None ), 'null' )
+#
+test.finish()
+#
+#############################################################################################
+#
+test.start( "shorten_json_string (tuples)" )
+#
+test.check_equal( short( (1,2,'string') ), '[1,2,"string"]' )
+test.check_equal( short( (1,2,'string'), 11 ), '[1,2, ... ]' )
+test.check_equal( short( '(1,2,"string")' ), '(1,2,"string")' )
+#
+test.finish()
+#
+#############################################################################################
+#
+test.start( "shorten_json_string (json)" )
+#
+# Just like string input is not enforced as valid json, neither is the output expected to be:
+#
+test.check_equal( short(
+    {'some':'one','two':[1,2, 3, 'dkjsahdkjashdkjhsakjdhada',213123123,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9]} ),
+    '{"some":"one","two":[1,2,3,"dkjsahdkjashdkjhsakjdhada",213123123,1,2,3,4,5,6,7,8,9,0,1,2, ... ]}' )
+test.check_equal( short(
+    {'some':'one','two':"1,2, 3, 'dkjsahdkjashdkjhsakjdhada',213123123,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9"} ),
+    '{"some":"one","two":"1,2, 3, \'dkjsahdkjashdkjhsakjdhada\',213123123,1,2,3,4,5,6,7,8,9,0,1,2 ... }' )
+#
+s = {"a[1]":1,"b[2":3,"d":[1,2,[3,4,5,6,7,8,9],6,7,8]}
+ss = '{"a[1]":1,"b[2":3,"d":[1,2,[3,4,5,6,7,8,9],6,7,8]}'
+test.check_equal( short( s ), ss )
+test.check_equal( short( s, len(ss)-1 ), '{"a[1]":1,"b[2":3,"d":[1,2,[3,4,5,6 ... ],6,7,8]}' )
+#
+test.finish()
+#
+#############################################################################################
+test.print_results_and_exit()


### PR DESCRIPTION
This is a utility function I used in one PoC that thought would be useful to have in rsutils, especially now that we're making a bigger use of json.

It also adds what I consider a very useful utility `slice`, similar to a `string_view`. For example, I wanted to refer to the json string inside `flexible_msg` but it's not null-teminated. The easy way is by using a slice:
`LOG_DEBUG( "publishing metadata: " << shorten_json_string( slice( md.custom_data< char const >(), md._data.size() )));`

Anyway I didn't want to lose this so decided to PR.