### PR TITLE
Draw cross in calibration ROI

### DIFF
--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -72,7 +72,7 @@ namespace rs2
         glPopAttrib();
     }
 
-    void draw_rect(const rect& r, int line_width)
+    void draw_rect( const rect & r, int line_width, bool draw_cross )
     {
         glPushAttrib(GL_ENABLE_BIT);
 
@@ -89,6 +89,20 @@ namespace rs2
         glVertex2f(r.x + r.w, r.y);
         glVertex2f(r.x, r.y);
         glEnd();
+
+        if( draw_cross )
+        {
+            glLineStipple( 1, 0x0808 );
+            glEnable( GL_LINE_STIPPLE );
+            glBegin( GL_LINES );
+            glVertex2f( r.x, r.y + r.h / 2 );
+            glVertex2f( r.x + r.w, r.y + r.h / 2 );
+            glEnd();
+            glBegin( GL_LINES );
+            glVertex2f( r.x + r.w / 2, r.y );
+            glVertex2f( r.x + r.w / 2, r.y + r.h );
+            glEnd();
+        }
 
         glPopAttrib();
     }
@@ -1618,7 +1632,7 @@ namespace rs2
 
             r = r.normalize(_normalized_zoom.unnormalize(get_original_stream_bounds())).unnormalize(stream_rect).cut_by(stream_rect);
             glColor3f(yellow.x, yellow.y, yellow.z);
-            draw_rect(r, 2);
+            draw_rect(r, 2, true);
 
             std::string message = "Metrics Region of Interest";
             auto msg_width = stb_easy_font_width((char*)message.c_str());

--- a/common/stream-model.h
+++ b/common/stream-model.h
@@ -14,7 +14,7 @@ namespace rs2
     class subdevice_model;
     class viewer_model;
 
-    void draw_rect(const rect& r, int line_width = 1);
+    void draw_rect(const rect& r, int line_width = 1, bool draw_cross = false);
 
     struct frame_metadata
     {


### PR DESCRIPTION
Drawing a cross in ROI during FL calibration and ground truth calculation.
The target is composed from 4 circles, each should be placed in a different quadrant of the frame. The cross helps setting the target correctly.
![ROI cross](https://github.com/IntelRealSense/librealsense/assets/100071798/5f76aab5-b00b-47de-b035-fc2a59db7914)
