### PR TITLE
DDS participant settings thru librs context

### DIFF
--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -27,8 +27,9 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error);
 * \param[in] api_version Users are expected to pass their version of \c RS2_API_VERSION to make sure they are running the correct librealsense version.
 * \param[in] json_settings Pointer to a string containing a JSON configuration to use, or null if none
 *            Possible settings:
-*                dds-discovery - (bool) false to disable DDS discovery; defaults to true (requires BUILD_WITH_DDS)
-*                dds-domain - (int) the number of the domain discovery is on (requires BUILD_WITH_DDS)
+*                dds               - (requires BUILD_WITH_DDS) false (bool) to disable DDS; otherwise the DDS settings:
+*                    domain        - (int) the number of the domain discovery is on; defaults to 0
+*                    participant   - (string) the name of the participant; defaults to the name of the executable
 *                use-basic-formats - (bool) true to make sensors stream only "basic" types without converting to formats
 *                                    other then the raw camera formats; defaults to false.
 *                                    Convert only interleaved formats (Y8I, Y12I), no colored infrared.

--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -26,13 +26,15 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error);
 * \brief Creates RealSense context that is required for the rest of the API, and accepts a settings JSON.
 * \param[in] api_version Users are expected to pass their version of \c RS2_API_VERSION to make sure they are running the correct librealsense version.
 * \param[in] json_settings Pointer to a string containing a JSON configuration to use, or null if none
-*            Possible settings:
-*                dds               - (requires BUILD_WITH_DDS) false (bool) to disable DDS; otherwise the DDS settings:
-*                    domain        - (int) the number of the domain discovery is on; defaults to 0
-*                    participant   - (string) the name of the participant; defaults to the name of the executable
-*                use-basic-formats - (bool) true to make sensors stream only "basic" types without converting to formats
-*                                    other then the raw camera formats; defaults to false.
-*                                    Convert only interleaved formats (Y8I, Y12I), no colored infrared.
+*     Possible <setting>:<default-value> :
+*         dds: {}                      - (requires BUILD_WITH_DDS) false disables DDS; otherwise the DDS settings:
+*             domain: 0                - (int) the number of the DDS domain [0-232]
+*             participant: <exe name>  - (string) the name of the participant
+*                 (see additional settings in realdds/doc/device.md#Settings)
+*         use-basic-formats: false     - (bool) true to make sensors stream only "basic" types
+*                                        without converting to formats other than the raw camera
+*                                        formats (Convert only interleaved formats (Y8I, Y12I), no
+*                                        colored infrared)
 * \param[out] error  If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return            Context object
 */

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -202,8 +202,7 @@ namespace librealsense
             // The DDS device watcher should always be on
             if( _dds_watcher && _dds_watcher->is_stopped() )
             {
-                start_dds_device_watcher(
-                    rsutils::json::get< size_t >( settings, std::string( "dds-message-timeout-ms", 22 ), 5000 ) );
+                start_dds_device_watcher();
             }
         }
 #endif //BUILD_WITH_DDS
@@ -583,10 +582,10 @@ namespace librealsense
     }
 
 #ifdef BUILD_WITH_DDS
