### PR TITLE
Handle exceptions during device creation

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -166,16 +166,16 @@ matcher_factory::create_timestamp_composite_matcher( std::vector< std::shared_pt
     return std::make_shared<timestamp_composite_matcher>(matchers);
 }
 
-device::device( std::shared_ptr<context> ctx,
+device::device(std::shared_ptr<context> ctx,
                const platform::backend_device_group group,
-               bool device_changed_notifications )
-    : _context( ctx ), _group( group ), _is_valid( true )
-    , _device_changed_notifications( device_changed_notifications )
-    , _is_alive( true )
+               bool device_changed_notifications)
+    : _context(ctx), _group(group), _is_valid(true),
+      _device_changed_notifications(device_changed_notifications),
+      _is_alive( true )
 {
-    _profiles_tags = lazy< std::vector< tagged_profile > >( [this]() { return get_profiles_tags(); } );
+    _profiles_tags = lazy<std::vector<tagged_profile>>([this]() { return get_profiles_tags(); });
 
-    if( _device_changed_notifications )
+    if (_device_changed_notifications)
     {
         std::weak_ptr< bool > weak = std::make_shared< bool >( _is_alive );
         auto cb = new devices_changed_callback_internal([this, weak = std::move( weak )](rs2_device_list* removed, rs2_device_list* added)
@@ -188,9 +188,9 @@ device::device( std::shared_ptr<context> ctx,
 
             // Update is_valid variable when device is invalid
             std::lock_guard<std::mutex> lock(_device_changed_mtx);
-            for( auto & dev_info : removed->list )
+            for (auto& dev_info : removed->list)
             {
-                if( dev_info.info->get_device_data() == _group )
+                if (dev_info.info->get_device_data() == _group)
                 {
                     _is_valid = false;
                     return;
@@ -206,9 +206,9 @@ device::~device()
 {
     _is_alive = false;
 
-    if( _device_changed_notifications )
+    if (_device_changed_notifications)
     {
-        _context->unregister_internal_device_callback( _callback_id );
+        _context->unregister_internal_device_callback(_callback_id);
     }
     _sensors.clear();
 }

--- a/src/device.h
+++ b/src/device.h
@@ -108,6 +108,8 @@ private:
     mutable std::mutex _device_changed_mtx;
     uint64_t _callback_id;
     lazy<std::vector<tagged_profile>> _profiles_tags;
+
+    bool _is_alive; // Used with shared_ptr to ensure object can be accessed
 };
 
 // Helper function that should be used when multiple FW calls needs to be made.


### PR DESCRIPTION
[DSO-18785]

Add flag protected by a weak_ptr to verify object is still "alive" when used by callback.