### PR TITLE
Fix device init messages w/ multiple clients

### DIFF
--- a/third-party/realdds/doc/initialization.md
+++ b/third-party/realdds/doc/initialization.md
@@ -6,7 +6,7 @@ See also: [device](device.md), [notifications](notifications.md)
 
 In order to stream, a client must know the stream names, available formats, etc.
 
-The only way for a client to get these is by subscribing to the `notification` topic. When the server detects a subscriber on this topic, it will broadcast initialization messages in the following order:
+The only way for a client to get these is by subscribing to the `notification` topic. When the server detects a subscriber on this topic, it will broadcast a set of initialization messages in the following order:
 
 - `device-header`
 - `device-options` - optional
@@ -17,6 +17,19 @@ The only way for a client to get these is by subscribing to the `notification` t
 These initialization messages should only have effect on devices that are not already initialized. They are expected in the above order.
 
 Once all streams have been received, the device is initialized and ready to use. See [Streaming](streaming.md).
+
+
+## "Atomic" Initialization
+
+
+Initialization may happen interspersed with regular notifications: for example, a server that's already serving data and notifications to an existing client may see another client and broadcast initialization messages.
+
+Only one set of initialization messages can be sent at a time. I.e., if a new client is detected while initialization messages for a previous client are still outgoing, a new set of messages must go out but only once the previous set is finished.
+
+While a set of initialization messages are outgoing, all other notifications must take a back seat and wait until the set is written out.
+
+
+## Messages
 
 
 #### `device-header`

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -677,6 +677,10 @@ PYBIND11_MODULE(NAME, m) {
                       streams.push_back( name2stream.second );
                   return streams;
               } )
+        .def(
+            "publish_notification",
+            []( dds_device_server & self, nlohmann::json const & j ) { self.publish_notification( j ); },
+            py::call_guard< py::gil_scoped_release >() )
         .def( "publish_metadata", &dds_device_server::publish_metadata, py::call_guard< py::gil_scoped_release >() )
         .def( "broadcast", &dds_device_server::broadcast );
 

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -87,6 +87,10 @@ std::ostream& operator<<( std::ostream& s, state_type st )
 /*static*/ dds_device::impl::notification_handlers const dds_device::impl::_notification_handlers{
     { id_set_option, &dds_device::impl::on_option_value },
     { id_query_option, &dds_device::impl::on_option_value },
+    { "device-header", &dds_device::impl::on_known_notification },
+    { "device-options", &dds_device::impl::on_known_notification },
+    { "stream-header", &dds_device::impl::on_known_notification },
+    { "stream-options", &dds_device::impl::on_known_notification },
 };
 
 
@@ -240,6 +244,12 @@ void dds_device::impl::on_option_value( nlohmann::json const & j )
         }
     }
     throw std::runtime_error( "option not found" );
+}
+
+
+void dds_device::impl::on_known_notification( nlohmann::json const & j )
+{
+    // This is a known notification, but we don't want to do anything for it
 }
 
 

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -82,6 +82,7 @@ private:
     static notification_handlers const _notification_handlers;
     void handle_notification( nlohmann::json const & );
     void on_option_value( nlohmann::json const & );
+    void on_known_notification( nlohmann::json const & );
 
     on_metadata_available_callback _on_metadata_available = nullptr;
 

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -77,6 +77,12 @@ private:
     void create_control_writer();
     bool init();
 
