### PR TITLE
redo device-broadcaster

### DIFF
--- a/third-party/realdds/include/realdds/dds-device-broadcaster.h
+++ b/third-party/realdds/include/realdds/dds-device-broadcaster.h
@@ -4,94 +4,54 @@
 #pragma once
 
 #include <realdds/topics/device-info-msg.h>
-#include <rsutils/concurrency/concurrency.h>
 
-#include <unordered_map>
-#include <vector>
-#include <atomic>
-#include <mutex>
-#include <condition_variable>
-
-// Forward declare FastDDS types
-namespace eprosima {
-namespace fastdds {
-namespace dds {
-class DomainParticipant;
-class Publisher;
-class Topic;
-class DataWriter;
-class TypeSupport;
-}  // namespace dds
-}  // namespace fastdds
-}  // namespace eprosima
+#include <memory>
 
 
 namespace realdds {
 
 
-class dds_participant;
 class dds_publisher;
 class dds_topic_writer;
-class dds_topic;
 
-// We're responsible for broadcasting each device to listeners on the DDS network
+
+namespace detail {
+    class broadcast_manager;
+}
+
+
+// Responsible for broadcasting a device to watchers on the DDS domain.
+// 
+// We have one topic on which these broadcasts are sent. On the other side, a device-watcher will be listening to pick
+// up on broadcasts.
+// 
+// Two main events need to be picked up by the watcher:
+//      - When a device is added, a message containing the device_info is expected or the device cannot be located, and
+//        the message must be associated with a GUID for the device
+//      - When a device is removed, this needs to be recognized
+//          - Note that a device may get disconnected, crash, or otherwise disappear without proper destruction
+//          - A message on the topic is therefore not expected
+//          - Instead, we rely on the DDS publication-match notifications to tell the client that a writer was removed
+// So for each device we maintain a DataWriter that will:
+//      - Have its own GUID (supplied by DDS automatically)
+//      - Supply its own dis/connect notifications (also supplied automatically)
 //
 class dds_device_broadcaster
 {
+    friend class detail::broadcast_manager;
+    std::shared_ptr< detail::broadcast_manager > _manager;
+
+protected:
+    topics::device_info _device_info;
+    std::shared_ptr< dds_topic_writer > _writer;
+
 public:
-    using device_info = topics::device_info;
+    dds_device_broadcaster( std::shared_ptr< dds_publisher > const &, topics::device_info const & );
+    virtual ~dds_device_broadcaster();
 
-    dds_device_broadcaster( std::shared_ptr< dds_participant > const & participant );
-    ~dds_device_broadcaster();
-
-    // Start listening for device changes
-    bool run();
-
-    // Broadcast a device addition
-    void add_device( device_info const & dev_info );
-
-    // Broadcast that a device was removed and is no longer available
-    void remove_device( device_info const & dev_info );
-
-private:
-
-    class dds_client_listener;
-
-    struct dds_device_handle
-    {
-        device_info info;
-        std::shared_ptr< dds_client_listener > client_listener;
-    };
-
-    // handles the DDS writers pool of connected/disconnected RS devices.
-    // It dispatch the DDS work to a worker thread.
-    // If a device was removed:
-    //   * remove it from the connected devices (destruct the data writer, the client will be
-    //   notified automatically)
-    // If a device was added:
-    //   * Create a new data writer for it
-    //   * Publish the device name
-
-    void handle_device_changes(const std::vector< std::string > & devices_to_remove,
-                               const std::vector< device_info > & devices_to_add );
-
-
-    void remove_dds_device( const std::string & serial_number );
-    bool add_dds_device( const device_info & dev_info );
-    bool create_device_writer( device_info const & dev_info );
-    bool send_device_info_msg( const dds_device_handle & handle );
-
-    std::atomic_bool _trigger_msg_send;
-    std::shared_ptr< dds_participant > _participant;
-    std::shared_ptr< dds_publisher > _publisher;
-    std::shared_ptr< dds_topic > _topic;
-    std::unordered_map< std::string, dds_device_handle > _device_handle_by_sn;
-    dispatcher _dds_device_dispatcher;
-    active_object<> _new_client_handler;
-    std::condition_variable _new_client_cv;
-    std::mutex _new_client_mutex;
-    std::atomic_bool _active = { false };
-};  // class dds_device_broadcaster
+protected:
+    virtual void broadcast() const;
+};
 
 
 }  // namespace realdds

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -35,6 +35,7 @@ class dds_stream_server;
 class dds_notification_server;
 class dds_topic_reader;
 class dds_topic_writer;
+class dds_device_broadcaster;
 struct image_header;
 
 
@@ -63,6 +64,8 @@ public:
     // to subscribe.
     void init( const std::vector< std::shared_ptr< dds_stream_server > > & streams,
                const dds_options & options, const extrinsics_map & extr );
+
+    void broadcast( topics::device_info const & );
 
     bool is_valid() const { return( nullptr != _notification_server.get() ); }
     bool operator!() const { return ! is_valid(); }
@@ -99,8 +102,9 @@ private:
     std::shared_ptr< dds_notification_server > _notification_server;
     std::shared_ptr< dds_topic_reader > _control_reader;
     std::shared_ptr< dds_topic_writer > _metadata_writer;
+    std::shared_ptr< dds_device_broadcaster > _broadcaster;
     dispatcher _control_dispatcher;
-    
+
     control_callback _open_streams_callback = nullptr;
     set_option_callback _set_option_callback = nullptr;
     query_option_callback _query_option_callback = nullptr;

