### PR TITLE
scripts: ipu6: fix media controller index

### DIFF
--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -33,6 +33,13 @@
 # i2c 	2	d4xx   	Firmware 	/dev/d4xx-dfu-c	/dev/d4xx-dfu-2
 
 # Dependency: v4l-utils
+v4l2_util=$(which v4l2-ctl)
+media_util=$(which media-ctl)
+if [ -z ${v4l2_util} ]; then
+  echo "v4l2-ctl not found, install with: sudo apt install v4l-utils"
+  exit 1
+fi
+
 #
 # parse command line parameters
 # for '-i' parameter, print links only
@@ -71,7 +78,7 @@ camera_vid=("depth" "depth-md" "color" "color-md" "ir" "imu")
 [[ $quiet -eq 0 ]] && printf "Bus\tCamera\tSensor\tNode Type\tVideo Node\tRS Link\n"
 
 # For Jetson we have simple method
-if [ -n "$(v4l2-ctl --list-devices | grep tegra)" ]; then
+if [ -n "$(${v4l2_util} --list-devices | grep tegra)" ]; then
   for ((i = 0; i < 127; i++)); do
     if [ ! -c /dev/video${i} ]; then
       break;
@@ -79,7 +86,7 @@ if [ -n "$(v4l2-ctl --list-devices | grep tegra)" ]; then
     cam_id=$((i/6))
     sens_id=$((i%6))
     vid="/dev/video${i}"
-    dev_name=$(v4l2-ctl -d ${vid} -D | grep 'Driver name' | head -n1 | awk -F' : ' '{print $2}')
+    dev_name=$(${v4l2_util} -d ${vid} -D | grep 'Driver name' | head -n1 | awk -F' : ' '{print $2}')
     dev_ln="/dev/video-rs-${camera_vid[${sens_id}]}-${cam_id}"
     bus="mipi"
     if [ "$dev_name" = "uvcvideo" ]; then
@@ -98,7 +105,7 @@ if [ -n "$(v4l2-ctl --list-devices | grep tegra)" ]; then
       [[ -e $dev_ln ]] && sudo unlink $dev_ln
       sudo ln -s $vid $dev_ln
       # Create DFU device link for camera on jetson
-      subdev=$(media-ctl --print-dot | grep "D4XX depth ${camera} | awk -F'|' '{print $2}' | awk -F'/' '{print $3}' | tr -d ' '")
+      subdev=$(${media_util} --print-dot | grep "D4XX depth ${camera} | awk -F'|' '{print $2}' | awk -F'/' '{print $3}' | tr -d ' '")
       i2cdev=$(ls -l /sys/class/video4linux/${subdev}/device | awk -F'/' '{print $9}')
       dev_dfu_name="/dev/d4xx-dfu-${i2cdev}"
       dev_dfu_ln="/dev/d4xx-dfu-${cam_id}"
@@ -110,10 +117,10 @@ exit 0
 fi
 
 #ADL-P IPU6
-mdev=$(v4l2-ctl --list-devices | grep -A1 ipu6 | grep media)
+mdev=$(${v4l2_util} --list-devices | grep -A1 ipu6 | grep media)
 #media-ctl -r
 # cache media-ctl output
-dot=$(media-ctl -d ${mdev} --print-dot)
+dot=$(${media_util} -d ${mdev} --print-dot)
 # for all d457 muxes a, b, c and d
 for camera in $mux_list; do
   create_dfu_dev=0
@@ -133,7 +140,7 @@ for camera in $mux_list; do
     vid=$(echo "${dot}" | grep "${vid_nd}" | grep video | tr '\\n' '\n' | grep video | awk -F'"' '{print $1}')
     [[ -z $vid ]] && continue;
     dev_ln="/dev/video-rs-${camera_names["${sens}"]}-${camera_idx[${camera}]}"
-    dev_name=$(v4l2-ctl -d $vid -D | grep Model | awk -F':' '{print $2}')
+    dev_name=$(${v4l2_util} -d $vid -D | grep Model | awk -F':' '{print $2}')
 
     [[ $quiet -eq 0 ]] && printf '%s\t%d\t%s\tStreaming\t%s\t%s\n' "$dev_name" ${camera_idx[${camera}]} ${camera_names["${sens}"]} $vid $dev_ln
 
@@ -142,7 +149,7 @@ for camera in $mux_list; do
       [[ -e $dev_ln ]] && sudo unlink $dev_ln
       sudo ln -s $vid $dev_ln
       # activate ipu6 link enumeration feature
