### PR TITLE
Add full version attribute for python wrapper

### DIFF
--- a/wrappers/python/pyrealsense2.cpp
+++ b/wrappers/python/pyrealsense2.cpp
@@ -13,6 +13,7 @@ PYBIND11_MODULE(NAME, m) {
         Library for accessing Intel RealSenseTM cameras
     )pbdoc";
     m.attr("__version__") = RS2_API_VERSION_STR;
+    m.attr("__full_version__") = RS2_API_FULL_VERSION_STR;
 
     init_c_files(m);
     init_types(m);


### PR DESCRIPTION
We add a full version attribute to the python wrapper so we can distinguish between different build versions

```
>>> import pyrealsense2 as rs
>>> rs.__version__
'2.55.0'
>>> rs.__full_version__
'2.55.0.5292'
>>>
```