### PR TITLE
create temporary file in build directory instead of source

### DIFF
--- a/CMake/connectivity_check.cmake
+++ b/CMake/connectivity_check.cmake
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 message(STATUS "Checking internet connection...")
-file(DOWNLOAD "https://librealsense.intel.com/Releases/connectivity_check" "${CMAKE_CURRENT_SOURCE_DIR}/connectivity_check" SHOW_PROGRESS TIMEOUT 5 STATUS status)
+file(DOWNLOAD "https://librealsense.intel.com/Releases/connectivity_check" "${CMAKE_CURRENT_BINARY_DIR}/connectivity_check" SHOW_PROGRESS TIMEOUT 5 STATUS status)
 list (FIND status "\"No error\"" _index)
 if (${_index} EQUAL -1)
     message(STATUS "Failed to identify Internet connection")


### PR DESCRIPTION
Hello 

I think that would be better to create connectivity_check file in build directory, instead of source

For example, we have a build process in docker under custom user, and that user don't have permissions to modify sources

BR