### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 #  minimum required cmake version: 3.1.0
 cmake_minimum_required(VERSION 3.1.0)
+set(CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
 project(librealsense2 LANGUAGES CXX C)
 
 # Allow librealsense2 and all of the nested project to include the main repo folder


### PR DESCRIPTION
When using Nvidia Jetson devices, using cmake to manually build the library requires CUDA path if it is enabled using `-DBUILD_WITH_CUDA:bool=true`