--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -27,6 +27,11 @@ class Storage;
 }  // namespace base
 }  // namespace el
 #endif
+namespace rsutils {
+namespace string {
+class slice;
+}  // namespace string
+}  // namespace rsutils
 
 
 namespace realdds {
@@ -73,6 +78,10 @@ public:
     // The prefix is a combination of (vendor, host, process, participant-id).
     //
     dds_guid const & guid() const;
+
+    // Returns this participant's name from the QoS
+    //
+    rsutils::string::slice name() const;
 
     // Utility to create a custom GUID, to help
     //

--- a/third-party/realdds/include/realdds/dds-topic-writer.h
+++ b/third-party/realdds/include/realdds/dds-topic-writer.h
@@ -30,7 +30,7 @@ class dds_publisher;
 // You may choose to create one via a 'publisher' that manages the activities of several writers and determines when the
 // data is actually sent. By default, data is sent as soon as the writer’s write() function is called.
 //
-class dds_topic_writer : public eprosima::fastdds::dds::DataWriterListener
+class dds_topic_writer : protected eprosima::fastdds::dds::DataWriterListener
 {
     std::shared_ptr< dds_topic > const _topic;
     std::shared_ptr< dds_publisher > const _publisher;
@@ -48,6 +48,7 @@ public:
     bool is_running() const { return ( get() != nullptr ); }
 
     std::shared_ptr< dds_topic > const & topic() const { return _topic; }
+    std::shared_ptr< dds_publisher > const & publisher() const { return _publisher; }
 
     typedef std::function< void( eprosima::fastdds::dds::PublicationMatchedStatus const & ) >
         on_publication_matched_callback;

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -453,10 +453,7 @@ PYBIND11_MODULE(NAME, m) {
 
     using realdds::dds_device_broadcaster;
     py::class_< dds_device_broadcaster >( m, "device_broadcaster" )
-        .def( py::init< std::shared_ptr< dds_participant > const & >() )
-        .def( "run", &dds_device_broadcaster::run )
-        .def( "add_device", &dds_device_broadcaster::add_device )
-        .def( "remove_device", &dds_device_broadcaster::remove_device );
+        .def( py::init< std::shared_ptr< dds_publisher > const &, device_info const & >() );
 
     using realdds::dds_option_range;
     py::class_< dds_option_range >( m, "dds_option_range" )
@@ -616,7 +613,8 @@ PYBIND11_MODULE(NAME, m) {
                       streams.push_back( name2stream.second );
                   return streams;
               } )
-        .def( "publish_metadata", &dds_device_server::publish_metadata, py::call_guard< py::gil_scoped_release >() );
+        .def( "publish_metadata", &dds_device_server::publish_metadata, py::call_guard< py::gil_scoped_release >() )
+        .def( "broadcast", &dds_device_server::broadcast );
 
     using realdds::dds_stream;
     py::class_< dds_stream, std::shared_ptr< dds_stream > > stream_client_base( m, "stream", stream_base );

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -7,6 +7,7 @@
 #include <realdds/topics/flexible/flexiblePubSubTypes.h>
 #include <realdds/topics/image/image-msg.h>
 #include <realdds/topics/ros2/ros2imagePubSubTypes.h>
+#include <realdds/topics/dds-topic-names.h>
 #include <realdds/dds-device-broadcaster.h>
 #include <realdds/dds-device-server.h>
 #include <realdds/dds-stream-server.h>
@@ -163,6 +164,10 @@ PYBIND11_MODULE(NAME, m) {
     //      topic = dds.topic( p, dds.types.device_info(), "realsense/device-info" )
     auto types = m.def_submodule( "types", "all the types that " SNAME " can work with" );
 
+    // The 'topics' submodule will contain pointers to the topic names:
+    auto topics = m.def_submodule( "topics", "all the topics that " SNAME " knows" );
+    topics.attr( "device_info" ) = realdds::topics::DEVICE_INFO_TOPIC_NAME;
+
     // We need to declare a basic TypeSupport or else dds_topic ctor won't work
     using eprosima::fastdds::dds::TypeSupport;
     py::class_< TypeSupport > topic_type( types, "topic_type" );
@@ -290,6 +295,8 @@ PYBIND11_MODULE(NAME, m) {
         .def_readwrite( "product_id", &device_info::product_id )
         .def_readwrite( "locked", &device_info::locked )
         .def_readwrite( "topic_root", &device_info::topic_root )
+        .def_static( "from_json", &device_info::from_json )
+        .def( "to_json", &device_info::to_json )
         .def( "__repr__",
               []( device_info const & self ) {
                   std::ostringstream os;
@@ -409,9 +416,10 @@ PYBIND11_MODULE(NAME, m) {
             py::arg( "reader" ), py::arg( "sample" ) = nullptr,
             py::call_guard< py::gil_scoped_release >() )
         .def_static( "create_topic", static_cast<flexible_msg_create_topic *>( &flexible_msg::create_topic ))
-        .def( "json_data", []( flexible_msg const & self ) {
-            return std::string( (char const *)self._data.data(), self._data.size() );
-        } )
+        .def( "json_data", &flexible_msg::json_data )
+        .def( "json_string",
+              []( flexible_msg const & self )
+              { return std::string( (char const *)self._data.data(), self._data.size() ); } )
         .def( "write_to", &flexible_msg::write_to, py::call_guard< py::gil_scoped_release >() );
 
 

--- a/third-party/realdds/src/dds-device-broadcaster.cpp
+++ b/third-party/realdds/src/dds-device-broadcaster.cpp
@@ -6,233 +6,154 @@
 #include <realdds/dds-participant.h>
 #include <realdds/dds-publisher.h>
 #include <realdds/dds-topic-writer.h>
+#include <realdds/dds-topic.h>
 #include <realdds/dds-utilities.h>
-#include <realdds/dds-guid.h>
 #include <realdds/topics/dds-topic-names.h>
 #include <realdds/topics/flexible/flexible-msg.h>
-#include <realdds/topics/flexible/flexiblePubSubTypes.h>
 
+#include <fastdds/dds/publisher/DataWriter.hpp>
+#include <fastdds/dds/core/condition/WaitSet.hpp>
+#include <fastdds/dds/core/condition/GuardCondition.hpp>
+
+#include <rsutils/shared-ptr-singleton.h>
 #include <rsutils/string/slice.h>
 using rsutils::string::slice;
 
-#include <iostream>
 
-using namespace eprosima::fastdds::dds;
-using namespace realdds;
+namespace realdds {
 
-// We want to know when readers join our topic
-class dds_device_broadcaster::dds_client_listener : public realdds::dds_topic_writer //dds_topic_writer is a listener
+
+// Singleton, per participant
+// Manages the thread from which broadcast messages are sent
+//
+class detail::broadcast_manager
 {
+    std::thread _th;
+    std::shared_ptr< dds_topic_writer > _writer;
+    eprosima::fastdds::dds::GuardCondition _stopped, _ready_for_broadcast;
+
+    std::mutex _broadcasters_mutex;
+    std::set< dds_device_broadcaster * > _broadcasters;
+
 public:
-    dds_client_listener( std::shared_ptr< dds_topic > const & topic,
-                         std::shared_ptr< dds_publisher > const & publisher,
-                         dds_device_broadcaster * owner )
-        : dds_topic_writer( topic, publisher )
-        , _owner( owner )
+    broadcast_manager( std::shared_ptr< dds_publisher > const & publisher )
     {
-    }
+        auto topic = topics::flexible_msg::create_topic( publisher->get_participant(), topics::DEVICE_INFO_TOPIC_NAME );
 
-    std::atomic_bool _new_reader_joined = { false };  // Used to indicate that a new reader has joined for this writer
-
-protected:
-    void on_publication_matched( eprosima::fastdds::dds::DataWriter * writer,
-                                 eprosima::fastdds::dds::PublicationMatchedStatus const & info ) override
-    {
-        if( info.current_count_change == 1 )
-        {
-            // We send the work to the dispatcher to avoid waiting on the mutex here.
-            _owner->_dds_device_dispatcher.invoke( [this]( dispatcher::cancellable_timer ) {
-                {
-                    std::lock_guard< std::mutex > lock( _owner->_new_client_mutex ); //TODO - mutxe locking needed here? Dispatcher needed here?
-                    _new_reader_joined = true;
-                    _owner->_trigger_msg_send = true;
-                }
-                _owner->_new_client_cv.notify_all();
+        // We keep our own writer just for the thread status notifications
+        _writer = std::make_shared< dds_topic_writer >( topic, publisher );
+        _writer->on_publication_matched(
+            [this]( eprosima::fastdds::dds::PublicationMatchedStatus const & status )
+            {
+                LOG_DEBUG( _writer->topic()->get_participant()->name()
+                           << ": " << status.current_count << " total watchers for broadcast ("
+                           << ( status.current_count_change >= 0 ? "+" : "" ) << status.current_count_change << ")" );
+                // We get called from the participant thread; trigger our own thread for actual broadcast
+                if( status.current_count_change > 0 )
+                    _ready_for_broadcast.set_trigger_value( true );
             } );
-        }
-        else if( info.current_count_change == -1 )
+        _writer->run();
+
+        _th = std::thread(
+            [this]()
+            {
+                LOG_DEBUG( _writer->topic()->get_participant()->name() << ": broadcaster thread running" );
+                eprosima::fastdds::dds::WaitSet wait_set;
+                //auto & publication_matched = _writer->get()->get_statuscondition();
+                //publication_matched.set_enabled_statuses( eprosima::fastdds::dds::StatusMask::publication_matched() );
+                //wait_set.attach_condition( publication_matched );
+                wait_set.attach_condition( _ready_for_broadcast );
+                wait_set.attach_condition( _stopped );
+
+                while( ! _stopped.get_trigger_value() )
+                {
+                    eprosima::fastdds::dds::ConditionSeq active_conditions;
+                    wait_set.wait( active_conditions, eprosima::fastrtps::c_TimeInfinite );
+                    if( _stopped.get_trigger_value() )
+                        break;
+                    // Let multiple broadcasts gather and do it only once
+                    std::this_thread::sleep_for( std::chrono::milliseconds( 50 ) );
+                    _ready_for_broadcast.set_trigger_value( false );
+
+                    std::lock_guard< std::mutex > lock( _broadcasters_mutex );
+                    LOG_DEBUG( _writer->topic()->get_participant()->name() << ": broadcasting" );
+                    for( dds_device_broadcaster const * broadcaster : _broadcasters )
+                        broadcaster->broadcast();
+                }
+                LOG_DEBUG( _writer->topic()->get_participant()->name() << ": broadcaster thread stopped" );
+            } );
+    }
+
+    ~broadcast_manager()
+    {
+        if( _th.joinable() )
         {
-        }
-        else
-        {
-            LOG_ERROR( std::to_string( info.current_count_change )
-                       << " is not a valid value for on_publication_matched" );
+            _stopped.set_trigger_value( true );
+            _th.join();
         }
     }
 
-private:
-    dds_device_broadcaster * _owner;
+    std::shared_ptr< dds_topic_writer > register_broadcaster( dds_device_broadcaster * broadcaster )
+    {
+        // Each broadcaster (for a single device) gets its own writer, with a GUID, from which its broadcasts will be
+        // made. This lets the watcher associate the GUID with that specific device, and can tell when the GUID
+        // disappears that the device is no longer online...
+        auto writer = std::make_shared< dds_topic_writer >( _writer->topic(), _writer->publisher() );
+        writer->run();
+        {
+            std::lock_guard< std::mutex > lock( _broadcasters_mutex );
+            _broadcasters.insert( broadcaster );
+        }
+        return writer;
+    }
+
+    void unregister_broadcaster( dds_device_broadcaster * broadcaster )
+    {
+        std::lock_guard< std::mutex > lock( _broadcasters_mutex );
+        _broadcasters.erase( broadcaster );
+    }
 };
 
 
-dds_device_broadcaster::dds_device_broadcaster( std::shared_ptr< dds_participant > const & participant )
-    : _trigger_msg_send( false )
-    , _participant( participant )
-    , _publisher( std::make_shared< dds_publisher >( participant ) )
-    , _dds_device_dispatcher( 10 )
-    , _new_client_handler( [this]( dispatcher::cancellable_timer ) {
-        // We wait until the new reader callback indicate a new reader has joined or until the active object is stopped
-        if( _active )
-        {
-            std::unique_lock< std::mutex > lock( _new_client_mutex );
-            _new_client_cv.wait( lock, [this]() { return ! _active || _trigger_msg_send.load(); } );
-            if( _active && _trigger_msg_send.load() )
-            {
-                _trigger_msg_send = false;
-                _dds_device_dispatcher.invoke( [this]( dispatcher::cancellable_timer ) {
-                    for( auto const & sn_and_handle : _device_handle_by_sn )
-                    {
-                        if( sn_and_handle.second.client_listener->_new_reader_joined )
-                        {
-                            if( send_device_info_msg( sn_and_handle.second ) )
-                            {
-                                sn_and_handle.second.client_listener->_new_reader_joined = false;
-                            }
-                        }
-                    }
-                } );
-            }
-        }
-    } )
+static std::map< realdds::dds_guid, rsutils::shared_ptr_singleton< detail::broadcast_manager > >
+    participant_broadcast_manager;
+
+
+dds_device_broadcaster::dds_device_broadcaster( std::shared_ptr< dds_publisher > const & publisher,
+                                                topics::device_info const & dev_info )
+    : _device_info( dev_info )
 {
-    if( ! _participant )
-        DDS_THROW( runtime_error, "dds_device_broadcaster called with a null participant" );
+    if( ! publisher )
+        DDS_THROW( runtime_error, "null publisher" );
+
+    auto participant_guid = publisher->get_participant()->guid();
+    _manager = participant_broadcast_manager[participant_guid].instance( publisher );
+    _writer = _manager->register_broadcaster( this );
+
+    broadcast();  // possible we have no subscribers, but can't hurt
 }
 
-bool dds_device_broadcaster::run()
+
+void dds_device_broadcaster::broadcast() const
 {
-    if( _active )
-        DDS_THROW( runtime_error, "dds_device_broadcaster::run() called when already-active" );
-
-    _dds_device_dispatcher.start();
-    _new_client_handler.start();
-    _active = true;
-    return true;
-}
-
-void dds_device_broadcaster::add_device( device_info const & dev_info )
-{
-    if( ! _active )
-        DDS_THROW( runtime_error, "dds_device_broadcaster::add_device called before run()" );
-    // Post the connected device
-    handle_device_changes( {}, { dev_info } );
-}
-
-void dds_device_broadcaster::remove_device( device_info const & dev_info )
-{
-    if( ! _active )
-        DDS_THROW( runtime_error, "dds_device_broadcaster::remove_device called before run()" );
-    // Post the disconnected device
-    handle_device_changes( { dev_info.serial }, {} );
-}
-
-void dds_device_broadcaster::handle_device_changes( const std::vector< std::string > & devices_to_remove,
-                                                    const std::vector< device_info > & devices_to_add )
-{
-    // We want to be as quick as possible and not wait for DDS in any way -- so we handle
-    // device changes in the background, using invoke:
-    _dds_device_dispatcher.invoke( [this, devices_to_add, devices_to_remove]( dispatcher::cancellable_timer ) {
-        try
-        {
-            for( auto const & dev_to_remove : devices_to_remove )
-            {
-                remove_dds_device( dev_to_remove );
-            }
-
-            for( auto const & dev_to_add : devices_to_add )
-            {
-                if( ! add_dds_device( dev_to_add ) )
-                {
-                    LOG_ERROR( "Error creating a DDS writer" );
-                }
-            }
-        }
-        catch( ... )
-        {
-            LOG_ERROR( "Unknown error when trying to remove/add a DDS device" );
-        }
-    } );
-}
-
-void dds_device_broadcaster::remove_dds_device( const std::string & serial_number )
-{
-    auto it = _device_handle_by_sn.find( serial_number );
-    if( it == _device_handle_by_sn.end() )
-    {
-        LOG_ERROR( "failed to remove non-existing device by serial number " << serial_number );
-        return;
-    }
-    auto & handle = it->second;
-
-    handle.client_listener.reset(); // deleting the writer notifies the clients (through DDS middleware)
-    _device_handle_by_sn.erase( it );
-}
-
-bool dds_device_broadcaster::add_dds_device( const device_info & dev_info )
-{
-    if( _device_handle_by_sn.find( dev_info.serial ) == _device_handle_by_sn.end() )
-    {
-        if( ! create_device_writer( dev_info ) )
-        {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-bool dds_device_broadcaster::create_device_writer( const device_info & dev_info )
-{
-    if( ! _topic )
-        _topic = topics::flexible_msg::create_topic( _publisher->get_participant(), topics::DEVICE_INFO_TOPIC_NAME );
-
-    // Create a data writer for the topic
-    auto writer = std::make_shared< dds_client_listener >( _topic, _publisher, this );
-    if( ! writer )
-        return false;
-
-    dds_topic_writer::qos wqos( RELIABLE_RELIABILITY_QOS ); //RELIABLE_RELIABILITY_QOS default but worth mentioning
-    writer->run( wqos );
-
-    auto it_inserted = _device_handle_by_sn.emplace( dev_info.serial,
-                                                     dds_device_handle{ dev_info, writer } );
-    assert( it_inserted.second );
-
-    return true;
-}
-
-bool dds_device_broadcaster::send_device_info_msg( const dds_device_handle & handle )
-{
-    // Publish the device info, but only after a matching reader is found.
-    topics::flexible_msg msg( handle.info.to_json() );
-
-    // Post a DDS message with the new added device
     try
     {
+        topics::flexible_msg msg( _device_info.to_json() );
         LOG_DEBUG( "sending device-info message " << slice( msg.custom_data< char const >(), msg._data.size() ) );
-        msg.write_to( *handle.client_listener );
-        return true;
+        msg.write_to( *_writer );
     }
-    catch( ... )
+    catch( std::exception const & e )
     {
-        LOG_ERROR( "Error writing new device message for device : " << handle.info.serial );
+        LOG_ERROR( "Error sending device-info message for S/N " << _device_info.serial << ": " << e.what() );
     }
-    return false;
 }
+
 
 dds_device_broadcaster::~dds_device_broadcaster()
 {
-    // Mark this class as inactive and wake up the active object do we can properly stop it.
-    _active = false; 
-    _new_client_cv.notify_all(); 
-    
-    _dds_device_dispatcher.stop();
-    _new_client_handler.stop();
-
-    // TODO - Will be destructed anyway by shared_ptr, worth mentioning explicitly?
-    for( auto & sn_and_handle : _device_handle_by_sn )
-    {
-        sn_and_handle.second.client_listener.reset(); // deleting the writer notifies the clients (through DDS middleware)
-    }
-    _device_handle_by_sn.clear();
+    _manager->unregister_broadcaster( this );
+    // _th ref count will be decreased and, if no others hold it, destroyed -- thereby stopping the thread
 }
+
+
+}  // namespace realdds

--- a/third-party/realdds/src/dds-device-broadcaster.cpp
+++ b/third-party/realdds/src/dds-device-broadcaster.cpp
@@ -30,7 +30,8 @@ class detail::broadcast_manager
 {
     std::thread _th;
     std::shared_ptr< dds_topic_writer > _writer;
-    eprosima::fastdds::dds::GuardCondition _stopped, _ready_for_broadcast;
+    eprosima::fastdds::dds::GuardCondition _stopped;
+    eprosima::fastdds::dds::GuardCondition _ready_for_broadcast;
 
     std::mutex _broadcasters_mutex;
     std::set< dds_device_broadcaster * > _broadcasters;

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -10,8 +10,10 @@
 #include <realdds/dds-stream-profile.h>
 #include <realdds/dds-notification-server.h>
 #include <realdds/dds-topic-reader.h>
+#include <realdds/dds-device-broadcaster.h>
 #include <realdds/dds-utilities.h>
 #include <realdds/topics/dds-topic-names.h>
+#include <realdds/topics/device-info-msg.h>
 #include <realdds/topics/flexible/flexible-msg.h>
 #include <realdds/dds-topic.h>
 #include <realdds/dds-topic-writer.h>
@@ -195,6 +197,16 @@ void dds_device_server::init( std::vector< std::shared_ptr< dds_stream_server > 
         _control_reader.reset();
         throw;
     }
+}
+
+
+void dds_device_server::broadcast( topics::device_info const & device_info )
+{
+    if( _broadcaster )
+        DDS_THROW( runtime_error, "device server was already broadcast" );
+    if( device_info.topic_root != _topic_root )
+        DDS_THROW( runtime_error, "topic roots do not match" );
+    _broadcaster = std::make_shared< dds_device_broadcaster >( _publisher, device_info );
 }
 
 

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -12,6 +12,8 @@
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 
+#include <rsutils/string/slice.h>
+
 #include <map>
 #include <mutex>
 
@@ -103,7 +105,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
                 std::lock_guard< std::mutex > lock( participants_mutex );
                 participant_info pinfo( info.info.m_participantName, info.info.m_guid.guidPrefix );
                 name = pinfo.name;
-                LOG_DEBUG( "+participant '" << name << "' " << guid );
+                LOG_DEBUG( _owner.name() << ": +participant '" << name << "' " << guid );
                 participants.emplace( info.info.m_guid.guidPrefix, std::move( pinfo ) );
             }
             _owner.on_participant_added( info.info.m_guid, name.c_str() );
@@ -111,7 +113,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
         }
         case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::REMOVED_PARTICIPANT:
         case eprosima::fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT:
-            LOG_DEBUG( "-participant " << _owner.print( info.info.m_guid ) );
+            LOG_DEBUG( _owner.name() << ": -participant " << _owner.print( info.info.m_guid ) );
             _owner.on_participant_removed( info.info.m_guid, info.info.m_participantName.c_str() );
             {
                 std::lock_guard< std::mutex > lock( participants_mutex );
@@ -130,15 +132,15 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
         {
         case eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER:
             /* Process the case when a new publisher was found in the domain */
-            LOG_DEBUG( "+writer (" << _owner.print( info.info.guid() ) << ") publishing '" << info.info.topicName()
-                                   << "' of type '" << info.info.typeName() << "'" );
+            LOG_DEBUG( _owner.name() << ": +writer (" << _owner.print( info.info.guid() ) << ") publishing '"
+                                     << info.info.topicName() << "' of type '" << info.info.typeName() << "'" );
             _owner.on_writer_added( info.info.guid(), info.info.topicName().c_str() );
             break;
 
         case eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER:
             /* Process the case when a publisher was removed from the domain */
-            LOG_DEBUG( "-writer (" << _owner.print( info.info.guid() ) << ") publishing '" << info.info.topicName()
-                                   << "'" );
+            LOG_DEBUG( _owner.name() << ": -writer (" << _owner.print( info.info.guid() ) << ") publishing '"
+                                     << info.info.topicName() << "'" );
             _owner.on_writer_removed( info.info.guid(), info.info.topicName().c_str() );
             break;
         }
@@ -150,13 +152,14 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
         switch( info.status )
         {
         case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER:
-            LOG_DEBUG( "+reader (" << _owner.print( info.info.guid() ) << ") of '" << info.info.topicName()
-                                   << "' of type '" << info.info.typeName() << "'" );
+            LOG_DEBUG( _owner.name() << ": +reader (" << _owner.print( info.info.guid() ) << ") of '"
+                                     << info.info.topicName() << "' of type '" << info.info.typeName() << "'" );
             _owner.on_reader_added( info.info.guid(), info.info.topicName().c_str() );
             break;
 
         case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER:
-            LOG_DEBUG( "-reader (" << _owner.print( info.info.guid() ) << ") of '" << info.info.topicName() << "'" );
+            LOG_DEBUG( _owner.name() << ": -reader (" << _owner.print( info.info.guid() ) << ") of '"
+                                     << info.info.topicName() << "'" );
             _owner.on_reader_removed( info.info.guid(), info.info.topicName().c_str() );
             break;
         }
@@ -170,7 +173,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
                                     eprosima::fastrtps::types::DynamicType_ptr dyn_type ) override
     {
         TypeSupport type_support( new eprosima::fastrtps::types::DynamicPubSubType( dyn_type ) );
-        LOG_DEBUG( "discovered topic " << topic_name << " of type: " << type_support->getName() );
+        LOG_DEBUG( _owner.name() << ": discovered topic " << topic_name << " of type: " << type_support->getName() );
         _owner.on_type_discovery( topic_name.c_str(), dyn_type );
     }
 };
@@ -249,6 +252,13 @@ dds_participant::~dds_participant()
 dds_guid const & dds_participant::guid() const
 {
     return get()->guid();
+}
+
+
+rsutils::string::slice dds_participant::name() const
+{
+    auto & string_255 = get()->get_qos().name();
+    return rsutils::string::slice( string_255.c_str(), string_255.size() );
 }
 
 

--- a/third-party/realdds/src/dds-stream-server.cpp
+++ b/third-party/realdds/src/dds-stream-server.cpp
@@ -137,14 +137,14 @@ void dds_stream_server::run_stream()
             {
                 if( auto self = weak_this.lock() )
                     try
-                {
-                    LOG_DEBUG( status.current_count << " total readers on '" << self->name() << "'" );
-                    on_readers_changed( self, status.current_count );
-                }
-                catch( std::exception const & e )
-                {
-                    LOG_ERROR( "exception from 'on_readers_changed': " << e.what() );
-                }
+                    {
+                        LOG_DEBUG( status.current_count << " total readers on '" << self->name() << "'" );
+                        on_readers_changed( self, status.current_count );
+                    }
+                    catch( std::exception const & e )
+                    {
+                        LOG_ERROR( "exception from 'on_readers_changed': " << e.what() );
+                    }
             } );
     }
     

--- a/third-party/realdds/src/dds-topic-reader-thread.cpp
+++ b/third-party/realdds/src/dds-topic-reader-thread.cpp
@@ -58,8 +58,6 @@ void dds_topic_reader_thread::run( qos const & rqos )
 
             while( ! _stopped.get_trigger_value() )
             {
-                _stopped.set_trigger_value( false );
-
                 eprosima::fastdds::dds::ConditionSeq active_conditions;
                 wait_set.wait( active_conditions, eprosima::fastrtps::c_TimeInfinite );
 

--- a/unit-tests/dds/device-broadcaster.py
+++ b/unit-tests/dds/device-broadcaster.py
@@ -13,11 +13,8 @@ dds.debug( True, log.nested )
 participant = dds.participant()
 participant.init( 123, "device-broadcaster" )
 
-# Start a broadcaster to communicate to our client (librealsense)
-broadcaster = dds.device_broadcaster( participant )
-broadcaster.run()
 # These are the servers currently broadcast
-servers = {}
+servers = dict()
 
 
 def broadcast_device( camera, device_info ):
@@ -29,11 +26,12 @@ def broadcast_device( camera, device_info ):
     instance = device_info.serial
     if not instance:
         raise RuntimeError( "serial-number must be filled out" )
+    server = camera.build( participant )
     servers[instance] = {
         'info' : device_info,
-        'server' : camera.build( participant )
+        'server' : server
         }
-    broadcaster.add_device( device_info )
+    server.broadcast( device_info )
     return instance
 
 
@@ -42,9 +40,7 @@ def close_server( instance ):
     Close the instance returned by broadcast_device()
     """
     global servers
-    entry = servers[instance]  # throws if does not exist
-    broadcaster.remove_device( entry['info'] )
-    del servers[instance]
+    del servers[instance]  # throws if does not exist
 
 
 # From here down, we're in "interactive" mode (see test-device-init.py)

--- a/unit-tests/dds/test-streaming.py
+++ b/unit-tests/dds/test-streaming.py
@@ -49,7 +49,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         remote.run( 'topic.write( """' + sample1_json + '""" )', timeout=5 )
         msg = topic.read()
         test.check( topic.empty() )
-        test.check_equal( json.loads( msg.json_data() ), sample1 )
+        test.check_equal( msg.json_data(), sample1 )
     except:
         test.unexpected_exception()
     remote.run( 'topic.stop()', timeout=5 )
@@ -72,9 +72,9 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         msg2 = topic.read()
         msg3 = topic.read()
         test.check( topic.empty() )
-        test.check_equal( json.loads( msg1.json_data() ), sample1 )
-        test.check_equal( json.loads( msg2.json_data() ), sample2 )
-        test.check_equal( json.loads( msg3.json_data() ), sample3 )
+        test.check_equal( msg1.json_data(), sample1 )
+        test.check_equal( msg2.json_data(), sample2 )
+        test.check_equal( msg3.json_data(), sample3 )
     except:
         test.unexpected_exception()
     remote.run( 'topic.stop()', timeout=5 )
@@ -97,8 +97,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         msg2 = r2.read()
         test.check( r1.empty() )
         test.check( r2.empty() )
-        test.check_equal( json.loads( msg1.json_data() ), sample1 )
-        test.check_equal( json.loads( msg2.json_data() ), sample1 )
+        test.check_equal( msg1.json_data(), sample1 )
+        test.check_equal( msg2.json_data(), sample1 )
     except:
         test.unexpected_exception()
     remote.run( 'topic.stop()', timeout=5 )

--- a/unit-tests/dds/test-watcher.py
+++ b/unit-tests/dds/test-watcher.py
@@ -3,47 +3,136 @@
 
 #test:donotrun:!dds
 
-import pyrealdds as client
 from rspy import log, test
 
-
-import dds
-client.debug( True, 'C  ' )
+import pyrealdds as dds
+dds.debug( True, 'C  ' )
 log.nested = 'C  '
 
+import threading
 
-#############################################################################################
-#
-test.start( "Checking we can detect devices..." )
 
+participant = dds.participant()
+participant.init( 123, "client" )
+
+
+# We listen directly on the device-info topic
+device_info_topic = dds.flexible_msg.create_topic( participant, dds.topics.device_info )
+device_info = dds.topic_reader( device_info_topic )
+broadcast_received = threading.Event()
+broadcast_devices = []
+def on_device_info_available( reader ):
+    while True:
+        msg = dds.flexible_msg.take_next( reader )
+        if not msg:
+            break
+        j = msg.json_data()
+        log.d( f'on_device_info_available {j}' )
+        di = dds.device_info.from_json( j )
+        global broadcast_devices
+        broadcast_devices.append( di )
+    broadcast_received.set()
+device_info.on_data_available( on_device_info_available )
+device_info.run( dds.topic_reader.qos() )
+
+def detect_broadcast():
+    global broadcast_received, broadcast_devices
+    broadcast_received.clear()
+    broadcast_devices = []
+
+from rspy.stopwatch import Stopwatch
+def wait_for_broadcast( count=1, timeout=1 ):
+    while timeout > 0:
+        sw = Stopwatch()
+        if not broadcast_received.wait( timeout ):
+            raise TimeoutError( 'timeout waiting for broadcast' )
+        if count <= len(broadcast_devices):
+            return
+        broadcast_received.clear()
+        timeout -= sw.get_elapsed()
+    if count is None:
+        raise TimeoutError( 'timeout waiting broadcast' )
+    raise TimeoutError( f'timeout waiting for {count} broadcasts; {len(broadcast_devices)} received' )
+
+class broadcast_expected:
+    def __init__( self, n_expected=1, timeout=1 ):
+        self._timeout = timeout
+        self._n_expected = n_expected
+    def __enter__( self ):
+        detect_broadcast()
+    def __exit__( self, type, value, traceback ):
+        if type is None:  # If an exception is thrown, don't do anything
+            wait_for_broadcast( count=self._n_expected, timeout=self._timeout )
+
+
+# Start a watcher, too...
 devices_added = 0
 def on_device_added( watcher, dev ):
     global devices_added
     devices_added += 1
-    log.d( 'added', dev )
+    log.d( 'watcher detected device added', dev )
     watcher.foreach_device( lambda dev: log.d( dev ) )
+
 devices_removed = 0
 def on_device_removed( watcher, dev ):
     global devices_removed
     devices_removed += 1
-    log.d( 'removed', dev )
+    log.d( 'watcher detected device removed', dev )
 
-participant = client.participant()
-participant.init( 123, "test-watcher-client" )
-
-watcher = client.device_watcher( participant )
+watcher = dds.device_watcher( participant )
 watcher.on_device_added( on_device_added )
 watcher.on_device_removed( on_device_removed )
 watcher.start()
 
-dds.run_server( 'watcher-server.py', nested_indent="  S" )
 
-test.check_equal( devices_added, 2 )
-test.check_equal( devices_removed, 2 )
+import os.path
+cwd = os.path.dirname(os.path.realpath(__file__))
+remote_script = os.path.join( cwd, 'watcher-server.py' )
+with test.remote( remote_script, nested_indent='  S' ) as remote:
+    #############################################################################################
+    #
+    test.start( "Broadcast first; expect 1" )
+    with broadcast_expected():
+        remote.run( 'broadcast({ "serial" : "123" })', timeout=5 )
+    test.check_equal( len(broadcast_devices), 1 )
+    test.finish()
+    #
+    #############################################################################################
+    #
+    test.start( "Broadcast second; expect 1" )
+    with broadcast_expected():
+        remote.run( 'broadcast({ "serial" : "456" })', timeout=5 )
+    test.check_equal( len(broadcast_devices), 1 )
+    test.finish()
+    #
+    #############################################################################################
+    #
+    test.start( "Add another client; expect 2!" )
+    with broadcast_expected( 2 ):
+        reader_2 = dds.topic_reader( device_info_topic )
+        reader_2.run( dds.topic_reader.qos() )
+    test.check_equal( len(broadcast_devices), 2 )
+    del reader_2
+    test.finish()
+    #
+    #############################################################################################
+    #
+    test.start( "We should see both in the watcher" )
+    test.check_equal( devices_added, 2 )
+    test.finish()
+    #
+    #############################################################################################
+    #
+    test.start( "Get both removals" )
+    remote.run( 'unbroadcast_all()', timeout=5 )
+    from time import sleep
+    sleep(1)
+    test.check_equal( devices_removed, 2 )
+    test.finish()
+    #
+    #############################################################################################
 
-watcher = None
-participant = None
-test.finish()
-#
-#############################################################################################
+del watcher
+del device_info
+del participant
 test.print_results_and_exit()

--- a/unit-tests/dds/watcher-server.py
+++ b/unit-tests/dds/watcher-server.py
@@ -16,15 +16,14 @@ participant = server.participant()
 participant.init( 123, "test-watcher-server" )
 test.check( participant.is_valid() )
 
-broadcaster = server.device_broadcaster( participant )
-broadcaster.run()
+publisher = server.publisher( participant )
 
 di = server.device_info()
 di.name = 'my device'
 di.serial = '12345'
 di.product_line = 'PL'
 di.topic_root = 'testing/my/device/sn'
-broadcaster.add_device( di  )
+broadcaster1 = server.device_broadcaster( publisher, di )
 
 from time import sleep
 sleep(1)  # give the client some time with it
@@ -34,12 +33,12 @@ di.name = 'another device'
 di.serial = '67890'
 di.product_line = 'PL'
 di.topic_root = 'testing/my/device2/sn'
-broadcaster.add_device( di  )
+broadcaster2 = server.device_broadcaster( publisher, di )
 
 from time import sleep
 sleep(1)  # give the client some time with it
 
-broadcaster = None
+broadcaster1 = broadcaster2 = None
 participant = None
 test.finish()
 #

--- a/unit-tests/dds/watcher-server.py
+++ b/unit-tests/dds/watcher-server.py
@@ -1,46 +1,36 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
-import pyrealdds as server
+import pyrealdds as dds
 from rspy import log, test
 
 
-server.debug( True, log.nested )
+dds.debug( True, log.nested )
 
 
-#############################################################################################
-#
-test.start( "broadcast two devices" )
-
-participant = server.participant()
-participant.init( 123, "test-watcher-server" )
+participant = dds.participant()
+participant.init( 123, "server" )
 test.check( participant.is_valid() )
 
-publisher = server.publisher( participant )
+publisher = dds.publisher( participant )
 
-di = server.device_info()
-di.name = 'my device'
-di.serial = '12345'
-di.product_line = 'PL'
-di.topic_root = 'testing/my/device/sn'
-broadcaster1 = server.device_broadcaster( publisher, di )
+broadcasters = []
 
-from time import sleep
-sleep(1)  # give the client some time with it
 
-di = server.device_info()
-di.name = 'another device'
-di.serial = '67890'
-di.product_line = 'PL'
-di.topic_root = 'testing/my/device2/sn'
-broadcaster2 = server.device_broadcaster( publisher, di )
+def broadcast( props ):
+    global broadcasters, publisher
+    di = dds.device_info()
+    di.serial = props.get( 'serial', str(len(broadcasters)) )
+    di.name = props.get( 'name', f'device{di.serial}' )
+    di.product_line = props.get( 'product_line', '' )
+    di.topic_root = props.get( 'topic_root', f'path/to/{di.name}' )
+    broadcasters.append( dds.device_broadcaster( publisher, di ) )
 
-from time import sleep
-sleep(1)  # give the client some time with it
 
-broadcaster1 = broadcaster2 = None
-participant = None
-test.finish()
-#
-#############################################################################################
-test.print_results_and_exit()
+def unbroadcast_all():
+    global broadcasters
+    broadcasters = []
+
+
+# From here down, we're in "interactive" mode (see test-watcher.py)
+# ...


### PR DESCRIPTION
After having some issues (which this did NOT end up resolving!), I took a look at the broadcaster and found it... lacking:
* I found it really hard to understand, and overly complicated
* I wrote a unit-test that was failing!
* I didn't like the usage; I imagined something more akin to RAII where, when a device-server goes away, the broadcaster would immediately know about it and **automatically** make sure to remove the dedicated writer we have for it
* I didn't like the threading: it was using 2 additional threads with concurrency objects (which, IMO, are too much for small appllcations)

I decided to try and achieve the above, which this does nicely while simplifying usage.
