### PR TITLE
refactor & optimize frame creation, invocation, metadata syncing

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -33,6 +33,8 @@ struct metadata_array_value
 };
 #pragma pack( pop )
 
+typedef std::array< metadata_array_value, RS2_FRAME_METADATA_ACTUAL_COUNT > metadata_array;
+
 static_assert( sizeof( metadata_array_value ) == sizeof( rs2_metadata_type ) + 1,
                "unexpected size for metadata array members" );
 
@@ -71,7 +73,7 @@ struct frame_additional_data : frame_header
 {
     uint32_t metadata_size = 0;
     bool fisheye_ae_mode = false;  // TODO: remove in future release
-    std::array< uint8_t, RS2_FRAME_METADATA_ACTUAL_COUNT * sizeof( metadata_array_value ) > metadata_blob;
+    std::array< uint8_t, sizeof( metadata_array ) > metadata_blob = {};
     rs2_time_t last_timestamp = 0;
     unsigned long long last_frame_number = 0;
     bool is_blocking  = false;  // when running from recording, this bit indicates
@@ -84,6 +86,12 @@ struct frame_additional_data : frame_header
     uint32_t raw_size = 0;     // The frame transmitted size (payload only)
 
     frame_additional_data() {}
+
+    frame_additional_data( metadata_array const & metadata )
+    {
+        metadata_size = (uint32_t) sizeof( metadata );
+        memcpy( metadata_blob.data(), metadata.data(), metadata_size );
+    }
 
     frame_additional_data( rs2_time_t in_timestamp,
                            unsigned long long in_frame_number,

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -292,14 +292,14 @@ namespace librealsense
     }
 
 
-    void software_sensor::invoke_new_frame( frame_interface * frame,
+    void software_sensor::invoke_new_frame( frame_holder && frame,
                                             void const * pixels,
                                             std::function< void() > on_release )
     {
         // The frame pixels/data are stored in the continuation object!
         if( pixels )
             frame->attach_continuation( frame_continuation( on_release, pixels ) );
-        _source.invoke_callback( frame );
+        _source.invoke_callback( std::move( frame ) );
     }
 
 

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -315,14 +315,11 @@ namespace librealsense
         if( ! _is_streaming )
             return;
 
-        frame_additional_data data;
+        frame_additional_data data( _metadata_map );
         data.timestamp = software_frame.timestamp;
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
         data.depth_units = software_frame.depth_units;
-
-        data.metadata_size = (uint32_t)( _metadata_map.size() * sizeof( metadata_array_value ) );
-        memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         auto frame
             = allocate_new_video_frame( vid_profile, software_frame.stride, software_frame.bpp, std::move( data ) );
@@ -336,13 +333,10 @@ namespace librealsense
         if( ! _is_streaming )
             return;
 
-        frame_additional_data data;
+        frame_additional_data data( _metadata_map );
         data.timestamp = software_frame.timestamp;
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
-
-        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( metadata_array_value ));
-        memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         auto frame
             = allocate_new_frame( RS2_EXTENSION_MOTION_FRAME, software_frame.profile->profile, std::move( data ) );
@@ -356,13 +350,10 @@ namespace librealsense
         if( ! _is_streaming )
             return;
 
-        frame_additional_data data;
+        frame_additional_data data( _metadata_map );
         data.timestamp = software_frame.timestamp;
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
-
-        data.metadata_size = (uint32_t) (_metadata_map.size() * sizeof( metadata_array_value ));
-        memcpy( data.metadata_blob.data(), _metadata_map.data(), data.metadata_size );
 
         auto frame = allocate_new_frame( RS2_EXTENSION_POSE_FRAME, software_frame.profile->profile, std::move( data ) );
         if( frame )
@@ -374,7 +365,6 @@ namespace librealsense
         notification n{ notif.category, notif.type, notif.severity, notif.description };
         n.serialized_data = notif.serialized_data;
         _notifications_processor->raise_notification(n);
-
     }
 
     void software_sensor::add_read_only_option(rs2_option option, float val)

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -125,7 +125,7 @@ namespace librealsense
         frame_interface * allocate_new_video_frame( video_stream_profile_interface *, int stride, int bpp, frame_additional_data && );
         void invoke_new_frame( frame_interface * frame, void const * pixels, std::function< void() > on_release );
 
