### PR TITLE
Linux collaterals in single build dir

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -230,7 +230,7 @@ jobs:
     
     - name: Build
       shell: bash
-      run: | 
+      run: |
         cd build
         cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_RUN_CONFIG}} -DBUILD_SHARED_LIBS=false -DBUILD_EXAMPLES=true -DBUILD_TOOLS=true -DCHECK_FOR_UPDATES=true -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
         cmake --build . -- -j4
@@ -241,10 +241,10 @@ jobs:
       # We set continue-on-error: true as a workaround for not skipping the upload log step on failure,
       # The final step will check the return value from the test step and decide if to fail/pass the job
       continue-on-error: true 
-      run: | 
+      run: |
         export LRS_LOG_LEVEL="DEBUG";
-        cd build   
-        ./unit-tests/live-test -d yes -i [software-device]        
+        cd build/${{env.LRS_RUN_CONFIG}}/
+        ./live-test -d yes -i [software-device]        
 
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v3
@@ -397,12 +397,12 @@ jobs:
       continue-on-error: true 
       run: | 
         export LRS_LOG_LEVEL="DEBUG";
-        cd build   
-        ./unit-tests/live-test -d yes -i [software-device]        
+        cd build/${{env.LRS_BUILD_CONFIG}}/
+        ./live-test -d yes -i [software-device]
 
     - name: Upload RS log artifact
       uses: actions/upload-artifact@v3