-      v4l2-ctl -d $dev_ln -c enumerate_graph_link=1
+      ${v4l2_util} -d $dev_ln -c enumerate_graph_link=1
     fi
     create_dfu_dev=1 # will create DFU device link for camera
     # metadata link
@@ -153,14 +160,14 @@ for camera in $mux_list; do
 
     vid_num=$(echo $vid | grep -o '[0-9]\+')
     dev_md_ln="/dev/video-rs-${camera_names["${sens}"]}-md-${camera_idx[${camera}]}"
-    dev_name=$(v4l2-ctl -d "/dev/video$(($vid_num+1))" -D | grep Model | awk -F':' '{print $2}')
+    dev_name=$(${v4l2_util} -d "/dev/video$(($vid_num+1))" -D | grep Model | awk -F':' '{print $2}')
 
     [[ $quiet -eq 0 ]] && printf '%s\t%d\t%s\tMetadata\t/dev/video%s\t%s\n' "$dev_name" ${camera_idx[${camera}]} ${camera_names["${sens}"]} $(($vid_num+1)) $dev_md_ln
     # create link only in case we choose not only to show it
     if [[ $info -eq 0 ]]; then
       [[ -e $dev_md_ln ]] && sudo unlink $dev_md_ln
       sudo ln -s "/dev/video$(($vid_num+1))" $dev_md_ln
-      v4l2-ctl -d $dev_md_ln -c enumerate_graph_link=3
+      ${v4l2_util} -d $dev_md_ln -c enumerate_graph_link=3
     fi
   done
   # create DFU device link for camera

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -110,8 +110,10 @@ exit 0
 fi
 
 #ADL-P IPU6
+mdev=$(v4l2-ctl --list-devices | grep -A1 ipu6 | grep media)
+#media-ctl -r
 # cache media-ctl output
-dot=$(media-ctl --print-dot)
+dot=$(media-ctl -d ${mdev} --print-dot)
 # for all d457 muxes a, b, c and d
 for camera in $mux_list; do
   create_dfu_dev=0

--- a/scripts/rs_ipu6_d457_bind.sh
+++ b/scripts/rs_ipu6_d457_bind.sh
@@ -24,9 +24,11 @@ declare -A media_mux_csi2_link=( [a]=0 [b]=1 [c]=2 [d]=3 )
 declare -A serdes_mux_i2c_bus=( [a]=2 [b]=2 [c]=4 [d]=4 )
 mux_list=${mux_param:-'a b c d'}
 
+mdev=$(v4l2-ctl --list-devices | grep -A1 ipu6 | grep media)
+media_ctl_cmd="$(which media-ctl) -d ${mdev}"
 #media-ctl -r
 # cache media-ctl output
-dot=$(media-ctl --print-dot)
+dot=$($media_ctl_cmd --print-dot)
 
 # DS5 MUX. Can be {a, b, c, d}.
 for mux in $mux_list; do
@@ -40,27 +42,27 @@ csi2="CSI-2 ${media_mux_csi2_link[${mux}]}"
 
 be_soc_cap="BE SOC ${media_mux_capture_link[${mux}]}capture"
 
-media-ctl -v -l "\"Intel IPU6 ${csi2}\":1 -> \"Intel IPU6 ${csi2_be_soc}\":0[1]" 1>/dev/null
-media-ctl -v -l "\"DS5 mux ${mux}\":0 -> \"Intel IPU6 ${csi2}\":0[1]" 1>/dev/null
+$media_ctl_cmd -v -l "\"Intel IPU6 ${csi2}\":1 -> \"Intel IPU6 ${csi2_be_soc}\":0[1]" 1>/dev/null
+$media_ctl_cmd -v -l "\"DS5 mux ${mux}\":0 -> \"Intel IPU6 ${csi2}\":0[1]" 1>/dev/null
 
-media-ctl -v -l "\"D4XX depth ${mux}\":0 -> \"DS5 mux ${mux}\":1[1]" 1>/dev/null
+$media_ctl_cmd -v -l "\"D4XX depth ${mux}\":0 -> \"DS5 mux ${mux}\":1[1]" 1>/dev/null
 # DEPTH video streaming node
-media-ctl -v -l "\"Intel IPU6 ${csi2_be_soc}\":1 -> \"Intel IPU6 ${be_soc_cap} 0\":0[5]" 1>/dev/null
+$media_ctl_cmd -v -l "\"Intel IPU6 ${csi2_be_soc}\":1 -> \"Intel IPU6 ${be_soc_cap} 0\":0[5]" 1>/dev/null
 # DEPTH metadata node