+    struct init_context;
+    void handle_device_header( init_context &, nlohmann::json const & );
+    void handle_device_options( init_context &, nlohmann::json const & );
+    void handle_stream_header( init_context &, nlohmann::json const & );
+    void handle_stream_options( init_context &, nlohmann::json const & );
+
     // notification handlers
     typedef std::map< std::string, void ( dds_device::impl::* )( nlohmann::json const & ) > notification_handlers;
     static notification_handlers const _notification_handlers;

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -75,7 +75,7 @@ static void on_discovery_device_header( size_t const n_streams,
         extrinsics_json.push_back( json::array( { ex.first.first, ex.first.second, ex.second->to_json() } ) );
 
     topics::flexible_msg device_header( json{
-        { "id", "device-header" },
+        { id_key, "device-header" },
         { "n-streams", n_streams },
         { "extrinsics", std::move( extrinsics_json ) }
     } );
@@ -88,7 +88,7 @@ static void on_discovery_device_header( size_t const n_streams,
     for( auto & opt : options )
         device_options.push_back( std::move( opt->to_json() ) );
     topics::flexible_msg device_options_message( json {
-        { "id", "device-options" },
+        { id_key, "device-options" },
         { "options", std::move( device_options ) }
     } );
     json_string = slice( device_options_message.custom_data< char const >(), device_options_message._data.size() );
@@ -105,7 +105,7 @@ static void on_discovery_stream_header( std::shared_ptr< dds_stream_server > con
     for( auto & sp : stream->profiles() )
         profiles.push_back( std::move( sp->to_json() ) );
     topics::flexible_msg stream_header_message( json{
-        { "id", "stream-header" },
+        { id_key, "stream-header" },
         { "type", stream->type_string() },
         { "name", stream->name() },
         { "sensor-name", stream->sensor_name() },
@@ -135,7 +135,7 @@ static void on_discovery_stream_header( std::shared_ptr< dds_stream_server > con
     for( auto & filter : stream->recommended_filters() )
         stream_filters.push_back( filter );
     topics::flexible_msg stream_options_message( json {
-        { "id", "stream-options" },
+        { id_key, "stream-options" },
         { "stream-name", stream->name() },
         { "options" , std::move( stream_options ) },
         { "intrinsics" , intrinsics },

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -142,7 +142,7 @@ void dds_notification_server::send_discovery_notifications()
 {
     // Send all initialization notifications
     LOG_DEBUG( "broadcasting discovery notifications" );
-    for( auto notification : _discovery_notifications )
+    for( auto & notification : _discovery_notifications )
     {
         DDS_API_CALL( _writer->get()->write( &notification ) );
     }

--- a/unit-tests/dds/device-2nd-client.py
+++ b/unit-tests/dds/device-2nd-client.py
@@ -4,11 +4,11 @@
 import pyrealdds as dds
 from rspy import log, test
 
-dds.debug( True, log.nested )
+dds.debug( log.is_debug_on(), log.nested )
 
 
 participant = dds.participant()
-participant.init( 123, "device-2nd-client" )
+participant.init( 123, f'client-{log.nested.strip()}' )
 
 
 info = dds.device_info()

--- a/unit-tests/dds/test-device-init.py
+++ b/unit-tests/dds/test-device-init.py
@@ -29,8 +29,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     #############################################################################################
     #
-    test.start( "Test 1 stream..." )
-    try:
+    with test.closure( "Test 1 stream..." ):
         remote.run( 'test_one_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
         device.run( 1000 )  # If no device is available in 30 seconds, this will throw
@@ -45,15 +44,11 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             test.check_equal( profiles[0].stream(), stream )
             test.check_equal( stream.default_profile_index(), 0 )
         remote.run( 'close_server()' )
-    except:
-        test.unexpected_exception()
     device = None
-    test.finish()
     #
     #############################################################################################
     #
-    test.start( "Test motion stream..." )
-    try:
+    with test.closure( "Test motion stream..." ):
         remote.run( 'test_one_motion_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
         device.run( 1000 )  # If no device is available in 30 seconds, this will throw
@@ -69,15 +64,11 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             test.check_equal( profiles[0].stream(), stream )
             test.check_equal( stream.default_profile_index(), 0 )
         remote.run( 'close_server()' )
-    except:
-        test.unexpected_exception()
     device = None
-    test.finish()
     #
     #############################################################################################
     #
-    test.start( "Test no streams..." )
-    try:
+    with test.closure( "Test no streams..." ):
         remote.run( 'test_no_streams()' )
         device = dds.device( participant, participant.create_guid(), info )
         device.run( 1000 )  # If no device is available in 30 seconds, this will throw
@@ -86,28 +77,21 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         for stream in device.streams():
             test.unreachable()
         remote.run( 'close_server()' )
-    except:
-        test.unexpected_exception()
     device = None
-    test.finish()
     #
     #############################################################################################
     #
-    test.start( "Test no profiles... (should fail on server side)" )
-    try:
-        remote.run( 'test_no_profiles()' )
-    except test.remote.Error as e:
-        # this fails because streams require at least one profile
-        test.check_exception( e, test.remote.Error, "RuntimeError: at least one profile is required to initialize stream 's1'" )
-    except:
-        test.unexpected_exception()
+    with test.closure( "Test no profiles... (should fail on server side)" ):
+        try:
+            remote.run( 'test_no_profiles()' )
+        except test.remote.Error as e:
+            # this fails because streams require at least one profile
+            test.check_exception( e, test.remote.Error, "RuntimeError: at least one profile is required to initialize stream 's1'" )
     device = None
-    test.finish()
     #
     #############################################################################################
     #
-    test.start( "Test 10 profiles..." )
-    try:
+    with test.closure( "Test 10 profiles..." ):
         remote.run( 'test_n_profiles(10)' )
         device = dds.device( participant, participant.create_guid(), info )
         device.run( 1000 )  # If no device is available in 30 seconds, this will throw
@@ -125,15 +109,11 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             test.check_equal( profiles[i].width(), i )
             test.check_equal( profiles[i].height(), v )
         remote.run( 'close_server()' )
-    except:
-        test.unexpected_exception()
     device = None
-    test.finish()
     #
     #############################################################################################
     #
-    test.start( "Test D435i..." )
-    try:
+    with test.closure( "Test D435i..." ):
         remote.run( 'test_d435i()' )
         device = dds.device( participant, participant.create_guid(), d435i.device_info )
         device.run( 1000 )  # If no device is available in 30 seconds, this will throw
@@ -142,15 +122,11 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         for stream in device.streams():
             profiles = stream.profiles()
         remote.run( 'close_server()' )
-    except:
-        test.unexpected_exception()
     device = None
-    test.finish()
     #
     #############################################################################################
     #
-    test.start( "Test discovery of another client device..." )
-    try:
+    with test.closure( "Test discovery of another client device..." ):
         remote.run( 'test_one_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
         device.run( 1000 )  # If no device is available in 30 seconds, this will throw
@@ -165,10 +141,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             # should ignore them...
             remote2.run( 'close_device()' )
         remote.run( 'close_server()' )
-    except:
-        test.unexpected_exception()
     device = None
-    test.finish()
     #
     #############################################################################################
 


### PR DESCRIPTION
* added unit-test in test-device-init:
  * initializes multiple clients all at once in different processes - this makes them happen simultaneously and failed
* ignore init messages after init
* stop init loop once done
* ignore init messages if we're still waiting for a device-header
  * i.e., before we get the device-header, we ignore already in-progress init sequences

and:

* improve exception handling in rspy.test
* add pyrealdds.device_server.publish_notification()
* improve docs for device initialization, to cover "atomic" initialization

Tracked on [LRS-797]