### PR TITLE
GHA - Remove Foxy (EOL) and Galactic (EOL), add Iron (New Distro)

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -40,7 +40,7 @@ jobs:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
       - name: build librealsense ROS 2
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           skip-tests: true

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -18,11 +18,11 @@ jobs:
           - rolling
 
         include:
-          # Galactic Geochelone
+          # Humble Hawksbill
           - docker_image: ubuntu:jammy
             ros_distribution: humble
 
-          # Humble Hawksbill
+          # Iron Irwini
           - docker_image: ubuntu:jammy
             ros_distribution: iron
 

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -13,23 +13,18 @@ jobs:
     strategy:
       matrix:
         ros_distribution:
-          - foxy
-          - galactic
           - humble
+          - iron
           - rolling
 
         include:
-          # Foxy Fitzroy
-          - docker_image: ubuntu:focal
-            ros_distribution: foxy
-
           # Galactic Geochelone
-          - docker_image: ubuntu:focal
-            ros_distribution: galactic
+          - docker_image: ubuntu:jammy
+            ros_distribution: humble
 
           # Humble Hawksbill
           - docker_image: ubuntu:jammy
-            ros_distribution: humble
+            ros_distribution: iron
 
           # Rolling Ridley
           - docker_image: ubuntu:jammy

--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: setup ROS environment
-        uses: ros-tooling/setup-ros@v0.4
+        uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 


### PR DESCRIPTION
- Update ROS2 build of librealsense CI to support new distro (Iron), and remove EOL distros (Foxy, Galactic)
- Update action-ros-ci tool to latest release (v0.3) which supports iron
- Update setup-ros to latest (v0.7) which supports iron
