### PR TITLE
add DDS device 'log' notification handling

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -444,24 +444,14 @@ namespace librealsense
             _dds_watcher->foreach_device(
                 [&]( std::shared_ptr< realdds::dds_device > const & dev ) -> bool
                 {
-                    if( ! dev->is_running() )
+                    if( ! dev->is_ready() )
                     {
-                        LOG_DEBUG( "device '" << dev->device_info().topic_root << "' is not yet running" );
+                        LOG_DEBUG( "device '" << dev->device_info().debug_name() << "' is not yet ready" );
                         return true;
                     }
                     if( dev->device_info().product_line == "D400" )
                     {
                         if( ! ( mask & RS2_PRODUCT_LINE_D400 ) )
-                            return true;
-                    }
-                    else if( dev->device_info().product_line == "L500" )
-                    {
-                        if( ! ( mask & RS2_PRODUCT_LINE_L500 ) )
-                            return true;
-                    }
-                    else if( dev->device_info().product_line == "SR300" )
-                    {
-                        if( ! ( mask & RS2_PRODUCT_LINE_SR300 ) )
                             return true;
                     }
                     else if( ! ( mask & RS2_PRODUCT_LINE_NON_INTEL ) )
@@ -585,7 +575,7 @@ namespace librealsense
     void context::start_dds_device_watcher()
     {
         _dds_watcher->on_device_added( [this]( std::shared_ptr< realdds::dds_device > const & dev ) {
-            dev->run();
+            dev->wait_until_ready();  // make sure handshake is complete
 
             std::vector<rs2_device_info> rs2_device_info_added;
             std::vector<rs2_device_info> rs2_device_info_removed;

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -344,8 +344,7 @@ void dds_sensor_proxy::handle_new_metadata( std::string const & stream_name, nlo
         it->second.syncer.enqueue_metadata(
             rsutils::json::get< realdds::dds_nsec >( dds_md[metadata_header_key], timestamp_key ),
             std::move( dds_md ) );
-    else
-        throw std::runtime_error( "Stream '" + stream_name + "' received metadata but does not enable metadata" );
+    // else we're not streaming -- must be another client that's subscribed
 }
 
 

--- a/third-party/realdds/doc/device.md
+++ b/third-party/realdds/doc/device.md
@@ -32,7 +32,7 @@ Device behavior can be fine-tuned with certain JSON settings passed through the 
 | Field                    | Default | Type    | Description        |
 |--------------------------|---------|---------|--------------------|
 | device-reply-timeout-ms  |    1000 | size_t  | How long to wait for a control reply to arrive, in millisec
-| device-init-timeout-ms   |    5000 | size_t  | How long to try achieving device handshake, in millisec
+| disable-metadata         |   false | bool    | When true, the metadata topic will be disabled, even with metadata-enabled streams
 
 
 

--- a/third-party/realdds/doc/discovery.md
+++ b/third-party/realdds/doc/discovery.md
@@ -87,7 +87,7 @@ When it is expected that a server will go offline, the server can elect to send 
 }
 ```
 
-The `stopping` field has no set type at this time - it just has to exist. When it's there, any client should immediately assume the server is offline.
+The `stopping` field has no set type at this time so any value will do. When it's there, any client should immediately assume the server is offline.
 
 No other fields are necessary with `stopping` -- the server is recognized by its GUID.
 

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -85,7 +85,9 @@ public:
 
     void publish_notification( topics::flexible_msg && );
     void publish_metadata( nlohmann::json && );
-    
+
+    bool has_metadata_readers() const;
+
     typedef std::function< void( const nlohmann::json & msg ) > control_callback;
     void on_open_streams( control_callback callback ) { _open_streams_callback = std::move( callback ); }
 

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -68,6 +68,11 @@ public:
     typedef std::function< void( nlohmann::json && md ) > on_metadata_available_callback;
     void on_metadata_available( on_metadata_available_callback cb );
 
+    typedef std::function< void(
+        dds_time const & timestamp, char type, std::string const & text, nlohmann::json const & data ) >
+        on_device_log_callback;
+    void on_device_log( on_device_log_callback cb );
+
 private:
     class impl;
     std::shared_ptr< impl > _impl;

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -25,7 +25,8 @@ class dds_participant;
 // Represents a device via the DDS system. Such a device exists as of its identification by the device-watcher, and
 // always contains a device-info and GUID of the remote DataWriter to which it belongs.
 // 
-// The device may not be ready for use (will not contain sensors, profiles, etc.) until it is "run".
+// The device may not be ready for use (will not contain sensors, profiles, etc.) until it received all handshake
+// notifications from the server, but it will start receiving notifications and be able to send controls right away.
 //
 class dds_device
 {
@@ -43,10 +44,11 @@ public:
     // The device GUID is that of the DataWriter which declares it!
     dds_guid const & guid() const;
 
-    bool is_running() const;
+    // A device is ready for use after it's gone through handshake and can start streaming
+    bool is_ready() const;
 
-    // Make the device ready for use. This may take time! Better to do it in the background...
-    void run();
+    // Wait until ready. Will throw if not ready within the timeout!
+    void wait_until_ready( size_t timeout_ns = 5000 );
 
     //----------- below this line, a device must be running!
 

--- a/third-party/realdds/include/realdds/dds-exceptions.h
+++ b/third-party/realdds/include/realdds/dds-exceptions.h
@@ -5,7 +5,7 @@
 
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <stdexcept>
-#include <string>
+#include <rsutils/string/from.h>
 
 
 // E.g.:
@@ -14,8 +14,8 @@
 #define DDS_THROW( ERR_TYPE, WHAT )                                                                                    \
     do                                                                                                                 \
     {                                                                                                                  \
-        LOG_ERROR( "throwing: " << ( WHAT ) );                                                                         \
-        throw realdds::dds_##ERR_TYPE( WHAT );                                                                         \
+        LOG_ERROR( "throwing: " << WHAT );                                                                             \
+        throw realdds::dds_##ERR_TYPE( rsutils::string::from() << WHAT );                                              \
     }                                                                                                                  \
     while( 0 )
 

--- a/third-party/realdds/include/realdds/dds-topic-reader-thread.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader-thread.h
@@ -29,12 +29,10 @@ namespace realdds {
 //
 class dds_topic_reader_thread : public dds_topic_reader
 {
+    typedef dds_topic_reader super;
+
     eprosima::fastdds::dds::GuardCondition _stopped;
     std::thread _th;
-
-
-
-    typedef dds_topic_reader super;
 
 public:
     dds_topic_reader_thread( std::shared_ptr< dds_topic > const & topic );

--- a/third-party/realdds/include/realdds/dds-topic-writer.h
+++ b/third-party/realdds/include/realdds/dds-topic-writer.h
@@ -37,6 +37,8 @@ class dds_topic_writer : protected eprosima::fastdds::dds::DataWriterListener
 
     eprosima::fastdds::dds::DataWriter * _writer = nullptr;
 
+    int _n_readers = 0;
+
 public:
     dds_topic_writer( std::shared_ptr< dds_topic > const & topic );
     dds_topic_writer( std::shared_ptr< dds_topic > const & topic, std::shared_ptr< dds_publisher > const & publisher );
@@ -46,6 +48,7 @@ public:
     eprosima::fastdds::dds::DataWriter * operator->() const { return get(); }
 
     bool is_running() const { return ( get() != nullptr ); }
+    bool has_readers() const { return _n_readers > 0; }
 
     std::shared_ptr< dds_topic > const & topic() const { return _topic; }
     std::shared_ptr< dds_publisher > const & publisher() const { return _publisher; }

--- a/third-party/realdds/include/realdds/topics/dds-topic-names.h
+++ b/third-party/realdds/include/realdds/topics/dds-topic-names.h
@@ -6,6 +6,14 @@
 namespace realdds {
 namespace topics {
 
+// The character used to separate topic path elements
+constexpr char SEPARATOR = '/';
+
+// Every topic should be under ROOT (which includes the separator):
+constexpr char const * ROOT = "realsense/";
+constexpr size_t ROOT_LEN = 10;
+// NOTE: actual streams will be ROS-compatible, meaning rt/ROOT
+
 constexpr char const * DEVICE_INFO_TOPIC_NAME = "realsense/device-info";
 
 // The next topic names should be concatenated to a topic root

--- a/third-party/realdds/include/realdds/topics/device-info-msg.h
+++ b/third-party/realdds/include/realdds/topics/device-info-msg.h
@@ -21,6 +21,10 @@ public:
 
     nlohmann::json to_json() const;
     static device_info from_json( nlohmann::json const & j );
+
+    // Substring of information already stored in the device-info that can be used to print the devide 'name'.
+    // (mostly for use with debug messages)
+    char const * debug_name() const;
 };
 
 

--- a/third-party/realdds/include/realdds/topics/device-info-msg.h
+++ b/third-party/realdds/include/realdds/topics/device-info-msg.h
@@ -5,7 +5,7 @@
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <string>
+#include <rsutils/string/slice.h>
 
 namespace realdds {
 namespace topics {
@@ -22,9 +22,9 @@ public:
     nlohmann::json to_json() const;
     static device_info from_json( nlohmann::json const & j );
 
-    // Substring of information already stored in the device-info that can be used to print the devide 'name'.
+    // Substring of information already stored in the device-info that can be used to print the device 'name'.
     // (mostly for use with debug messages)
-    char const * debug_name() const;
+    rsutils::string::slice debug_name() const;
 };
 
 

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -785,8 +785,11 @@ PYBIND11_MODULE(NAME, m) {
         .def( "device_info", &dds_device::device_info )
         .def( "participant", &dds_device::participant )
         .def( "guid", &dds_device::guid )
-        .def( "is_running", &dds_device::is_running )
-        .def( "run", &dds_device::run, py::call_guard< py::gil_scoped_release >() )
+        .def( "is_ready", &dds_device::is_ready )
+        .def( "wait_until_ready",
+              &dds_device::wait_until_ready,
+              py::call_guard< py::gil_scoped_release >(),
+              "timeout-ms"_a = 5000 )
         .def( FN_FWD( dds_device,
                       on_metadata_available,
                       ( dds_device &, py::object && ),

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -186,6 +186,8 @@ PYBIND11_MODULE(NAME, m) {
 
     // The 'topics' submodule will contain pointers to the topic names:
     auto topics = m.def_submodule( "topics", "all the topics that " SNAME " knows" );
+    topics.attr( "separator" ) = realdds::topics::SEPARATOR;
+    topics.attr( "root" ) = realdds::topics::ROOT;
     topics.attr( "device_info" ) = realdds::topics::DEVICE_INFO_TOPIC_NAME;
     topics.attr( "device_notification" ) = realdds::topics::NOTIFICATION_TOPIC_NAME;
     topics.attr( "device_control" ) = realdds::topics::CONTROL_TOPIC_NAME;
@@ -402,6 +404,10 @@ PYBIND11_MODULE(NAME, m) {
 
     py::class_< flexible_msg >( message, "flexible" )
         .def( py::init<>() )
+        .def( py::init( []( py::dict const & dict, uint32_t version )
+                        { return flexible_msg( py_to_json( dict ), version ); } ),
+              "json"_a,
+              "version"_a = 0 )
         .def( py::init( []( std::string const & json_string ) {
             return flexible_msg( flexible_msg::data_format::JSON, nlohmann::json::parse( json_string ) );
         } ) )
@@ -786,6 +792,11 @@ PYBIND11_MODULE(NAME, m) {
                       ( dds_device &, py::object && ),
                       ( nlohmann::json && j ),
                       callback( self, json_to_py( j ) ); ) )
+        .def( FN_FWD( dds_device,
+                      on_device_log,
+                      (dds_device &, dds_time const &, char, std::string const &, py::object && ),
+                      (dds_time const & timestamp, char type, std::string const & text, nlohmann::json const & data),
+                      callback( self, timestamp, type, text, json_to_py( data ) ); ) )
         .def( "n_streams", &dds_device::number_of_streams )
         .def( "streams",
               []( dds_device const & self ) {

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -51,55 +51,63 @@ static std::string const entries_key( "entries", 7 );
 
 namespace realdds {
 
-namespace {
 
-enum class state_type
-{
-    WAIT_FOR_DEVICE_HEADER,
-    WAIT_FOR_DEVICE_OPTIONS,
-    WAIT_FOR_STREAM_HEADER,
-    WAIT_FOR_STREAM_OPTIONS,
-    DONE
-    // Note - Assuming all profiles of a stream will be sent in a single video_stream_profiles_msg
-    // Otherwise need a stream header message with expected number of profiles for each stream
-    // But then need all stream header messages to be sent before any profile message for a simple state machine
-};
-
-char const * to_string( state_type st )
+/*static*/ char const * dds_device::impl::to_string( state_t st )
 {
     switch( st )
     {
-    case state_type::WAIT_FOR_DEVICE_HEADER:
+    case state_t::WAIT_FOR_DEVICE_HEADER:
         return "WAIT_FOR_DEVICE_HEADER";
-    case state_type::WAIT_FOR_DEVICE_OPTIONS:
+    case state_t::WAIT_FOR_DEVICE_OPTIONS:
         return "WAIT_FOR_DEVICE_OPTIONS";
-    case state_type::WAIT_FOR_STREAM_HEADER:
+    case state_t::WAIT_FOR_STREAM_HEADER:
         return "WAIT_FOR_STREAM_HEADER";
-    case state_type::WAIT_FOR_STREAM_OPTIONS:
+    case state_t::WAIT_FOR_STREAM_OPTIONS:
         return "WAIT_FOR_STREAM_OPTIONS";
-    case state_type::DONE:
-        return "DONE";
+    case state_t::READY:
+        return "READY";
     default:
         return "UNKNOWN";
     }
 }
 
-std::ostream& operator<<( std::ostream& s, state_type st )
-{
-    s << to_string( st );
-    return s;
-}
 
-}  // namespace
+void dds_device::impl::set_state( state_t new_state )
+{
+    if( new_state == _state )
+        return;
+
+    if( state_t::READY == new_state )
+    {
+        if( _metadata_reader )
+        {
+            if( rsutils::json::get( _participant->settings(), "disable-metadata", false ) )
+            {
+                LOG_DEBUG( "... metadata is available but 'disable-metadata' is set" );
+                _metadata_reader.reset();
+            }
+            else
+            {
+                LOG_DEBUG( "... metadata is enabled" );
+                dds_topic_reader::qos rqos( eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS );
+                rqos.history().depth = 10; // Support receive metadata from multiple streams
+                _metadata_reader->run( rqos );
+            }
+        }
+        LOG_DEBUG( "device '" << _info.debug_name() << "' (" << _participant->print( _guid ) << ") is ready" );
+    }
+
+    _state = new_state;
+}
 
 
 /*static*/ dds_device::impl::notification_handlers const dds_device::impl::_notification_handlers{
     { id_set_option, &dds_device::impl::on_option_value },
     { id_query_option, &dds_device::impl::on_option_value },
-    { id_device_header, &dds_device::impl::on_known_notification },
-    { id_device_options, &dds_device::impl::on_known_notification },
-    { id_stream_header, &dds_device::impl::on_known_notification },
-    { id_stream_options, &dds_device::impl::on_known_notification },
+    { id_device_header, &dds_device::impl::on_device_header },
+    { id_device_options, &dds_device::impl::on_device_options },
+    { id_stream_header, &dds_device::impl::on_stream_header },
+    { id_stream_options, &dds_device::impl::on_stream_options },
     { id_open_streams, &dds_device::impl::on_known_notification },
     { id_log, &dds_device::impl::on_log },
 };
@@ -115,21 +123,24 @@ dds_device::impl::impl( std::shared_ptr< dds_participant > const & participant,
     , _reply_timeout_ms( rsutils::json::get< size_t >( participant->settings(), "device-reply-timeout-ms", 1000 ) )
 {
     create_notifications_reader();
+    create_control_writer();
 }
 
 
-void dds_device::impl::run()
+void dds_device::impl::wait_until_ready( size_t timeout_ms )
 {
-    if( _running )
-        DDS_THROW( runtime_error, "device '" + _info.name + "' is already running" );
+    if( is_ready() )
+        return;
 
-    if( ! init() )
-        DDS_THROW( runtime_error, "failed getting stream data from '" + _info.topic_root + "'" );
-    create_control_writer();
-
-    LOG_DEBUG( "device '" << _info.topic_root << "' (" << _participant->print( _guid )
-                          << ") initialized successfully" );
-    _running = true;
+    LOG_DEBUG( "waiting for '" << _info.debug_name() << "' ..." );
+    rsutils::time::timer timer{ std::chrono::milliseconds( timeout_ms ) };
+    do
+    {
+        if( timer.has_expired() )
+            DDS_THROW( runtime_error, "timeout waiting for '" + std::string( _info.debug_name() ) + "'" );
+        std::this_thread::sleep_for( std::chrono::milliseconds( 500 ) );
+    }
+    while( ! is_ready() );
 }
 
 
@@ -181,7 +192,7 @@ void dds_device::impl::handle_notification( nlohmann::json const & j )
 
 void dds_device::impl::on_option_value( nlohmann::json const & j )
 {
-    if( ! _running )
+    if( ! is_ready() )
         return;
 
     // This is the notification for "set-option" or "query-option", meaning someone sent a control request to set/get an
@@ -397,14 +408,15 @@ void dds_device::impl::create_notifications_reader()
 
     auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + topics::NOTIFICATION_TOPIC_NAME );
 
-    _notifications_reader = std::make_shared< dds_topic_reader >( topic, _subscriber );
+    // We have some complicated topic structures. In particular, the metadata topic is created on demand while handling
+    // other notifications, which doesn't work well (deadlock) if the notification is not called from another thread. So
+    // we need the notification handling on another thread:
+    _notifications_reader = std::make_shared< dds_topic_reader_thread >( topic, _subscriber );
 
     dds_topic_reader::qos rqos( eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS );
     //On discovery writer sends a burst of messages, if history is too small we might loose some of them
     //(even if reliable). Setting depth to cover known use-cases plus some spare
     rqos.history().depth = 24;
-
-    _notifications_reader->run( rqos );
 
     _notifications_reader->on_data_available(
         [&]()
@@ -427,6 +439,8 @@ void dds_device::impl::create_notifications_reader()
                 }
             }
         } );
+
+    _notifications_reader->run( rqos );
 }
 
 void dds_device::impl::create_metadata_reader()
@@ -435,12 +449,7 @@ void dds_device::impl::create_metadata_reader()
         return;
 
     auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + topics::METADATA_TOPIC_NAME );
-
     _metadata_reader = std::make_shared< dds_topic_reader_thread >( topic, _subscriber );
-
-    dds_topic_reader::qos rqos( eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS );
-    rqos.history().depth = 10; // Support receive metadata from multiple streams
-
     _metadata_reader->on_data_available(
         [this]()
         {
@@ -461,7 +470,7 @@ void dds_device::impl::create_metadata_reader()
             }
         } );
 
-    _metadata_reader->run( rqos );
+    // NOTE: the metadata thread is only run() when we've reached the READY state
 }
 
 void dds_device::impl::create_control_writer()
@@ -477,69 +486,13 @@ void dds_device::impl::create_control_writer()
 }
 
 
-struct dds_device::impl::init_context
+void dds_device::impl::on_device_header( nlohmann::json const & j )
 {
-    state_type state = state_type::WAIT_FOR_DEVICE_HEADER;
-    size_t n_streams_expected = 0;
-    size_t n_stream_options_received = 0;
-};
+    if( _state != state_t::WAIT_FOR_DEVICE_HEADER )
+        return;
 
-
-bool dds_device::impl::init()
-{
-    // We expect to receive all of the sensors data under a timeout
-    std::chrono::milliseconds timeout(
-        rsutils::json::get< size_t >( _participant->settings(), "device-init-timeout-ms", 5000 ) );
-    rsutils::time::timer timer( timeout );
-    init_context init;
-    while( ! timer.has_expired() && state_type::DONE != init.state )
-    {
-        LOG_DEBUG( init.state << "..." );
-        eprosima::fastrtps::Duration_t one_second = { 1, 0 };
-        if( _notifications_reader->get()->wait_for_unread_message( one_second ) )
-        {
-            topics::flexible_msg notification;
-            eprosima::fastdds::dds::SampleInfo info;
-            while( init.state != state_type::DONE
-                   && topics::flexible_msg::take_next( *_notifications_reader, &notification, &info ) )
-            {
-                if( ! notification.is_valid() )
-                    continue;
-                try
-                {
-                    auto j = notification.json_data();
-                    auto id = rsutils::json::get< std::string >( j, id_key );
-                    if( state_type::WAIT_FOR_DEVICE_HEADER == init.state && id == id_device_header )
-                        handle_device_header( init, j );
-                    else if( state_type::WAIT_FOR_DEVICE_OPTIONS == init.state && id == id_device_options )
-                        handle_device_options( init, j );
-                    else if( state_type::WAIT_FOR_STREAM_HEADER == init.state && id == id_stream_header )
-                        handle_stream_header( init, j );
-                    else if( state_type::WAIT_FOR_STREAM_OPTIONS == init.state && id == id_stream_options )
-                        handle_stream_options( init, j );
-                    else if( init.state != state_type::WAIT_FOR_DEVICE_HEADER )
-                    {
-                        DDS_THROW( runtime_error, "unexpected notification '" + id + "' in " + to_string( init.state ) );
-                    }
-                }
-                catch( std::exception const & e )
-                {
-                    LOG_ERROR( "Error during DDS device initialization: " << e.what() );
-                    return false;
-                }
-            }
-        }
-    }
-
-    LOG_DEBUG( "... " << ( state_type::DONE == init.state ? "" : "timed out; state is " ) << init.state );
-    return( state_type::DONE == init.state );
-}
-
-
-void dds_device::impl::handle_device_header( init_context & init, nlohmann::json const & j )
-{
-    init.n_streams_expected = rsutils::json::get< size_t >( j, "n-streams" );
-    LOG_DEBUG( "... " << id_device_header << ": " << init.n_streams_expected << " streams expected" );
+    _n_streams_expected = rsutils::json::get< size_t >( j, "n-streams" );
+    LOG_DEBUG( "... " << id_device_header << ": " << _n_streams_expected << " streams expected" );
 
     if( rsutils::json::has( j, "extrinsics" ) )
     {
@@ -547,18 +500,21 @@ void dds_device::impl::handle_device_header( init_context & init, nlohmann::json
         {
             std::string from_name = rsutils::json::get< std::string >( ex, 0 );
             std::string to_name = rsutils::json::get< std::string >( ex, 1 );
-            LOG_DEBUG( "... got extrinsics from " << from_name << " to " << to_name );
+            LOG_DEBUG( "    ... got extrinsics from " << from_name << " to " << to_name );
             extrinsics extr = extrinsics::from_json( rsutils::json::get< json >( ex, 2 ) );
             _extrinsics_map[std::make_pair( from_name, to_name )] = std::make_shared< extrinsics >( extr );
         }
     }
 
-    init.state = state_type::WAIT_FOR_DEVICE_OPTIONS;
+    set_state( state_t::WAIT_FOR_DEVICE_OPTIONS );
 }
 
 
-void dds_device::impl::handle_device_options( init_context & init, nlohmann::json const & j )
+void dds_device::impl::on_device_options( nlohmann::json const & j )
 {
+    if( _state != state_t::WAIT_FOR_DEVICE_OPTIONS )
+        return;
+
     if( rsutils::json::has( j, "options" ) )
     {
         LOG_DEBUG( "... " << id_device_options << ": " << j["options"].size() << " options received" );
@@ -571,18 +527,21 @@ void dds_device::impl::handle_device_options( init_context & init, nlohmann::jso
         }
     }
 
-    if( init.n_streams_expected )
-        init.state = state_type::WAIT_FOR_STREAM_HEADER;
+    if( _n_streams_expected )
+        set_state( state_t::WAIT_FOR_STREAM_HEADER );
     else
-        init.state = state_type::DONE;
+        set_state( state_t::READY );
 }
 
 
-void dds_device::impl::handle_stream_header( init_context & init, nlohmann::json const & j )
+void dds_device::impl::on_stream_header( nlohmann::json const & j )
 {
-    if( _streams.size() >= init.n_streams_expected )
+    if( _state != state_t::WAIT_FOR_STREAM_HEADER )
+        return;
+
+    if( _streams.size() >= _n_streams_expected )
         DDS_THROW( runtime_error,
-                   "more streams than expected (" + std::to_string( init.n_streams_expected ) + ") received" );
+                   "more streams than expected (" + std::to_string( _n_streams_expected ) + ") received" );
     auto stream_type = rsutils::json::get< std::string >( j, "type" );
     auto stream_name = rsutils::json::get< std::string >( j, "name" );
 
@@ -629,23 +588,25 @@ void dds_device::impl::handle_stream_header( init_context & init, nlohmann::json
                    "failed to instantiate stream type '" + stream_type + "' (instead, got '" + stream->type_string()
                        + "')" );
 
-    LOG_DEBUG( "... stream '" << stream_name << "' (" << _streams.size() << "/" << init.n_streams_expected
-                              << ") received with " << profiles.size() << " profiles" );
+    LOG_DEBUG( "... stream " << _streams.size() << "/" << _n_streams_expected << " '" << stream_name
+                             << "' received with " << profiles.size() << " profiles"
+                             << ( stream->metadata_enabled() ? " and metadata" : "" ) );
 
-    init.state = state_type::WAIT_FOR_STREAM_OPTIONS;
+    set_state( state_t::WAIT_FOR_STREAM_OPTIONS );
 }
 
 
-void dds_device::impl::handle_stream_options( init_context & init, nlohmann::json const & j )
+void dds_device::impl::on_stream_options( nlohmann::json const & j )
 {
+    if( _state != state_t::WAIT_FOR_STREAM_OPTIONS )
+        return;
+
     auto stream_it = _streams.find( rsutils::json::get< std::string >( j, "stream-name" ) );
     if( stream_it == _streams.end() )
         DDS_THROW( runtime_error,
                    std::string( "Received stream options for stream '" )
                        + rsutils::json::get< std::string >( j, "stream-name" )
                        + "' whose header was not received yet" );
-
-    ++init.n_stream_options_received;
 
     if( rsutils::json::has( j, "options" ) )
     {
@@ -687,10 +648,10 @@ void dds_device::impl::handle_stream_options( init_context & init, nlohmann::jso
         stream_it->second->set_recommended_filters( std::move( filter_names ) );
     }
 
-    if( _streams.size() >= init.n_streams_expected )
-        init.state = state_type::DONE;
+    if( _streams.size() >= _n_streams_expected )
+        set_state( state_t::READY );
     else
-        init.state = state_type::WAIT_FOR_STREAM_HEADER;
+        set_state( state_t::WAIT_FOR_STREAM_HEADER );
 }
 
 

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -47,6 +47,7 @@ public:
     std::mutex _replies_mutex;
     std::condition_variable _replies_cv;
     std::map< dds_sequence_number, nlohmann::json > _replies;
+    size_t _reply_timeout_ms;
 
     std::shared_ptr< dds_topic_reader > _notifications_reader;
     std::shared_ptr< dds_topic_reader > _metadata_reader;
@@ -71,6 +72,11 @@ public:
     typedef std::function< void( nlohmann::json && md ) > on_metadata_available_callback;
     void on_metadata_available( on_metadata_available_callback cb ) { _on_metadata_available = cb; }
 
+    typedef std::function< void(
+        dds_time const & timestamp, char type, std::string const & text, nlohmann::json const & data ) >
+        on_device_log_callback;
+    void on_device_log( on_device_log_callback cb ) { _on_device_log = cb; }
+
 private:
     void create_notifications_reader();
     void create_metadata_reader();
@@ -89,10 +95,10 @@ private:
     void handle_notification( nlohmann::json const & );
     void on_option_value( nlohmann::json const & );
     void on_known_notification( nlohmann::json const & );
+    void on_log( nlohmann::json const & );
 
     on_metadata_available_callback _on_metadata_available = nullptr;
-
-    size_t _message_timeout_ms = 5000;
+    on_device_log_callback _on_device_log = nullptr;
 };
 
 

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -239,6 +239,7 @@ void dds_device_server::publish_notification( topics::flexible_msg && notificati
     _notification_server->send_notification( std::move( notification ) );
 }
 
+
 void dds_device_server::publish_metadata( nlohmann::json && md )
 {
     if( ! _metadata_writer )
@@ -249,6 +250,12 @@ void dds_device_server::publish_metadata( nlohmann::json && md )
         "publishing metadata: " << shorten_json_string( slice( msg.custom_data< char const >(), msg._data.size() ),
                                                         300 ) );
     msg.write_to( *_metadata_writer );
+}
+
+
+bool dds_device_server::has_metadata_readers() const
+{
+    return _metadata_writer && _metadata_writer->has_readers();
 }
 
 

--- a/third-party/realdds/src/dds-device-watcher.cpp
+++ b/third-party/realdds/src/dds-device-watcher.cpp
@@ -70,7 +70,13 @@ dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const
                 // NOTE: device removals are handled via the writer-removed notification; see the
                 // listener callback in init().
                 if( _on_device_added )
-                    _on_device_added( device );
+                {
+                    std::thread(
+                        [device, on_device_added = _on_device_added]() {  //
+                            on_device_added( device );
+                        } )
+                        .detach();
+                }
             }
         } );
 

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -74,14 +74,14 @@ dds_device::dds_device( std::shared_ptr< impl > impl )
 {
 }
 
-bool dds_device::is_running() const
+bool dds_device::is_ready() const
 {
-    return _impl->_running;
+    return _impl->is_ready();
 }
 
-void dds_device::run()
+void dds_device::wait_until_ready( size_t timeout_ns )
 {
-    _impl->run();
+    _impl->wait_until_ready( timeout_ns );
 }
 
 std::shared_ptr< dds_participant > const& dds_device::participant() const

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -169,5 +169,10 @@ void dds_device::on_metadata_available( on_metadata_available_callback cb )
     _impl->on_metadata_available( cb );
 }
 
+void dds_device::on_device_log( on_device_log_callback cb )
+{
+    _impl->on_device_log( cb );
+}
+
 
 }  // namespace realdds

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -55,7 +55,7 @@ std::shared_ptr< dds_device > dds_device::create( std::shared_ptr< dds_participa
     std::shared_ptr< dds_device > dev = find_internal( guid );
     if( ! dev )
     {
-        LOG_DEBUG( "+device (" << participant->print( guid ) << ") on " << info.topic_root );
+        LOG_DEBUG( "+device '" << info.debug_name() << "' (" << participant->print( guid ) << ") on " << info.topic_root );
         auto impl = std::make_shared< dds_device::impl >( participant, guid, info );
         // Use a custom deleter to automatically remove the device from the map when it's done with
         dev = std::shared_ptr< dds_device >( new dds_device( impl ), [guid]( dds_device * ptr ) {

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -4,6 +4,7 @@
 #include <realdds/dds-participant.h>
 #include <realdds/dds-utilities.h>
 #include <realdds/dds-guid.h>
+#include <realdds/dds-time.h>
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -194,6 +195,9 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
     }
 
     _domain_listener = std::make_shared< listener_impl >( *this );
+
+    // Initialize the timestr "start" time
+    timestr{ realdds::now() };
 
     DomainParticipantQos pqos;
     pqos.name( participant_name );

--- a/third-party/realdds/src/dds-stream-server.cpp
+++ b/third-party/realdds/src/dds-stream-server.cpp
@@ -107,7 +107,7 @@ void dds_stream_server::run_stream()
     if( _on_readers_changed )
     {
         std::weak_ptr< dds_stream_server > weak_this(
-            std::static_pointer_cast<dds_stream_server>(shared_from_this()) );
+            std::static_pointer_cast< dds_stream_server >( shared_from_this() ) );
         _writer->on_publication_matched(
             [weak_this, on_readers_changed = _on_readers_changed](
                 eprosima::fastdds::dds::PublicationMatchedStatus const & status )

--- a/third-party/realdds/src/dds-topic-writer.cpp
+++ b/third-party/realdds/src/dds-topic-writer.cpp
@@ -86,7 +86,8 @@ void dds_topic_writer::run( qos const & wqos )
 void dds_topic_writer::on_publication_matched( eprosima::fastdds::dds::DataWriter *,
                                                eprosima::fastdds::dds::PublicationMatchedStatus const & info )
 {
-    // Called when the subscriber is matched (un)with a Writer
+    // Called when the subscriber is (un)matched with a Writer
+    _n_readers = info.current_count;
     if( _on_publication_matched )
         _on_publication_matched( info );
 }

--- a/third-party/realdds/src/topics/device-info-msg.cpp
+++ b/third-party/realdds/src/topics/device-info-msg.cpp
@@ -38,12 +38,13 @@ nlohmann::json device_info::to_json() const
 }
 
 
-char const * device_info::debug_name() const
+rsutils::string::slice device_info::debug_name() const
 {
-    auto lpsz = topic_root.c_str();
-    if( topic_root.length() > ROOT_LEN && SEPARATOR == lpsz[ROOT_LEN-1] )
-        lpsz += ROOT_LEN;
-    return lpsz;
+    auto begin = topic_root.c_str();
+    auto end = begin + topic_root.length();
+    if( topic_root.length() > ROOT_LEN && SEPARATOR == begin[ROOT_LEN-1] )
+        begin += ROOT_LEN;
+    return{ begin, end };
 }
 
 

--- a/third-party/realdds/src/topics/device-info-msg.cpp
+++ b/third-party/realdds/src/topics/device-info-msg.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
 #include <realdds/topics/device-info-msg.h>
+#include <realdds/topics/dds-topic-names.h>
 
 #include <rsutils/json.h>
 #include <rsutils/easylogging/easyloggingpp.h>
@@ -23,6 +24,7 @@ namespace topics {
     return ret;
 }
 
+
 nlohmann::json device_info::to_json() const
 {
     auto msg = nlohmann::json( {
@@ -34,6 +36,16 @@ nlohmann::json device_info::to_json() const
     } );
     return msg;
 }
+
+
+char const * device_info::debug_name() const
+{
+    auto lpsz = topic_root.c_str();
+    if( topic_root.length() > ROOT_LEN && SEPARATOR == lpsz[ROOT_LEN-1] )
+        lpsz += ROOT_LEN;
+    return lpsz;
+}
+
 
 }  // namespace topics
 }  // namespace realdds

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -647,6 +647,9 @@ void lrs_device_controller::start_streaming( const json & msg )
 
 void lrs_device_controller::publish_frame_metadata( const rs2::frame & f, realdds::dds_time const & timestamp )
 {
+    if( ! _dds_device_server->has_metadata_readers() )
+        return;
+
     nlohmann::json md_header = nlohmann::json::object( {
         { "frame-number", f.get_frame_number() },               // communicated; up to client to pick up
         { "timestamp", timestamp.to_ns() },                     // syncer key: needs to match the image timestamp, bit-for-bit!

--- a/unit-tests/dds/device-2nd-client.py
+++ b/unit-tests/dds/device-2nd-client.py
@@ -19,7 +19,7 @@ info.topic_root = "realdds/device/topic-root"
 def test_second_device():
     global device
     device = dds.device( participant, participant.create_guid(), info )
-    device.run()  # If no device is available before timeout, this will throw
+    device.wait_until_ready()  # If no device is available before timeout, this will throw
 
 def close_device():
     global device

--- a/unit-tests/dds/test-device-init.py
+++ b/unit-tests/dds/test-device-init.py
@@ -33,8 +33,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test 1 stream..." ):
         remote.run( 'test_one_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()  # If no device is available before timeout, this will throw
-        test.check( device.is_running() )
+        device.wait_until_ready()  # If no device is available before timeout, this will throw
+        test.check( device.is_ready() )
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
             profiles = stream.profiles()
@@ -52,8 +52,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test motion stream..." ):
         remote.run( 'test_one_motion_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()  # If no device is available before timeout, this will throw
-        test.check( device.is_running() )
+        device.wait_until_ready()  # If no device is available before timeout, this will throw
+        test.check( device.is_ready() )
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
             profiles = stream.profiles()
@@ -72,8 +72,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test no streams..." ):
         remote.run( 'test_no_streams()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()  # If no device is available before timeout, this will throw
-        test.check( device.is_running() )
+        device.wait_until_ready()  # If no device is available before timeout, this will throw
+        test.check( device.is_ready() )
         test.check_equal( device.n_streams(), 0 )
         for stream in device.streams():
             test.unreachable()
@@ -95,8 +95,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test 10 profiles..." ):
         remote.run( 'test_n_profiles(10)' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()  # If no device is available before timeout, this will throw
-        test.check( device.is_running() )
+        device.wait_until_ready()  # If no device is available before timeout, this will throw
+        test.check( device.is_ready() )
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
             profiles = stream.profiles()
@@ -117,8 +117,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test D435i..." ):
         remote.run( 'test_d435i()' )
         device = dds.device( participant, participant.create_guid(), d435i.device_info )
-        device.run()  # If no device is available before timeout, this will throw
-        test.check( device.is_running() )
+        device.wait_until_ready()  # If no device is available before timeout, this will throw
+        test.check( device.is_ready() )
         test.check_equal( device.n_streams(), 5 )
         for stream in device.streams():
             profiles = stream.profiles()
@@ -130,8 +130,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test discovery of another client device..." ):
         remote.run( 'test_one_stream()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()  # If no device is available before timeout, this will throw
-        test.check( device.is_running() )
+        device.wait_until_ready()  # If no device is available before timeout, this will throw
+        test.check( device.is_ready() )
         test.check_equal( device.n_streams(), 1 )
         # now start another server, and have it access the device
         # NOTE: I had trouble nesting another 'with' statement here...

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -35,8 +35,8 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
 
     # set up the client device and keep all its streams - this is connected directly and we can get notifications on it!
     device_direct = dds.device( participant, participant.create_guid(), d435i.device_info )
-    device_direct.run()
-    test.check( device_direct.is_running(), on_fail=test.ABORT )
+    device_direct.wait_until_ready()
+    test.check( device_direct.is_ready(), on_fail=test.ABORT )
     for stream_direct in device_direct.streams():
         pass  # should be only one
     topic_name = 'rt/' + d435i.device_info.topic_root + '_' + stream_direct.name()

--- a/unit-tests/dds/test-no-metadata.py
+++ b/unit-tests/dds/test-no-metadata.py
@@ -23,8 +23,8 @@ device_server.init( [color_stream], [], {} )
 
 # set up the client device and keep all its streams
 device = dds.device( participant, participant.create_guid(), d435i.device_info )
-device.run()  # this will throw if something's wrong
-test.check( device.is_running() )
+device.wait_until_ready()  # this will throw if something's wrong
+test.check( device.is_ready() )
 
 def on_metadata_available( device, md ):
     log.d( f'-----> {md}')

--- a/unit-tests/dds/test-options.py
+++ b/unit-tests/dds/test-options.py
@@ -30,8 +30,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     with test.closure( "Test no options" ):
         remote.run( 'test_no_options()' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()
-        test.check( device.is_running() )
+        device.wait_until_ready()
 
         options = device.options();
         for option in options:
@@ -52,8 +51,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         test_values = list(range(17))
         remote.run( 'test_device_options_discovery(' + str( test_values ) + ')' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()
-        test.check( device.is_running() )
+        device.wait_until_ready()
 
         options = device.options();
         test.check_equal( len( options ), len(test_values) )
@@ -76,8 +74,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         #send values to be checked later as string parameter to the function
         remote.run( 'test_stream_options_discovery(1, 0, 123456, 123, 12, "opt3 of s1")' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()
-        test.check( device.is_running() )
+        device.wait_until_ready()
         test.check_equal( device.n_streams(), 1 )
         for stream in device.streams():
             options = stream.options();
@@ -107,8 +104,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         test_values = list(range(5))
         remote.run( 'test_device_and_multiple_stream_options_discovery(' + str( test_values ) + ', ' + str( test_values ) + ')' )
         device = dds.device( participant, participant.create_guid(), info )
-        device.run()
-        test.check( device.is_running() )
+        device.wait_until_ready()
 
         options = device.options();
         test.check_equal( len( options ), len(test_values) )

--- a/unit-tests/dds/test-stream-sensor-bridge.py
+++ b/unit-tests/dds/test-stream-sensor-bridge.py
@@ -86,8 +86,8 @@ class change_expected:
 
 # set up the client device and keep all its streams
 device = dds.device( participant, participant.create_guid(), d435i.device_info )
-device.run()  # this will throw if something's wrong
-test.check( device.is_running() )
+device.wait_until_ready()  # this will throw if something's wrong
+test.check( device.is_ready() )
 streams = {}
 for stream in device.streams():
     streams[stream.name()] = stream


### PR DESCRIPTION
First part. Next is to enable log sending in the notification-server.

* currently, logs have to be sent as regular notifications, using `publish_notification`
* callback available in dds-device, `on_device_log` - if not set, goes to debug output
* includes python code and unit-test

Note:
* I changed it so the device notification (cnd control) handler is initialized automatically on construction, so that you do not need to `run()` to get notifications - i.e., you do not need a running, complete server to get notifications (or send controls).
* The whole `run()` mechanism was annoying in that it was "required" to have a device working. It's now called `wait_until_ready()` as the device will initialize itself from the notifications. There's now also `is_ready()`.
* Removed the `device-init-timeout-ms` setting -- it's now an argument to `wait_until_ready()`
* There's now a `disable-metadata` field for device-settings, which makes devices not subscribe to metadata.
* The server was updated to no longer publish metadata if nobody is listening to the topic

Tracked on [LRS-804]