### PR TITLE
libCI tests not requiring a camera now run in GHA

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -64,7 +64,7 @@ jobs:
 
 
   #--------------------------------------------------------------------------------
-  Win_ST_Py_DDS:  # Windows, Static, Python, Tools, DDS
+  Win_ST_Py_DDS_CI:  # Windows, Static, Python, Tools, DDS, libCI
     runs-on: windows-2019
     timeout-minutes: 60
     steps:
@@ -104,7 +104,13 @@ jobs:
       shell: bash
       run: |
         cd ${{env.WIN_BUILD_DIR}}
-        cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -m    
+        cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -m
+
+    - name: LibCI
+      # Build your program with the given configuration
+      shell: bash
+      run: |
+        python3 unit-tests/run-unit-tests.py --no-color --debug --stdout --not-live --context "dds windows" ${{env.WIN_BUILD_DIR}}/Release
 
 
   #--------------------------------------------------------------------------------
@@ -210,7 +216,7 @@ jobs:
 
 
   #--------------------------------------------------------------------------------
-  U20_SH_Py_DDS:  # Ubuntu 2020, Shared, Python, DDS
+  U20_SH_Py_DDS_CI:  # Ubuntu 2020, Shared, Python, DDS, LibCI
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
@@ -243,6 +249,12 @@ jobs:
         cd build
         cmake .. -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
         cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4  
+
+    - name: LibCI
+      # Build your program with the given configuration
+      shell: bash
+      run: |
+        python3 unit-tests/run-unit-tests.py --no-color --debug --stdout --not-live --context "dds linux"
   
 
   #--------------------------------------------------------------------------------

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -224,7 +224,6 @@ def query( monitor_changes = True ):
     _context = rs.context()
     _device_by_sn = dict()
     try:
-        log.d( 'discovering devices ...' )
         log.debug_indent()
         for retry in range(3):
             try:

--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -47,7 +47,9 @@ def run( cmd, stdout = None, timeout = 200, append = False ):
     start_time = time.time()
     try:
         log.debug_indent()
