### PR TITLE
Fix unsigned fw update

### DIFF
--- a/src/ds/ds-device-common.cpp
+++ b/src/ds/ds-device-common.cpp
@@ -188,7 +188,10 @@ namespace librealsense
         for (auto sector_index = first_sector; sector_index < sector_count; sector_index++)
         {
             command cmdFES(ds::FES);
-            cmdFES.require_response = false;
+            // On both FES & FWB commands We don't really need the response but we see that setting
+            // false and sending many commands cause a failure. 
+            // Looks like the FW is expecting it.
+            cmdFES.require_response = true;
             cmdFES.param1 = (int)sector_index;
             cmdFES.param2 = 1;
             auto res = hwm->send(cmdFES);
@@ -200,7 +203,7 @@ namespace librealsense
                     break;
                 int packet_size = std::min((int)(HW_MONITOR_COMMAND_SIZE - (i % HW_MONITOR_COMMAND_SIZE)), (int)(ds::FLASH_SECTOR_SIZE - i));
                 command cmdFWB(ds::FWB);
-                cmdFWB.require_response = false;
+                cmdFWB.require_response = true;
                 cmdFWB.param1 = (int)index;
                 cmdFWB.param2 = packet_size;
                 cmdFWB.data.assign(image.data() + index, image.data() + index + packet_size);


### PR DESCRIPTION
We changed the behavior and do not wait for HWM response when we don't need it (previous PR) .
Unsigned FW update process loop and send HWM byte by byte for writing the new image.
Looks like he cannot handle the write speed and the previous action bought it some time. (or it is really expecting the `get` command)
The process does not end without it..

I restored the old behavior on that case and it fixed the issue.
LibCI test? I think it's needed for regression.
Next PR.

Tracked on [LRS-745]