### PR TITLE
sw-dev profiles work; shorter rs-enum-devs output; use-basic-formats -> format-conversion

### DIFF
--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -31,10 +31,10 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error);
 *             domain: 0                - (int) the number of the DDS domain [0-232]
 *             participant: <exe name>  - (string) the name of the participant
 *                 (see additional settings in realdds/doc/device.md#Settings)
-*         use-basic-formats: false     - (bool) true to make sensors stream only "basic" types
-*                                        without converting to formats other than the raw camera
-*                                        formats (Convert only interleaved formats (Y8I, Y12I), no
-*                                        colored infrared)
+*         format-conversion: full      - (string) how to convert formats
+*             full: provide all conversions (e.g., YUYV -> RGB8 etc.)
+*             basic: use mostly raw camera formats (no RGB8 etc.); convert interleaved (Y8I -> 2xY8)
+*             raw: leave all formats from camera as they are
 * \param[out] error  If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return            Context object
 */

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -25,6 +25,13 @@ namespace librealsense
 
     class context;
 
+    enum class format_conversion
+    {
+        raw,
+        basic,
+        full
+    };
+
     typedef enum profile_tag
     {
         PROFILE_TAG_SUPERSET = 1, // to be included in enable_all

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -148,6 +148,7 @@ namespace librealsense
     public:
         virtual stream_profiles get_stream_profiles(int tag = profile_tag::PROFILE_TAG_ANY) const = 0;
         virtual stream_profiles get_active_streams() const = 0;
+        virtual stream_profiles const & get_raw_stream_profiles() const = 0;
         virtual void open(const stream_profiles& requests) = 0;
         virtual void close() = 0;
         virtual notifications_callback_ptr get_notifications_callback() const = 0;

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -428,10 +428,11 @@ void dds_device_proxy::tag_default_profile_of_stream(
     const std::shared_ptr< const realdds::dds_stream > & stream ) const
 {
     auto const & dds_default_profile = stream->default_profile();
+    int target_format;
     auto dds_vsp = std::dynamic_pointer_cast< realdds::dds_video_stream_profile >( dds_default_profile );
-    auto target_format = dds_vsp->encoding().to_rs2();
     if( dds_vsp )
     {
+        target_format = dds_vsp->encoding().to_rs2();
         switch( target_format )
         {
         case RS2_FORMAT_YUYV:

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -235,7 +235,6 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< context > ctx, std::shared_
     for( auto & sensor_info : sensor_name_to_info )
     {
         LOG_DEBUG( sensor_info.first );
-        sensor_info.second.proxy->initialization_done();
 
         // Set profile's ID based on the dds_stream's ID (index already set). Connect the profile to the extrinsics graph.
         for( auto & profile : sensor_info.second.proxy->get_stream_profiles() )

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -80,7 +80,7 @@ std::shared_ptr< stream_profile_interface > dds_sensor_proxy::add_video_stream( 
     } );
     if( is_default )
         profile->tag_profile( profile_tag::PROFILE_TAG_DEFAULT );
-    _raw_rs_profiles.push_back( profile );
+    _sw_profiles.push_back( profile );
 
     return profile;
 }
@@ -101,7 +101,7 @@ std::shared_ptr< stream_profile_interface > dds_sensor_proxy::add_motion_stream(
     profile->set_intrinsics( [=]() { return motion_stream.intrinsics; } );
     if( is_default )
         profile->tag_profile( profile_tag::PROFILE_TAG_DEFAULT );
-    _raw_rs_profiles.push_back( profile );
+    _sw_profiles.push_back( profile );
 
     return profile;
 }
@@ -112,9 +112,9 @@ stream_profiles dds_sensor_proxy::init_stream_profiles()
     register_basic_converters();
     if( should_use_basic_formats() )
         _formats_converter.drop_non_basic_formats();
-    _profiles = _formats_converter.get_all_possible_profiles( _raw_rs_profiles );
-    sort_profiles( _profiles );
-    return _profiles;
+    auto profiles = _formats_converter.get_all_possible_profiles( get_raw_stream_profiles() );
+    sort_profiles( profiles );
+    return profiles;
 }
 
 

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -109,10 +109,22 @@ std::shared_ptr< stream_profile_interface > dds_sensor_proxy::add_motion_stream(
 
 stream_profiles dds_sensor_proxy::init_stream_profiles()
 {
-    register_basic_converters();
-    if( should_use_basic_formats() )
-        _formats_converter.drop_non_basic_formats();
-    auto profiles = _formats_converter.get_all_possible_profiles( get_raw_stream_profiles() );
+    auto profiles = get_raw_stream_profiles();
+
+    auto format = get_format_conversion();
+    if( format_conversion::raw == format )
+    {
+        // NOTE: this is not meant for actual streaming at this time -- actual behavior of the
+        // formats_converter has not been implemented!
+    }
+    else
+    {
+        register_basic_converters();
+        if( format_conversion::basic == format )
+            _formats_converter.drop_non_basic_formats();
+        profiles = _formats_converter.get_all_possible_profiles( profiles );
+    }
+
     sort_profiles( profiles );
     return profiles;
 }

--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -67,8 +67,6 @@ public:
     void add_dds_stream( sid_index sidx, std::shared_ptr< realdds::dds_stream > const & stream );
     std::shared_ptr<stream_profile_interface> add_video_stream( rs2_video_stream video_stream, bool is_default ) override;
     std::shared_ptr<stream_profile_interface> add_motion_stream( rs2_motion_stream motion_stream, bool is_default ) override;
-    // Not adding streams or profiles after this
-    void initialization_done();
 
     void open( const stream_profiles & profiles ) override;
     void start( frame_callback_ptr callback ) override;
@@ -86,6 +84,7 @@ public:
 
 private:
     void register_basic_converters();
+    stream_profiles init_stream_profiles() override;
 
     std::shared_ptr< realdds::dds_video_stream_profile >
     find_profile( sid_index sidx, realdds::dds_video_stream_profile const & profile ) const;

--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -53,9 +53,6 @@ class dds_sensor_proxy : public software_sensor
     std::map< std::string, streaming_impl > _streaming_by_name;
 
     formats_converter _formats_converter;
-    // DDS profiles are stored in _streams, _raw_rs_profiles stores librealsense representation of them,
-    // software_device::_profiles stores librealsense profiles after conversion from raw to a user friendly format.
-    stream_profiles _raw_rs_profiles;
 
 public:
     dds_sensor_proxy( std::string const & sensor_name,

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -168,15 +168,16 @@ matcher_factory::create_timestamp_composite_matcher( std::vector< std::shared_pt
     return std::make_shared<timestamp_composite_matcher>(matchers);
 }
 
-device::device(std::shared_ptr<context> ctx,
-               const platform::backend_device_group & group,
-               bool device_changed_notifications)
-    : _context(ctx), _group(group), _is_valid(true),
-      _device_changed_notifications(device_changed_notifications),
-      _is_alive( std::make_shared< bool >( true ) )
+device::device( std::shared_ptr< context > ctx,
+                const platform::backend_device_group & group,
+                bool device_changed_notifications )
+    : _context( ctx )
+    , _group( group )
+    , _is_valid( true )
+    , _device_changed_notifications( device_changed_notifications )
+    , _is_alive( std::make_shared< bool >( true ) )
+    , _profiles_tags( [this]() { return get_profiles_tags(); } )
 {
-    _profiles_tags = lazy<std::vector<tagged_profile>>([this]() { return get_profiles_tags(); });
-
     if (_device_changed_notifications)
     {
         std::weak_ptr< bool > weak = _is_alive;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -7,6 +7,7 @@
 #include "device.h"
 
 #include <rsutils/string/from.h>
+#include <rsutils/json.h>
 
 using namespace librealsense;
 
@@ -337,6 +338,23 @@ std::vector<rs2_format> device::map_supported_color_formats(rs2_format source_fo
         LOG_ERROR("Format is not supported for mapping");
     }
     return target_formats;
+}
+
+format_conversion device::get_format_conversion() const
+{
+    auto context = get_context();
+    if( ! context )
+        return format_conversion::full;
+    std::string const format_conversion( "format-conversion", 17 );
+    std::string const full( "full", 4 );
+    auto const value = rsutils::json::get( context->get_settings(), format_conversion, full );
+    if( value == full )
+        return format_conversion::full;
+    if( value == "basic" )
+        return format_conversion::basic;
+    if( value == "raw" )
+        return format_conversion::raw;
+    throw invalid_value_exception( "invalid " + format_conversion + " value '" + value + "'" );
 }
 
 void device::tag_profiles(stream_profiles profiles) const

--- a/src/device.h
+++ b/src/device.h
@@ -87,6 +87,8 @@ public:
 
     bool device_changed_notifications_on() const { return _device_changed_notifications; }
 
+    format_conversion get_format_conversion() const;
+
     uint16_t _pid;
 protected:
     int add_sensor(const std::shared_ptr<sensor_interface>& sensor_base);

--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -973,9 +973,26 @@ namespace librealsense
             int color_height = 480;
             int fps = usb3mode ?  30 : 10;
 
-            tags.push_back({ RS2_STREAM_COLOR, -1, color_width, color_height, RS2_FORMAT_RGB8, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_DEPTH, -1, depth_width, depth_height, RS2_FORMAT_Z16, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_INFRARED, -1, depth_width, depth_height, RS2_FORMAT_Y8, fps, profile_tag::PROFILE_TAG_SUPERSET });
+            auto format_conversion = get_format_conversion();
+
+            tags.push_back( { RS2_STREAM_COLOR,
+                              -1,  // index
+                              color_width, color_height,
+                              ( format_conversion == format_conversion::full ) ? RS2_FORMAT_RGB8 : RS2_FORMAT_YUYV,
+                              fps,
+                              profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT } );
+            tags.push_back( { RS2_STREAM_DEPTH,
+                              -1,  // index
+                              depth_width, depth_height,
+                              RS2_FORMAT_Z16,
+                              fps,
+                              profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT } );
+            tags.push_back( { RS2_STREAM_INFRARED,
+                              -1,  // index
+                              depth_width, depth_height,
+                              ( format_conversion == format_conversion::raw ) ? RS2_FORMAT_Y8I : RS2_FORMAT_Y8,
+                              fps,
+                              profile_tag::PROFILE_TAG_SUPERSET } );
 
             return tags;
         }

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -46,7 +46,7 @@ namespace librealsense
         return _roi;
     }
 
-    ds_fisheye_sensor::ds_fisheye_sensor(std::shared_ptr<sensor_base> sensor, device* owner)
+    ds_fisheye_sensor::ds_fisheye_sensor( std::shared_ptr< raw_sensor_base > const & sensor, device * owner )
         : synthetic_sensor("Wide FOV Camera", sensor, owner, fisheye_fourcc_to_rs2_format, fisheye_fourcc_to_rs2_stream),
         _owner(owner)
     {}
@@ -116,21 +116,23 @@ namespace librealsense
         return uvc_raw_sensor;
     }
     
-    ds_motion_sensor::ds_motion_sensor(std::string name,
-        std::shared_ptr<sensor_base> sensor, device* owner)
-        : synthetic_sensor(name, sensor, owner),
-        _owner(owner)
-    {}
+    ds_motion_sensor::ds_motion_sensor( std::string const & name,
+                                        std::shared_ptr< raw_sensor_base > const & sensor,
+                                        device * owner )
+        : synthetic_sensor( name, sensor, owner )
+        , _owner( owner )
+    {
+    }
 
-    ds_motion_sensor::ds_motion_sensor(std::string name,
-        std::shared_ptr<sensor_base> sensor, device* owner,
-        const std::map<uint32_t, rs2_format>& motion_fourcc_to_rs2_format,
-        const std::map<uint32_t, rs2_stream>& motion_fourcc_to_rs2_stream)
-        : synthetic_sensor(name, sensor, owner,
-                           motion_fourcc_to_rs2_format,
-                           motion_fourcc_to_rs2_stream),
-        _owner(owner)
-    {}
+    ds_motion_sensor::ds_motion_sensor( std::string const & name,
+                                        std::shared_ptr< raw_sensor_base > const & sensor,
+                                        device * owner,
+                                        const std::map< uint32_t, rs2_format > & motion_fourcc_to_rs2_format,
+                                        const std::map< uint32_t, rs2_stream > & motion_fourcc_to_rs2_stream )
+        : synthetic_sensor( name, sensor, owner, motion_fourcc_to_rs2_format, motion_fourcc_to_rs2_stream )
+        , _owner( owner )
+    {
+    }
 
     rs2_motion_device_intrinsic ds_motion_sensor::get_motion_intrinsics(rs2_stream stream) const
     {

--- a/src/ds/ds-motion-common.h
+++ b/src/ds/ds-motion-common.h
@@ -62,7 +62,7 @@ namespace librealsense
     class ds_fisheye_sensor : public synthetic_sensor, public video_sensor_interface, public roi_sensor_base, public fisheye_sensor
     {
     public:
-        explicit ds_fisheye_sensor(std::shared_ptr<sensor_base> sensor, device* owner);
+        explicit ds_fisheye_sensor( std::shared_ptr< raw_sensor_base > const & sensor, device * owner );
 
         rs2_intrinsics get_intrinsics(const stream_profile& profile) const override;
         stream_profiles init_stream_profiles() override;
@@ -79,13 +79,15 @@ namespace librealsense
                           public motion_sensor
     {
     public:
-        explicit ds_motion_sensor(std::string name,
-            std::shared_ptr<sensor_base> sensor, device* owner);
+        explicit ds_motion_sensor( std::string const & name,
+                                   std::shared_ptr< raw_sensor_base > const & sensor,
+                                   device * owner );
 
-        explicit ds_motion_sensor(std::string name,
-            std::shared_ptr<sensor_base> sensor, device* owner,
-            const std::map<uint32_t, rs2_format>& motion_fourcc_to_rs2_format,
-            const std::map<uint32_t, rs2_stream>& motion_fourcc_to_rs2_stream);
+        explicit ds_motion_sensor( std::string const & name,
+                                   std::shared_ptr< raw_sensor_base > const & sensor,
+                                   device * owner,
+                                   const std::map< uint32_t, rs2_format > & motion_fourcc_to_rs2_format,
+                                   const std::map< uint32_t, rs2_stream > & motion_fourcc_to_rs2_stream );
 
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream stream) const;
 

--- a/src/media/playback/playback_sensor.h
+++ b/src/media/playback/playback_sensor.h
@@ -45,6 +45,7 @@ namespace librealsense
         frame_callback_ptr get_frames_callback() const override;
         void set_frames_callback(frame_callback_ptr callback) override;
         stream_profiles get_active_streams() const override;
+        stream_profiles const & get_raw_stream_profiles() const override { return m_available_profiles; }
         int register_before_streaming_changes_callback(std::function<void(bool)> callback) override;
         void unregister_before_start_callback(int token) override;
         void raise_notification(const notification& n);

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -202,6 +202,12 @@ stream_profiles record_sensor::get_active_streams() const
     return m_sensor.get_active_streams();
 }
 
+stream_profiles const & record_sensor::get_raw_stream_profiles() const
+{
+    return m_sensor.get_raw_stream_profiles();
+}
+
+
 int record_sensor::register_before_streaming_changes_callback(std::function<void(bool)> callback)
 {
     throw librealsense::not_implemented_exception("playback_sensor::register_before_streaming_changes_callback");

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -39,6 +39,7 @@ namespace librealsense
         frame_callback_ptr get_frames_callback() const override;
         void set_frames_callback(frame_callback_ptr callback) override;
         stream_profiles get_active_streams() const override;
+        stream_profiles const & get_raw_stream_profiles() const override;
         int register_before_streaming_changes_callback(std::function<void(bool)> callback) override;
         void unregister_before_start_callback(int token) override;
         signal<record_sensor, const notification&> on_notification;

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -87,7 +87,7 @@ stream_profiles formats_converter::get_all_possible_profiles( const stream_profi
 
     for( auto & raw_profile : raw_profiles )
     {
-        LOG_DEBUG( "Getting possible profiles for raw profile: " << raw_profile );
+        LOG_DEBUG( "Raw profile: " << raw_profile );
         for( auto & pbf : _pb_factories )
         {
             const auto & sources = pbf->get_source_info();
@@ -117,7 +117,7 @@ stream_profiles formats_converter::get_all_possible_profiles( const stream_profi
                             const auto res = target.stream_resolution( { cloned_vsp->get_width(), cloned_vsp->get_height() } );
                             cloned_vsp->set_dims( res.width, res.height );
                         }
-                        LOG_DEBUG( "    Converting to " << cloned_profile );
+                        LOG_DEBUG( "         -> " << cloned_profile );
 
                         // Cache pbf supported profiles for efficiency in find_pbf_matching_most_profiles
                         _pbf_supported_profiles[pbf.get()].push_back( cloned_profile );

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -38,12 +38,20 @@ void formats_converter::drop_non_basic_formats()
     {
         const auto & source = _pb_factories[i]->get_source_info();
         const auto & target = _pb_factories[i]->get_target_info();
-        if( target.size() == 1 &&
-            source[0].format == target[0].format )
-        {
-            // Identity, does not actually convert, keep this converter, unless it is colored infrared.
-            bool colored_infrared = target[0].stream == RS2_STREAM_INFRARED && source[0].format == RS2_FORMAT_UYVY;
 
+        bool is_identity = true;
+        for( auto & t : target )
+        {
+            if( source[0].format != t.format )
+            {
+                is_identity = false;
+                break;
+            }
+        }
+        if( is_identity )
+        {
+            // Keep this converter unless it is colored infrared
+            bool colored_infrared = target[0].stream == RS2_STREAM_INFRARED && source[0].format == RS2_FORMAT_UYVY;
             if( ! colored_infrared )
                 continue;
         }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -1301,9 +1301,9 @@ void log_callback_end( uint32_t fps,
         return try_register_option(id, std::make_shared<uvc_pu_option>(*raw_uvc_sensor.get(), id));
     }
 
-    void synthetic_sensor::sort_profiles(stream_profiles* profiles)
+    void sensor_base::sort_profiles( stream_profiles & profiles )
     {
-        std::sort(profiles->begin(), profiles->end(), [](const std::shared_ptr<stream_profile_interface>& ap,
+        std::sort(profiles.begin(), profiles.end(), [](const std::shared_ptr<stream_profile_interface>& ap,
             const std::shared_ptr<stream_profile_interface>& bp)
         {
             const auto&& a = to_profile(ap.get());
@@ -1364,7 +1364,7 @@ void log_callback_end( uint32_t fps,
         stream_profiles result_profiles = _formats_converter.get_all_possible_profiles( raw_profiles );
 
         _owner->tag_profiles( result_profiles );
-        sort_profiles( &result_profiles );
+        sort_profiles( result_profiles );
 
         return result_profiles;
     }
@@ -1525,13 +1525,14 @@ void log_callback_end( uint32_t fps,
         snapshot = std::make_shared<fisheye_sensor_snapshot>();
     }
 
-    bool synthetic_sensor::should_use_basic_formats() const
+    bool sensor_base::should_use_basic_formats() const
     {
-        if( _owner->get_context() )
-        {
-            return rsutils::json::get< bool >( _owner->get_context()->get_settings(), std::string( "use-basic-formats", 17 ), false );
-        }
-
-        return false;
+        bool default_value = false;
+        auto context = _owner->get_context();
+        if( ! context )
+            return default_value;
+        return rsutils::json::get< bool >( context->get_settings(),
+                                           std::string( "use-basic-formats", 17 ),
+                                           default_value );
     }
 }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -1539,20 +1539,8 @@ void log_callback_end( uint32_t fps,
         snapshot = std::make_shared<fisheye_sensor_snapshot>();
     }
 
-    sensor_base::format_conversion sensor_base::get_format_conversion() const
+    format_conversion sensor_base::get_format_conversion() const
     {
-        auto context = _owner->get_context();
-        if( ! context )
-            return format_conversion::full;
-        std::string const format_conversion( "format-conversion", 17 );
-        std::string const full( "full", 4 );
-        auto const value = rsutils::json::get( context->get_settings(), format_conversion, full );
-        if( value == full )
-            return format_conversion::full;
-        if( value == "basic" )
-            return format_conversion::basic;
-        if( value == "raw" )
-            return format_conversion::raw;
-        throw invalid_value_exception( "invalid " + format_conversion + " value '" + value + "'" );
+        return _owner->get_format_conversion();
     }
 }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -1312,8 +1312,8 @@ void log_callback_end( uint32_t fps,
             // stream == RS2_STREAM_COLOR && format == RS2_FORMAT_RGB8 element works around the fact that Y16 gets priority over RGB8 when both
             // are available for pipeline stream resolution
             // Note: Sort Stream Index decsending to make sure IR1 is chosen over IR2
-            const auto&& at = std::make_tuple(a.stream, -a.index, a.width, a.height, a.fps, a.stream == RS2_STREAM_COLOR && a.format == RS2_FORMAT_RGB8, a.format);
-            const auto&& bt = std::make_tuple(b.stream, -b.index, b.width, b.height, b.fps, b.stream == RS2_STREAM_COLOR && b.format == RS2_FORMAT_RGB8, b.format);
+            const auto&& at = std::make_tuple(a.stream, -a.index, a.width, a.height, a.stream == RS2_STREAM_COLOR && a.format == RS2_FORMAT_RGB8, a.format, a.fps);
+            const auto&& bt = std::make_tuple(b.stream, -b.index, b.width, b.height, b.stream == RS2_STREAM_COLOR && b.format == RS2_FORMAT_RGB8, b.format, b.fps);
 
             return at > bt;
         });

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -96,12 +96,6 @@ namespace librealsense
         void assign_stream(const std::shared_ptr<stream_interface>& stream,
                            std::shared_ptr<stream_profile_interface> target) const;
 
-        enum class format_conversion
-        {
-            raw,
-            basic,
-            full
-        };
         format_conversion get_format_conversion() const;
 
         void sort_profiles( stream_profiles & );

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -96,7 +96,13 @@ namespace librealsense
         void assign_stream(const std::shared_ptr<stream_interface>& stream,
                            std::shared_ptr<stream_profile_interface> target) const;
 
-        bool should_use_basic_formats() const;
+        enum class format_conversion
+        {
+            raw,
+            basic,
+            full
+        };
+        format_conversion get_format_conversion() const;
 
         void sort_profiles( stream_profiles & );
 

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -124,7 +124,6 @@ namespace librealsense
         sensor_base* _source_owner = nullptr;
         frame_source _source;
         device* _owner;
-        std::vector<platform::stream_profile> _uvc_profiles;
 
         std::shared_ptr<std::map<uint32_t, rs2_format>> _fourcc_to_rs2_format;
         std::shared_ptr<std::map<uint32_t, rs2_stream>> _fourcc_to_rs2_stream;
@@ -385,6 +384,7 @@ namespace librealsense
         };
 
         std::shared_ptr<platform::uvc_device> _device;
+        std::vector< platform::stream_profile > _uvc_profiles;
         std::atomic<int> _user_count;
         std::mutex _power_lock;
         std::mutex _configure_lock;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -41,13 +41,17 @@ namespace librealsense
         virtual void reset() = 0;
     };
 
-    class sensor_base : public std::enable_shared_from_this<sensor_base>,
-                        public virtual sensor_interface, public options_container, public virtual info_container, public recommended_proccesing_blocks_base
+    class sensor_base
+        : public std::enable_shared_from_this< sensor_base >
+        , public virtual sensor_interface
+        , public options_container
+        , public virtual info_container
+        , public recommended_proccesing_blocks_base
     {
     public:
-        explicit sensor_base(std::string const & name,
-                             device* device, 
-                             recommended_proccesing_blocks_interface* owner);
+        explicit sensor_base( std::string const & name,
+                              device * device,
+                              recommended_proccesing_blocks_interface * owner );
         virtual ~sensor_base() override { _source.flush(); }
 
         void set_source_owner(sensor_base* owner); // will direct the source to the top in the source hierarchy.
@@ -105,8 +109,6 @@ namespace librealsense
         }
 
         std::vector<byte> align_width_to_64(int width, int height, int bpp, byte* pix) const;
-
-        std::vector<platform::stream_profile> _internal_config;
 
         std::atomic<bool> _is_streaming;
         std::atomic<bool> _is_opened;
@@ -408,6 +410,7 @@ namespace librealsense
 
         std::shared_ptr<platform::uvc_device> _device;
         std::vector< platform::stream_profile > _uvc_profiles;
+        std::vector< platform::stream_profile > _internal_config;
         std::atomic<int> _user_count;
         std::mutex _power_lock;
         std::mutex _configure_lock;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -85,6 +85,9 @@ namespace librealsense
         }
 
     protected:
+        // Since _profiles is private, we need a way to get the final profiles
+        stream_profiles const & initialized_profiles() const { return *_profiles; }
+
         void raise_on_before_streaming_changes(bool streaming);
         void set_active_streams(const stream_profiles& requests);
 
@@ -213,6 +216,9 @@ namespace librealsense
         rs2_stream fourcc_to_rs2_stream( uint32_t ) const;
 
     public:
+        // Raw sensor doesn't do any manipulation on the profiles from the backend
+        stream_profiles const & get_raw_stream_profiles() const override { return initialized_profiles(); }
+
         std::shared_ptr< std::map< uint32_t, rs2_format > > & get_fourcc_to_rs2_format_map();
         std::shared_ptr< std::map< uint32_t, rs2_stream > > & get_fourcc_to_rs2_stream_map();
     };
@@ -237,6 +243,9 @@ namespace librealsense
         bool try_register_pu(rs2_option id);
 
         virtual stream_profiles init_stream_profiles() override;
+
+        // Our raw profiles are the ones that the raw sensor gave us, before we manipulated them
+        stream_profiles const & get_raw_stream_profiles() const override { return _raw_sensor->get_raw_stream_profiles(); }
 
         void open(const stream_profiles& requests) override;
         void close() override;
@@ -409,7 +418,6 @@ namespace librealsense
         };
 
         std::shared_ptr<platform::uvc_device> _device;
-        std::vector< platform::stream_profile > _uvc_profiles;
         std::vector< platform::stream_profile > _internal_config;
         std::atomic<int> _user_count;
         std::mutex _power_lock;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -95,6 +95,10 @@ namespace librealsense
         void assign_stream(const std::shared_ptr<stream_interface>& stream,
                            std::shared_ptr<stream_profile_interface> target) const;
 
+        bool should_use_basic_formats() const;
+
+        void sort_profiles( stream_profiles & );
+
         std::shared_ptr<frame> generate_frame_from_data(const platform::frame_object& fo,
             frame_timestamp_reader* timestamp_reader,
             const rs2_time_t& last_timestamp,
@@ -239,11 +243,8 @@ namespace librealsense
         bool is_opened() const override;
 
     private:
-        void sort_profiles(stream_profiles * profiles);
         void register_processing_block_options(const processing_block& pb);
         void unregister_processing_block_options(const processing_block& pb);
-
-        bool should_use_basic_formats() const;
 
         std::mutex _synthetic_configure_lock;
 

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -93,7 +93,7 @@ namespace librealsense
         return md_parser_map;
     }
 
-    software_sensor::software_sensor(std::string name, software_device* owner)
+    software_sensor::software_sensor( std::string const & name, software_device * owner )
         : sensor_base( name, owner, &_pbs )
         , _stereo_extension( [this]() { return stereo_extension( this ); } )
         , _depth_extension( [this]() { return depth_extension( this ); } )
@@ -130,7 +130,7 @@ namespace librealsense
         profile->set_unique_id(video_stream.uid);
         profile->set_intrinsics([=]() {return video_stream.intrinsics; });
         if (is_default) profile->tag_profile(profile_tag::PROFILE_TAG_DEFAULT);
-        _profiles.push_back(profile);
+        _sw_profiles.push_back(profile);
 
         return profile;
     }
@@ -146,7 +146,7 @@ namespace librealsense
         profile->set_unique_id(motion_stream.uid);
         profile->set_intrinsics([=]() {return motion_stream.intrinsics; });
         if (is_default) profile->tag_profile(profile_tag::PROFILE_TAG_DEFAULT);
-        _profiles.push_back(profile);
+        _sw_profiles.push_back(profile);
 
         return std::move(profile);
     }
@@ -164,7 +164,7 @@ namespace librealsense
         profile->set_stream_type(pose_stream.type);
         profile->set_unique_id(pose_stream.uid);
         if (is_default) profile->tag_profile(profile_tag::PROFILE_TAG_DEFAULT);
-        _profiles.push_back(profile);
+        _sw_profiles.push_back(profile);
 
         return std::move(profile);
     }
@@ -194,7 +194,8 @@ namespace librealsense
 
     stream_profiles software_sensor::init_stream_profiles()
     {
-        return _profiles;
+        // By default the raw profiles we're given is what we output
+        return _sw_profiles;
     }
 
     void software_sensor::open(const stream_profiles& requests)

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -94,7 +94,7 @@ namespace librealsense
     class software_sensor : public sensor_base, public extendable_interface
     {
     public:
-        software_sensor(std::string name, software_device* owner);
+        software_sensor( std::string const & name, software_device * owner );
 
         virtual std::shared_ptr<stream_profile_interface> add_video_stream(rs2_video_stream video_stream, bool is_default = false);
         virtual std::shared_ptr<stream_profile_interface> add_motion_stream(rs2_motion_stream motion_stream, bool is_default = false);
@@ -103,6 +103,7 @@ namespace librealsense
         bool extend_to(rs2_extension extension_type, void** ptr) override;
 
         stream_profiles init_stream_profiles() override;
+        stream_profiles const & get_raw_stream_profiles() const override { return _sw_profiles; }
 
         void open(const stream_profiles& requests) override;
         void close() override;
@@ -134,7 +135,9 @@ namespace librealsense
 
         software_recommended_proccesing_blocks & get_software_recommended_proccesing_blocks() { return _pbs; }
 
-        stream_profiles _profiles;
+        // We build profiles using add_video_stream(), etc., and feed those into init_stream_profiles() which could in
+        // theory change them: so these are our "raw" profiles before initialization...
+        stream_profiles _sw_profiles;
 
     private:
         friend class software_device;

--- a/third-party/realdds/scripts/devices.py
+++ b/third-party/realdds/scripts/devices.py
@@ -4,7 +4,7 @@
 from argparse import ArgumentParser
 args = ArgumentParser()
 args.add_argument( '--debug', action='store_true', help='enable debug mode' )
-args.add_argument( '--quiet', action='store_true', help='No output; just the minimum FPS as a number' )
+args.add_argument( '--quiet', action='store_true', help='no output' )
 def time_arg(x):
     t = int(x)
     if t <= 0:
@@ -13,7 +13,7 @@ def time_arg(x):
 args.add_argument( '--time', metavar='<seconds>', type=time_arg, default=2, help='seconds to gather devices for (default 2)' )
 def domain_arg(x):
     t = int(x)
-    if t <= 0:
+    if t <= 0 or t > 232:
         raise ValueError( f'--domain should be [0,232]' )
     return t
 args.add_argument( '--domain', metavar='<0-232>', type=domain_arg, default=0, help='DDS domain to use (default=0)' )
@@ -36,7 +36,7 @@ import time
 dds.debug( args.debug )
 
 participant = dds.participant()
-participant.init( args.domain, 'dds-devices' )
+participant.init( args.domain, 'devices' )
 
 watcher = dds.device_watcher( participant )
 watcher.start()
@@ -47,6 +47,7 @@ time.sleep( args.time )
 def device_found( device ):
     di = device.device_info()
     print( di.topic_root )
+    return True  # keep going
 watcher.foreach_device( device_found )
 
 

--- a/third-party/realdds/scripts/devices.py
+++ b/third-party/realdds/scripts/devices.py
@@ -1,0 +1,52 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+from argparse import ArgumentParser
+args = ArgumentParser()
+args.add_argument( '--debug', action='store_true', help='enable debug mode' )
+args.add_argument( '--quiet', action='store_true', help='No output; just the minimum FPS as a number' )
+def time_arg(x):
+    t = int(x)
+    if t <= 0:
+        raise ValueError( f'--time should be a positive integer' )
+    return t
+args.add_argument( '--time', metavar='<seconds>', type=time_arg, default=2, help='seconds to gather devices for (default 2)' )
+def domain_arg(x):
+    t = int(x)
+    if t <= 0:
+        raise ValueError( f'--domain should be [0,232]' )
+    return t
+args.add_argument( '--domain', metavar='<0-232>', type=domain_arg, default=0, help='DDS domain to use (default=0)' )
+args = args.parse_args()
+
+
+if args.quiet:
+    def i( *a, **kw ):
+        pass
+else:
+    def i( *a, **kw ):
+        print( '-I-', *a, **kw )
+def e( *a, **kw ):
+    print( '-E-', *a, **kw )
+
+
+import pyrealdds as dds
+import time
+
+dds.debug( args.debug )
+
+participant = dds.participant()
+participant.init( args.domain, 'dds-devices' )
+
+watcher = dds.device_watcher( participant )
+watcher.start()
+
+i( 'Waiting for devices...' )
+time.sleep( args.time )
+
+def device_found( device ):
+    di = device.device_info()
+    print( di.topic_root )
+watcher.foreach_device( device_found )
+
+

--- a/third-party/realdds/scripts/fps.py
+++ b/third-party/realdds/scripts/fps.py
@@ -1,0 +1,126 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+from argparse import ArgumentParser
+args = ArgumentParser()
+args.add_argument( '--debug', action='store_true', help='enable debug mode' )
+args.add_argument( '--quiet', action='store_true', help='No output; just the minimum FPS as a number' )
+args.add_argument( '--device', metavar='<path>', required=True, help='the topic root for the device' )
+def time_arg(x):
+    t = int(x)
+    if t <= 0:
+        raise ValueError( f'--time should be a positive integer' )
+    return t
+args.add_argument( '--time', metavar='<seconds>', type=time_arg, default=5, help='how long to gather frames for (default=5)' )
+def domain_arg(x):
+    t = int(x)
+    if t <= 0:
+        raise ValueError( f'--domain should be [0,232]' )
+    return t
+args.add_argument( '--domain', metavar='<0-232>', type=domain_arg, default=0, help='DDS domain to use (default=0)' )
+args.add_argument( '--with-metadata', action='store_true', help='stream with metadata, if available (default off)' )
+args = args.parse_args()
+
+
+if args.quiet:
+    def i( *a, **kw ):
+        pass
+else:
+    def i( *a, **kw ):
+        print( '-I-', *a, **kw )
+def e( *a, **kw ):
+    print( '-E-', *a, **kw )
+
+
+import pyrealdds as dds
+import time
+import sys
+
+dds.debug( args.debug )
+
+settings = {}
+if not args.with_metadata:
+    settings['disable-metadata'] = True
+
+participant = dds.participant()
+participant.init( args.domain, 'print-fps', settings )
+
+# Most important is the topic-root: this assumes we know it in advance and do not have to
+# wait for a device-info message (which would complicate the code here).
+info = dds.message.device_info()
+info.name = 'Dummy Device'
+info.topic_root = args.device
+
+# Create the device and initialize
+# The server must be up and running, or the init will time out!
+device = dds.device( participant, participant.create_guid(), info )
+try:
+    i( 'Looking for device at', info.topic_root, '...' )
+    device.wait_until_ready()  # If unavailable before timeout, this throws
+except:
+    e( 'Cannot find device' )
+    sys.exit(1)
+
+n_depth = 0
+def on_depth_image( stream, image ):
+    #d( f'----> depth {image}')
+    global n_depth
+    n_depth += 1
+
+n_color = 0
+def on_color_image( stream, image ):
+    #d( f'----> color {image}')
+    global n_color
+    n_color += 1
+
+i( device.n_streams(), 'streams available' )
+depth_stream = None
+color_stream = None
+for stream in device.streams():
+    profiles = stream.profiles()
+    i( '   ', stream.sensor_name(), '/', stream.default_profile().to_string()[1:-1] )
+    if stream.type_string() == 'depth':
+        depth_stream = stream
+        stream.on_data_available( on_depth_image )
+    elif stream.type_string() == 'color':
+        color_stream = stream
+        stream.on_data_available( on_color_image )
+    else:
+        continue
+
+    stream_topic = 'rt/' + info.topic_root + '_' + stream.name()
+    stream.open( stream_topic, dds.subscriber( participant ) )
+    stream.start_streaming()
+
+# Wait until we have at least one frame from each
+tries = 3
+while tries > 0:
+    if n_depth > 0  and  n_color > 0:
+        break
+    time.sleep( 1 )
+else:
+    raise RuntimeError( 'timed out waiting for frames to arrive' )
+n_depth = n_color = 0
+time_started = time.time()
+i( 'Starting                       :', time_started )
+
+# Measure number of frames in a period of time
+time.sleep( args.time )
+
+result_depth = n_depth
+result_color = n_color
+time_stopped = time.time()
+i( 'Stopping                       :', time_stopped )
+depth_stream.stop_streaming()
+color_stream.stop_streaming()
+depth_stream.close()
+color_stream.close()
+
+time_delta = time_stopped - time_started
+i( 'Elapsed                        :', time_delta )
+i( 'Number of Depth frames received:', result_depth, '=', result_depth / time_delta, 'fps' )
+i( 'Number of Color frames received:', result_color, '=', result_color / time_delta, 'fps' )
+
+if args.quiet:
+    print( min( result_color, result_depth ) / time_delta )
+

--- a/third-party/realdds/scripts/fps.py
+++ b/third-party/realdds/scripts/fps.py
@@ -14,7 +14,7 @@ def time_arg(x):
 args.add_argument( '--time', metavar='<seconds>', type=time_arg, default=5, help='how long to gather frames for (default=5)' )
 def domain_arg(x):
     t = int(x)
-    if t <= 0:
+    if t <= 0 or t > 232:
         raise ValueError( f'--domain should be [0,232]' )
     return t
 args.add_argument( '--domain', metavar='<0-232>', type=domain_arg, default=0, help='DDS domain to use (default=0)' )
@@ -43,7 +43,7 @@ if not args.with_metadata:
     settings['disable-metadata'] = True
 
 participant = dds.participant()
-participant.init( args.domain, 'print-fps', settings )
+participant.init( args.domain, 'fps', settings )
 
 # Most important is the topic-root: this assumes we know it in advance and do not have to
 # wait for a device-info message (which would complicate the code here).

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -202,6 +202,8 @@ std::vector< std::shared_ptr< realdds::dds_stream_server > > lrs_device_controll
         auto default_profile_it = stream_name_to_default_profile.find( stream_name );
         if( default_profile_it != stream_name_to_default_profile.end() )
             default_profile_index = default_profile_it->second;
+        else
+            LOG_ERROR( "no default profile found; using first available in " << stream_name );
 
         auto const & profiles = it.second;
         if( profiles.empty() )
@@ -751,6 +753,7 @@ void lrs_device_controller::override_default_profiles( const std::map< std::stri
     std::string const product_line = _rs_dev.get_info( RS2_CAMERA_INFO_PRODUCT_LINE );
     if( product_line == "D400" )
     {
+        static const std::string RS405_PID( "0B5B", 4 );
         static const std::string RS410_PID( "0AD2", 4 );
         static const std::string RS415_PID( "0AD3", 4 );
 
@@ -774,6 +777,11 @@ void lrs_device_controller::override_default_profiles( const std::map< std::stri
 
         width = 1280;
         height = 720;
+        if( product_id == RS405_PID )
+        {
+            width = 848;
+            height = 480;
+        }
         stream_name_to_default_profile["Color"] = get_index_of_profile( stream_name_to_profiles.at( "Color" ),
             realdds::dds_video_stream_profile( fps, realdds::dds_video_encoding::from_rs2( RS2_FORMAT_YUYV ), width, height ) );
     }

--- a/tools/dds/dds-adapter/rs-dds-adapter.cpp
+++ b/tools/dds/dds-adapter/rs-dds-adapter.cpp
@@ -121,8 +121,8 @@ try
 
     // Create a RealSense context
     nlohmann::json j = {
-        { "dds",               false }, // Don't discover DDS devices from the network, we want local devices only 
-        { "use-basic-formats", true  }  // Don't convert raw sensor formats (except interleaved) will be done by receiver
+        { "dds",               false   }, // Don't discover DDS devices from the network, we want local devices only 
+        { "format-conversion", "basic" }  // Don't convert raw sensor formats (except interleaved) will be done by receiver
     };
     rs2::context ctx( j.dump() );
 

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -185,6 +185,111 @@ string get_str_formats(const set<rs2_format>& formats)
     return ss.str();
 }
 
+void output_modes( std::vector< stream_profile > const & profiles, bool verbose, bool show_defaults )
+{
+    size_t const w_res = 15;
+    size_t const w_format = 15;
+
+    size_t w_stream = 10;
+    bool video_stream = false;
+    for( auto const & profile : profiles )
+    {
+        w_stream = std::max( profile.stream_name().length(), w_stream );
+        if( auto video = profile.as< video_stream_profile >() )
+            video_stream = true;
+    }
+    w_stream += 2;
+
+    // Heading
+    if( verbose )
+        cout << "   (UID.IDX)  ";
+    else
+        cout << "    ";
+    cout << setw( w_stream ) << "STREAM";
+    if( video_stream )
+        cout << setw( w_res ) << "RESOLUTION";
+    cout << setw( w_format ) << "FORMAT";
+    cout << "FPS";
+    cout << endl;
+    // Show which streams are supported by this device
+    if( verbose )
+    {
+        for( auto const & profile : profiles )
+        {
+            cout << ( show_defaults && profile.is_default() ? " +  " : "    " );
+            cout << " (" << profile.unique_id() << '.' << profile.stream_index() << ")    ";
+            cout << setw( w_stream ) << profile.stream_name();
+            if( auto video = profile.as< video_stream_profile >() )
+            {
+                cout << setw( w_res ) << ( std::to_string( video.width() ) + 'x' + std::to_string( video.height() ) );
+            }
+            cout << setw( w_format ) << profile.format();
+            cout << "@ " << profile.fps() << " Hz";
+            cout << endl;
+        }
+    }
+    else
+    {
+        std::ostringstream ss;
+        int p_width = 0, p_height = 0, pp_w = 0, pp_h = 0;
+        rs2_format p_format = RS2_FORMAT_ANY;
+        std::string p_stream_name;
+        bool p_default = false;
+        auto print_last_stream = [&]()
+        {
+            cout << ( p_default ? " +  " : "    " );
+            p_default = false;
+            cout << setw( w_stream ) << p_stream_name;
+            if( p_width || p_height )
+            {
+                cout << setw( w_res );
+                if( p_width == pp_w && p_height == pp_h )
+                    cout << "   |";
+                else
+                {
+                    cout << (std::to_string( p_width ) + 'x' + std::to_string( p_height ));
+                    pp_w = p_width;
+                    pp_h = p_height;
+                }
+            }
+            cout << setw( w_format ) << p_format;
+            cout << "@ " << ss.str() << " Hz";
+            cout << endl;
+        };
+        for( auto && profile : profiles )
+        {
+            std::string stream_name = profile.stream_name();
+            int w = 0, h = 0;
+            if( auto video = profile.as< video_stream_profile >() )
+            {
+                w = video.width();
+                h = video.height();
+            }
+            if( stream_name != p_stream_name || profile.format() != p_format || w != p_width || h != p_height )
+            {
+                if( ! ss.str().empty() )
+                {
+                    print_last_stream();
+                    ss.str( std::string() );
+                }
+                p_stream_name = stream_name;
+                p_format = profile.format();
+                p_width = w;
+                p_height = h;
+            }
+            else
+            {
+                ss << '/';
+            }
+            if( profile.is_default() && show_defaults )
+                ss << "+", p_default = true;
+            ss << profile.fps();
+        }
+        print_last_stream();
+    }
+}
+
+
 int main(int argc, char** argv) try
 {
     CmdLine cmd("librealsense rs-enumerate-devices tool", ' ', RS2_API_VERSION_STR);
@@ -403,105 +508,24 @@ int main(int argc, char** argv) try
 
         if (show_modes)
         {
-            size_t w_res = 12;
-            size_t w_format = 10;
-
             for( auto&& sensor : dev.query_sensors() )
             {
                 cout << "Stream Profiles supported by " << sensor.get_info( RS2_CAMERA_INFO_NAME ) << endl;
+                
                 cout << " Supported modes:\n";
-
-                size_t w_stream = 10;
-                bool video_stream = false;
-                for( auto const & profile : sensor.get_stream_profiles() )
-                {
-                    w_stream = std::max( profile.stream_name().length(), w_stream );
-                    if( auto video = profile.as<video_stream_profile>() )
-                        video_stream = true;
-                }
-                w_stream += 2;
-
-                // Heading
-                if( verbose )
-                    cout << "   (UID.IDX)  ";
-                else
-                    cout << "    ";
-                cout << setw( w_stream ) << "STREAM";
-                if( video_stream )
-                    cout << setw( w_res ) << "RESOLUTION";
-                cout << setw( w_format ) << "FORMAT";
-                cout << "FPS";
+                output_modes( sensor.get_stream_profiles(), verbose, show_defaults.getValue() );
                 cout << endl;
-                // Show which streams are supported by this device
-                if( verbose )
+
+                if( auto ds = debug_stream_sensor( sensor ) )
                 {
-                    for( auto const & profile : sensor.get_stream_profiles() )
+                    auto debug_profiles = ds.get_debug_stream_profiles();
+                    if( !debug_profiles.empty() )
                     {
-                        cout << ( show_defaults.getValue() && profile.is_default() ? " +  " : "    " );
-                        cout << " (" << profile.unique_id() << '.' << profile.stream_index() << ")    ";
-                        cout << setw( w_stream ) << profile.stream_name();
-                        if( auto video = profile.as< video_stream_profile >() )
-                        {
-                            cout << setw( w_res )
-                                 << ( std::to_string( video.width() ) + 'x' + std::to_string( video.height() ) );
-                        }
-                        cout << setw( w_format ) << profile.format();
-                        cout << "@ " << profile.fps() << " Hz";
+                        cout << " Supported debug modes:\n";
+                        output_modes( debug_profiles, verbose, show_defaults.getValue() );
                         cout << endl;
                     }
                 }
-                else
-                {
-                    std::ostringstream ss;
-                    int p_width = 0, p_height = 0;
-                    rs2_format p_format = RS2_FORMAT_ANY;
-                    std::string p_stream_name;
-                    bool p_default = false;
-                    auto print_last_stream = [&]()
-                    {
-                        cout << ( p_default ? " +  " : "    " );
-                        p_default = false;
-                        cout << setw( w_stream ) << p_stream_name;
-                        if( p_width || p_height )
-                            cout << setw( w_res ) << (std::to_string( p_width ) + 'x' + std::to_string( p_height ));
-                        cout << setw( w_format ) << p_format;
-                        cout << "@ " << ss.str() << " Hz";
-                        cout << endl;
-                    };
-                    for( auto && profile : sensor.get_stream_profiles() )
-                    {
-                        std::string stream_name = profile.stream_name();
-                        int w = 0, h = 0;
-                        if( auto video = profile.as< video_stream_profile >() )
-                        {
-                            w = video.width();
-                            h = video.height();
-                        }
-                        if( stream_name != p_stream_name || profile.format() != p_format || w != p_width
-                            || h != p_height )
-                        {
-                            if( ! ss.str().empty() )
-                            {
-                                print_last_stream();
-                                ss.str( std::string() );
-                            }
-                            p_stream_name = stream_name;
-                            p_format = profile.format();
-                            p_width = w;
-                            p_height = h;
-                        }
-                        else
-                        {
-                            ss << '/';
-                        }
-                        if( profile.is_default() && show_defaults.getValue() )
-                            ss << "+", p_default = true;
-                        ss << profile.fps();
-                    }
-                    print_last_stream();
-                }
-
-                cout << endl;
             }
         }
 

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -221,7 +221,9 @@ void output_modes( std::vector< stream_profile > const & profiles, bool verbose,
             cout << setw( w_stream ) << profile.stream_name();
             if( auto video = profile.as< video_stream_profile >() )
             {
-                cout << setw( w_res ) << ( std::to_string( video.width() ) + 'x' + std::to_string( video.height() ) );
+                cout << setw( 4 ) << right << video.width();
+                cout << 'x';
+                cout << setw( w_res - 5 ) << left << video.height();
             }
             cout << setw( w_format ) << profile.format();
             cout << "@ " << profile.fps() << " Hz";
@@ -244,10 +246,12 @@ void output_modes( std::vector< stream_profile > const & profiles, bool verbose,
             {
                 cout << setw( w_res );
                 if( p_width == pp_w && p_height == pp_h )
-                    cout << "   |";
+                    cout << "    |";
                 else
                 {
-                    cout << (std::to_string( p_width ) + 'x' + std::to_string( p_height ));
+                    cout << setw( 4 ) << right << p_width;
+                    cout << 'x';
+                    cout << setw( w_res - 5 ) << left << p_height;
                     pp_w = p_width;
                     pp_h = p_height;
                 }

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -188,21 +188,23 @@ string get_str_formats(const set<rs2_format>& formats)
 void output_modes( std::vector< stream_profile > const & profiles, bool verbose, bool show_defaults )
 {
     size_t const w_res = 15;
-    size_t const w_format = 15;
-
+    
+    size_t w_format = 10;
     size_t w_stream = 10;
     bool video_stream = false;
     for( auto const & profile : profiles )
     {
         w_stream = std::max( profile.stream_name().length(), w_stream );
+        w_format = std::max( strlen( rs2_format_to_string( profile.format() ) ), w_format );
         if( auto video = profile.as< video_stream_profile >() )
             video_stream = true;
     }
     w_stream += 2;
+    w_format += 2;
 
     // Heading
     if( verbose )
-        cout << "   (UID.IDX)  ";
+        cout << "    (UID.IDX) ";
     else
         cout << "    ";
     cout << setw( w_stream ) << "STREAM";
@@ -217,7 +219,9 @@ void output_modes( std::vector< stream_profile > const & profiles, bool verbose,
         for( auto const & profile : profiles )
         {
             cout << ( show_defaults && profile.is_default() ? " +  " : "    " );
-            cout << " (" << profile.unique_id() << '.' << profile.stream_index() << ")    ";
+            cout << setw( 4 ) << right << ( " (" + std::to_string( profile.unique_id() ) );
+            cout << '.';
+            cout << setw( 5 ) << left << ( std::to_string( profile.stream_index() ) + ')' );
             cout << setw( w_stream ) << profile.stream_name();
             if( auto video = profile.as< video_stream_profile >() )
             {

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -49,7 +49,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         if test.check( sensor ):
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'RGB Camera' )
-            test.check_equal( len(sensor.get_stream_profiles()), 64 ) # As measured running rs-sensor-control example
+            test.check_equal( len(sensor.get_stream_profiles()), 160 ) # As measured running rs-sensor-control example
         sensor = dev.first_motion_sensor()
         if test.check( sensor ):
             test.check( sensors[sensor.name] )
@@ -79,7 +79,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         if test.check( sensor ):
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'Stereo Module' )
-            test.check_equal( len(sensor.get_stream_profiles()), 146 ) # As measured running rs-sensor-control example
+            test.check_equal( len(sensor.get_stream_profiles()), 230 ) # As measured running rs-sensor-control example
         remote.run( 'close_server( instance )' )
     except:
         test.unexpected_exception()
@@ -109,7 +109,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         if test.check( sensor ):
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'RGB Camera' )
-            test.check_equal( len(sensor.get_stream_profiles()), 62 ) # As measured running rs-sensor-control example
+            test.check_equal( len(sensor.get_stream_profiles()), 155 ) # As measured running rs-sensor-control example
         sensor = dev.first_motion_sensor()
         if test.check( sensor ):
             test.check( sensors[sensor.name] )

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -48,9 +48,12 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             sensor = sensors.get('YUYV-sensor')
             profiles = sensor.get_stream_profiles()
 
-            test.check_equal( len( profiles ), 2 ) # YUYV can stay YUYV or be converted into RGB8
-            test.check_equal( profiles[0].format(), rs.format.yuyv )
-            test.check_equal( profiles[1].format(), rs.format.rgb8 )
+            test.check_equal( len( profiles ), 5 ) # YUYV -> YUYV/RGB8/RGBA8/BGR8/BGRA8
+            test.check_equal( profiles[0].format(), rs.format.rgb8 )
+            test.check_equal( profiles[1].format(), rs.format.bgra8 )
+            test.check_equal( profiles[2].format(), rs.format.rgba8 )
+            test.check_equal( profiles[3].format(), rs.format.bgr8 )
+            test.check_equal( profiles[4].format(), rs.format.yuyv )
     #
     #############################################################################################
     #
@@ -59,9 +62,13 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             sensor = sensors.get('UYVY-sensor')
             profiles = sensor.get_stream_profiles()
 
-            test.check_equal( len( profiles ), 2 ) # UYVY can stay UYVY or be converted into RGB8
-            test.check_equal( profiles[0].format(), rs.format.uyvy )
-            test.check_equal( profiles[1].format(), rs.format.rgb8 )
+            test.check_equal( len( profiles ), 6 ) # UYVY -> UYVY/YUYV/RGB8/RGBA8/BGR8/BGRA8
+            test.check_equal( profiles[0].format(), rs.format.rgb8 )
+            test.check_equal( profiles[1].format(), rs.format.uyvy )
+            test.check_equal( profiles[2].format(), rs.format.bgra8 )
+            test.check_equal( profiles[3].format(), rs.format.rgba8 )
+            test.check_equal( profiles[4].format(), rs.format.bgr8 )
+            test.check_equal( profiles[5].format(), rs.format.yuyv )
     #
     #############################################################################################
     #
@@ -102,10 +109,24 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             sensor = sensors.get('multiple-color-sensor')
             profiles = sensor.get_stream_profiles()
 
-            test.check_equal( len( profiles ), 6 )
-            for i in range(3):
-                test.check_equal( profiles[i * 2 + 0].format(), rs.format.yuyv )
-                test.check_equal( profiles[i * 2 + 1].format(), rs.format.rgb8 )
+            # Streams are sorted by format then fps:
+            #     RGB8 @ 30/15/5 Hz
+            #     BGRA8 @ 30/15/5 Hz
+            #     RGBA8 @ 30/15/5 Hz
+            #     BGR8 @ 30/15/5 Hz
+            #     YUYV @ 30/15/5 Hz
+            test.check_equal( len( profiles ), 15 )
+            for i,f in zip( range(3), (30,15,5) ):
+                test.check_equal( profiles[0 + i].format(), rs.format.rgb8 )
+                test.check_equal( profiles[0 + i].fps(), f )
+                test.check_equal( profiles[3 + i].format(), rs.format.bgra8 )
+                test.check_equal( profiles[3 + i].fps(), f )
+                test.check_equal( profiles[6 + i].format(), rs.format.rgba8 )
+                test.check_equal( profiles[6 + i].fps(), f )
+                test.check_equal( profiles[9 + i].format(), rs.format.bgr8 )
+                test.check_equal( profiles[9 + i].fps(), f )
+                test.check_equal( profiles[12 + i].format(), rs.format.yuyv )
+                test.check_equal( profiles[12 + i].fps(), f )
     #
     #############################################################################################
     #

--- a/unit-tests/py/rspy/log.py
+++ b/unit-tests/py/rspy/log.py
@@ -39,11 +39,22 @@ def _stream_has_color( stream ):
         # guess false in case of error
         return False
 
+
+def find_flag( arg ):
+    for x in range( 1, len(sys.argv) ):
+        a = sys.argv[x]
+        if a == arg:
+            return x
+        if a == '--':
+            break
+    return None
+
+
 _have_no_color = False
-if '--color' in sys.argv:
+if find_flag( '--color' ):
     sys.argv.remove( '--color' )
     _have_color = True
-elif '--no-color' in sys.argv:
+elif find_flag( '--no-color' ):
     sys.argv.remove( '--no-color' )
     _have_color = False
     _have_no_color = True
@@ -146,7 +157,7 @@ def debug_on():
 def is_debug_on():
     global _debug_on
     return _debug_on
-if '--debug' in sys.argv:
+if find_flag( '--debug' ):
     sys.argv.remove( '--debug' )
     debug_on()
 def debug_indent( n = 1, indentation = '    ' ):


### PR DESCRIPTION
* refactored some stuff in `sensor_base` and split off `raw_sensor_base`
* `_profiles` now only in `sensor_base`; software_device uses `_sw_profiles` and no more `_raw_rs_profiles`
* added `sensor_interface::get_raw_stream_profiles()`
* DDS color profiles were previously using only `RGB8`; now all the permutations supported by LibRS
* DDS profiles are now sorted, same as elsewhere
* profiles can now be `raw`, `basic`, or `full` (`use-basic-formats` -> `format-conversion`)
* `rs-enumerate-devices` output now aggregates all FPS lines together, so more readable
* fix non-basic format removal for DDS IR
* adjust dds-adapter default Color res for D405 to 848x480
* add realdds/scripts/devices.py and fps.py

Tracked on [LRS-848]
