### PR TITLE
Add a short stress test for start/stop

### DIFF
--- a/unit-tests/live/frames/test-pipeline-start-stop.py
+++ b/unit-tests/live/frames/test-pipeline-start-stop.py
@@ -31,7 +31,7 @@ def verify_frame_received(config):
 ################################################################################################
 test.start("Testing pipeline start/stop stress test")
 for i in range(10):
-    log.out("starting iteration #", i, "/", 10)
+    log.out("starting iteration #", i + 1, "/", 10)
     cfg = rs.config()
     cfg.enable_all_streams()
     verify_frame_received(cfg)

--- a/unit-tests/live/frames/test-pipeline-start-stop.py
+++ b/unit-tests/live/frames/test-pipeline-start-stop.py
@@ -1,7 +1,8 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
-# test:device each(D400*)
+# Currently, we exclude D457 as it's failing
+# test:device each(D400*) !D457
 
 import pyrealsense2 as rs
 from rspy.stopwatch import Stopwatch

--- a/unit-tests/live/frames/test-pipeline-start-stop.py
+++ b/unit-tests/live/frames/test-pipeline-start-stop.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
-# test:device D400*
+# test:device each(D400*)
 
 import pyrealsense2 as rs
 from rspy.stopwatch import Stopwatch
@@ -22,6 +22,7 @@ def verify_frame_received(config):
     pipe = rs.pipeline()
     start_call_stopwatch = Stopwatch()
     pipe.start(config)
+    # wait_for_frames will through if no frames received so no assert is needed
     f = pipe.wait_for_frames()
     delay = start_call_stopwatch.get_elapsed()
     log.out("After ", delay, " [sec] got first frame of ", f)

--- a/unit-tests/live/frames/test-pipeline-start-stop.py
+++ b/unit-tests/live/frames/test-pipeline-start-stop.py
@@ -6,23 +6,16 @@
 import pyrealsense2 as rs
 from rspy.stopwatch import Stopwatch
 from rspy import test, log
-import time
-import platform
 
+# Run multiple start stop of all streams and verify we get a frame for each once
 
-# Start depth + color streams and measure the time from stream opened until first frame arrived using pipeline API.
-# Verify that the time does not exceed the maximum time allowed
-# Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
-
-
-# Set maximum delay for first frame according to product line
 dev = test.find_first_device_or_exit()
 
 def verify_frame_received(config):
     pipe = rs.pipeline()
     start_call_stopwatch = Stopwatch()
     pipe.start(config)
-    # wait_for_frames will through if no frames received so no assert is needed
+    # wait_for_frames will throw if no frames received so no assert is needed
     f = pipe.wait_for_frames()
     delay = start_call_stopwatch.get_elapsed()
     log.out("After ", delay, " [sec] got first frame of ", f)

--- a/unit-tests/live/frames/test-pipeline-start-stop.py
+++ b/unit-tests/live/frames/test-pipeline-start-stop.py
@@ -1,0 +1,41 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+# test:device D400*
+
+import pyrealsense2 as rs
+from rspy.stopwatch import Stopwatch
+from rspy import test, log
+import time
+import platform
+
+
+# Start depth + color streams and measure the time from stream opened until first frame arrived using pipeline API.
+# Verify that the time do not exceeds the maximum time allowed
+# Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
+
+
+# Set maximum delay for first frame according to product line
+dev = test.find_first_device_or_exit()
+
+def verify_frame_received(config):
+    pipe = rs.pipeline()
+    start_call_stopwatch = Stopwatch()
+    pipe.start(config)
+    f = pipe.wait_for_frames()
+    delay = start_call_stopwatch.get_elapsed()
+    log.out("After ", delay, " [sec] got first frame of ", f)
+    pipe.stop()
+
+
+################################################################################################
+test.start("Testing pipeline start/stop stress test")
+for i in range(10):
+    log.out("starting iteration #", i, "/", 10)
+    cfg = rs.config()
+    cfg.enable_all_streams()
+    verify_frame_received(cfg)
+test.finish()
+
+################################################################################################
+test.print_results_and_exit()

