### PR TITLE
Patch 5.4.232 noiio

### DIFF
--- a/scripts/patch-realsense-ubuntu-lts-hwe.sh
+++ b/scripts/patch-realsense-ubuntu-lts-hwe.sh
@@ -17,6 +17,7 @@ rebuild_ko=0
 debug_uvc=0
 retpoline_retrofit=0
 skip_hid_patch=0
+skip_hid_accel_patch=0
 #Parse input
 while test $# -gt 0; do
 	case "$1" in
@@ -80,6 +81,7 @@ k_tick=$(echo ${kernel_version[2]} | awk -F'-' '{print $2}')
 # For version 5.15.0-72 hid patch already applied
 [ $k_maj_min -gt 515 ] && skip_hid_patch=1
 [ $k_maj_min -eq 515 ] && [ $k_tick -ge 72 ] && skip_hid_patch=1
+[ $k_maj_min -eq 504 ] && [ $k_tick -ge 232 ] && skip_hid_accel_patch=1 && skip_hid_patch=1
 
 # Construct branch name from distribution codename {xenial,bionic,..} and kernel version
 # ubuntu_codename=`. /etc/os-release; echo ${UBUNTU_CODENAME/*, /}`
@@ -169,6 +171,10 @@ then
 		if [ ${skip_hid_patch} -eq 0 ]; then
 			echo -e "\e[32mApplying realsense-hid patch\e[0m"
 			patch -p1 < ../scripts/realsense-hid-${ubuntu_codename}-${kernel_branch}.patch ||  patch -p1 < ../scripts/realsense-hid-${ubuntu_codename}-master.patch
+		fi
+		if [ ${skip_hid_accel_patch} -eq 0 ]; then
+			echo -e "\e[32mApplying realsense-hid gyro patch\e[0m"
+			patch -p1 < ../scripts/realsense-hid-focal-hwe-5.4.232.patch
 		fi
 		echo -e "\e[32mApplying realsense-powerlinefrequency-fix patch\e[0m"
 		patch -p1 < ../scripts/realsense-powerlinefrequency-control-fix.patch || patch -p1 < ../scripts/realsense-powerlinefrequency-control-fix-${ubuntu_codename}.patch

--- a/scripts/patch-realsense-ubuntu-lts-hwe.sh
+++ b/scripts/patch-realsense-ubuntu-lts-hwe.sh
@@ -81,7 +81,8 @@ k_tick=$(echo ${kernel_version[2]} | awk -F'-' '{print $2}')
 # For version 5.15.0-72 hid patch already applied
 [ $k_maj_min -gt 515 ] && skip_hid_patch=1
 [ $k_maj_min -eq 515 ] && [ $k_tick -ge 72 ] && skip_hid_patch=1
-[ $k_maj_min -eq 504 ] && [ $k_tick -ge 232 ] && skip_hid_accel_patch=1 && skip_hid_patch=1
+# linux-image-generic for focal is 5.4.0.156.152 is same hid as 5.4.232
+[ $k_maj_min -eq 504 ] && [ $k_tick -ge 156 ] && skip_hid_accel_patch=1 && skip_hid_patch=1
 
 # Construct branch name from distribution codename {xenial,bionic,..} and kernel version
 # ubuntu_codename=`. /etc/os-release; echo ${UBUNTU_CODENAME/*, /}`

