### PR TITLE
fix build error for gcc 13

### DIFF
--- a/third-party/rsutils/include/rsutils/version.h
+++ b/third-party/rsutils/include/rsutils/version.h
@@ -5,6 +5,9 @@
 
 #include <string>
 #include <iosfwd>
+#if __cplusplus >= 201103L
+#include <cstdint>
+#endif
 
 
 struct tm;


### PR DESCRIPTION
Fix problem of missing uint64_t definition in rsutils/version.h.