### PR TITLE
(gcc-13) include cstdint for *int*_t

### DIFF
--- a/common/sw-update/http-downloader.h
+++ b/common/sw-update/http-downloader.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <functional>
 #include <vector>


### PR DESCRIPTION
Otherwise we see errors like this with gcc13:
```
common/sw-update/http-downloader.h:16:47: error: 'uint64_t' was not declared in this scope
```