### PR TITLE
Add GHA timeout

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -10,6 +10,7 @@ jobs:
 
   build_lrs_ros2_package:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         ros_distribution:

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   cppcheck:
     name: cppcheck
+    timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
GHA defauly timeout is 6 hours and we have a limited credit of running hours, added missing timeout specifications to all jobs.