### PR TITLE
fix dds query_devices: discard non-running devices

### DIFF
--- a/third-party/realdds/src/dds-device-broadcaster.cpp
+++ b/third-party/realdds/src/dds-device-broadcaster.cpp
@@ -12,6 +12,9 @@
 #include <realdds/topics/flexible/flexible-msg.h>
 #include <realdds/topics/flexible/flexiblePubSubTypes.h>
 
+#include <rsutils/string/slice.h>
+using rsutils::string::slice;
+
 #include <iostream>
 
 using namespace eprosima::fastdds::dds;
@@ -206,8 +209,8 @@ bool dds_device_broadcaster::send_device_info_msg( const dds_device_handle & han
     // Post a DDS message with the new added device
     try
     {
+        LOG_DEBUG( "sending device-info message " << slice( msg.custom_data< char const >(), msg._data.size() ) );
         msg.write_to( *handle.client_listener );
-        LOG_DEBUG( "DDS device message sent!" );
         return true;
     }
     catch( ... )

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -89,10 +89,6 @@ void dds_device::impl::run( size_t message_timeout_ms )
     if( ! init() )
         DDS_THROW( runtime_error, "failed getting stream data from '" + _info.topic_root + "'" );
 
-    LOG_DEBUG( "device '" << _info.topic_root << "' (" << _participant->print( _guid )
-                          << ") initialized successfully" );
-    _running = true;
-
     // Start handling options only after init() is done
     _notifications_reader->on_data_available( [&]() {
         topics::flexible_msg notification;
@@ -110,6 +106,10 @@ void dds_device::impl::run( size_t message_timeout_ms )
             }
         }
     } );
+
+    LOG_DEBUG( "device '" << _info.topic_root << "' (" << _participant->print( _guid )
+                          << ") initialized successfully" );
+    _running = true;
 }
 
 void dds_device::impl::open( const dds_stream_profiles & profiles )

--- a/third-party/realdds/src/topics/device-info-msg.cpp
+++ b/third-party/realdds/src/topics/device-info-msg.cpp
@@ -34,7 +34,6 @@ nlohmann::json device_info::to_json() const
         { "topic-root", topic_root },
         { "locked", locked },
     } );
-    LOG_DEBUG( "-----> JSON = " << msg.dump() );
     return msg;
 }
 

--- a/unit-tests/dds/dds.py
+++ b/unit-tests/dds/dds.py
@@ -31,13 +31,15 @@ def run_server( server_script, nested_indent = 'svr' ):
         log.d( "server took", run_time, "seconds" )
 
 
-def wait_for_devices( context, mask, tries = 3 ):
+def wait_for_devices( context, mask, timeout=3 ):
     """
     Since DDS devices may take time to be recognized and then initialized, we try over time:
     """
-    while tries:
+    if 'gha' in test.context:
+        timeout *= 3  # GHA VMs have only 2 cores
+    while timeout:
         devices = context.query_devices( mask )
         if len(devices) > 0:
             return devices
-        tries -= 1
+        timeout -= 1
         sleep( 1 )

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -15,7 +15,7 @@ import pyrealsense2 as rs
 rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( '{"dds-domain":123}' )
+context = rs.context( '{"dds-domain":123,"dds-participant-name":"device-properties-client"}' )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -27,7 +27,7 @@ test_in_progress = False
 test_info = {} # Dictionary for holding additional information to print in case of a failed check.
 
 # if --context flag was sent, the test is running under a specific context which could affect its run
-context = None
+context = []
 if '--context' in sys.argv:
     context_index = sys.argv.index( '--context' )
     try:

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -36,6 +36,13 @@ if '--context' in sys.argv:
         log.f( "Received --context flag but no context" )
     sys.argv.pop( context_index )
 
+# automatically detect github actions based on environment variable
+# see https://docs.github.com/en/actions/learn-github-actions/variables
+if 'gha' not in context:
+    if os.environ.get( 'GITHUB_ACTIONS' ):
+        context.append( 'gha' )
+        log.d( '    github actions detected' )
+
 # If --rslog flag was sent, enable LibRS logging (LOG_DEBUG, etc.)
 try:
     sys.argv.remove( '--rslog' )


### PR DESCRIPTION
Recent GHA runs of the DDS tests are failing. This is an attempt to stabilize.

In general, GHA tasks run on only two cores and some of our tests use multiple processes and multiple threads and are therefore sensitive.

At least one problem seen is:
* The broadcaster broadcasts a device
* The client sees it in thread 1
* The client is waiting for devices in thread 2 (python)
  * Thread 2 is, every second, performing a query_devices() until it sees the device
  * Query devices sees the device (it's part of the devices that can be iterated on the device-watcher)
  * Thread 2 wakes up and tries to act on the device

But Thread 1 is not yet done initializing the device!

Changes:
* fix rspy.test.context initialization to []
* add "gha" to rspy.test.context using GITHUB_ACTIONS env var
  * i.e., you can now limit libci tests to be GHA-specific
* allow 3x timeout waiting for dds devices under GHA
* give dds test-librs-device-properties context a name
* fix dds query_devices: discard non-running devices; now product-line sensitive
