### PR TITLE
Avoid device_watcher deadlock after reset

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -139,7 +139,8 @@ namespace librealsense
         devices_changed_callback_ptr _devices_changed_callback;
         std::map<int, std::weak_ptr<const stream_interface>> _streams;
         std::map<int, std::map<int, std::weak_ptr<lazy<rs2_extrinsics>>>> _extrinsics;
-        std::mutex _streams_mutex, _devices_changed_callbacks_mtx;
+        std::mutex _streams_mutex;
+        std::timed_mutex _devices_changed_callbacks_mtx;
     };
 
     class readonly_device_info : public device_info


### PR DESCRIPTION
Fixing: #10482 

**Issue:**
- Deadlock happens after reset

**Root cause:**
- After hardware_reset, when the device class object is created, it detects that the devices are changed (due to reset) and triggers the `on_device_changed()` callback
    - Before this callback getting executed, the class object goes out of scope and the destructor `~device()` is getting called in different thread
- When both `on_device_changed()` callback and destructor `~device()` runs at same time in different threads, deadlock happens as both of their call stacks require same set of mutexes but in different order
    - First thread: (Dispatcher thread)
        - Acquired the `_dispatch_mutex` at [line](https://github.com/IntelRealSense/librealsense/blob/master/third-party/rsutils/src/dispatcher.cpp#L29) and following the callstack it calls the `on_device_changed()` callback and waits for mutex `_devices_changed_callbacks_mtx` at [line](https://github.com/IntelRealSense/librealsense/blob/master/src/context.cpp#L371)
    - Second thread:
        - When the device object goes out of scope, `~device()` destructor is called and then, it calls `unregister_internal_device_callback()` function at [line](https://github.com/IntelRealSense/librealsense/blob/master/src/device.cpp#L211)
            - There it acquires `_devices_changed_callbacks_mtx` at [line](https://github.com/IntelRealSense/librealsense/blob/master/src/context.cpp#L431)
        - Then it calls  `device_watcher->stop()`, which calls `dispatcher::stop()` 
            - Here it waits for `_dispatch_mutex` at [line](https://github.com/IntelRealSense/librealsense/blob/master/third-party/rsutils/src/dispatcher.cpp#L90)

**Proposed Fix:**
- To have a timed mutex lock in `on_device_changed()` callback. If the timeout happens, this callback can be stopped - which will in turn resumes the other thread as well