-media-ctl -v -l "\"Intel IPU6 ${csi2_be_soc}\":2 -> \"Intel IPU6 ${be_soc_cap} 1\":0[5]" 1>/dev/null
+$media_ctl_cmd -v -l "\"Intel IPU6 ${csi2_be_soc}\":2 -> \"Intel IPU6 ${be_soc_cap} 1\":0[5]" 1>/dev/null
 
-media-ctl -v -l "\"D4XX rgb ${mux}\":0 -> \"DS5 mux ${mux}\":2[1]" 1>/dev/null
+$media_ctl_cmd -v -l "\"D4XX rgb ${mux}\":0 -> \"DS5 mux ${mux}\":2[1]" 1>/dev/null
 # RGB link
-media-ctl -v -l "\"Intel IPU6 ${csi2_be_soc}\":3 -> \"Intel IPU6 ${be_soc_cap} 2\":0[5]" 1>/dev/null
+$media_ctl_cmd -v -l "\"Intel IPU6 ${csi2_be_soc}\":3 -> \"Intel IPU6 ${be_soc_cap} 2\":0[5]" 1>/dev/null
 # RGB metadata node
-media-ctl -v -l "\"Intel IPU6 ${csi2_be_soc}\":4 -> \"Intel IPU6 ${be_soc_cap} 3\":0[5]" 1>/dev/null
+$media_ctl_cmd -v -l "\"Intel IPU6 ${csi2_be_soc}\":4 -> \"Intel IPU6 ${be_soc_cap} 3\":0[5]" 1>/dev/null
 
 # IR link
-media-ctl -v -l "\"D4XX motion detection ${mux}\":0 -> \"DS5 mux ${mux}\":3[1]" 1>/dev/null
-media-ctl -v -l "\"Intel IPU6 ${csi2_be_soc}\":5 -> \"Intel IPU6 ${be_soc_cap} 4\":0[5]" 1>/dev/null
+$media_ctl_cmd -v -l "\"D4XX motion detection ${mux}\":0 -> \"DS5 mux ${mux}\":3[1]" 1>/dev/null
+$media_ctl_cmd -v -l "\"Intel IPU6 ${csi2_be_soc}\":5 -> \"Intel IPU6 ${be_soc_cap} 4\":0[5]" 1>/dev/null
 
 # IMU link
-media-ctl -v -l "\"D4XX imu ${mux}\":0 -> \"DS5 mux ${mux}\":4[1]" 1>/dev/null
-media-ctl -v -l "\"Intel IPU6 ${csi2_be_soc}\":6 -> \"Intel IPU6 ${be_soc_cap} 5\":0[5]" 1>/dev/null
+$media_ctl_cmd -v -l "\"D4XX imu ${mux}\":0 -> \"DS5 mux ${mux}\":4[1]" 1>/dev/null
+$media_ctl_cmd -v -l "\"Intel IPU6 ${csi2_be_soc}\":6 -> \"Intel IPU6 ${be_soc_cap} 5\":0[5]" 1>/dev/null
 [[ $quiet -eq 0 ]] && echo done
 done

--- a/scripts/rs_ipu6_d457_bind.sh
+++ b/scripts/rs_ipu6_d457_bind.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# Dependency: v4l-utils
+v4l2_util=$(which v4l2-ctl)
+media_util=$(which media-ctl)
+if [ -z ${v4l2_util} ]; then
+  echo "v4l2-ctl not found, install with: sudo apt install v4l-utils"
+  exit 1
+fi
+
 # d457_bind.sh
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -24,8 +32,8 @@ declare -A media_mux_csi2_link=( [a]=0 [b]=1 [c]=2 [d]=3 )
 declare -A serdes_mux_i2c_bus=( [a]=2 [b]=2 [c]=4 [d]=4 )
 mux_list=${mux_param:-'a b c d'}
 
-mdev=$(v4l2-ctl --list-devices | grep -A1 ipu6 | grep media)
-media_ctl_cmd="$(which media-ctl) -d ${mdev}"
+mdev=$(${v4l2_util} --list-devices | grep -A1 ipu6 | grep media)
+media_ctl_cmd="${media_util} -d ${mdev}"
 #media-ctl -r
 # cache media-ctl output
 dot=$($media_ctl_cmd --print-dot)


### PR DESCRIPTION
The media controller index used by media-ctl command by default is 0. In case system boot with USB camera plugged in,
the ipu6 media controller will be not zero.

This will fix default media-ctl index.
HSD: 13010862930
IPU6 not registering with media framework with USB camera plugged in on boot.