### PR TITLE
Formats conversion

### DIFF
--- a/src/proc/CMakeLists.txt
+++ b/src/proc/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/motion-transform.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/auto-exposure-processor.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/y411-converter.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/formats-converter.cpp"
 
         "${CMAKE_CURRENT_LIST_DIR}/processing-blocks-factory.h"
         "${CMAKE_CURRENT_LIST_DIR}/align.h"
@@ -67,4 +68,5 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/motion-transform.h"
         "${CMAKE_CURRENT_LIST_DIR}/auto-exposure-processor.h"
         "${CMAKE_CURRENT_LIST_DIR}/y411-converter.h"
+        "${CMAKE_CURRENT_LIST_DIR}/formats-converter.h"
 )

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
 #include "proc/formats-converter.h"
 #include "stream.h"
@@ -70,10 +70,11 @@ stream_profiles formats_converter::get_all_possible_target_profiles( const strea
                         // Cache each target profile to its source profiles which were generated from.
                         _target_to_source_profiles_map[target].push_back( from_profile );
 
-                        // Duplicates in the list happen when 2 from_profiles have conversion to same target.
+                        // TODO - Duplicates in the list happen when 2 from_profiles have conversion to same target.
                         // In this case it is faster to check if( _target_to_source_profiles_map[target].size() > 1 )
-                        // rather then if( is_profile_in_list( cloned_profile, to_profiles ) )
-                        if( _target_to_source_profiles_map[target].size() > 1 )
+                        // rather then if( is_profile_in_list( cloned_profile, to_profiles ) ), but L500 unit-tests
+                        // fail if we change. Need to understand difference
+                        if( is_profile_in_list( cloned_profile, to_profiles ) )
                             continue;
 
                         // Only injective cloning in many to one mapping.

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -150,8 +150,8 @@ stream_profiles formats_converter::get_source_of_profiles( stream_profiles targe
             source_profile->set_stream_index( target_profile->get_stream_index() );
             source_profile->set_unique_id( target_profile->get_unique_id() );
             source_profile->set_stream_type( target_profile->get_stream_type() );
-            auto & source_video_profile = As<video_stream_profile, stream_profile_interface>( source_profile );
-            const auto & target_video_profile = As<video_stream_profile, stream_profile_interface>( target_profile );
+            auto source_video_profile = As<video_stream_profile, stream_profile_interface>( source_profile );
+            const auto target_video_profile = As<video_stream_profile, stream_profile_interface>( target_profile );
             if( source_video_profile )
             {
                 source_video_profile->set_intrinsics( [target_video_profile]() {
@@ -338,7 +338,7 @@ std::shared_ptr<stream_profile_interface> formats_converter::filter_frame_by_req
         return nullptr;
 
     auto & reqs = cached_req->second;
-    auto & req_it = std::find_if( begin( reqs ), end( reqs ), [&f]( const std::shared_ptr<stream_profile_interface> & req ) {
+    auto req_it = std::find_if( begin( reqs ), end( reqs ), [&f]( const std::shared_ptr<stream_profile_interface> & req ) {
         return ( req->get_stream_index() == f->get_stream()->get_stream_index() &&
                  req->get_stream_type() == f->get_stream()->get_stream_type() );
         } );

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -1,0 +1,349 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+
+#include "proc/formats-converter.h"
+#include "stream.h"
+
+namespace librealsense
+{
+
+void formats_converter::register_processing_block( const std::vector< stream_profile > & from,
+                                                    const std::vector< stream_profile > & to,
+                                                    std::function< std::shared_ptr< processing_block >( void ) > generate_func )
+{
+    _pb_factories.push_back( std::make_shared< processing_block_factory >( from, to, generate_func ) );
+}
+
+
+void formats_converter::register_processing_block( const processing_block_factory & pbf )
+{
+    _pb_factories.push_back( std::make_shared<processing_block_factory>( pbf ) );
+}
+
+void formats_converter::register_processing_block( const std::vector< processing_block_factory > & pbfs )
+{
+    for( auto && pbf : pbfs )
+        register_processing_block( pbf );
+}
+
+stream_profiles formats_converter::get_all_possible_target_profiles( const stream_profiles & from_profiles )
+{
+    // For each profile that can be used as input (from_profiles) check all registered factories if they can create
+    // a converter from the profile type (source). If so, create appropriate profiles for all possible target types
+    // that the converters support.
+    // Note - User profile type is stream_profile_interface, factories profile type is stream_profile.
+    stream_profiles to_profiles;
+
+    for( auto & from_profile : from_profiles )
+    {
+        for( auto && pbf : _pb_factories )
+        {
+            const auto && sources = pbf->get_source_info();
+            for( auto && source : sources )
+            {
+                if( from_profile->get_format() == source.format &&
+                   ( source.stream == from_profile->get_stream_type() || source.stream == RS2_STREAM_ANY ) )
+                {
+                    const auto & targets = pbf->get_target_info();
+                    // targets are saved with format and type only. Updating fps and resolution before using as key
+                    for( auto target : targets )
+                    {
+
+                        target.fps = from_profile->get_framerate();
+
+                        auto && cloned_profile = clone_profile( from_profile );
+                        cloned_profile->set_format( target.format );
+                        cloned_profile->set_stream_index( target.index ); //TODO - shouldn't be from_profile.index?
+                        cloned_profile->set_stream_type( target.stream );
+
+                        auto && cloned_vsp = As< video_stream_profile, stream_profile_interface >( cloned_profile );
+                        if( cloned_vsp )
+                        {
+                            target.height = cloned_vsp->get_height();
+                            target.width = cloned_vsp->get_width();
+                        }
+
+                        // Cache pbf supported profiles for efficiency in find_pbf_matching_most_profiles
+                        _pbf_supported_profiles[pbf.get()].push_back( cloned_profile );
+
+                        // Cache each target profile to its source profiles which were generated from.
+                        _target_to_source_profiles_map[target].push_back( from_profile );
+
+                        // Duplicates in the list happen when 2 from_profiles have conversion to same target.
+                        // In this case it is faster to check if( _target_to_source_profiles_map[target].size() > 1 )
+                        // rather then if( is_profile_in_list( cloned_profile, to_profiles ) )
+                        if( _target_to_source_profiles_map[target].size() > 1 )
+                            continue;
+
+                        // Only injective cloning in many to one mapping.
+                        // One to many is not affected.
+                        if( sources.size() > 1 && target.format != source.format )
+                            continue;
+
+                        to_profiles.push_back( cloned_profile );
+                    }
+                }
+            }
+        }
+    }
+
+    return to_profiles;
+}
+
+std::shared_ptr< stream_profile_interface > formats_converter::clone_profile( const std::shared_ptr< stream_profile_interface > & profile ) const
+{
+    std::shared_ptr< stream_profile_interface > cloned = nullptr;
+
+    if( auto vsp = std::dynamic_pointer_cast< video_stream_profile >( profile ) )
+    {
+        cloned = vsp->clone();
+    }
+    else if( auto msp = std::dynamic_pointer_cast< motion_stream_profile >( profile ) )
+    {
+        cloned = msp->clone();
+    }
+    else
+        throw librealsense::not_implemented_exception( "Unsupported profile type to clone" );
+
+    if( !cloned )
+        throw librealsense::invalid_value_exception( "failed to clone profile" );
+
+    // No need to set the ID, when calling get_all_possible_target_profiles the from_profiles don't have an assigned ID
+    // yet, it will be assigned according to stream later on.
+    // cloned->set_unique_id( profile->get_unique_id() ); // clone() issues a new id for the profile, we want to use old one
+    // 
+    // Needed for clone_profile wholeness but will be overwritten later by target profile fields. Can skip.
+    // cloned->set_format( profile->get_format() );
+    // cloned->set_stream_index( profile->get_stream_index() );
+    // cloned->set_stream_type( profile->get_stream_type() );
+
+    return cloned;
+}
+
+bool formats_converter::is_profile_in_list( const std::shared_ptr< stream_profile_interface > & profile, const stream_profiles & profiles ) const
+{
+    // Converting to stream_profile to avoid dynamic casting to video/motion_stream_profile
+    const auto && is_duplicate_predicate = [&profile]( const std::shared_ptr< stream_profile_interface > & spi ) {
+        return to_profile( spi.get() ) == to_profile( profile.get() );
+    };
+
+    return std::any_of( begin( profiles ), end( profiles ), is_duplicate_predicate );
+}
+
+//std::vector< processing_block > formats_converter::get_converters( std::vector< stream_profile > ) const
+//{
+//
+//}
+
+stream_profiles formats_converter::get_source_of_profiles( stream_profiles target_profiles )
+{
+    std::unordered_set<std::shared_ptr<stream_profile_interface>> resolved_req_set;
+    stream_profiles resolved_req;
+
+    // Add missing data to source profiles (was not available during get_all_possible_target_profiles)
+    for( auto & target_profile : target_profiles )
+    {
+        //TODO - original code only updates source[0], why?
+        for( auto & source_profile : _target_to_source_profiles_map[to_profile( target_profile.get() )] )
+        {
+            source_profile->set_unique_id( target_profile->get_unique_id() );
+            source_profile->set_stream_index( target_profile->get_stream_index() );
+            source_profile->set_unique_id( target_profile->get_unique_id() );
+            source_profile->set_stream_type( target_profile->get_stream_type() );
+            auto & source_video_profile = As<video_stream_profile, stream_profile_interface>( source_profile );
+            const auto & target_video_profile = As<video_stream_profile, stream_profile_interface>( target_profile );
+            if( source_video_profile )
+            {
+                source_video_profile->set_intrinsics( [target_video_profile]() {
+                    if( target_video_profile )
+                        return target_video_profile->get_intrinsics();
+                    else
+                        return rs2_intrinsics {};
+                } );
+            }
+        }
+    }
+
+    // cache the requests
+    for( auto && target_profile : target_profiles )
+    {
+        // Caching target profiles to set as processed frames profile before calling user callback
+        _format_to_target_profiles[target_profile->get_format()].push_back( target_profile );
+    }
+
+    // while not finished handling all of the requests do
+    while( ! target_profiles.empty() )
+    {
+        const auto & best_match = find_pbf_matching_most_profiles( target_profiles );
+        auto & best_match_pbf = best_match.first;
+        auto & best_match_target_profiles = best_match.second;
+
+        // mark as handled resolved requests
+        for( auto & profile : best_match_target_profiles )
+        {
+            const auto & matching_profiles_predicate = [&profile]( const std::shared_ptr<stream_profile_interface> & sp ) {
+                return to_profile( profile.get() ) == to_profile( sp.get() );
+            };
+            target_profiles.erase( std::remove_if( begin( target_profiles ), end( target_profiles ), matching_profiles_predicate ) );
+        }
+
+        // Retrieve source profile from cached map and generate the relevant processing block.
+        std::unordered_set<std::shared_ptr<stream_profile_interface>> current_resolved_reqs;
+        auto best_pb = best_match_pbf->generate();
+        //register_processing_block_options( *best_pb );
+        for( const auto & target_profile : best_match_target_profiles )
+        {
+            auto & mapped_source_profiles = _target_to_source_profiles_map[to_profile( target_profile.get() )];
+
+            for( const auto & source_profile : mapped_source_profiles )
+            {
+                if( best_match_pbf->has_source( source_profile ) )
+                {
+                    resolved_req_set.insert( source_profile );
+                    current_resolved_reqs.insert( source_profile );
+
+                    // Caching processing blocks to set their callback during sensor::start
+                    _source_profile_to_converters[source_profile].insert( best_pb );
+                }
+            }
+        }
+        const stream_profiles & print_current_resolved_reqs = { current_resolved_reqs.begin(), current_resolved_reqs.end() };
+        LOG_INFO( "Request: " << best_match_target_profiles << "\nResolved to: " << print_current_resolved_reqs );
+    }
+
+    resolved_req = { resolved_req_set.begin(), resolved_req_set.end() };
+    return resolved_req;
+}
+
+std::pair< std::shared_ptr< processing_block_factory >, stream_profiles >
+formats_converter::find_pbf_matching_most_profiles( const stream_profiles & profiles )
+{
+    // Find and retrieve best fitting processing block to the given requests, and the requests which were the best fit.
+
+    // For video stream, the best fitting processing block is defined as the processing block which its sources
+    // covers the maximum amount of requests.
+
+    stream_profiles best_match_profiles;
+    std::shared_ptr<processing_block_factory> best_match_processing_block_factory;
+
+    size_t best_source_size = 0;
+    size_t max_satisfied_count = 0;
+
+    for( auto & pbf : _pb_factories )
+    {
+        stream_profiles && satisfied_req = pbf->find_satisfied_requests( profiles, _pbf_supported_profiles[pbf.get()] );
+        size_t satisfied_count = satisfied_req.size();
+        size_t source_size = pbf->get_source_info().size();
+        if( satisfied_count > max_satisfied_count ||
+           ( satisfied_count == max_satisfied_count && source_size < best_source_size ) )
+        {
+            max_satisfied_count = satisfied_count;
+            best_source_size = source_size;
+            best_match_processing_block_factory = pbf;
+            best_match_profiles = std::move( satisfied_req );
+        }
+    }
+
+    return { best_match_processing_block_factory, best_match_profiles };
+}
+
+void formats_converter::clear_cached_source_list()
+{
+    _source_profile_to_converters.clear();
+    _format_to_target_profiles.clear();
+}
+
+template<class T>
+frame_callback_ptr make_callback( T callback )
+{
+    return {
+        new internal_frame_callback<T>( callback ),
+        []( rs2_frame_callback * p ) { p->release(); }
+    };
+}
+
+void formats_converter::set_frames_callback( frame_callback_ptr callback )
+{
+    _converted_frames_callback = callback;
+
+    // After processing callback
+    const auto && output_cb = make_callback( [&]( frame_holder f ) {
+        std::vector< frame_interface * > frames_to_be_processed;
+        frames_to_be_processed.push_back( f.frame );
+
+        const auto & composite = dynamic_cast< composite_frame * >( f.frame );
+        if( composite )
+        {
+            for( size_t i = 0; i < composite->get_embedded_frames_count(); i++ )
+            {
+                frames_to_be_processed.push_back( composite->get_frame( static_cast< int >( i ) ) );
+            }
+        }
+
+        // Process only frames which aren't composite.
+        for( auto && fr : frames_to_be_processed )
+        {
+            if( !dynamic_cast< composite_frame * >( fr ) )
+            {
+                //TODO - find out why we need to find a target profile with the same format+index+type as the frame profile
+                // and save if back to the frame. Different unique_id?
+                // Reason - viewer uses syncher and matcher that uses rs2::stream_profile.clone() that generate a new ID
+                // for the clone and than the match can fail.
+                auto && cached_profile = filter_frame_by_requests( fr );
+
+                if( cached_profile )
+                {
+                    fr->set_stream( cached_profile );
+                }
+                else
+                    continue;
+
+                fr->acquire();
+                if( _converted_frames_callback )
+                    _converted_frames_callback->on_frame( ( rs2_frame * )fr );
+            }
+        }
+    } );
+
+    // Set callbacks for all of the relevant processing blocks
+    for( const auto & entry : _source_profile_to_converters )
+    {
+        auto & converters = entry.second;
+        for( auto & converter : converters )
+            if( converter )
+            {
+                converter->set_output_callback( output_cb );
+            }
+    }
+}
+
+void formats_converter::convert_frame( frame_holder & f )
+{
+    if( !f )
+        return;
+
+    auto & converters = _source_profile_to_converters[f->get_stream()];
+    for( auto && converter : converters )
+    {
+        f->acquire();
+        converter->invoke( f.frame );
+    }
+}
+
+//////////////////
+std::shared_ptr<stream_profile_interface> formats_converter::filter_frame_by_requests( const frame_interface * f )
+{
+    const auto & cached_req = _format_to_target_profiles.find( f->get_stream()->get_format() );
+    if( cached_req == _format_to_target_profiles.end() )
+        return nullptr;
+
+    auto & reqs = cached_req->second;
+    auto & req_it = std::find_if( begin( reqs ), end( reqs ), [&f]( const std::shared_ptr<stream_profile_interface> & req ) {
+        return ( req->get_stream_index() == f->get_stream()->get_stream_index() &&
+                 req->get_stream_type() == f->get_stream()->get_stream_type() );
+        } );
+
+    return req_it != end( reqs ) ? *req_it : nullptr;
+}
+
+} // namespace librealsense

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -334,7 +334,7 @@ void formats_converter::set_frames_callback( frame_callback_ptr callback )
                 // We find a target profile with the same format+index+type as the frame profile and save it back
                 // to the frame. Reason - viewer uses syncher and matcher that uses rs2::stream_profile.clone()
                 // that generates a new ID for the clone and than the match can fail.
-                auto & cached_profile = filter_frame_by_requests( fr );
+                auto cached_profile = filter_frame_by_requests( fr );
 
                 if( cached_profile )
                 {

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -203,10 +203,8 @@ void formats_converter::update_source_data( const stream_profiles & target_profi
 {
     for( auto & target_profile : target_profiles )
     {
-        // TODO - original code only updates source[0], why?
         for( auto & source_profile : _target_to_source_profiles_map[to_profile( target_profile.get() )] )
         {
-            source_profile->set_unique_id( target_profile->get_unique_id() );
             source_profile->set_stream_index( target_profile->get_stream_index() );
             source_profile->set_unique_id( target_profile->get_unique_id() );
             source_profile->set_stream_type( target_profile->get_stream_type() );

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -178,6 +178,9 @@ stream_profiles formats_converter::get_source_of_profiles( stream_profiles targe
                     else
                         return rs2_intrinsics {};
                 } );
+
+                //Hack for L515 confidence. Requesting source resolution from the camera, getting frame size of target (*2 y axis resolution)
+                source_video_profile->set_dims( target_video_profile->get_width(), target_video_profile->get_height() );
             }
         }
     }

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -59,8 +59,11 @@ stream_profiles formats_converter::get_all_possible_target_profiles( const strea
                         auto && cloned_vsp = As< video_stream_profile, stream_profile_interface >( cloned_profile );
                         if( cloned_vsp )
                         {
-                            target.height = cloned_vsp->get_height();
-                            target.width = cloned_vsp->get_width();
+                            // Converter may rotate the image, invoke stream_resolution function to get actual result
+                            const auto res = target.stream_resolution( { cloned_vsp->get_width(), cloned_vsp->get_height() } );
+                            target.height = res.height;
+                            target.width = res.width;
+                            cloned_vsp->set_dims( target.width, target.height );
                         }
 
                         // Cache pbf supported profiles for efficiency in find_pbf_matching_most_profiles
@@ -72,7 +75,7 @@ stream_profiles formats_converter::get_all_possible_target_profiles( const strea
                         // Duplicates in the list happen when 2 from_profiles have conversion to same target.
                         // In this case it is faster to check if( _target_to_source_profiles_map[target].size() > 1 )
                         // rather then if( is_profile_in_list( cloned_profile, to_profiles ) )
-                        if( _target_to_source_profiles_map[target].size() > 1 )
+                        if( is_profile_in_list( cloned_profile, to_profiles ) )
                             continue;
 
                         // Only injective cloning in many to one mapping.

--- a/src/proc/formats-converter.h
+++ b/src/proc/formats-converter.h
@@ -22,15 +22,18 @@ namespace librealsense
         void register_processing_block( const std::vector< processing_block_factory > & pbfs );
 
         stream_profiles get_all_possible_target_profiles( const stream_profiles & from_profiles );
-        stream_profiles get_source_of_profiles( stream_profiles target_profiles );
-        //std::vector< processing_block > get_converters( std::vector< stream_profile > ) const;
-        void clear_cached_source_list();
+        void prepare_to_convert( stream_profiles target_profiles );
+
+        stream_profiles get_active_source_profiles() const;
+        std::vector< std::shared_ptr< processing_block > > get_active_converters() const;
 
         void set_frames_callback( frame_callback_ptr callback );
         frame_callback_ptr get_frames_callback() const { return _converted_frames_callback; }
         void convert_frame( frame_holder & f );
 
     protected:
+        void clear_active_cache();
+
         std::shared_ptr< stream_profile_interface > clone_profile( const std::shared_ptr< stream_profile_interface > & profile ) const;
         bool is_profile_in_list( const std::shared_ptr< stream_profile_interface > & profile, const stream_profiles & profiles ) const;
 

--- a/src/proc/formats-converter.h
+++ b/src/proc/formats-converter.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "proc/processing-blocks-factory.h"
-#include "core/streaming.h"
+#include "processing-blocks-factory.h"
+#include "../core/streaming.h"
 
 #include <vector>
 #include <unordered_set>
@@ -22,7 +22,7 @@ namespace librealsense
         void register_processing_block( const std::vector< processing_block_factory > & pbfs );
 
         stream_profiles get_all_possible_target_profiles( const stream_profiles & from_profiles );
-        stream_profiles formats_converter::get_source_of_profiles( stream_profiles target_profiles );
+        stream_profiles get_source_of_profiles( stream_profiles target_profiles );
         //std::vector< processing_block > get_converters( std::vector< stream_profile > ) const;
         void clear_cached_source_list();
 

--- a/src/proc/formats-converter.h
+++ b/src/proc/formats-converter.h
@@ -33,6 +33,8 @@ namespace librealsense
 
     protected:
         void clear_active_cache();
+        void update_source_data( const stream_profiles & target_profiles );
+        void cache_target_profiles( const stream_profiles & target_profiles );
 
         std::shared_ptr< stream_profile_interface > clone_profile( const std::shared_ptr< stream_profile_interface > & profile ) const;
         bool is_profile_in_list( const std::shared_ptr< stream_profile_interface > & profile, const stream_profiles & profiles ) const;

--- a/src/proc/formats-converter.h
+++ b/src/proc/formats-converter.h
@@ -1,0 +1,51 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include "proc/processing-blocks-factory.h"
+#include "core/streaming.h"
+
+#include <vector>
+#include <unordered_set>
+#include <memory>
+
+namespace librealsense
+{
+    class formats_converter
+    {
+    public:
+        void register_processing_block( const std::vector< stream_profile > & from,
+                                        const std::vector< stream_profile > & to,
+                                        std::function< std::shared_ptr< processing_block >( void ) > generate_func );
+        void register_processing_block( const processing_block_factory & pbf );
+        void register_processing_block( const std::vector< processing_block_factory > & pbfs );
+
+        stream_profiles get_all_possible_target_profiles( const stream_profiles & from_profiles );
+        stream_profiles formats_converter::get_source_of_profiles( stream_profiles target_profiles );
+        //std::vector< processing_block > get_converters( std::vector< stream_profile > ) const;
+        void clear_cached_source_list();
+
+        void set_frames_callback( frame_callback_ptr callback );
+        void convert_frame( frame_holder & f );
+
+    protected:
+        std::shared_ptr< stream_profile_interface > clone_profile( const std::shared_ptr< stream_profile_interface > & profile ) const;
+        bool is_profile_in_list( const std::shared_ptr< stream_profile_interface > & profile, const stream_profiles & profiles ) const;
+
+        std::pair< std::shared_ptr< processing_block_factory >, stream_profiles >
+            find_pbf_matching_most_profiles( const stream_profiles & profiles );
+
+        std::shared_ptr<stream_profile_interface> filter_frame_by_requests( const frame_interface * f );
+
+        std::vector< std::shared_ptr< processing_block_factory > > _pb_factories;
+        std::unordered_map< processing_block_factory *, stream_profiles > _pbf_supported_profiles;
+        std::unordered_map< stream_profile, stream_profiles > _target_to_source_profiles_map;
+
+        std::unordered_map< std::shared_ptr< stream_profile_interface >,
+                            std::unordered_set< std::shared_ptr< processing_block > > > _source_profile_to_converters;
+        std::unordered_map< rs2_format, stream_profiles > _format_to_target_profiles;
+
+        frame_callback_ptr _converted_frames_callback = nullptr;
+    };
+}

--- a/src/proc/formats-converter.h
+++ b/src/proc/formats-converter.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "processing-blocks-factory.h"
-#include "../core/streaming.h"
 
 #include <vector>
 #include <unordered_set>

--- a/src/proc/formats-converter.h
+++ b/src/proc/formats-converter.h
@@ -27,6 +27,7 @@ namespace librealsense
         void clear_cached_source_list();
 
         void set_frames_callback( frame_callback_ptr callback );
+        frame_callback_ptr get_frames_callback() const { return _converted_frames_callback; }
         void convert_frame( frame_holder & f );
 
     protected:

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -307,6 +307,7 @@ void log_callback_end( uint32_t fps,
 
         if (_metadata_modifier)
             _metadata_modifier(additional_data);
+        fr->additional_data = additional_data;
 
         // update additional data
         additional_data.timestamp = timestamp_reader->get_frame_timestamp(fr);

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -307,7 +307,6 @@ void log_callback_end( uint32_t fps,
 
         if (_metadata_modifier)
             _metadata_modifier(additional_data);
-        fr->additional_data = additional_data;
 
         // update additional data
         additional_data.timestamp = timestamp_reader->get_frame_timestamp(fr);

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -1478,14 +1478,14 @@ void log_callback_end( uint32_t fps,
 
     frame_callback_ptr synthetic_sensor::get_frames_callback() const
     {
-        return _post_process_callback;
+        return _formats_converter.get_frames_callback();
     }
 
     void synthetic_sensor::set_frames_callback(frame_callback_ptr callback)
     {
         // This callback is mutable, might be modified.
         // For instance, record_sensor modifies this callback in order to hook it to record frames.
-        _post_process_callback = callback;
+        _formats_converter.set_frames_callback( callback );
     }
 
     void synthetic_sensor::register_notifications_callback(notifications_callback_ptr callback)

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -21,8 +21,7 @@
 #include "core/options.h"
 #include "source.h"
 #include "core/extension.h"
-#include "proc/processing-blocks-factory.h"
-#include "proc/identity-processing-block.h"
+#include "proc/formats-converter.h"
 
 namespace librealsense
 {
@@ -246,10 +245,6 @@ namespace librealsense
         stream_profiles resolve_requests(const stream_profiles& requests);
         std::shared_ptr<stream_profile_interface> filter_frame_by_requests(const frame_interface* f);
         void sort_profiles(stream_profiles * profiles);
-        std::pair<std::shared_ptr<processing_block_factory>, stream_profiles> find_requests_best_pb_match(const stream_profiles& sp);
-        void add_source_profile_missing_data(std::shared_ptr<stream_profile_interface>& source_profile);
-        bool is_duplicated_profile(const std::shared_ptr<stream_profile_interface>& duplicate, const stream_profiles& profiles);
-        std::shared_ptr<stream_profile_interface> clone_profile(const std::shared_ptr<stream_profile_interface>& profile);
         void register_processing_block_options(const processing_block& pb);
         void unregister_processing_block_options(const processing_block& pb);
 
@@ -257,12 +252,7 @@ namespace librealsense
 
         frame_callback_ptr _post_process_callback;
         std::shared_ptr<sensor_base> _raw_sensor;
-        std::vector<std::shared_ptr<processing_block_factory>> _pb_factories;
-        std::unordered_map<processing_block_factory*, stream_profiles> _pbf_supported_profiles;
-        std::unordered_map<std::shared_ptr<stream_profile_interface>, std::unordered_set<std::shared_ptr<processing_block>>> _profiles_to_processing_block;
-        std::unordered_map<std::shared_ptr<stream_profile_interface>, stream_profiles> _source_to_target_profiles_map;
-        std::unordered_map<stream_profile, stream_profiles> _target_to_source_profiles_map;
-        std::unordered_map<rs2_format, stream_profiles> _cached_requests;
+        formats_converter _formats_converter;
         std::vector<rs2_option> _cached_processing_blocks_options;
     };
 

--- a/unit-tests/live/extrinsics/test-consistency.cpp
+++ b/unit-tests/live/extrinsics/test-consistency.cpp
@@ -2,8 +2,6 @@
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 //#test:device D400*
-//#test:device L500*
-//#test:device SR300*
 
 #include <rsutils/easylogging/easyloggingpp.h>
 
@@ -123,7 +121,19 @@ std::string to_string(const rs2_extrinsics& extrinsics)
     std::stringstream ss;
     ss << extrinsics.rotation[0] << " " << extrinsics.rotation[3] << " " << extrinsics.rotation[6] << std::endl;
     ss << extrinsics.rotation[1] << " " << extrinsics.rotation[4] << " " << extrinsics.rotation[7] << std::endl;
-    ss << extrinsics.rotation[2] << " " << extrinsics.rotation[5] << " " << extrinsics.rotation[8] << std::endl;
+    ss << extrinsics.rotation[2] << " " << extrinsics.rotation[5] << " " << extrinsics.rotation[8] << std::endl << std::endl;
+    ss << extrinsics.translation[0] << " " << extrinsics.translation[1] << " " << extrinsics.translation[2] << std::endl;
+
+    return ss.str();
+}
+
+std::string to_string( const position_and_rotation & mat )
+{
+    std::stringstream ss;
+    ss << mat.pos_and_rot[0][0] << " " << mat.pos_and_rot[0][1] << " " << mat.pos_and_rot[0][2] << " " << mat.pos_and_rot[0][3] << std::endl;
+    ss << mat.pos_and_rot[1][0] << " " << mat.pos_and_rot[1][1] << " " << mat.pos_and_rot[1][2] << " " << mat.pos_and_rot[1][3] << std::endl;
+    ss << mat.pos_and_rot[2][0] << " " << mat.pos_and_rot[2][1] << " " << mat.pos_and_rot[2][2] << " " << mat.pos_and_rot[2][3] << std::endl;
+    ss << mat.pos_and_rot[3][0] << " " << mat.pos_and_rot[3][1] << " " << mat.pos_and_rot[3][2] << " " << mat.pos_and_rot[3][3] << std::endl;
 
     return ss.str();
 }
@@ -248,6 +258,8 @@ TEST_CASE("Extrinsics graph - matrices 4x4", "[live]")
                     std::cout << "extr_j_to_i : " << std::endl;
                     std::cout << to_string(extr_j_to_i) << std::endl;
                     std::cout << std::endl;
+
+                    std::cout << to_string( product ) << std::endl;
                 }
                 REQUIRE(product.is_identity());
 

--- a/unit-tests/live/extrinsics/test-consistency.cpp
+++ b/unit-tests/live/extrinsics/test-consistency.cpp
@@ -2,6 +2,8 @@
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 //#test:device D400*
+//#test:device L500*
+//#test:device SR300*
 
 #include <rsutils/easylogging/easyloggingpp.h>
 


### PR DESCRIPTION
Pull conversion code out of `synthetic_sensor`.

There was some refactoring of names and other small bits, but the logic remains the same.

IMO, this class needs major refactoring, in next PRs.
There are many code lines that are not related directly to the conversion, but rather fix behavior of other parts of the code. In addition there are assumptions on the call timing to the different functions, and some workarounds when calling functions without all the needed data. 