### PR TITLE
log_to_console now logs to console in Windows

### DIFF
--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -63,14 +63,7 @@ namespace rs2
         config_file::instance().set_default(configurations::window::saved_size, false);
 
         config_file::instance().set_default(configurations::viewer::is_measuring, false);
-        config_file::instance().set_default(configurations::viewer::log_to_console,
-#ifdef WIN32
-                                             // In Windows, there is no console by default
-                                             false
-#else
-                                             true
-#endif
-        );
+        config_file::instance().set_default(configurations::viewer::log_to_console, true);
         config_file::instance().set_default(configurations::viewer::log_to_file, false);
         config_file::instance().set_default(configurations::viewer::log_severity, 2);
         config_file::instance().set_default(configurations::viewer::metric_system, true);

--- a/common/ux-window.cpp
+++ b/common/ux-window.cpp
@@ -63,7 +63,14 @@ namespace rs2
         config_file::instance().set_default(configurations::window::saved_size, false);
 
         config_file::instance().set_default(configurations::viewer::is_measuring, false);
-        config_file::instance().set_default(configurations::viewer::log_to_console, true);
+        config_file::instance().set_default(configurations::viewer::log_to_console,
+#ifdef WIN32
+                                             // In Windows, there is no console by default
+                                             false
+#else
+                                             true
+#endif
+        );
         config_file::instance().set_default(configurations::viewer::log_to_file, false);
         config_file::instance().set_default(configurations::viewer::log_severity, 2);
         config_file::instance().set_default(configurations::viewer::metric_system, true);

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -838,6 +838,10 @@ namespace rs2
         {
             rs2::log_to_console(min_severity);
         }
