### PR TITLE
Minor changes in DDS

### DIFF
--- a/third-party/realdds/doc/discovery.md
+++ b/third-party/realdds/doc/discovery.md
@@ -75,6 +75,23 @@ The message format is a [flexible message](../include/realdds/topics/flexible/) 
 All are optional except `name` and `topic-root`. Any fields not shown above will be ignored.
 
 
+# Disconnection
+
+Under normal operation, the DDS subsystem will notify participants of entity disconnections without much delay. If a participant crashes or goes offline unexpectedly, a timeout (currently 10 seconds) is triggered and only then participants are notified.
+
+When it is expected that a server will go offline, the server can elect to send a `stopping` message so that clients can remove the device immediately rather than waiting for DDS to do its thing.
+
+```JSON
+{
+  "stopping": true
+}
+```
+
+The `stopping` field has no set type at this time - it just has to exist. When it's there, any client should immediately assume the server is offline.
+
+No other fields are necessary with `stopping` -- the server is recognized by its GUID.
+
+
 # Topic Root
 
 This points to the topic used as the device root. This is how to access the device; without it, we're just guessing.

--- a/third-party/realdds/doc/notifications.md
+++ b/third-party/realdds/doc/notifications.md
@@ -44,17 +44,18 @@ These logs are output as notifications.
 Multiple log entries can be packaged together. It is up to the server to decide the frequency of notification. It is recommended that logs be flushed prior to any other notification being sent out, to maintain temporal cohesion in the logs.
 
 - `entries` is an array containing 1 or more log entries
-    - Each entry is a JSON object containing:
-        - `timestamp`: the event occurred (see [timestamps](#timestamps))
+    - Each log entry is a JSON array of `[timestamp, type, text, data]` containing:
+        - `timestamp`: when the event occurred (see [timestamps](#timestamps))
         - `type`: one of `EWID` (Error, Warning, Info, Debug)
         - `text`: any text that needs output
+        - `data`: optional; an object containing any pertinent information about the event
 
 ```JSON
 {
     "id": "log",
     "entries": [
-        {"timestamp": 1234567890, "type": "E", "text": "Error message"},
-        {"timestamp": 1234567892, "type": "W", "text": "Message"},
+        [1234567890, "E", "Error message", { "file": "some.cpp", "line-number": 35 }],
+        [1234567892, "W", "Message"],
         ...
     ]
 }

--- a/third-party/realdds/include/realdds/dds-device-watcher.h
+++ b/third-party/realdds/include/realdds/dds-device-watcher.h
@@ -54,6 +54,8 @@ private:
     // Restrictions: May throw
     void init();  
 
+    void remove_device( dds_guid const & );
+
     std::shared_ptr< dds_participant > _participant;
     std::shared_ptr< dds_participant::listener > _listener;
     std::shared_ptr< dds_topic_reader > _device_info_topic;

--- a/third-party/realdds/include/realdds/dds-metadata-syncer.h
+++ b/third-party/realdds/include/realdds/dds-metadata-syncer.h
@@ -35,10 +35,10 @@ class dds_metadata_syncer
 {
 public:
     // We don't want the queue to get large, it means lots of drops and data that we store to (probably) throw later
-    static constexpr size_t max_md_queue_size = 8;
+    static const size_t max_md_queue_size;
     // If a metadata is lost we wait for it until the next frame arrives, causing a small delay but we prefer passing
     // the frame late and without metadata over losing it.
-    static constexpr size_t max_frame_queue_size = 2;
+    static const size_t max_frame_queue_size;
 
     // We synchronize using some abstract "key" used to identify each frame and its metadata. We don't need to know
     // the nature of the key; only that it is increasing in value over time so that, given key1 > key2, then key1

--- a/third-party/realdds/src/dds-device-watcher.cpp
+++ b/third-party/realdds/src/dds-device-watcher.cpp
@@ -43,7 +43,15 @@ dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const
                 if( device )
                     continue;
 
-                topics::device_info device_info = topics::device_info::from_json( msg.json_data() );
+                auto j = msg.json_data();
+                if( j.find( "stopping" ) != j.end() )
+                {
+                    // This device is stopping for whatever reason (e.g., HW reset); remove it
+                    LOG_DEBUG( "DDS device (" << _participant->print( guid ) << ") is stopping" );
+                    remove_device( guid );
+                    continue;
+                }
+                topics::device_info device_info = topics::device_info::from_json( j );
 
                 LOG_DEBUG( "DDS device (" << _participant->print( guid ) << ") detected:"
                                           << "\n\tName: " << device_info.name
@@ -110,29 +118,38 @@ dds_device_watcher::~dds_device_watcher()
 void dds_device_watcher::init()
 {
     if( ! _listener )
-        _participant->create_listener( &_listener )->on_writer_removed( [this]( dds_guid guid, char const * ) {
-            std::shared_ptr< dds_device > device;
-            {
-                std::lock_guard< std::mutex > lock( _devices_mutex );
-                auto it = _dds_devices.find( guid );
-                if( it == _dds_devices.end() )
-                    return;
-                device = it->second;
-                _dds_devices.erase( it );
-            }
-            // rest must happen outside the mutex
-            std::thread( [device, on_device_removed = _on_device_removed]() {
-                if( on_device_removed )
-                    on_device_removed( device );
-                // If we're holding the device, it will get destroyed here, from another thread.
-                // Not sure why, but if we delete the outside this thread (in the listener callback), it will cause some
-                // sort of invalid state in DDS. The thread will get killed and we won't get any notification of the
-                // remote participant getting removed... and the process will even hang on exit.
-            } ).detach();
-        } );
+        _participant->create_listener( &_listener )
+            ->on_writer_removed( [this]( dds_guid guid, char const * ) { remove_device( guid ); } );
 
     if( ! _device_info_topic->is_running() )
         _device_info_topic->run( dds_topic_reader::qos() );
+}
+
+
+void dds_device_watcher::remove_device( dds_guid const & guid )
+{
+    std::shared_ptr< dds_device > device;
+    {
+        std::lock_guard< std::mutex > lock( _devices_mutex );
+        auto it = _dds_devices.find( guid );
+        if( it == _dds_devices.end() )
+            return;
+        device = it->second;
+        _dds_devices.erase( it );
+    }
+    // rest must happen outside the mutex
+    std::thread(
+        [device, on_device_removed = _on_device_removed]()
+        {
+            if( on_device_removed )
+                on_device_removed( device );
+            // If we're holding the device, it will get destroyed here, from another thread.
+            // Not sure why, but if we delete the outside this thread (in the listener callback), it
+            // will cause some sort of invalid state in DDS. The thread will get killed and we won't get
+            // any notification of the remote participant getting removed... and the process will even
+            // hang on exit.
+        } )
+        .detach();
 }
 
 

--- a/third-party/realdds/src/dds-metadata-syncer.cpp
+++ b/third-party/realdds/src/dds-metadata-syncer.cpp
@@ -8,6 +8,10 @@
 namespace realdds {
 
 
+const size_t dds_metadata_syncer::max_md_queue_size = 8;
+const size_t dds_metadata_syncer::max_frame_queue_size = 2;
+
+
 dds_metadata_syncer::dds_metadata_syncer() :
     _is_alive( std::make_shared< bool >( true ) )
 {


### PR DESCRIPTION
* change 'log' notification format in docs/
* add disconnection to docs and device-watcher (useful for HW reset, DFU)
* move dds-metadata-syncer consts to cpp to avoid gcc linkage error