--- a/unit-tests/live/frames/test-pipeline-start-stop.py
+++ b/unit-tests/live/frames/test-pipeline-start-stop.py
@@ -11,7 +11,7 @@ import platform
 
 
 # Start depth + color streams and measure the time from stream opened until first frame arrived using pipeline API.
-# Verify that the time do not exceeds the maximum time allowed
+# Verify that the time does not exceed the maximum time allowed
 # Note - Using Windows Media Foundation to handle power management between USB actions take time (~27 ms)
 
 


### PR DESCRIPTION
Tracked on [LRS-751]

Test result
```
-D- found <pyrealsense2.device: Intel RealSense D435 (S/N: 722312070458  FW: 5.14.0  UNLOCKED  on USB3.2)>
-D- in <module 'pyrealsense2' from 'C:\\jenkins_sys_rsbuild\\workspace\\LRS_windows_compile_pipeline\\win10\\win64\\static\\RelWithDebInfo\\pyrealsense2.cp37-win_amd64.pyd'>
Testing pipeline start/stop stress test
starting iteration # 1 / 10
After  0.7407785  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #7 @1681135427247.455566>
starting iteration # 2 / 10
After  0.7779392  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #7 @1681135429736.040771>
starting iteration # 3 / 10
After  0.7775243999999999  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #7 @1681135432275.888184>
starting iteration # 4 / 10
After  0.7821805  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #2 @1681135435088.820068>
starting iteration # 5 / 10
After  0.7463107999999998  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #7 @1681135437345.772949>
starting iteration # 6 / 10
After  0.7443069999999992  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #2 @1681135440118.626709>
starting iteration # 7 / 10
After  0.7465039000000004  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #0 @1681135442537.441406>
starting iteration # 8 / 10
After  0.7834516000000029  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #0 @1681135445262.806396>
starting iteration # 9 / 10
After  0.7375328000000003  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #2 @1681135447820.812012>
starting iteration # 10 / 10
After  0.7451611999999983  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 #0 @1681135450278.246094>
Test passed

___
All tests passed (0 assertions in 1 test cases)

----------TEST-SEPARATOR----------

-D- found <pyrealsense2.device: Intel RealSense D455 (S/N: 114222251278  FW: 5.14.0  UNLOCKED  on USB3.2)>
-D- in <module 'pyrealsense2' from 'C:\\jenkins_sys_rsbuild\\workspace\\LRS_windows_compile_pipeline\\win10\\win64\\static\\RelWithDebInfo\\pyrealsense2.cp37-win_amd64.pyd'>
Testing pipeline start/stop stress test
starting iteration # 1 / 10
After  1.0972542  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #6 @1681135455121.212891>
starting iteration # 2 / 10
After  1.0288057999999998  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #7 @1681135460052.879395>
starting iteration # 3 / 10
After  0.8258337000000004  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135464815.625488>
starting iteration # 4 / 10
After  0.7924810999999998  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135469714.635742>
starting iteration # 5 / 10
After  0.9951992000000018  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135474578.448975>
starting iteration # 6 / 10
After  0.8303162000000022  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135479437.717529>
starting iteration # 7 / 10
After  1.0722765999999986  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135484335.053223>
starting iteration # 8 / 10
After  0.8278710999999959  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135489174.121338>
starting iteration # 9 / 10
After  0.8337026999999964  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135494040.557373>
starting iteration # 10 / 10
After  0.8296413999999999  [sec] got first frame of  <pyrealsense2.frameset Z16 Y8 Y8 RGB8 MOTION_XYZ32F MOTION_XYZ32F #5 @1681135498914.182129>
Test passed

___
All tests passed (0 assertions in 1 test cases)
```