--- a/scripts/realsense-hid-focal-hwe-5.4.232.patch
+++ b/scripts/realsense-hid-focal-hwe-5.4.232.patch
@@ -1,0 +1,93 @@
+Signed-off-by: Evgeni <evgeni.raikhel@intel.com>
+From 001649b143e1a4e0924ac6fc47883a45ba28ff63 Mon Sep 17 00:00:00 2001
+Date: Fri, 13 Aug 2023 12:38:24 +0300
+Subject: [PATCH] Adding missing HID timestamp patch for Gyro sensor.
+         Ubuntu 20.04. Kernel 5.4.232
+	The patch was written by Srinivas Pandruvada <srinivas.pandruvada@intel.com>
+	Additionally, timestamp conversion is fixed
+
+---
+ drivers/iio/gyro/hid-sensor-gyro-3d.c   | 31 ++++++++++++++++++-------
+ 2 files changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/iio/gyro/hid-sensor-gyro-3d.c b/drivers/iio/gyro/hid-sensor-gyro-3d.c
+index 08cacbbf31e6..f6e88eecd145 100644
+--- a/drivers/iio/gyro/hid-sensor-gyro-3d.c
++++ b/drivers/iio/gyro/hid-sensor-gyro-3d.c
+@@ -29,11 +29,13 @@ struct gyro_3d_state {
+ 	struct hid_sensor_hub_callbacks callbacks;
+ 	struct hid_sensor_common common_attributes;
+ 	struct hid_sensor_hub_attribute_info gyro[GYRO_3D_CHANNEL_MAX];
+-	u32 gyro_val[GYRO_3D_CHANNEL_MAX];
++	/* Reserve for 3 channels + padding + timestamp */
++	u32 gyro_val[GYRO_3D_CHANNEL_MAX + 3];
+ 	int scale_pre_decml;
+ 	int scale_post_decml;
+ 	int scale_precision;
+ 	int value_offset;
++	int64_t timestamp;
+ };
+ 
+ static const u32 gyro_3d_addresses[GYRO_3D_CHANNEL_MAX] = {
+@@ -74,7 +76,8 @@ static const struct iio_chan_spec gyro_3d_channels[] = {
+ 		BIT(IIO_CHAN_INFO_SAMP_FREQ) |
+ 		BIT(IIO_CHAN_INFO_HYSTERESIS),
+ 		.scan_index = CHANNEL_SCAN_INDEX_Z,
+-	}
++	},
++	IIO_CHAN_SOFT_TIMESTAMP(3)
+ };
+ 
+ /* Adjust channel real bits based on report descriptor */
+@@ -181,11 +184,11 @@ static const struct iio_info gyro_3d_info = {
+ };
+ 
+ /* Function to push data to buffer */
+-static void hid_sensor_push_data(struct iio_dev *indio_dev, const void *data,
+-	int len)
++static void hid_sensor_push_data(struct iio_dev *indio_dev, void *data,
++	int len, int64_t timestamp)
+ {
+ 	dev_dbg(&indio_dev->dev, "hid_sensor_push_data\n");
+-	iio_push_to_buffers(indio_dev, data);
++	iio_push_to_buffers_with_timestamp(indio_dev, data, timestamp);
+ }
+ 
+ /* Callback handler to send event after all samples are received and captured */
+@@ -197,11 +200,16 @@ static int gyro_3d_proc_event(struct hid_sensor_hub_device *hsdev,
+ 	struct gyro_3d_state *gyro_state = iio_priv(indio_dev);
+ 
+ 	dev_dbg(&indio_dev->dev, "gyro_3d_proc_event\n");
+-	if (atomic_read(&gyro_state->common_attributes.data_ready))
++	if (atomic_read(&gyro_state->common_attributes.data_ready)) {
++		if (!gyro_state->timestamp)
++			gyro_state->timestamp = iio_get_time_ns(indio_dev);
++
+ 		hid_sensor_push_data(indio_dev,
+ 				gyro_state->gyro_val,
+-				sizeof(gyro_state->gyro_val));
+-
++				sizeof(gyro_state->gyro_val),
++				gyro_state->timestamp);
++		gyro_state->timestamp = 0;
++	}
+ 	return 0;
+ }
+ 
+@@ -225,6 +233,13 @@ static int gyro_3d_capture_sample(struct hid_sensor_hub_device *hsdev,
+ 						*(u32 *)raw_data;
+ 		ret = 0;
+ 	break;
++	case HID_USAGE_SENSOR_TIME_TIMESTAMP:
++		gyro_state->timestamp =
++			hid_sensor_convert_timestamp(
++					&gyro_state->common_attributes,
++					*(int64_t *)raw_data);
++		ret = 0;
++	break;
+ 	default:
+ 		break;
+ 	}
+-- 
+2.17.1
+


### PR DESCRIPTION
scripts: match ubuntu kernel versioning
    
    As for 14 Aug 2023, linux-image-generic for focal is 5.4.0.156.152
    is same hid sources as 5.4.232
    with accel return value bugfix and gyro without timestamp