-    void context::start_dds_device_watcher( size_t message_timeout_ms )
+    void context::start_dds_device_watcher()
     {
-        _dds_watcher->on_device_added( [this, message_timeout_ms]( std::shared_ptr< realdds::dds_device > const & dev ) {
-            dev->run( message_timeout_ms );
+        _dds_watcher->on_device_added( [this]( std::shared_ptr< realdds::dds_device > const & dev ) {
+            dev->run();
 
             std::vector<rs2_device_info> rs2_device_info_added;
             std::vector<rs2_device_info> rs2_device_info_removed;

--- a/src/context.h
+++ b/src/context.h
@@ -156,7 +156,7 @@ namespace librealsense
         std::shared_ptr< realdds::dds_participant > _dds_participant;
         std::shared_ptr< realdds::dds_device_watcher > _dds_watcher;
 
-        void start_dds_device_watcher( size_t message_timeout_ms );
+        void start_dds_device_watcher();
 #endif
 
         nlohmann::json _settings; // Save operation settings

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -14,7 +14,7 @@ using rsutils::deferred;
 namespace librealsense
 {
     software_device::software_device()
-        : device( std::make_shared< context >( nlohmann::json( { { "dds-discovery", false } } ) ), {}, false )
+        : device( std::make_shared< context >( nlohmann::json::object( { { "dds", false } } ) ), {}, false )
         , _user_destruction_callback()
     {
         register_info( RS2_CAMERA_INFO_NAME, "Software-Device" );

--- a/third-party/realdds/doc/device.md
+++ b/third-party/realdds/doc/device.md
@@ -25,6 +25,17 @@ Currently, the topic root as used by `rs-dds-adapter` is built as:
 > realsense/ `<device-model>` _ `<serial-number>`
 
 
+## Settings
+
+Device behavior can be fine-tuned with certain JSON settings passed through the participant (and therefore from the librealsense context's `dds` settings):
+
+| Field                    | Default | Type    | Description        |
+|--------------------------|---------|---------|--------------------|
+| device-reply-timeout-ms  |    1000 | size_t  | How long to wait for a control reply to arrive, in millisec
+| device-init-timeout-ms   |    5000 | size_t  | How long to try achieving device handshake, in millisec
+
+
+
 ## Continue with:
 
 * [Notifications](notifications.md)

--- a/third-party/realdds/doc/discovery.md
+++ b/third-party/realdds/doc/discovery.md
@@ -88,10 +88,11 @@ Librealsense manages a single point from which all other objects are derived: th
 
 The `context` has been augmented to be able to see DDS devices. This is on by default if `BUILD_WITH_DDS` is on.
 
-When a context is created, a JSON representation may be passed to it, e.g.: `{"dds-domain":123,"dds-participant-name":"librs"}`. This allows various customizations:
+When a context is created, a JSON representation may be passed to it, e.g.: `{"dds": { "domain": 123, "participant": "librs" }}`. This allows various customizations:
 
 | Field                | Description                            |
 |----------------------|------------------------------------------------------|
-| dds-discovery        | Default to `true`; set to `false` to turn off DDS in this context
-| dds-domain           | The domain number to use (0-232); `0` is the default
-| dds-participant-name | The name given this context (how other participants will see it); defaults to the executable name
+| dds                  | Set to `false` to turn off DDS in this context; otherwise a JSON object containing:
+| domain               | The domain number to use (0-232); `0` is the default
+| participant          | The name given this context (how other participants will see it); defaults to the executable name
+

--- a/third-party/realdds/doc/discovery.md
+++ b/third-party/realdds/doc/discovery.md
@@ -91,8 +91,14 @@ The `context` has been augmented to be able to see DDS devices. This is on by de
 When a context is created, a JSON representation may be passed to it, e.g.: `{"dds": { "domain": 123, "participant": "librs" }}`. This allows various customizations:
 
 | Field                | Description                            |
-|----------------------|------------------------------------------------------|
-| dds                  | Set to `false` to turn off DDS in this context; otherwise a JSON object containing:
+|----------------------|----------------------------------------|
+| dds                  | Set to `false` to turn off DDS in this context; otherwise a JSON object
+
+The `dds` is there by default (i.e., not `false`). The value may contain the following settings dealing with discovery:
+
+| Field                | Description                            |
+|----------------------|----------------------------------------|
 | domain               | The domain number to use (0-232); `0` is the default
 | participant          | The name given this context (how other participants will see it); defaults to the executable name
 
+See a comprehensive list of settings under [device](device.md#Settings).

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -46,7 +46,7 @@ public:
     bool is_running() const;
 
     // Make the device ready for use. This may take time! Better to do it in the background...
-    void run( size_t message_timeout_ms );
+    void run();
 
     //----------- below this line, a device must be running!
 

--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -5,6 +5,8 @@
 
 #include "dds-defines.h"
 
+#include <nlohmann/json.hpp>
+
 #include <memory>
 #include <functional>
 #include <string>
@@ -50,6 +52,8 @@ class dds_participant
 
     struct listener_impl;
 
+    nlohmann::json _settings;
+
 public:
     dds_participant() = default;
     dds_participant( const dds_participant & ) = delete;
@@ -57,13 +61,15 @@ public:
 
     // Creates the underlying DDS participant and sets the QoS
     // If need to use callbacks set them before calling init, they may be called before init returns.
-    void init( dds_domain_id, std::string const & participant_name );
+    void init( dds_domain_id, std::string const & participant_name, nlohmann::json const & );
 
     bool is_valid() const { return ( nullptr != _participant ); }
     bool operator!() const { return ! is_valid(); }
 
     eprosima::fastdds::dds::DomainParticipant * get() const { return _participant; }
     eprosima::fastdds::dds::DomainParticipant * operator->() const { return get(); }
+
+    nlohmann::json const & settings() const { return _settings; }
 
     // RTPS 8.2.4.2 "Every Participant has GUID <prefix, ENTITYID_PARTICIPANT>, where the constant ENTITYID_PARTICIPANT
     //     is a special value defined by the RTPS protocol. Its actual value depends on the PSM."

--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -61,7 +61,7 @@ public:
 
     // Creates the underlying DDS participant and sets the QoS
     // If need to use callbacks set them before calling init, they may be called before init returns.
-    void init( dds_domain_id, std::string const & participant_name, nlohmann::json const & );
+    void init( dds_domain_id, std::string const & participant_name, nlohmann::json const & settings );
 
     bool is_valid() const { return ( nullptr != _participant ); }
     bool operator!() const { return ! is_valid(); }

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -146,7 +146,7 @@ PYBIND11_MODULE(NAME, m) {
                 >
         participant( m, "participant" );
     participant.def( py::init<>() )
-        .def( "init", &dds_participant::init, "domain-id"_a, "participant-name"_a )
+        .def( "init", &dds_participant::init, "domain-id"_a, "participant-name"_a, "settings"_a = nlohmann::json::object() )
         .def( "is_valid", &dds_participant::is_valid )
         .def( "guid", &dds_participant::guid )
         .def( "create_guid", &dds_participant::create_guid )
@@ -160,6 +160,7 @@ PYBIND11_MODULE(NAME, m) {
               } )
         .def( "name_from_guid", []( dds_guid const & guid ) { return dds_participant::name_from_guid( guid ); } )
         .def( "names", []( dds_participant const & self ) { return self.get()->get_participant_names(); } )
+        .def( "settings", &dds_participant::settings )
         .def( "__repr__",
               []( const dds_participant & self ) {
                   std::ostringstream os;

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -111,12 +111,12 @@ dds_device::impl::impl( std::shared_ptr< dds_participant > const & participant,
 }
 
 
-void dds_device::impl::run( size_t message_timeout_ms )
+void dds_device::impl::run()
 {
     if( _running )
         DDS_THROW( runtime_error, "device '" + _info.name + "' is already running" );
 
-    _message_timeout_ms = message_timeout_ms;
+    _message_timeout_ms = rsutils::json::get< size_t >( _participant->settings(), "device-reply-timeout-ms", 3000 );
 
     create_notifications_reader();
     create_control_writer();
@@ -429,7 +429,8 @@ struct dds_device::impl::init_context
 bool dds_device::impl::init()
 {
     // We expect to receive all of the sensors data under a timeout
-    rsutils::time::timer timer( std::chrono::seconds( 5 ) );
+    rsutils::time::timer timer( std::chrono::seconds(
+        rsutils::json::get< size_t >( _participant->settings(), "device-init-timeout-ms", 5000 ) ) );
     init_context init;
     while( ! timer.has_expired() && state_type::DONE != init.state )
     {

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -116,7 +116,7 @@ void dds_device::impl::run()
     if( _running )
         DDS_THROW( runtime_error, "device '" + _info.name + "' is already running" );
 
-    _message_timeout_ms = rsutils::json::get< size_t >( _participant->settings(), "device-reply-timeout-ms", 3000 );
+    _message_timeout_ms = rsutils::json::get< size_t >( _participant->settings(), "device-reply-timeout-ms", 1000 );
 
     create_notifications_reader();
     create_control_writer();
@@ -429,8 +429,9 @@ struct dds_device::impl::init_context
 bool dds_device::impl::init()
 {
     // We expect to receive all of the sensors data under a timeout
-    rsutils::time::timer timer( std::chrono::seconds(
-        rsutils::json::get< size_t >( _participant->settings(), "device-init-timeout-ms", 5000 ) ) );
+    std::chrono::milliseconds timeout(
+        rsutils::json::get< size_t >( _participant->settings(), "device-init-timeout-ms", 5000 ) );
+    rsutils::time::timer timer( timeout );
     init_context init;
     while( ! timer.has_expired() && state_type::DONE != init.state )
     {

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -60,7 +60,7 @@ public:
           dds_guid const & guid,
           topics::device_info const & info );
 
-    void run( size_t message_timeout_ms );
+    void run();
     void open( const dds_stream_profiles & profiles );
 
     void write_control_message( topics::flexible_msg &&, nlohmann::json * reply = nullptr );

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -79,9 +79,9 @@ bool dds_device::is_running() const
     return _impl->_running;
 }
 
-void dds_device::run( size_t message_timeout_ms )
+void dds_device::run()
 {
-    _impl->run( message_timeout_ms );
+    _impl->run();
 }
 
 std::shared_ptr< dds_participant > const& dds_device::participant() const

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -184,7 +184,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
 };
 
 
-void dds_participant::init( dds_domain_id domain_id, std::string const & participant_name )
+void dds_participant::init( dds_domain_id domain_id, std::string const & participant_name, nlohmann::json const & settings )
 {
     if( is_valid() )
     {
@@ -227,8 +227,12 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
                    "failed creating participant " + participant_name + " on domain id " + std::to_string( domain_id ) );
     }
 
+    if( ! settings.is_object() )
+        DDS_THROW( runtime_error, "provided settings are invalid" );
+    _settings = settings;
+
     LOG_DEBUG( "participant '" << participant_name << "' (" << realdds::print( guid() ) << ") is up on domain "
-                               << domain_id );
+                               << domain_id << " with settings: " << _settings.dump( 4 ) );
 #ifdef BUILD_EASYLOGGINGPP
     // DDS participant destruction happens when all contexts are done with it but, in some situations (e.g., Python), it
     // means that it may happen last -- even after ELPP has already been destroyed! So, just like we keep the participant

--- a/tools/dds/dds-adapter/rs-dds-adapter.cpp
+++ b/tools/dds/dds-adapter/rs-dds-adapter.cpp
@@ -106,7 +106,8 @@ try
 
     // Create a DDS publisher
     auto participant = std::make_shared< dds_participant >();
-    participant->init( domain, "rs-dds-adapter" );
+    auto settings = nlohmann::json::object();
+    participant->init( domain, "rs-dds-adapter", std::move( settings ) );
 
     struct device_handler
     {
@@ -120,8 +121,8 @@ try
 
     // Create a RealSense context
     nlohmann::json j = {
-        { "dds-discovery", false }, // Don't discover DDS devices from the network, we want local devices only 
-        { "use-basic-formats", true }  // Don't convert raw sensor formats (except interleaved) will be done by receiver
+        { "dds",               false }, // Don't discover DDS devices from the network, we want local devices only 
+        { "use-basic-formats", true  }  // Don't convert raw sensor formats (except interleaved) will be done by receiver
     };
     rs2::context ctx( j.dump() );
 

--- a/tools/dds/dds-sniffer/rs-dds-sniffer.cpp
+++ b/tools/dds/dds-sniffer/rs-dds-sniffer.cpp
@@ -207,7 +207,8 @@ bool dds_sniffer::init( realdds::dds_domain_id domain )
             on_type_discovery( topic_name, dyn_type );
         } );
 
-    _participant.init( domain, "rs-dds-sniffer" );
+    auto settings = nlohmann::json::object();
+    _participant.init( domain, "rs-dds-sniffer", std::move( settings ) );
 
     return _participant.is_valid();
 }

--- a/unit-tests/dds/device-2nd-client.py
+++ b/unit-tests/dds/device-2nd-client.py
@@ -19,7 +19,7 @@ info.topic_root = "realdds/device/topic-root"
 def test_second_device():
     global device
     device = dds.device( participant, participant.create_guid(), info )
-    device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+    device.run()  # If no device is available before timeout, this will throw
 
 def close_device():
     global device

--- a/unit-tests/dds/test-device-init.py
+++ b/unit-tests/dds/test-device-init.py
@@ -33,7 +33,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test 1 stream..." ):
         remote.run( 'test_one_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()  # If no device is available before timeout, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
@@ -52,7 +52,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test motion stream..." ):
         remote.run( 'test_one_motion_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()  # If no device is available before timeout, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
@@ -72,7 +72,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test no streams..." ):
         remote.run( 'test_no_streams()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()  # If no device is available before timeout, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 0 )
         for stream in device.streams():
@@ -95,7 +95,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test 10 profiles..." ):
         remote.run( 'test_n_profiles(10)' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()  # If no device is available before timeout, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
@@ -117,7 +117,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test D435i..." ):
         remote.run( 'test_d435i()' )
         device = dds.device( participant, participant.create_guid(), d435i.device_info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()  # If no device is available before timeout, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 5 )
         for stream in device.streams():
@@ -130,7 +130,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test discovery of another client device..." ):
         remote.run( 'test_one_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()  # If no device is available before timeout, this will throw
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 1 )
         # now start another server, and have it access the device

--- a/unit-tests/dds/test-librs-connections.py
+++ b/unit-tests/dds/test-librs-connections.py
@@ -29,7 +29,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         remote.run( 'instance2 = broadcast_device( d405, d405.device_info )' )
 
         # Create context after remote device is ready to test discovery on start-up
-        context = rs.context( { "dds-domain": 123, "dds-participant-name": "librs" } )
+        context = rs.context( { 'dds': { 'domain': 123, 'participant': 'librs' }} )
         # The DDS devices take time to be recognized and we just created the context; we
         # should not see them yet!
         #test.check( len( context.query_devices( only_sw_devices )) != 2 )

--- a/unit-tests/dds/test-librs-connections.py
+++ b/unit-tests/dds/test-librs-connections.py
@@ -29,7 +29,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         remote.run( 'instance2 = broadcast_device( d405, d405.device_info )' )
 
         # Create context after remote device is ready to test discovery on start-up
-        context = rs.context( '{"dds-domain":123,"dds-participant-name":"librs"}' )
+        context = rs.context( { "dds-domain": 123, "dds-participant-name": "librs" } )
         # The DDS devices take time to be recognized and we just created the context; we
         # should not see them yet!
         #test.check( len( context.query_devices( only_sw_devices )) != 2 )

--- a/unit-tests/dds/test-librs-context.py
+++ b/unit-tests/dds/test-librs-context.py
@@ -16,14 +16,14 @@ if log.is_debug_on():
 test.start( "Multiple participants on the same domain should fail" )
 try:
     contexts = []
-    contexts.append( rs.context( { "dds-domain": 124, "dds-participant-name": "context1" } ))
+    contexts.append( rs.context( { 'ddd': { 'domain': 124, 'participant': 'context1' }} ))
     # another context, same domain and name -> OK
-    contexts.append( rs.context( { "dds-domain": 124, "dds-participant-name": "context1" } ))
+    contexts.append( rs.context( { 'dds': { 'domain': 124, 'participant': 'context1' }} ))
     # without a name -> pick up the name from the existing participant (default is "librealsense")
-    contexts.append( rs.context( { "dds-domain": 124 } ))
+    contexts.append( rs.context( { 'dds': { 'domain': 124 }} ))
     # same name, different domain -> different participant; should be OK:
-    contexts.append( rs.context( { "dds-domain": 125, "dds-participant-name": "context1" } ))
-    test.check_throws( lambda: rs.context( { "dds-domain": 124, "dds-participant-name": "context2" } ),
+    contexts.append( rs.context( { 'dds': { 'domain': 125, 'participant': 'context1' }} ))
+    test.check_throws( lambda: rs.context( { 'dds': { 'domain': 124, 'participant': 'context2' }} ),
         RuntimeError, "A DDS participant 'context1' already exists in domain 124; cannot create 'context2'" )
 except:
     test.unexpected_exception()

--- a/unit-tests/dds/test-librs-context.py
+++ b/unit-tests/dds/test-librs-context.py
@@ -16,7 +16,7 @@ if log.is_debug_on():
 test.start( "Multiple participants on the same domain should fail" )
 try:
     contexts = []
-    contexts.append( rs.context( { 'ddd': { 'domain': 124, 'participant': 'context1' }} ))
+    contexts.append( rs.context( { 'dds': { 'domain': 124, 'participant': 'context1' }} ))
     # another context, same domain and name -> OK
     contexts.append( rs.context( { 'dds': { 'domain': 124, 'participant': 'context1' }} ))
     # without a name -> pick up the name from the existing participant (default is "librealsense")

--- a/unit-tests/dds/test-librs-context.py
+++ b/unit-tests/dds/test-librs-context.py
@@ -16,14 +16,14 @@ if log.is_debug_on():
 test.start( "Multiple participants on the same domain should fail" )
 try:
     contexts = []
-    contexts.append( rs.context( '{"dds-domain":124,"dds-participant-name":"context1"}' ))
+    contexts.append( rs.context( { "dds-domain": 124, "dds-participant-name": "context1" } ))
     # another context, same domain and name -> OK
-    contexts.append( rs.context( '{"dds-domain":124,"dds-participant-name":"context1"}' ))
+    contexts.append( rs.context( { "dds-domain": 124, "dds-participant-name": "context1" } ))
     # without a name -> pick up the name from the existing participant (default is "librealsense")
-    contexts.append( rs.context( '{"dds-domain":124}' ))
+    contexts.append( rs.context( { "dds-domain": 124 } ))
     # same name, different domain -> different participant; should be OK:
-    contexts.append( rs.context( '{"dds-domain":125,"dds-participant-name":"context1"}' ))
-    test.check_throws( lambda: rs.context( '{"dds-domain":124,"dds-participant-name":"context2"}' ),
+    contexts.append( rs.context( { "dds-domain": 125, "dds-participant-name": "context1" } ))
+    test.check_throws( lambda: rs.context( { "dds-domain": 124, "dds-participant-name": "context2" } ),
         RuntimeError, "A DDS participant 'context1' already exists in domain 124; cannot create 'context2'" )
 except:
     test.unexpected_exception()

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -16,7 +16,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( { "dds-domain": 123, "dds-participant-name": "device-properties-client" } )
+context = rs.context( { 'dds': { 'domain': 123, 'participant': 'device-properties-client' }} )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -16,7 +16,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( '{"dds-domain":123,"dds-participant-name":"device-properties-client"}' )
+context = rs.context( { "dds-domain": 123, "dds-participant-name": "device-properties-client" } )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 

--- a/unit-tests/dds/test-librs-extrinsics.py
+++ b/unit-tests/dds/test-librs-extrinsics.py
@@ -12,7 +12,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( { "dds-domain": 123 } )
+context = rs.context( { 'dds': { 'domain': 123 }} )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 import os.path

--- a/unit-tests/dds/test-librs-extrinsics.py
+++ b/unit-tests/dds/test-librs-extrinsics.py
@@ -12,7 +12,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( '{"dds-domain":123}' )
+context = rs.context( { "dds-domain": 123 } )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 import os.path

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -11,7 +11,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 log.nested = 'C  '
 
-context = rs.context( { "dds-domain": 123, "dds-participant-name": "test-formats-conversion" } )
+context = rs.context( { 'dds': { 'domain': 123, 'participant': 'test-formats-conversion' }} )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 import os.path

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -11,7 +11,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 log.nested = 'C  '
 
-context = rs.context( '{"dds-domain":123,"dds-participant-name":"test-formats-conversion"}' )
+context = rs.context( { "dds-domain": 123, "dds-participant-name": "test-formats-conversion" } )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 import os.path
@@ -50,7 +50,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
 
             test.check_equal( len( profiles ), 2 ) # YUYV can stay YUYV or be converted into RGB8
             test.check_equal( profiles[0].format(), rs.format.yuyv )
-            test.check_equal( profiles[1].format(), rs.format.rgb8 )            
+            test.check_equal( profiles[1].format(), rs.format.rgb8 )
     #
     #############################################################################################
     #
@@ -61,7 +61,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
 
             test.check_equal( len( profiles ), 2 ) # UYVY can stay UYVY or be converted into RGB8
             test.check_equal( profiles[0].format(), rs.format.uyvy )
-            test.check_equal( profiles[1].format(), rs.format.rgb8 )            
+            test.check_equal( profiles[1].format(), rs.format.rgb8 )
     #
     #############################################################################################
     #

--- a/unit-tests/dds/test-librs-intrinsics.py
+++ b/unit-tests/dds/test-librs-intrinsics.py
@@ -12,7 +12,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( { "dds-domain": 123 } )
+context = rs.context( { 'dds': { 'domain': 123 }} )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 import os.path

--- a/unit-tests/dds/test-librs-intrinsics.py
+++ b/unit-tests/dds/test-librs-intrinsics.py
@@ -12,7 +12,7 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( '{"dds-domain":123}' )
+context = rs.context( { "dds-domain": 123 } )
 only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 import os.path

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -140,7 +140,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         if log.is_debug_on():
             rs.log_to_console( rs.log_severity.debug )
         from dds import wait_for_devices
-        context = rs.context( '{"dds-domain":123,"dds-participant-name":"librs"}' )
+        context = rs.context( { "dds-domain": 123, "dds-participant-name": "librs" } )
         only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
         device = wait_for_devices( context, only_sw_devices, n=1. )[0]
         sensors = device.sensors

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -140,7 +140,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         if log.is_debug_on():
             rs.log_to_console( rs.log_severity.debug )
         from dds import wait_for_devices
-        context = rs.context( { "dds-domain": 123, "dds-participant-name": "librs" } )
+        context = rs.context( { 'dds': { 'domain': 123, 'participant': 'librs' }} )
         only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
         device = wait_for_devices( context, only_sw_devices, n=1. )[0]
         sensors = device.sensors

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -35,7 +35,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
 
     # set up the client device and keep all its streams - this is connected directly and we can get notifications on it!
     device_direct = dds.device( participant, participant.create_guid(), d435i.device_info )
-    device_direct.run( 1000 )  # this will throw if something's wrong
+    device_direct.run()
     test.check( device_direct.is_running(), on_fail=test.ABORT )
     for stream_direct in device_direct.streams():
         pass  # should be only one

--- a/unit-tests/dds/test-no-metadata.py
+++ b/unit-tests/dds/test-no-metadata.py
@@ -23,7 +23,7 @@ device_server.init( [color_stream], [], {} )
 
 # set up the client device and keep all its streams
 device = dds.device( participant, participant.create_guid(), d435i.device_info )
-device.run( 1000 )  # this will throw if something's wrong
+device.run()  # this will throw if something's wrong
 test.check( device.is_running() )
 
 def on_metadata_available( device, md ):

--- a/unit-tests/dds/test-options.py
+++ b/unit-tests/dds/test-options.py
@@ -30,7 +30,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test no options" ):
         remote.run( 'test_no_options()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()
         test.check( device.is_running() )
 
         options = device.options();
@@ -52,7 +52,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         test_values = list(range(17))
         remote.run( 'test_device_options_discovery(' + str( test_values ) + ')' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()
         test.check( device.is_running() )
 
         options = device.options();
@@ -76,7 +76,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         #send values to be checked later as string parameter to the function
         remote.run( 'test_stream_options_discovery(1, 0, 123456, 123, 12, "opt3 of s1")' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()
         test.check( device.is_running() )
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
@@ -107,7 +107,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         test_values = list(range(5))
         remote.run( 'test_device_and_multiple_stream_options_discovery(' + str( test_values ) + ', ' + str( test_values ) + ')' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run( 1000 )  # If no device is available in 30 seconds, this will throw
+        device.run()
         test.check( device.is_running() )
 
         options = device.options();

--- a/unit-tests/dds/test-stream-sensor-bridge.py
+++ b/unit-tests/dds/test-stream-sensor-bridge.py
@@ -86,7 +86,7 @@ class change_expected:
 
 # set up the client device and keep all its streams
 device = dds.device( participant, participant.create_guid(), d435i.device_info )
-device.run( 1000 )  # this will throw if something's wrong
+device.run()  # this will throw if something's wrong
 test.check( device.is_running() )
 streams = {}
 for stream in device.streams():

--- a/unit-tests/live/memory/test-extrinsics.cpp
+++ b/unit-tests/live/memory/test-extrinsics.cpp
@@ -99,7 +99,7 @@ TEST_CASE("Extrinsic memory leak detection", "[live]")
 {
     // Require at least one device to be plugged in
 
-    rs2::context ctx( "{\"dds-discovery\":false}" );
+    rs2::context ctx( "{\"dds\":false}" );
     rs2::log_to_file(RS2_LOG_SEVERITY_DEBUG, "lrs_log.txt");
 
     std::cout << "Extrinsic memory leak detection started" << std::endl;

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -221,7 +221,7 @@ def query( monitor_changes = True ):
     #
     # Get all devices, and store by serial-number
     global _device_by_sn, _context, _port_to_sn
-    _context = rs.context( '{"dds-discovery":false}' )
+    _context = rs.context( { "dds-discovery": False } )
     _device_by_sn = dict()
     try:
         log.debug_indent()

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -221,7 +221,7 @@ def query( monitor_changes = True ):
     #
     # Get all devices, and store by serial-number
     global _device_by_sn, _context, _port_to_sn
-    _context = rs.context( { "dds-discovery": False } )
+    _context = rs.context( { 'dds': False } )
     _device_by_sn = dict()
     try:
         log.debug_indent()

--- a/unit-tests/unit-tests-common.cpp
+++ b/unit-tests/unit-tests-common.cpp
@@ -215,7 +215,7 @@ rs2::context make_context( const char * /*id*/ )
     rs2::context ctx( rs2::context::uninitialized );
     try
     {
-        ctx = rs2::context( "{\"dds-discovery\":false}" );
+        ctx = rs2::context( "{\"dds\":false}" );
         g_found_any_section = true;
     }
     catch( ... )

--- a/wrappers/python/pyrs_context.cpp
+++ b/wrappers/python/pyrs_context.cpp
@@ -17,8 +17,8 @@ void init_context(py::module &m) {
     // Not binding devices_changed_callback, templated
 
     py::class_< rs2::context >( m, "context", "Librealsense context class. Includes realsense API version." )
-        .def( py::init< char const * >(),
-              py::arg( "json-settings" ) = nullptr )
+        .def( py::init< char const * >(), py::arg( "json-settings" ) = nullptr )
+        .def( py::init<>( []( nlohmann::json const & j ) { return rs2::context( j.dump() ); } ), py::arg( "json-settings" ) )
         .def("query_devices", (rs2::device_list(rs2::context::*)() const) &rs2::context::query_devices, "Create a static"
              " snapshot of all connected devices at the time of the call.")
         .def( "query_devices", ( rs2::device_list( rs2::context::* )(int) const ) & rs2::context::query_devices, "Create a static"


### PR DESCRIPTION
* changed dds-related context settings
    * now under a `dds` object that's passed to the participant
    * can use `'dds': false` to turn off dds (equivalent to previous `'dds-discovery': false`)
    * `dds-participant-name` is now `dds/participant`
    * `dds-domain` is now `dds/domain`
* added `dds_participant::settings()`, which are populated at `init()` time
* two settings currently in `dds_device`, dealing with timeouts
    * removed `dds_device::run()` argument
* updated docs

Tracked on [LRS-833]