### PR TITLE
LibCI enhancement - recycle all ports at start & disable all ports when finish

### DIFF
--- a/unit-tests/live/hw-reset/test-sanity.py
+++ b/unit-tests/live/hw-reset/test-sanity.py
@@ -1,0 +1,63 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+
+# test:device each(D400*) !D457  # D457 device is known for HW reset issues..
+
+import pyrealsense2 as rs
+from rspy import test, log
+from rspy.timer import Timer
+import time
+
+# hw reset test, we want to make sure the device disconnect & reconnect successfully
+
+dev = None
+device_removed = False
+device_added = False
+
+
+def device_changed( info ):
+    global dev, device_removed, device_added
+    if info.was_removed(dev):
+        log.out( "Device removal detected at: ", time.perf_counter())
+        device_removed = True
+    for new_dev in info.get_new_devices():
+        added_sn = new_dev.get_info(rs.camera_info.serial_number)
+        tested_dev_sn = dev.get_info(rs.camera_info.serial_number)
+        if added_sn == tested_dev_sn:
+            log.out( "Device addition detected at: ", time.perf_counter())
+            device_added = True
+
+
+################################################################################################
+test.start( "HW reset - verify disconnect & reconnect" )
+
+t = Timer( 10 )
+dev = test.find_first_device_or_exit()
+context = rs.context()
+context.set_devices_changed_callback( device_changed )
+log.out( "Sending HW-reset command" )
+dev.hardware_reset()
+
+log.out( "Pending for device removal" )
+t.start()
+while not t.has_expired():
+    if (device_removed):
+        break
+    time.sleep( 0.1 )
+
+test.check(device_removed)
+
+log.out("Pending for device addition")
+t.start()
+while not t.has_expired():
+    if ( device_added ):
+        break
+    time.sleep(0.1)
+
+test.check( device_added )
+
+test.finish()
+
+################################################################################################
+test.print_results_and_exit()

--- a/unit-tests/live/hw-reset/test-t2enum.py
+++ b/unit-tests/live/hw-reset/test-t2enum.py
@@ -1,0 +1,75 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+# test:device each(D400*) !D457  # D457 device is known for HW reset issues..
+
+import pyrealsense2 as rs
+from rspy import test, log
+from rspy.timer import Timer
+from rspy.stopwatch import Stopwatch
+import time
+
+# Verify reasonable enumeration time for the device
+
+dev = None
+device_removed = False
+device_added = False
+MAX_ENUM_TIME_D400 = 5 # [sec]
+
+def device_changed( info ):
+    global dev, device_removed, device_added
+    if info.was_removed(dev):
+        log.out( "Device removal detected at: ", time.perf_counter())
+        device_removed = True
+    for new_dev in info.get_new_devices():
+        added_sn = new_dev.get_info(rs.camera_info.serial_number)
+        tested_dev_sn = dev.get_info(rs.camera_info.serial_number)
+        if added_sn == tested_dev_sn:
+            log.out( "Device addition detected at: ", time.perf_counter())
+            device_added = True
+
+def get_max_enum_rime_by_device( dev ):
+    if dev.get_info( rs.camera_info.product_line ) == "D400":
+        return MAX_ENUM_TIME_D400;
+    return 0;
+
+################################################################################################
+test.start( "HW reset to enumeration time" )
+
+# get max enumeration time per device
+context = rs.context()
+context.set_devices_changed_callback( device_changed )
+dev = test.find_first_device_or_exit()
+
+max_dev_enum_time = get_max_enum_rime_by_device( dev )
+log.out( "Sending HW-reset command" )
+enumeration_sw = Stopwatch() # we know we add the device removal time, but it shouldn't take long
+dev.hardware_reset()
+
+log.out( "Pending for device removal" )
+t = Timer( 10 )
+t.start()
+while not t.has_expired():
+    if ( device_removed ):
+        break
+    time.sleep( 0.1 )
+
+test.check( device_removed and not t.has_expired() ) # verifying we are not timed out
+
+log.out( "Pending for device addition" )
+t.start()
+r_2_e_time = 0 # reset to enumeration time
+while not t.has_expired():
+    if ( device_added ):
+        r_2_e_time = enumeration_sw.get_elapsed()
+        break
+    time.sleep(0.1)
+
+test.check( device_added )
+test.check( r_2_e_time < max_dev_enum_time )
+log.d( "Enumeration time took", r_2_e_time, "[sec]" )
+
+test.finish()
+
+################################################################################################
+test.print_results_and_exit()

