### PR TITLE
fix: close ObjectPool race condition (IntelRealSense#8334)

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Helpers/ObjectPool.cs
+++ b/wrappers/csharp/Intel.RealSense/Helpers/ObjectPool.cs
@@ -74,23 +74,17 @@ namespace Intel.RealSense
         private static object Get(Type t, IntPtr ptr)
         {
             var stack = GetPool(t);
-            int count;
             lock ((stack as ICollection).SyncRoot)
             {
-                count = stack.Count;
-            }
-
-            if (count > 0)
-            {
-                Base.PooledObject obj;
-                lock ((stack as ICollection).SyncRoot)
+                if (stack.Count > 0)
                 {
+                    Base.PooledObject obj;
                     obj = stack.Pop();
-                }
 
-                obj.m_instance.Reset(ptr);
-                obj.Initialize();
-                return obj;
+                    obj.m_instance.Reset(ptr);
+                    obj.Initialize();
+                    return obj;
+                }
             }
 
             return CreateInstance(t, ptr);


### PR DESCRIPTION
This closes a race condition in `ObjectPool.Get` that caused "Stack empty." exceptions when multiple sensor pipelines are being polled concurrently.  Addresses #8334.  Credit to @cdrose.