+        else
+        {
+            rs2::log_to_console( RS2_LOG_SEVERITY_NONE );
+        }
         if (config_file::instance().get_or_default(
             configurations::viewer::log_to_file, false))
         {

--- a/src/log.h
+++ b/src/log.h
@@ -6,6 +6,7 @@
 #include "types.h"
 #include <rsutils/string/from.h>
 #include <rsutils/easylogging/easyloggingpp.h>
+#include <rsutils/os/ensure-console.h>
 #include <librealsense2/h/rs_types.h>  // rs2_log_severity
 
 #include <stdexcept>
@@ -180,6 +181,8 @@ namespace librealsense
 
         void log_to_console(rs2_log_severity min_severity)
         {
+            if( min_severity != RS2_LOG_SEVERITY_NONE )
+                rsutils::os::ensure_console();
             minimum_console_severity = min_severity;
             open();
         }

--- a/src/log.h
+++ b/src/log.h
@@ -182,7 +182,7 @@ namespace librealsense
         void log_to_console(rs2_log_severity min_severity)
         {
             if( min_severity != RS2_LOG_SEVERITY_NONE )
-                rsutils::os::ensure_console();
+                rsutils::os::ensure_console( false );  // don't create if none available
             minimum_console_severity = min_severity;
             open();
         }

--- a/third-party/rsutils/include/rsutils/os/ensure-console.h
+++ b/third-party/rsutils/include/rsutils/os/ensure-console.h
@@ -1,0 +1,26 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+
+namespace rsutils {
+namespace os {
+
+
+// In a Windows application, console output does not automatically get relfected in a console, even if run from a
+// console. Calling this will ensure a console is open (opening one in a window if none is available) and std::cout etc.
+// are directed to it.
+//
+void ensure_console();
+
+
+// This utility function allows reopening of the standard output streams to make sure they're current with the
+// application. Useful especially after messing around with the console. Automatically called by ensure_console() but
+// may need manual activation in other execution units (e.g., when librealsense is in shared mode).
+//
+void reopen_console_streams();
+
+
+}
+}

--- a/third-party/rsutils/include/rsutils/os/ensure-console.h
+++ b/third-party/rsutils/include/rsutils/os/ensure-console.h
@@ -12,14 +12,7 @@ namespace os {
 // console. Calling this will ensure a console is open (opening one in a window if none is available) and std::cout etc.
 // are directed to it.
 //
-void ensure_console();
-
-
-// This utility function allows reopening of the standard output streams to make sure they're current with the
-// application. Useful especially after messing around with the console. Automatically called by ensure_console() but
-// may need manual activation in other execution units (e.g., when librealsense is in shared mode).
-//
-void reopen_console_streams();
+void ensure_console( bool create_if_none = true );
 
 
 }

--- a/third-party/rsutils/src/ensure-console.cpp
+++ b/third-party/rsutils/src/ensure-console.cpp
@@ -1,0 +1,72 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#if defined( WIN32 )
+#include <rsutils/easylogging/easyloggingpp.h>
+#include <rsutils/os/hresult.h>
+#endif
+
+
+namespace rsutils {
+namespace os {
+
+
+void reopen_console_streams()
+{
+#if defined( WIN32 )
+    // Need to re-open the standard streams if we have a console attached
+    if( GetStdHandle( STD_OUTPUT_HANDLE ) )
+    {
+        // see https://stackoverflow.com/questions/15543571/allocconsole-not-displaying-cout
+        FILE * fDummy;
+        freopen_s( &fDummy, "CONOUT$", "w", stdout );
+        freopen_s( &fDummy, "CONOUT$", "w", stderr );
+        // Sync std::cout/cerr with stdout/err
+        std::ios::sync_with_stdio();
+        // Make sure they're clear of any error bits
+        std::cout.clear();
+        std::cerr.clear();
+    }
+#endif
+}
+
+
+void ensure_console()
+{
+#if defined( WIN32 )
+    if( AttachConsole( ATTACH_PARENT_PROCESS ) )
+    {
+        reopen_console_streams();
+    }
+    else
+    {
+        HRESULT hr = GetLastError();
+        if( ERROR_ACCESS_DENIED == hr )
+        {
+            // "If the calling process is already attached to a console"
+        }
+        else if( ERROR_INVALID_HANDLE == hr || ERROR_INVALID_PARAMETER == hr )
+        {
+            // "If the specified process does not have a console"
+            // "If the specified process does not exist"
+            if( AllocConsole() )
+            {
+                reopen_console_streams();
+            }
+            else
+            {
+                LOG_ERROR( "Parent process has no console; failed AllocConsole - "
+                           << rsutils::hresult::hr_to_string( GetLastError() ) );
+            }
+        }
+        else
+        {
+            LOG_ERROR( "failed AttachConsole - " << rsutils::hresult::hr_to_string( GetLastError() ) );
+        }
+    }
+#endif
+}
+
+
+}  // namespace os
+}  // namespace rsutils

--- a/third-party/rsutils/src/ensure-console.cpp
+++ b/third-party/rsutils/src/ensure-console.cpp
@@ -7,11 +7,7 @@
 #endif
 
 
-namespace rsutils {
-namespace os {
-
-
-void reopen_console_streams()
+static void reopen_console_streams()
 {
 #if defined( WIN32 )
     // Need to re-open the standard streams if we have a console attached
@@ -31,7 +27,11 @@ void reopen_console_streams()
 }
 
 
-void ensure_console()
+namespace rsutils {
+namespace os {
+
+
+void ensure_console( bool create_if_none )
 {
 #if defined( WIN32 )
     if( AttachConsole( ATTACH_PARENT_PROCESS ) )
@@ -49,7 +49,11 @@ void ensure_console()
         {
             // "If the specified process does not have a console"
             // "If the specified process does not exist"
-            if( AllocConsole() )
+            if( ! create_if_none )
+            {
+                LOG_DEBUG( "parent process has no console; none created" );
+            }
+            else if( AllocConsole() )
             {
                 reopen_console_streams();
             }

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -277,7 +277,12 @@ int main(int argc, const char** argv) try
 {
 
 #ifdef BUILD_EASYLOGGINGPP
-    rs2::log_to_console(RS2_LOG_SEVERITY_INFO);
+#if defined( WIN32 )
+    // In Windows, we have no console unless we start the viewer from one; without one, calling log_to_console will
+    // ensure a console, so we want to avoid it by default!
+    if( GetStdHandle( STD_OUTPUT_HANDLE ) )
+#endif
+        rs2::log_to_console( RS2_LOG_SEVERITY_INFO );
 #endif
 
     std::shared_ptr<device_models_list> device_models = std::make_shared<device_models_list>();
@@ -289,8 +294,8 @@ int main(int argc, const char** argv) try
     device_changes devices_connection_changes(ctx);
     std::vector<std::pair<std::string, std::string>> device_names;
 
-    std::string error_message{ "" };
-    std::string label{ "" };
+    std::string error_message;
+    std::string label;
 
     device_model* device_to_remove = nullptr;
     bool is_ip_device_connected = false;


### PR DESCRIPTION
The viewer has a setting:
![image](https://github.com/IntelRealSense/librealsense/assets/54848706/4d8b325c-e819-4316-b93e-2fb766303d94)
The default is to log to console, minimum level Warning.

This did **nothing** in Windows. It does not affect the Debug Console Window in the Viewer.

This changes:
* When turned on, it will attempt to connect to a parent console
    * if run from a console, the console will show logs
    * if run from GUI (or GUI debugger), a console window will not open
* Added `rsutils` function to `ensure_console()` which we now use when calling `log_to_console`
* Fixed the code so it will turn OFF console output if the user unchecks this box (it left it on before!)

NOTE that I had to make this work in both Shared and Static builds. In the former, anything outside of librealsense will not affect the librealsense logs - so I had to place the console-opening inside librealsense (originally it was only in the Viewer).