### PR TITLE
Fix get_intrinsics for unrectified image

### DIFF
--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -272,7 +272,10 @@ void formats_converter::update_target_profiles_data( const stream_profiles & fro
             raw_profile->set_stream_type( from_profile->get_stream_type() );
             auto video_raw_profile = As< video_stream_profile, stream_profile_interface >( raw_profile );
             const auto video_from_profile = As< video_stream_profile, stream_profile_interface >( from_profile );
-            if( video_raw_profile )
+            // from_profile intrinsics is expected to be set by the device, otherwise a cycle of calls is created
+            // (clone_profile intrinsics function calling raw_profile function here that calls it back).
+            // Y12I indicate unrectified images, no intrinsics are available for these. Not set be the device!
+            if( video_raw_profile && video_raw_profile->get_format() != RS2_FORMAT_Y12I )
             {
                 video_raw_profile->set_intrinsics( [video_from_profile]()
                 {

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -274,8 +274,8 @@ void formats_converter::update_target_profiles_data( const stream_profiles & fro
             const auto video_from_profile = As< video_stream_profile, stream_profile_interface >( from_profile );
             // from_profile intrinsics is expected to be set by the device, otherwise a cycle of calls is created
             // (clone_profile intrinsics function calling raw_profile function here that calls it back).
-            // Y12I indicate unrectified images, no intrinsics are available for these. Not set be the device!
-            if( video_raw_profile && video_raw_profile->get_format() != RS2_FORMAT_Y12I )
+            // Y16 indicate unrectified images, no intrinsics are available for these. Not set be the device!
+            if( video_raw_profile && video_from_profile->get_format() != RS2_FORMAT_Y16 )
             {
                 video_raw_profile->set_intrinsics( [video_from_profile]()
                 {


### PR DESCRIPTION
Should throw `not_implement_exception` but we get stack overflow.
Problem was a cycle of calls between cloned profile intrinsics function and raw profile intrinsics function.
We are counting on the device to set the cloned profile function and break the cycle, but the device does not set for unrectified image.

Fixes RealCI issue and also RSDEV-424