### PR TITLE
backend-v4l: stop metadata before video for ipu6

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2222,12 +2222,18 @@ namespace librealsense
 
         void v4l_uvc_meta_device::streamoff() const
         {
-            v4l_uvc_device::streamoff();
+            bool jetson_platform = is_platform_jetson();
+            // IPU6 platform should stop md, then video
+            if (jetson_platform)
+                v4l_uvc_device::streamoff();
+
             if (_md_fd != -1)
             {
                 // D457 development - added for mipi device, for IR because no metadata there
                 stream_off(_md_fd, _md_type);
             }
+            if (!jetson_platform)
+                v4l_uvc_device::streamoff();
         }
 
         void v4l_uvc_meta_device::negotiate_kernel_buffers(size_t num) const


### PR DESCRIPTION
Addressing validation team found stability issues