### PR TITLE
Handle dds_metadata_syncer threading issues

### DIFF
--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -299,7 +299,6 @@ namespace librealsense
         // The frame pixels/data are stored in the continuation object!
         if( pixels )
             frame->attach_continuation( frame_continuation( on_release, pixels ) );
-        //auto callback = frame->get_owner()->begin_callback();
         _source.invoke_callback( std::move( frame ) );
     }
 

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -299,6 +299,7 @@ namespace librealsense
         // The frame pixels/data are stored in the continuation object!
         if( pixels )
             frame->attach_continuation( frame_continuation( on_release, pixels ) );
+        //auto callback = frame->get_owner()->begin_callback();
         _source.invoke_callback( std::move( frame ) );
     }
 

--- a/third-party/realdds/include/realdds/dds-metadata-syncer.h
+++ b/third-party/realdds/include/realdds/dds-metadata-syncer.h
@@ -74,20 +74,18 @@ private:
     on_frame_ready_callback _on_frame_ready = nullptr;
     on_metadata_dropped_callback _on_metadata_dropped = nullptr;
 
+    std::shared_ptr< bool > _is_alive; // Ensures object can be accessed
+
 public:
+    dds_metadata_syncer();
+    virtual ~dds_metadata_syncer();
+
     void enqueue_frame( key_type, frame_holder && );
     void enqueue_metadata( key_type, metadata_type && );
 
     void on_frame_release( on_frame_release_callback cb ) { _on_frame_release = cb; }
     void on_frame_ready( on_frame_ready_callback cb ) { _on_frame_ready = cb; }
     void on_metadata_dropped( on_metadata_dropped_callback cb ) { _on_metadata_dropped = cb; }
-
-    void clear()
-    {
-        std::lock_guard< std::mutex > lock( _queues_lock );
-        _frame_queue.clear();
-        _metadata_queue.clear();
-    }
 
     // Helper to create frame_holder
     template< class Frame >
@@ -99,9 +97,9 @@ public:
 private:
     // Call these under lock:
     void search_for_match( std::unique_lock< std::mutex > & );
-    void handle_match( std::unique_lock< std::mutex > & );
-    void handle_frame_without_metadata( std::unique_lock< std::mutex > & );
-    void drop_metadata( std::unique_lock< std::mutex > & );
+    bool handle_match( std::unique_lock< std::mutex > & );
+    bool handle_frame_without_metadata( std::unique_lock< std::mutex > & );
+    bool drop_metadata( std::unique_lock< std::mutex > & );
 };
 
 

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -874,8 +874,7 @@ PYBIND11_MODULE(NAME, m) {
                       ( dds_metadata_syncer::key_type key, nlohmann::json && metadata ),
                       callback( key, std::move( metadata ) ); ) )
         .def( "enqueue_frame", &dds_metadata_syncer::enqueue_frame )
-        .def( "enqueue_metadata", &dds_metadata_syncer::enqueue_metadata )
-        .def( "clear", &dds_metadata_syncer::clear );
+        .def( "enqueue_metadata", &dds_metadata_syncer::enqueue_metadata );
     metadata_syncer.attr( "max_frame_queue_size" ) = dds_metadata_syncer::max_frame_queue_size;
     metadata_syncer.attr( "max_md_queue_size" ) = dds_metadata_syncer::max_md_queue_size;
 }