-        std::array< metadata_array_value, RS2_FRAME_METADATA_ACTUAL_COUNT > _metadata_map;
+        metadata_array _metadata_map;
 
         processing_blocks get_recommended_processing_blocks() const override
         {

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -123,7 +123,7 @@ namespace librealsense
     protected:
         frame_interface * allocate_new_frame( rs2_extension, stream_profile_interface *, frame_additional_data && );
         frame_interface * allocate_new_video_frame( video_stream_profile_interface *, int stride, int bpp, frame_additional_data && );
-        void invoke_new_frame( frame_interface * frame, void const * pixels, std::function< void() > on_release );
+        void invoke_new_frame( frame_holder &&, void const * pixels, std::function< void() > on_release );
 
         metadata_array _metadata_map;
 

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -240,7 +240,16 @@ void dds_device::impl::create_metadata_reader()
             while( topics::flexible_msg::take_next( *_metadata_reader, &message ) )
             {
                 if( message.is_valid() && _on_metadata_available )
-                    _on_metadata_available( std::move( message.json_data() ) );
+                {
+                    try
+                    {
+                        _on_metadata_available( std::move( message.json_data() ) );
+                    }
+                    catch( std::runtime_error const & e )
+                    {
+                        LOG_DEBUG( "metadata exception: " << e.what() );
+                    }
+                }
             }
         } );
 

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -58,11 +58,11 @@ static void on_discovery_device_header( size_t const n_streams, const dds_option
     topics::flexible_msg device_header( json{
         { "id", "device-header" },
         { "n-streams", n_streams },
-        { "extrinsics", extrinsics_json }
+        { "extrinsics", std::move( extrinsics_json ) }
     } );
-    LOG_DEBUG( "-----> JSON = " << device_header.json_data().dump() );
-    LOG_DEBUG( "-----> JSON size = " << device_header.json_data().dump().length() );
-    LOG_DEBUG( "-----> CBOR size = " << json::to_cbor( device_header.json_data() ).size() );
+    auto json_string = slice( device_header.custom_data< char const >(), device_header._data.size() );
+    LOG_DEBUG( "-----> JSON = " << shorten_json_string( json_string, 300 ) << " size " << json_string.length() );
+    //LOG_DEBUG( "-----> CBOR size = " << json::to_cbor( device_header.json_data() ).size() );
     notifications.add_discovery_notification( std::move( device_header ) );
 
     auto device_options = nlohmann::json::array();
@@ -70,11 +70,11 @@ static void on_discovery_device_header( size_t const n_streams, const dds_option
         device_options.push_back( std::move( opt->to_json() ) );
     topics::flexible_msg device_options_message( json {
         { "id", "device-options" },
-        { "options" , device_options }
+        { "options", std::move( device_options ) }
     } );
-    LOG_DEBUG( "-----> JSON = " << device_options_message.json_data().dump() );
-    LOG_DEBUG( "-----> JSON size = " << device_options_message.json_data().dump().length() );
-    LOG_DEBUG( "-----> CBOR size = " << json::to_cbor( device_options_message.json_data() ).size() );
+    json_string = slice( device_options_message.custom_data< char const >(), device_options_message._data.size() );
+    LOG_DEBUG( "-----> JSON = " << shorten_json_string( json_string, 300 ) << " size " << json_string.length() );
+    //LOG_DEBUG( "-----> CBOR size = " << json::to_cbor( device_options_message.json_data() ).size() );
     notifications.add_discovery_notification( std::move( device_options_message ) );
 }
 
@@ -90,7 +90,7 @@ static void on_discovery_stream_header( std::shared_ptr< dds_stream_server > con
         { "type", stream->type_string() },
         { "name", stream->name() },
         { "sensor-name", stream->sensor_name() },
-        { "profiles", profiles },
+        { "profiles", std::move( profiles ) },
         { "default-profile-index", stream->default_profile_index() },
         { "metadata-enabled", stream->metadata_enabled() },
     } );
@@ -118,7 +118,7 @@ static void on_discovery_stream_header( std::shared_ptr< dds_stream_server > con
     topics::flexible_msg stream_options_message( json {
         { "id", "stream-options" },
         { "stream-name", stream->name() },
-        { "options" , stream_options },
+        { "options" , std::move( stream_options ) },
         { "intrinsics" , intrinsics },
         { "recommended-filters", std::move( stream_filters ) },
     } );


### PR DESCRIPTION
* formalized `metadata_array` type with proper initialization and ctor in `frame_additional_data`
* additional move semantics inside device-server, per last CR
* `frame_metadata_syncer` no longer a template
* removed the profile-storage need in the syncer
* removed the need to allocate another pixel vector, instead using `frame::data`
* exception catching around `on_metadata_available`
* `frame_holder` usage for proper lifecycle

There may be a use-case where the timestamp+domain aren't set at all if no metadata is available. I'll take care of this in the next PR.

Also next, I'll be moving the syncer out of `context.cpp` (into realdds), generating unit-tests for it, and finish the metadata unit-tests. Then will be changing things to be timestamp-based.