### PR TITLE
DDS warnings; rs-enum-devs fix; UYVY -> uyvy for ROS2

### DIFF
--- a/src/dds/rs-dds-option.cpp
+++ b/src/dds/rs-dds-option.cpp
@@ -1,8 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
-#pragma once
-
 #include "rs-dds-option.h"
 
 #include <realdds/dds-option.h>

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -58,7 +58,7 @@ py::list get_vector3( geometry_msgs::msg::Vector3 const & v )
     obj[1] = py::float_( v.y() );
     obj[2] = py::float_( v.z() );
     return std::move( obj );
-};
+}
 
 
 void set_vector3( geometry_msgs::msg::Vector3 & v, std::array< double, 3 > const & l )

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -597,7 +597,7 @@ PYBIND11_MODULE(NAME, m) {
     video_encoding.attr( "y16" ) = dds_video_encoding( "Y16" );  // todo should be mono16
     video_encoding.attr( "byr2" ) = dds_video_encoding( "BYR2" );
     video_encoding.attr( "yuyv" ) = dds_video_encoding( "yuv422_yuy2" );
-    video_encoding.attr( "uyvy" ) = dds_video_encoding( "UYVY" );  // todo
+    video_encoding.attr( "uyvy" ) = dds_video_encoding( "uyvy" );
     video_encoding.attr( "rgb" ) = dds_video_encoding( "rgb8" );
 
     using realdds::dds_stream_profile;

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -78,7 +78,7 @@ int dds_video_encoding::to_rs2() const
 {
     static std::map< std::string, int > fcc_to_rs2{  // copy from ds5-device.cpp
         { "yuv422_yuy2", RS2_FORMAT_YUYV },  // Used by Color streams; ROS2-compatible
-        { "UYVY", RS2_FORMAT_UYVY },
+        { "uyvy", RS2_FORMAT_UYVY },
         { "mono8", RS2_FORMAT_Y8 },  // Used by IR streams; ROS2-compatible
         { "Y8I",  RS2_FORMAT_Y8I },
         { "W10",  RS2_FORMAT_W10 },
@@ -128,7 +128,7 @@ dds_video_encoding dds_video_encoding::from_rs2( int rs2_format )
     case RS2_FORMAT_RAW8: encoding = "CNF4"; break;
     case RS2_FORMAT_RAW16: encoding = "BYR2"; break;
     case RS2_FORMAT_RAW10: encoding = "R10"; break;
-    case RS2_FORMAT_UYVY: encoding = "UYVY"; break;
+    case RS2_FORMAT_UYVY: encoding = "uyvy"; break;
     case RS2_FORMAT_Y10BPACK: encoding = "Y10B"; break;
     default:
         DDS_THROW( runtime_error, "cannot translate rs2_format " + std::to_string( rs2_format ) + " to any known dds_video_encoding" );

--- a/tools/dds/dds-adapter/CMakeLists.txt
+++ b/tools/dds/dds-adapter/CMakeLists.txt
@@ -19,7 +19,7 @@ target_include_directories( ${PROJECT_NAME} PRIVATE
 target_link_libraries( ${PROJECT_NAME} PRIVATE realdds realsense2 )
 set_target_properties (${PROJECT_NAME} PROPERTIES
     FOLDER Tools/dds
-    CXX_STANDARD 11
+    CXX_STANDARD 14
     )
 
 install( TARGETS ${PROJECT_NAME}

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -195,19 +195,21 @@ int main(int argc, char** argv) try
     SwitchArg show_options_arg("o", "option", "Show all the supported options per subdevice");
     SwitchArg show_calibration_data_arg( "c", "calib_data", "Show extrinsic and intrinsic of all subdevices" );
     SwitchArg show_defaults("d", "defaults", "Show the default streams configuration");
-    SwitchArg only_sw_arg( "", "sw-only", "Show only software devices (playback, dds, etc. -- but not USB/HID/etc.)" );
+    SwitchArg only_sw_arg( "", "sw-only", "Show only software devices (playback, DDS, etc. -- but not USB/HID/etc.)" );
+    SwitchArg basic_formats_arg( "", "basic-formats", "Don't show non-raw conversions" );
     SwitchArg verbose_arg( "v", "verbose", "Show extra information" );
     ValueArg<string> show_playback_device_arg("p", "playback_device", "Inspect and enumerate playback device (from file)",
-        false, "", "Playback device - ROSBag record full path");
+        false, "", "path");
     cmd.add(debug_arg);
     cmd.add(short_view_arg);
     cmd.add(compact_view_arg);
     cmd.add(show_options_arg);
     cmd.add(show_calibration_data_arg);
     cmd.add(only_sw_arg);
+    cmd.add(basic_formats_arg);
     cmd.add(verbose_arg);
 #ifdef BUILD_WITH_DDS
-    ValueArg< int > domain_arg( "", "dds-domain", "Set the DDS domain ID", false, 0, "domain ID" );
+    ValueArg< int > domain_arg( "", "dds-domain", "Set the DDS domain ID (default to 0)", false, 0, "0-232" );
     cmd.add( domain_arg );
 #endif
     cmd.add(show_defaults);
@@ -242,8 +244,12 @@ int main(int argc, char** argv) try
     // Obtain a list of devices currently present on the system
     json settings;
 #ifdef BUILD_WITH_DDS
-    settings["dds-domain"] = domain_arg.getValue();
+    json dds;
+    dds["domain"] = domain_arg.getValue();
+    settings["dds"] = std::move( dds ); 
 #endif
+    if( basic_formats_arg.getValue() )
+        settings["use-basic-formats"] = true;
     context ctx( settings.dump() );
     
     rs2::device d;


### PR DESCRIPTION
* UYVY in ROS2 is `uyvy` (lower-case).
* there were 3 warnings in libCI once I re-enabled the DDS code there, so this should fix them
  * rs-dds-adapter is now C++14
* update rs-enumerate-devices DDS settings, and clean up some others