### PR TITLE
replace rspy.test abort_on_fail:bool with on_fail:str (ABORT/RAISE/LOG)

### DIFF
--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -36,7 +36,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     # set up the client device and keep all its streams - this is connected directly and we can get notifications on it!
     device_direct = dds.device( participant, participant.create_guid(), d435i.device_info )
     device_direct.run( 1000 )  # this will throw if something's wrong
-    test.check( device_direct.is_running(), abort_if_failed=True )
+    test.check( device_direct.is_running(), on_fail=test.ABORT )
     for stream_direct in device_direct.streams():
         pass  # should be only one
     topic_name = 'rt/' + d435i.device_info.topic_root + '_' + stream_direct.name()
@@ -143,9 +143,9 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
         device = wait_for_devices( context, only_sw_devices, n=1. )[0]
         sensors = device.sensors
-        test.check_equal( len(sensors), 1, abort_if_failed=True )
+        test.check_equal( len(sensors), 1, on_fail=test.RAISE )
         sensor = sensors[0]
-        test.check_equal( sensor.get_info( rs.camera_info.name ), 'RGB Camera', abort_if_failed=True )
+        test.check_equal( sensor.get_info( rs.camera_info.name ), 'RGB Camera', on_fail=test.RAISE )
         del sensors
         profile = rs.video_stream_profile( sensor.get_stream_profiles()[0] )  # take the first one
         log.d( f'using profile {profile}')

--- a/unit-tests/log/test-env-log-level-off.py
+++ b/unit-tests/log/test-env-log-level-off.py
@@ -9,19 +9,13 @@ import os
 
 #############################################################################################
 #
-test.start( "Without LRS_LOG_LEVEL" )
-
-try:
-    test.check( not os.environ.get('LRS_LOG_LEVEL'), abort_if_failed=True )
+with test.closure( "Without LRS_LOG_LEVEL" ):
+    test.check( not os.environ.get('LRS_LOG_LEVEL'), on_fail=test.ABORT )
 
     rs.log_to_callback( rs.log_severity.error, common.message_counter )
     test.check_equal( common.n_messages, 0 )
     common.log_all()
     test.check_equal( common.n_messages, 1 )
-except:
-    test.unexpected_exception()
-
-test.finish()
 #
 #############################################################################################
 test.print_results_and_exit()

--- a/unit-tests/log/test-env-log-level-on.py
+++ b/unit-tests/log/test-env-log-level-on.py
@@ -11,10 +11,8 @@ import os
 
 #############################################################################################
 #
-test.start( "With LRS_LOG_LEVEL" )
-
-try:
-    test.check_equal( os.environ.get('LRS_LOG_LEVEL'), 'WARN', abort_if_failed=True )
+with test.closure( "With LRS_LOG_LEVEL" ):
+    test.check_equal( os.environ.get('LRS_LOG_LEVEL'), 'WARN', on_fail=test.ABORT )
 
     rs.log_to_callback( rs.log_severity.error, common.message_counter )
     test.check_equal( common.n_messages, 0 )
@@ -23,10 +21,6 @@ try:
     #test.check_equal( common.n_messages, 1 )
     # But, since we have the log-level forced to warning:
     test.check_equal( common.n_messages, 2 )
-except:
-    test.unexpected_exception()
-
-test.finish()
 #
 #############################################################################################
 test.print_results_and_exit()

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -168,7 +168,7 @@ if current_fw_version == bundled_fw_version:
         test.print_results_and_exit()
 else:
     # It is expected that, post-recovery, the FW versions will be the same
-    test.check( not recovered, abort_if_failed = True )
+    test.check( not recovered, on_fail=test.ABORT )
 
 update_counter = get_update_counter( device )
 log.d( 'update counter:', update_counter )


### PR DESCRIPTION
Standardize `abort_on_fail` to `on_fail` across the board, with more options:
* You can now stop a test with `RAISE` if a check fails
  * it raises a `test.CheckFailed` exception
  * this is automatically caught by `test.closure` and translated to a closure-specific `on_fail` (so a check fails, raised, caught, and the closure decides whether to just log, or abort, re-raise, etc.)
* Default to `LOG`, same as before
* Can abort like before with `ABORT`