--- a/unit-tests/py/rspy/acroname.py
+++ b/unit-tests/py/rspy/acroname.py
@@ -182,9 +182,11 @@ def enable_ports( ports = None, disable_other_ports = False, sleep_on_change = 0
         #
         if ports is None or port in ports:
             if not is_port_enabled( port ):
+                #log.d( "enabling port", port)
                 action_result = hub.usb.setPortEnable( port )
                 if action_result != brainstem.result.Result.NO_ERROR:
                     result = False
+                    log.e("Failed to enable port", port)
                 else:
                     changed = True
         #
@@ -203,18 +205,28 @@ def enable_ports( ports = None, disable_other_ports = False, sleep_on_change = 0
     return result
 
 
-def disable_ports( ports ):
+def disable_ports( ports = None, sleep_on_change = 0 ):
     """
-    :param ports: List of port numbers
+    :param ports: List of port numbers; if not provided, disable all ports
+    :param sleep_on_change: Number of seconds to sleep if any change is made
     :return: True if no errors found, False otherwise
     """
     global hub
     result = True
-    for port in ports:
-        #
-        action_result = hub.usb.setPortDisable( port )
-        if action_result != brainstem.result.Result.NO_ERROR:
-            result = False
+    changed = False
+    for port in all_ports():
+        if ports is None or port in ports:
+            if is_port_enabled( port ):
+                    #log.d("disabling port", port)
+                    action_result = hub.usb.setPortDisable( port )
+                    if action_result != brainstem.result.Result.NO_ERROR:
+                        result = False
+                        log.e("Failed to disable port", port)
+                    else:
+                        changed = True
+    if changed and sleep_on_change:
+        import time
+        time.sleep( sleep_on_change )
     #
     return result
 

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -32,9 +32,10 @@ from rspy import repo
 pyrs_dir = repo.find_pyrs_dir()
 sys.path.insert( 1, pyrs_dir )
 
+MAX_ENUMERATION_TIME = 10  # [sec]
 
 # We need both pyrealsense2 and acroname. We can work without acroname, but
-# without rs no devices at all will be returned.
+# without pyrealsense2 no devices at all will be returned.
 try:
     import pyrealsense2 as rs
     log.d( rs )
@@ -175,7 +176,7 @@ def map_unknown_ports():
             log.d( 'enabling port', port )
             acroname.enable_ports( [port], disable_other_ports=True )
             sn = None
-            for retry in range( 5 ):
+            for retry in range( MAX_ENUMERATION_TIME ):
                 if len( enabled() ) == 1:
                     sn = list( enabled() )[0]
                     break
@@ -214,7 +215,10 @@ def query( monitor_changes = True ):
     if acroname:
         if not acroname.hub:
             acroname.connect()  # MAY THROW!
-            acroname.enable_ports( sleep_on_change = 5 )  # make sure all connected!
+
+            acroname.disable_ports( sleep_on_change = 5 )
+            acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
+
             if platform.system() == 'Linux':
                 global _acroname_hubs
                 _acroname_hubs = set( acroname.find_all_hubs() )
@@ -473,7 +477,7 @@ def recovery():
     return { device.serial_number for device in _device_by_sn.values() if device.handle.is_update_device() }
 
 
-def enable_only( serial_numbers, recycle = False, timeout = 5 ):
+def enable_only( serial_numbers, recycle = False, timeout = MAX_ENUMERATION_TIME ):
     """
     Enable only the devices corresponding to the given serial-numbers. This can work either
     with or without Acroname: without, the devices will simply be HW-reset, but other devices
@@ -496,8 +500,9 @@ def enable_only( serial_numbers, recycle = False, timeout = 5 ):
             #
             log.d( 'recycling ports via acroname:', ports )
             #
-            acroname.disable_ports( acroname.ports() )
-            _wait_until_removed( serial_numbers, timeout = timeout )
+            enabled_devices = enabled()
+            acroname.disable_ports( )
+            _wait_until_removed( enabled_devices, timeout = timeout )
             #
             acroname.enable_ports( ports )
             #
@@ -542,12 +547,13 @@ def _wait_until_removed( serial_numbers, timeout = 5 ):
             return True
         #
         if timeout <= 0:
+            log.e( "timed out waiting for devices to be removed" )
             return False
         timeout -= 1
         time.sleep( 1 )
 
 
-def _wait_for( serial_numbers, timeout = 5 ):
+def _wait_for( serial_numbers, timeout = MAX_ENUMERATION_TIME ):
     """
     Wait until the given serial numbers are all online
 
@@ -556,12 +562,7 @@ def _wait_for( serial_numbers, timeout = 5 ):
     :return: True if all have come online; False if timeout was reached
     """
     did_some_waiting = False
-    #
-    # In Linux, we don't have an active notification mechanism - we query devices every 5 seconds
-    # (see POLLING_DEVICES_INTERVAL_MS) - so we add extra timeout
-    if timeout and platform.system() == 'Linux':
-        timeout += 5
-    #
+
     while True:
         #
         have_all_devices = True
@@ -580,14 +581,13 @@ def _wait_for( serial_numbers, timeout = 5 ):
         #
         if timeout <= 0:
             if did_some_waiting:
-                log.d( 'timed out' )
+                log.d( 'timed out waiting for a device connection' )
             return False
         timeout -= 1
         time.sleep( 1 )
         did_some_waiting = True
 
-
-def hw_reset( serial_numbers, timeout = 5 ):
+def hw_reset( serial_numbers, timeout = MAX_ENUMERATION_TIME ):
     """
     Recycles the given devices manually, using a hardware-reset (rather than any acroname port
     reset). The devices are sent a HW-reset command and then we'll wait until they come back
@@ -599,11 +599,20 @@ def hw_reset( serial_numbers, timeout = 5 ):
     :param timeout: Maximum # of seconds to wait for the devices to come back online
     :return: True if all devices have come back online before timeout
     """
+
+    usb_serial_numbers = { sn for sn in serial_numbers if _device_by_sn[sn].port is not None }
+
     for sn in serial_numbers:
         dev = get( sn ).handle
         dev.hardware_reset()
     #
-    _wait_until_removed( serial_numbers )
+
+    if usb_serial_numbers:
+        _wait_until_removed( usb_serial_numbers )
+    else:
+        # normally we will get here with a mipi device,
+        # we want to allow some time for the device to reinitialize as it was not disconnected
+        time.sleep(3)
     #
     return _wait_for( serial_numbers, timeout = timeout )
 
@@ -751,7 +760,7 @@ if __name__ == '__main__':
             elif opt in ('--all'):
                 if not acroname:
                     log.f( 'No acroname available' )
-                acroname.enable_ports( sleep_on_change = 5 )
+                acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
             elif opt in ('--port'):
                 if not acroname:
                     log.f( 'No acroname available' )
@@ -760,7 +769,7 @@ if __name__ == '__main__':
                 ports = [int(port) for port in str_ports if port.isnumeric() and int(port) in all_ports]
                 if len(ports) != len(str_ports):
                     log.f( 'Invalid ports', str_ports )
-                acroname.enable_ports( ports, disable_other_ports = True, sleep_on_change = 5 )
+                acroname.enable_ports( ports, disable_other_ports = True, sleep_on_change = MAX_ENUMERATION_TIME )
             elif opt in ('--recycle'):
                 action = 'recycle'
             else:

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -562,8 +562,11 @@ try:
 finally:
     #
     # Disconnect from the Acroname -- if we don't it'll crash on Linux...
+    # Before that we close all ports, no need for cameras to stay on between LibCI runs
     if not list_only and not only_not_live:
         if devices.acroname:
+            devices.acroname.disable_ports()
+            devices.wait_until_all_ports_disabled()
             devices.acroname.disconnect()
 #
 sys.exit( 0 )


### PR DESCRIPTION
This PR change 2 behaviors:

1. When starting LibCI it used to enable all ports and discover the cameras,
If a device port was enabled on the previous run, it stays on.
If it failed and even the FW crashed on last run, this device will not be discovered in the next run as it's port is already on and the FW crashed.
Now we will always start from a fresh power cycle of the device

2. When LibCI finish, disable all ports.
No need to keep devices on between LibCI runs. D585S for example is projecting laser from the moment it get power.
No need for the laser to be on all weekend.
This should extend the HW life