--- a/third-party/realdds/src/dds-metadata-syncer.cpp
+++ b/third-party/realdds/src/dds-metadata-syncer.cpp
@@ -8,34 +8,66 @@
 namespace realdds {
 
 
+dds_metadata_syncer::dds_metadata_syncer() :
+    _is_alive( std::make_shared< bool >( true ) )
+{
+}
+
+
+dds_metadata_syncer::~dds_metadata_syncer()
+{
+    *_is_alive = false;
+
+    std::lock_guard< std::mutex > lock( _queues_lock );
+    _frame_queue.clear();
+    _metadata_queue.clear();
+}
+
+
 void dds_metadata_syncer::enqueue_frame( key_type id, frame_holder && frame )
 {
+    std::weak_ptr< bool > alive = _is_alive;
+    if( ! alive.lock() || ! *_is_alive ) // Check if was or being destructed by other thread
+        return;
+
     std::unique_lock< std::mutex > lock( _queues_lock );
     // Expect increasing order
     if( ! _frame_queue.empty() && _frame_queue.back().first >= id )
         DDS_THROW( runtime_error,
                    "frame " + std::to_string( id ) + " cannot be enqueued after "
                        + std::to_string( _frame_queue.back().first ) );
+
     // We must push the new one before releasing the lock, else someone else may push theirs ahead of ours
     _frame_queue.push_back( key_frame{ id, std::move( frame ) } );
+
     while( _frame_queue.size() > max_frame_queue_size )
-        handle_frame_without_metadata( lock );
+        if( ! handle_frame_without_metadata( lock ) ) // Lock released and aquired around callbacks, check we are alive
+            return;
+
     search_for_match( lock );
 }
 
 
 void dds_metadata_syncer::enqueue_metadata( key_type id, metadata_type && md )
 {
+    std::weak_ptr< bool > alive = _is_alive;
+    if( !alive.lock() || !*_is_alive ) // Check if was or being destructed by other thread
+        return;
+
     std::unique_lock< std::mutex > lock( _queues_lock );
     // Expect increasing order
     if( ! _metadata_queue.empty() && _metadata_queue.back().first >= id )
         DDS_THROW( runtime_error,
                    "metadata " + std::to_string( id ) + " cannot be enqueued after "
                        + std::to_string( _metadata_queue.back().first ) );
+
     // We must push the new one before releasing the lock, else someone else may push theirs ahead of ours
     _metadata_queue.push_back( key_metadata{ id, std::move( md ) } );
+
     while( _metadata_queue.size() > max_md_queue_size )
-        drop_metadata( lock );
+        if( ! drop_metadata( lock ) ) // Lock released and aquired around callbacks, check we are alive
+            return;
+
     search_for_match( lock );
 }
 
@@ -43,38 +75,37 @@ void dds_metadata_syncer::enqueue_metadata( key_type id, metadata_type && md )
 void dds_metadata_syncer::search_for_match( std::unique_lock< std::mutex > & lock )
 {
     // Wait for frame + metadata set
-    if( _frame_queue.empty() )
-        return;
-
-    // We're looking for metadata with the same ID as the next frame
-    auto frame_key = _frame_queue.front().first;
-
-    // Throw away any old metadata (with ID < the frame) since the frame ID will keep increasing
-    while( ! _metadata_queue.empty() )
+    while( !_frame_queue.empty() && !_metadata_queue.empty() )
     {
+        // We're looking for metadata with the same ID as the next frame
+        auto const frame_key = _frame_queue.front().first;
         auto const md_key = _metadata_queue.front().first;
-        while( frame_key < md_key )
+
+        if( frame_key < md_key )
         {
-            // newer metadata: we can release the frame
-            handle_frame_without_metadata( lock );
-            // and advance to the next, if there is any:
-            if( _frame_queue.empty() )
+            // Newer metadata: we can release the frame
+            if( !handle_frame_without_metadata( lock ) )
                 return;
-            frame_key = _frame_queue.front().first;
         }
-        if( frame_key == md_key )
+        else if( frame_key == md_key )
         {
-            handle_match( lock );
-            break;
+            if( !handle_match( lock ) )
+                return;
         }
-        // Metadata without frame, remove it from queue and check next
-        drop_metadata( lock );
+        else
+        {
+            // Throw away any old metadata (with ID < the frame) since the frame ID will keep increasing
+            if( !drop_metadata( lock ) )
+                return;
+        }
     }
 }
 
 
-void dds_metadata_syncer::handle_match( std::unique_lock< std::mutex > & lock )
+bool dds_metadata_syncer::handle_match( std::unique_lock< std::mutex > & lock )
 {
+    std::weak_ptr< bool > alive = _is_alive;
+
     frame_holder fh = std::move( _frame_queue.front().second );
     metadata_type md = std::move( _metadata_queue.front().second );
     _metadata_queue.pop_front();
@@ -84,13 +115,19 @@ void dds_metadata_syncer::handle_match( std::unique_lock< std::mutex > & lock )
     {
         lock.unlock();
         _on_frame_ready( std::move( fh ), std::move( md ) );
+        if( !alive.lock() || !*_is_alive ) // Check if was destructed by other thread during callback
+            return false;
         lock.lock();
     }
+
+    return true;
 }
 
 
-void dds_metadata_syncer::handle_frame_without_metadata( std::unique_lock< std::mutex > & lock )
+bool dds_metadata_syncer::handle_frame_without_metadata( std::unique_lock< std::mutex > & lock )
 {
+    std::weak_ptr< bool > alive = _is_alive;
+
     frame_holder fh = std::move( _frame_queue.front().second );
     _frame_queue.pop_front();
 
@@ -99,13 +136,19 @@ void dds_metadata_syncer::handle_frame_without_metadata( std::unique_lock< std::
         lock.unlock();
         metadata_type md;
         _on_frame_ready( std::move( fh ), std::move( md ) );
+        if( !alive.lock() || !*_is_alive ) // Check if was destructed by other thread during callback
+            return false;
         lock.lock();
     }
+
+    return true;
 }
 
 
-void dds_metadata_syncer::drop_metadata( std::unique_lock< std::mutex > & lock )
+bool dds_metadata_syncer::drop_metadata( std::unique_lock< std::mutex > & lock )
 {
+    std::weak_ptr< bool > alive = _is_alive;
+
     auto key = _metadata_queue.front().first;
     auto md = std::move( _metadata_queue.front().second );
     _metadata_queue.pop_front();  // Throw oldest
@@ -113,8 +156,12 @@ void dds_metadata_syncer::drop_metadata( std::unique_lock< std::mutex > & lock )
     {
         lock.unlock();
         _on_metadata_dropped( key, std::move( md ) );
+        if( !alive.lock() || !*_is_alive ) // Check if was destructed by other thread during callback
+            return false;
         lock.lock();
     }
+
+    return true;
 }
 
 

--- a/unit-tests/dds/test-metadata-syncer.py
+++ b/unit-tests/dds/test-metadata-syncer.py
@@ -339,5 +339,44 @@ with test.closure( 'Two threads, fast callback -> no drops, no parallel callback
         test.check_equal( md_id( last_metadata() ), 9 )
     test.check_equal( len(dropped_metadata), 0 )
 
+with test.closure( 'Two threads, slow callback -> different callbacks intervined' ):
+    """
+    Test correct handling of this scenario: (incorrect handling can trigger an exception)
+    Thread A enqueues frame0
+    Thread A enqueues frame1
+    Thread B enqueues metadata1
+        hadndle_frame_without_metadata( frame0 ) calls user callback in thread B context
+    while the callback is handled thread A enqueues frame2
+        handle_match( frame1, metadata1 ) calls user callback in thread A context
+    """
+    
+    def frame_callback( image, metadata ):
+        on_frame_ready( image, metadata )  # for reporting
+        sleep( 0.1 )
+        log.d( f'<{image_id(image):->4} {dds.now()} [{threading.get_native_id()}]' )
+
+    syncer = new_syncer( on_frame_ready=frame_callback )
+    
+    def frame_thread():
+        threadid = threading.get_native_id()
+        for i in range( 3 ):
+            image = new_image( i, time_stamp( i ) )
+            idstr = f'i{image_id(image)}'
+            log.d( f'{idstr:>5} {dds.now()} [{threadid}] enqueue {image}' )
+            syncer.enqueue_frame( i, image )
+            sleep( 0.05 )
+
+    threadA = threading.Thread( target=frame_thread )
+    threadA.start()
+    sleep( 0.12 ) # Between 2nd and 3rd enqueue_frame
+    md = new_metadata( 1, time_stamp( 1 ) )
+    syncer.enqueue_metadata( 1, md )    
+    threadA.join()
+    
+    if test.check( len(received_frames), 2 ):
+        test.check_equal( image_id( last_image() ), 1 )
+        test.check_equal( md_id( last_metadata() ), 1 )
+    test.check_equal( len(dropped_metadata), 0 )
+
 
 test.print_results_and_exit()


### PR DESCRIPTION
Fixed some bugs I encountered regarding multiple threads trying to dequeue metadata from same queue, and when stopping a sensor.