-        if stdout and stdout != subprocess.PIPE:
+        if stdout is None:
+            sys.stdout.flush()
+        elif stdout and stdout != subprocess.PIPE:
             if append:
                 handle = open( stdout, "a" )
                 handle.write(
@@ -391,6 +393,8 @@ class PyTest( Test ):
             #
             if log.is_color_on():
                 cmd += ['--color']
+            elif log.is_color_disabled():
+                cmd += ['--no-color']
             #
             if self.config.context:
                 cmd += ['--context', ' '.join(self.config.context)]

--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -184,9 +184,9 @@ class TestConfigFromText( TestConfig ):
                 #      0      |            1             | USE
                 #      1      |            0             | USE
                 #      1      |            1             | IGNORE
-                if not_context == (directive_context in self.context):
+                if not_context == (directive_context in self._context):
                     # log.d( "directive", line['line'], "ignored because of context mismatch with running context",
-                    #       self.context)
+                    #       self._context)
                     continue
             if directive == 'device':
                 # log.d( '    configuration:', params )

--- a/unit-tests/py/rspy/log.py
+++ b/unit-tests/py/rspy/log.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
-import sys
+import sys, os
 
 
 # We're usually the first to be imported, and so the first see the original arguments as passed
@@ -35,9 +35,14 @@ def _stream_has_color( stream ):
         # guess false in case of error
         return False
 
-_have_color = '--color' in sys.argv
-if _have_color:
+_have_no_color = False
+if '--color' in sys.argv:
     sys.argv.remove( '--color' )
+    _have_color = True
+elif '--no-color' in sys.argv:
+    sys.argv.remove( '--no-color' )
+    _have_color = False
+    _have_no_color = True
 else:
     _have_color = _stream_has_color( sys.stdout )
 if _have_color:
@@ -79,10 +84,15 @@ else:
     def progress(*args):
         if args:
             print( *args )
+        sys.stdout.flush()
 
 def is_color_on():
     global _have_color
     return _have_color
+
+def is_color_disabled():
+    global _have_no_color
+    return _have_no_color
 
 
 def quiet_on():
@@ -178,4 +188,17 @@ def n_warnings():
 def reset_warnings():
     global _n_warnings
     _n_warnings = 0
+
+
+def split():
+    """
+    Output an easy-to-distinguish line separating text above from below.
+    Currently a line of "_____"
+    """
+    try:
+        screen_width = os.get_terminal_size().columns
+    except:
+        # this happens under github actions, for example, or when a terminal does not exist
+        screen_width = 60
+    out( '\n' + '_' * screen_width )
 

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -295,6 +295,7 @@ def check_log_for_fails( path_to_log, testname, configuration = None, repetition
 
 
 def get_tests():
+    log.progress( '-I- Getting tests ...' )
     global regex, exe_dir, pyrs, current_dir, linux, context, list_only
     if regex:
         pattern = re.compile( regex )
@@ -389,7 +390,7 @@ def test_wrapper( test, configuration = None, repetition = 1 ):
     n_tests += 1
     #
     if not log.is_debug_on() or log.is_color_on():
-        log.progress( configuration_str( configuration, repetition, suffix=' ' ) + test.name, '...' )
+        log.progress( '-I- Running', configuration_str( configuration, repetition, suffix=' ' ) + test.name, '...' )
     #
     log_path = test.get_log()
     #
@@ -398,6 +399,7 @@ def test_wrapper( test, configuration = None, repetition = 1 ):
         opts.add( '--rslog' )
     try:
         test.run_test( configuration = configuration, log_path = log_path, opts = opts )
+        return True
     except FileNotFoundError as e:
         log.e( log.red + test.name + log.reset + ':', str( e ) + configuration_str( configuration, repetition, prefix=' ' ) )
     except subprocess.TimeoutExpired:
@@ -408,12 +410,16 @@ def test_wrapper( test, configuration = None, repetition = 1 ):
             log.e( log.red + test.name + log.reset + ':',
                    configuration_str( configuration, repetition, suffix=' ' ) + 'exited with non-zero value (' + str(
                        cpe.returncode ) + ')' )
+    return False
 
 
 # Run all tests
 try:
     list_only = list_tags or list_tests
-    if not list_only:
+    if only_not_live:
+        log.d( 'Only --not-live tests running; skipping device discovery' )
+    elif not list_only:
+        log.progress( '-I- Discovering devices ...' )
         if pyrs:
             sys.path.insert( 1, pyrs_path )  # Make sure we pick up the right pyrealsense2!
         from rspy import devices
@@ -442,33 +448,39 @@ try:
     log.reset_errors()
     available_tags = set()
     tests = []
+    failed_tests = []
     if context:
-        log.d( 'running under context:', context )
+        log.i( 'Running under context:', context )
     for test in prioritize_tests( get_tests() ):
-        #
-        log.d( 'found', test.name, '...' )
         try:
-            log.debug_indent()
-            test.debug_dump()
             #
             if only_live and not test.is_live():
+                log.d( f'{test.name} is not live; skipping' )
                 continue
             if only_not_live and test.is_live():
+                log.d( f'{test.name} is live; skipping' )
                 continue
             #
             if test.config.donotrun:
+                log.d( f'{test.name} is marked do-not-run; skipping' )
                 continue
             #
             if required_tags and not all( tag in test.config.tags for tag in required_tags ):
-                log.d( 'does not fit --tag:', test.config.tags )
+                log.d( f'{test.name} does not fit --tag {test.config.tags}; skipping' )
                 continue
             #
             if 'Windows' in test.config.flags and linux:
-                log.d( 'test has Windows flag and OS is Linux' )
+                log.d( f'{test.name} has Windows flag and OS is Linux; skipping' )
                 continue
             if 'Linux' in test.config.flags and not linux:
-                log.d( 'test has Linux flag and OS is Windows' )
+                log.d( f'{test.name} has Linux flag and OS is Windows; skipping' )
                 continue
+            #
+            if to_stdout:
+                log.split()
+            log.d( 'found', test.name, '...' )
+            log.debug_indent()
+            test.debug_dump()
             #
             available_tags.update( test.config.tags )
             tests.append( test )
@@ -477,8 +489,11 @@ try:
                 continue
             #
             if not test.is_live():
+                test_ok = True
                 for repetition in range(repeat):
-                    test_wrapper( test, repetition = repetition )
+                    test_ok = test_wrapper( test, repetition = repetition ) and test_ok
+                if not test_ok:
+                    failed_tests.append( test )
                 continue
             #
             if skip_live_tests:
@@ -488,6 +503,7 @@ try:
                     log.e( test.name + ':', 'is live and there are no cameras' )
                 continue
             #
+            test_ok = True
             for configuration, serial_numbers in devices_by_test_config( test, exceptions ):
                 for repetition in range(repeat):
                     try:
@@ -498,13 +514,17 @@ try:
                     except RuntimeError as e:
                         log.w( log.red + test.name + log.reset + ': ' + str( e ) )
                     else:
-                        test_wrapper( test, configuration, repetition )
+                        test_ok = test_wrapper( test, configuration, repetition ) and test_ok
                     finally:
                         log.debug_unindent()
+            if not test_ok:
+                failed_tests.append( test )
             #
         finally:
             log.debug_unindent()
 
+    if to_stdout:
+        log.split()
     log.progress()
     #
     if not n_tests:
@@ -528,6 +548,7 @@ try:
         if n_errors:
             log.out( log.red + str( n_errors ) + log.reset, 'of', n_tests, 'test(s)',
                      log.red + 'failed!' + log.reset + log.clear_eos )
+            log.d( 'Failed tests:\n    ' + '\n    '.join( [test.name for test in failed_tests] ))
             sys.exit( 1 )
         #
         log.out( str( n_tests ) + ' unit-test(s) completed successfully' + log.clear_eos )
@@ -535,7 +556,7 @@ try:
 finally:
     #
     # Disconnect from the Acroname -- if we don't it'll crash on Linux...
-    if not list_only:
+    if not list_only and not only_not_live:
         if devices.acroname:
             devices.acroname.disconnect()
 #


### PR DESCRIPTION
* added `--live` and `--not-live` as arguments to `run-unit-tests`
* changed the `Win_ST_Py_DDS` -> `Win_ST_Py_DDS_CI` and made it a `Release` build (otherwise libCI will have a problem finding the pyd files with the `d` suffix)
* changed `U20_SH_Py_DDS` -> `U20_SH_Py_DDS_CI`
* fixed a bug when not running with `--debug`
* various stdout formatting improvements, including flushing, splitter lines, a `--no-color` mode
* `run-unit-tests` will now show a list of the failed tests at the end as a debug output

Nightly and PR libCI runs are still running everything -- these will be addressed in a separate PR...