### PR TITLE
Fix unstable test metadata alive 

### DIFF
--- a/unit-tests/live/metadata/test-alive.py
+++ b/unit-tests/live/metadata/test-alive.py
@@ -80,7 +80,7 @@ def is_value_keep_increasing(metadata_value, number_frames_to_test=50) -> bool:
 
 
 queue_capacity = 1
-frame_queue = rs.frame_queue(queue_capacity, keep_frames=False)
+frame_queue = None
 device = test.find_first_device_or_exit()
 
 # We're using dictionary because we need save a profile and his sensor.
@@ -90,16 +90,17 @@ testing_profiles = {}
 append_testing_profiles(device)
 
 for profile, sensor in testing_profiles.items():
+    frame_queue = rs.frame_queue(queue_capacity)
     sensor.open(profile)
     sensor.start(frame_queue)
 
-    # Test #1
+    # Test #1 Increasing frame counter
     if is_frame_support_metadata(frame_queue.wait_for_frame(), rs.frame_metadata_value.frame_counter):
         test.start('Verifying increasing counter for profile ', profile)
         test.check(is_value_keep_increasing(rs.frame_metadata_value.frame_counter))
         test.finish()
 
-    # Test #2
+    # Test #2 Increasing frame timestamp
     if is_frame_support_metadata(frame_queue.wait_for_frame(), rs.frame_metadata_value.frame_timestamp):
         test.start('Verifying increasing time for profile ', profile)
         test.check(is_value_keep_increasing(rs.frame_metadata_value.frame_timestamp))

--- a/unit-tests/live/metadata/test-alive.py
+++ b/unit-tests/live/metadata/test-alive.py
@@ -59,7 +59,7 @@ def append_testing_profiles(dev) -> None:
 
 def is_value_keep_increasing(metadata_value, number_frames_to_test=50) -> bool:
     """
-    Check that a given counter in metadata increases.
+    Check that a given counter in metadata increases
     :param metadata_value: that we need to check
     :param number_frames_to_test: amount frames that we want to test
     :return: true if the counter value keep increasing otherwise false


### PR DESCRIPTION
The new frame queue was created for each sensor in the list.