### PR TITLE
Activate test-fw-update unit test for D457 mipi devices

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -3,7 +3,7 @@
 
 # we want this test to run first so that all tests run with updated FW versions, so we give it priority 0
 #test:priority 0
-#test:device each(D400*) !D457
+#test:device each(D400*)
 
 import sys
 import os


### PR DESCRIPTION
As rs-fw-update tool now works for MIPI devices we can use it to update FW in LibCI