### PR TITLE
Update GHA linux runners to Ubuntu 20

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -177,6 +177,7 @@ jobs:
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
         sudo apt-get install libglfw3-dev libglfw3;
+        # We force compiling with GCC 7 because the default installed GCC 9 compiled with LTO and gives an internal compiler error
         sudo apt-get install gcc-7 g++-7;
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
     
@@ -201,7 +202,7 @@ jobs:
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v3
       with: 
-        name: Log file - U18_ST_Py_EX_CfU_LiveTest
+        name: Log file - U20_ST_Py_EX_CfU_LiveTest
         path: build/*.log
 
     - name: Provide correct exit status for job 
@@ -231,6 +232,7 @@ jobs:
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
         sudo apt-get install libglfw3-dev libglfw3;
+        # We force compiling with GCC 7 because the default installed GCC 9 compiled with LTO and gives an internal compiler error
         sudo apt-get install gcc-7 g++-7;
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
 
@@ -285,6 +287,7 @@ jobs:
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
         sudo apt-get install libglfw3-dev libglfw3;
+        # We force compiling with GCC 7 because the default installed GCC 9 compiled with LTO and gives an internal compiler error
         sudo apt-get install gcc-7 g++-7;
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
 
@@ -309,7 +312,7 @@ jobs:
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v3
       with: 
-        name: Log file - U18_SH_RSUSB_LiveTest_NodeJS
+        name: Log file - U20_SH_RSUSB_LiveTest
         path: build/*.log
 
     - name: Provide correct exit status for job 
@@ -383,6 +386,7 @@ jobs:
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
         sudo apt-get install libglfw3-dev libglfw3;
+        # We force compiling with GCC 7 because the default installed GCC 9 compiled with LTO and gives an internal compiler error
         sudo apt-get install gcc-7 g++-7;
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
         

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -159,8 +159,8 @@ jobs:
 
 
   #--------------------------------------------------------------------------------
-  U18_ST_Py_EX_CfU_LiveTest:  # Ubuntu 2018, Static, Python, Examples & Tools, Check for Updates, Legacy Live-Tests
-    runs-on: ubuntu-18.04    
+  U20_ST_Py_EX_CfU_LiveTest:  # Ubuntu 2020, Static, Python, Examples & Tools, Check for Updates, Legacy Live-Tests
+    runs-on: ubuntu-20.04    
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
@@ -176,9 +176,9 @@ jobs:
         sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
-        #sudo apt-get install gcc-5 g++-5;
-        #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
         sudo apt-get install libglfw3-dev libglfw3;
+        sudo apt-get install gcc-7 g++-7;
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
     
     - name: Build
       shell: bash
@@ -230,9 +230,9 @@ jobs:
         sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
-        #sudo apt-get install gcc-5 g++-5;
-        #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
         sudo apt-get install libglfw3-dev libglfw3;
+        sudo apt-get install gcc-7 g++-7;
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
 
     - name: Check_API
       shell: bash
@@ -258,8 +258,8 @@ jobs:
   
 
   #--------------------------------------------------------------------------------
-  U18_SH_RSUSB_LiveTest:  # Ubuntu 2018, Shared, Legacy live-tests
-    runs-on: ubuntu-18.04     
+  U20_SH_RSUSB_LiveTest:  # Ubuntu 2020, Shared, Legacy live-tests
+    runs-on: ubuntu-20.04     
     timeout-minutes: 60
     env: 
       LRS_BUILD_NODEJS: true
@@ -284,9 +284,9 @@ jobs:
         sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
-        sudo apt-get install gcc-5 g++-5;
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
         sudo apt-get install libglfw3-dev libglfw3;
+        sudo apt-get install gcc-7 g++-7;
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
 
     - name: Build
       shell: bash
@@ -360,7 +360,7 @@ jobs:
 
   #--------------------------------------------------------------------------------
   Android_cpp:
-    runs-on: ubuntu-18.04   
+    runs-on: ubuntu-20.04   
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
@@ -382,9 +382,10 @@ jobs:
         sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
         sudo apt-get install -qq libusb-1.0-0-dev;
         sudo apt-get install -qq libgtk-3-dev;
-        sudo apt-get install gcc-5 g++-5;
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5;
         sudo apt-get install libglfw3-dev libglfw3;
+        sudo apt-get install gcc-7 g++-7;
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7;
+        
         
     - name: Build
       run: |


### PR DESCRIPTION
GHA deprecate Ubuntu 18 runners,
We update the CI to use Ubuntu 20 runners

See https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

When I used the default compiler (GCC 9.5) it used lto (link time optimization) and it failed on an internal error.

So I forced it to use GCC 7 which compile.

