### PR TITLE
on_participant_discovery - assert owner name can be accessed 

### DIFF
--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -107,7 +107,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
                 name = pinfo.name;
                 // When remote participant is active before this participant, listener callback can happen before
                 // create_participant funciton returns and _owner.name() can be used.
-                rsutils::string::slice & owner_name = _owner.get() ? _owner.name() : rsutils::string::slice( "" );
+                rsutils::string::slice owner_name = _owner.get() ? _owner.name() : rsutils::string::slice( "" );
                 LOG_DEBUG( owner_name << ": +participant '" << name << "' " << guid );
                 participants.emplace( info.info.m_guid.guidPrefix, std::move( pinfo ) );
             }

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -106,8 +106,10 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
                 participant_info pinfo( info.info.m_participantName, info.info.m_guid.guidPrefix );
                 name = pinfo.name;
                 // When remote participant is active before this participant, listener callback can happen before
-                // create_participant funciton returns and _owner.name() can be used.
-                rsutils::string::slice owner_name = _owner.get() ? _owner.name() : rsutils::string::slice( "" );
+                // create_participant function returns and _owner.name() can be used.
+                rsutils::string::slice owner_name;
+                if( _owner.get() )
+                    owner_name = _owner.name();
                 LOG_DEBUG( owner_name << ": +participant '" << name << "' " << guid );
                 participants.emplace( info.info.m_guid.guidPrefix, std::move( pinfo ) );
             }

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -188,8 +188,6 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
                        + std::to_string( domain_id ) );
     }
 
-    _domain_listener = std::make_shared< listener_impl >( *this );
-
     DomainParticipantQos pqos;
     pqos.name( participant_name );
 
@@ -208,11 +206,14 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
     pqos.transport().use_builtin_transports = false;
     pqos.transport().user_transports.push_back( udp_transport );
 
+    _participant_factory = DomainParticipantFactory::get_shared_instance();
+
     // Listener will call DataReaderListener::on_data_available for a specific reader,
     // not SubscriberListener::on_data_on_readers for any reader
     // ( See note on https://fast-dds.docs.eprosima.com/en/v2.7.0/fastdds/dds_layer/core/entity/entity.html )
     StatusMask par_mask = StatusMask::all() >> StatusMask::data_on_readers();
-    _participant_factory = DomainParticipantFactory::get_shared_instance();
+    _domain_listener = std::make_shared< listener_impl >( *this );
+
     _participant
         = DDS_API_CALL( _participant_factory->create_participant( domain_id, pqos, _domain_listener.get(), par_mask ) );
 


### PR DESCRIPTION
When remote participant is already up, `on_publisher_discovery` listener callback might be called before `_participant` is set. Trying to log the name will result in exception. Creating the listener as late as possible to minimize the risk.