-      with: 
+      with:
         name: Log file - U20_SH_RSUSB_LiveTest
         path: build/*.log
 

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -141,8 +141,6 @@ jobs:
        mkdir ${{env.WIN_BUILD_DIR}}
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       shell: bash
       run: |        
         LRS_SRC_DIR=$(pwd)   
@@ -193,8 +191,6 @@ jobs:
        mkdir ${{env.WIN_BUILD_DIR}}
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       shell: bash
       run: |   
         LRS_SRC_DIR=$(pwd)
@@ -236,8 +232,8 @@ jobs:
       shell: bash
       run: | 
         cd build
-        cmake .. -DBUILD_SHARED_LIBS=false -DBUILD_EXAMPLES=true -DBUILD_TOOLS=true -DCHECK_FOR_UPDATES=true -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
-        cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4
+        cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_RUN_CONFIG}} -DBUILD_SHARED_LIBS=false -DBUILD_EXAMPLES=true -DBUILD_TOOLS=true -DCHECK_FOR_UPDATES=true -DBUILD_LEGACY_LIVE_TEST=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
+        cmake --build . -- -j4
         
     - name: Test
       shell: bash
@@ -300,8 +296,8 @@ jobs:
       shell: bash
       run: |
         cd build
-        cmake .. -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_UNIT_TESTS=true -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=false -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
-        cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4  
+        cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_RUN_CONFIG}} -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_UNIT_TESTS=true -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=false -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
+        cmake --build . -- -j4  
 
     - name: LibCI
       # Note: requires BUILD_UNIT_TESTS or the executable C++ unit-tests won't run (and it won't complain)
@@ -343,8 +339,8 @@ jobs:
       shell: bash
       run: |
         cd build
-        cmake .. -DBUILD_SHARED_LIBS=false -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_UNIT_TESTS=false -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
-        cmake --build . --config ${{env.LRS_RUN_CONFIG}} -- -j4  
+        cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_RUN_CONFIG}} -DBUILD_SHARED_LIBS=false -DBUILD_EXAMPLES=false -DBUILD_TOOLS=true -DBUILD_UNIT_TESTS=false -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
+        cmake --build . -- -j4  
 
     - name: LibCI
       # Note: we specifically disable BUILD_UNIT_TESTS so the executable C++ unit-tests won't run
@@ -390,8 +386,8 @@ jobs:
       shell: bash
       run: | 
         cd build
-        cmake .. -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DCHECK_FOR_UPDATES=false -DFORCE_RSUSB_BACKEND=true -DBUILD_LEGACY_LIVE_TEST=true
-        cmake --build . --config $LRS_BUILD_CONFIG -- -j4
+        cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_BUILD_CONFIG}} -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DCHECK_FOR_UPDATES=false -DFORCE_RSUSB_BACKEND=true -DBUILD_LEGACY_LIVE_TEST=true
+        cmake --build . -- -j4
 
     - name: Test
       shell: bash
@@ -451,8 +447,8 @@ jobs:
         # We use "greadlink -f" which is mac-os parallel command to "readlink -f" from Linux (-f to convert relative link to absolute link)
         export OPENSSL_ROOT_DIR=`greadlink -f /usr/local/opt/openssl@1.1`        
         echo "OPENSSL_ROOT_DIR = ${OPENSSL_ROOT_DIR}"
-        cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCHECK_FOR_UPDATES=true
-        cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4
+        cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_BUILD_CONFIG}} -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCHECK_FOR_UPDATES=true
+        cmake --build . -- -j4
         ls
 
 
@@ -489,7 +485,7 @@ jobs:
     - name: Build
       run: |
        cd build
-       cmake .. -DCMAKE_TOOLCHAIN_FILE=../android-ndk-r20b/build/cmake/android.toolchain.cmake -DFORCE_RSUSB_BACKEND=true
-       cmake --build . --config ${{env.LRS_BUILD_CONFIG}} -- -j4
+       cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_BUILD_CONFIG}} -DCMAKE_TOOLCHAIN_FILE=../android-ndk-r20b/build/cmake/android.toolchain.cmake -DFORCE_RSUSB_BACKEND=true
+       cmake --build . -- -j4
        ls
   

--- a/CMake/unix_config.cmake
+++ b/CMake/unix_config.cmake
@@ -4,10 +4,13 @@ macro(os_set_flags)
 
     # Put all the collaterals together, so we can find when trying to run examples/tests
     # Note: this puts the outputs under <binary>/<build-type>
-    # NOTE: do not uncomment -- this ruins our CI procedures -- otherwise it mirrors Windows, simplifies
-    # scripts, makes things easier to find... c'est la vie!
-    #set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
-    #set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    if( "${CMAKE_BUILD_TYPE}" STREQUAL "" )
+        # This can happen according to the docs -- and in GHA...
+        message( STATUS "No output directory set; using ${CMAKE_BINARY_DIR}/Release/" )
+        set( CMAKE_BUILD_TYPE "Release" )
+    endif()
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE})
 
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -pedantic -g -D_DEFAULT_SOURCE")

--- a/common/processing-block-model.cpp
+++ b/common/processing-block-model.cpp
@@ -1,8 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
-#pragma once
-
 #include <librealsense2/rs.hpp>
 #include <string>
 #include "subdevice-model.h"

--- a/src/gl/align-gl.cpp
+++ b/src/gl/align-gl.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 
 #include <chrono>
-#include <strstream>
 
 #include "synthetic-stream-gl.h"
 

--- a/src/gl/colorizer-gl.cpp
+++ b/src/gl/colorizer-gl.cpp
@@ -19,7 +19,6 @@
 
 #include <iostream>
 #include <chrono>
-#include <strstream>
 
 static const char* fragment_shader_text =
 "#version 110\n"

--- a/src/gl/upload.cpp
+++ b/src/gl/upload.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #include <chrono>
-#include <strstream>
 
 #include "synthetic-stream-gl.h"
 

--- a/src/gl/yuy2rgb-gl.cpp
+++ b/src/gl/yuy2rgb-gl.cpp
@@ -18,7 +18,6 @@
 #include <iostream>
 
 #include <chrono>
-#include <strstream>
 
 #include "synthetic-stream-gl.h"
 

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -196,10 +196,7 @@ if pyrs_path:
     log.d( 'found python libraries in:', pyd_dirs )
     if not exe_dir:
         build_dir = find_build_dir( pyrs_path )
-        if linux:
-            exe_dir = build_dir
-        else:
-            exe_dir = pyrs_path
+        exe_dir = pyrs_path
 
 # Try to assume exe directory from inside build directory. Only works if there is only one location with tests
 if not exe_dir and build_dir:


### PR DESCRIPTION
Windows already does this -- so this does the same in Linux:
* Puts everything together, so it's easy to find and create artifacts
* Turns out, `cmake --build . --config <>` doesn't work in Linux!
  * See [here](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#build-configurations): "For single configuration generators like Makefile Generators ... the configuration is specified **at configure time** by the `CMAKE_BUILD_TYPE` variable"
  * So I changed all the GHA runners to use it in Linux/Mac/Android
  * This can default to be empty, so the default is `Release`
* Had to change LibCI to expect collaterals in same place as Windows

Plus fixed some warnings on Linux...

Note that this has to be accompanied by additional PRs in other repos for our CI.

Tracked on [LRS-817]