### PR TITLE
Fixed compile error: ‘uint64_t’ does not name a type

### DIFF
--- a/third-party/rsutils/include/rsutils/version.h
+++ b/third-party/rsutils/include/rsutils/version.h
@@ -5,7 +5,7 @@
 
 #include <string>
 #include <iosfwd>
-
+#include <cstdint>
 
 struct tm;
 


### PR DESCRIPTION
In Manjaro distro, building from source requires this change, it wouldn't compile otherwise. 

