### PR TITLE
Deprecate apt-key in distribution_linux.md to align with Debian policy #11644

### DIFF
--- a/doc/distribution_linux.md
+++ b/doc/distribution_linux.md
@@ -14,13 +14,21 @@ The steps are described in [Linux manual installation guide](./installation.md)
 
 
 ## Installing the packages:
-- Register the server's public key:  
-`sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE`
-In case the public key still cannot be retrieved, check and specify proxy settings: `export http_proxy="http://<proxy>:<port>"`  
-, and rerun the command. See additional methods in the following [link](https://unix.stackexchange.com/questions/361213/unable-to-add-gpg-key-with-apt-key-behind-a-proxy).  
+- Register the server's public key:
+```
+sudo mkdir -p /etc/apt/keyrings
+curl -sSf https://librealsense.intel.com/Debian/librealsense.pgp | sudo tee /etc/apt/keyrings/librealsense.pgp > /dev/null
+```
 
-- Add the server to the list of repositories:  
-`sudo add-apt-repository "deb https://librealsense.intel.com/Debian/apt-repo $(lsb_release -cs) main" -u`  
+- Make sure apt HTTPS support is installed:
+`sudo apt-get install apt-transport-https`
+
+- Add the server to the list of repositories:
+```
+echo "deb [signed-by=/etc/apt/keyrings/librealsense.pgp] https://librealsense.intel.com/Debian/apt-repo `lsb_release -cs` main" | \
+sudo tee /etc/apt/sources.list.d/librealsense.list
+sudo apt-get update
+```
 
 - Install the libraries (see section below if upgrading packages):  
   `sudo apt-get install librealsense2-dkms`  


### PR DESCRIPTION
Update apt repository configuration procedure and documentation to follow https://wiki.debian.org/DebianRepository/UseThirdParty.