### PR TITLE
Remove recordable<> from many interfaces

### DIFF
--- a/include/librealsense2/rs_advanced_mode.h
+++ b/include/librealsense2/rs_advanced_mode.h
@@ -4,10 +4,7 @@
 #ifndef RS400_ADVANCED_MODE_H
 #define RS400_ADVANCED_MODE_H
 
-#define RS400_ADVANCED_MODE_HPP
 #include "h/rs_advanced_mode_command.h"
-#undef RS400_ADVANCED_MODE_HPP
-
 #include "h/rs_types.h"
 
 #ifdef __cplusplus

--- a/src/color-sensor.h
+++ b/src/color-sensor.h
@@ -6,35 +6,15 @@
 #include "core/extension.h"
 
 namespace librealsense {
-class color_sensor : public recordable< color_sensor >
+
+
+class color_sensor
 {
 public:
     virtual ~color_sensor() = default;
-
-    void create_snapshot( std::shared_ptr< color_sensor > & snapshot ) const override;
-    void
-    enable_recording( std::function< void( const color_sensor & ) > recording_function ) override{};
 };
 
 MAP_EXTENSION( RS2_EXTENSION_COLOR_SENSOR, librealsense::color_sensor );
 
-class color_sensor_snapshot
-    : public virtual color_sensor
-    , public extension_snapshot
-{
-public:
-    color_sensor_snapshot() {}
 
-    void update( std::shared_ptr< extension_snapshot > ext ) override {}
-
-    void create_snapshot( std::shared_ptr< color_sensor > & snapshot ) const override
-    {
-        snapshot = std::make_shared< color_sensor_snapshot >( *this );
-    }
-    void
-    enable_recording( std::function< void( const color_sensor & ) > recording_function ) override
-    {
-        // empty
-    }
-};
 }  // namespace librealsense

--- a/src/composite-frame.h
+++ b/src/composite-frame.h
@@ -48,7 +48,7 @@ public:
         return first()->supports_frame_metadata( frame_metadata );
     }
     int get_frame_data_size() const override { return first()->get_frame_data_size(); }
-    const byte * get_frame_data() const override { return first()->get_frame_data(); }
+    const uint8_t * get_frame_data() const override { return first()->get_frame_data(); }
     rs2_time_t get_frame_timestamp() const override { return first()->get_frame_timestamp(); }
     rs2_timestamp_domain get_frame_timestamp_domain() const override
     {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/streaming.h"
         "${CMAKE_CURRENT_LIST_DIR}/debug.h"
         "${CMAKE_CURRENT_LIST_DIR}/advanced_mode.h"
+        "${CMAKE_CURRENT_LIST_DIR}/enum-helpers.h"
         "${CMAKE_CURRENT_LIST_DIR}/depth-frame.h"
         "${CMAKE_CURRENT_LIST_DIR}/disparity-frame.h"
         "${CMAKE_CURRENT_LIST_DIR}/frame-continuation.h"

--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -6,13 +6,10 @@
 #include "hw-monitor.h"
 #include "streaming.h"
 #include "option.h"
-#define RS400_ADVANCED_MODE_HPP
 #include "ds/advanced_mode/presets.h"
 #include "../../include/librealsense2/h/rs_advanced_mode_command.h"
 #include "serializable-interface.h"
 #include <rsutils/lazy.h>
-
-#undef RS400_ADVANCED_MODE_HPP
 
 
 typedef enum
@@ -56,7 +53,7 @@ namespace librealsense
     MAP_ADVANCED_MODE(STAFactor, etAFactor);
 
 
-    class ds_advanced_mode_interface : public serializable_interface, public recordable<ds_advanced_mode_interface>
+    class ds_advanced_mode_interface : public serializable_interface
     {
     public:
         virtual bool is_enabled() const = 0;
@@ -107,9 +104,6 @@ namespace librealsense
     public:
         explicit ds_advanced_mode_base(std::shared_ptr<hw_monitor> hwm,
             synthetic_sensor& depth_sensor);
-
-        void create_snapshot(std::shared_ptr<ds_advanced_mode_interface>& snapshot) const override {};
-        void enable_recording(std::function<void(const ds_advanced_mode_interface&)> recording_function) override {};
 
         virtual ~ds_advanced_mode_base() = default;
 

--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -8,7 +8,7 @@
 
 namespace librealsense
 {
-    class debug_interface : public recordable<debug_interface>
+    class debug_interface
     {
     public:
         virtual std::vector<uint8_t> send_receive_raw_data(const std::vector<uint8_t>& input) = 0;
@@ -19,21 +19,7 @@ namespace librealsense
             uint32_t param4 = 0,
             uint8_t const * data = nullptr,
             size_t dataLength = 0) const = 0;
-
     };
 
     MAP_EXTENSION(RS2_EXTENSION_DEBUG, librealsense::debug_interface);
-
-    class debug_snapshot : public extension_snapshot, public debug_interface
-    {
-    public:
-        debug_snapshot(const std::vector<uint8_t>& input) : m_data(input)
-        {
-        }
-
-    private:
-        std::vector<uint8_t> m_data;
-    };
-
-
 }

--- a/src/core/debug.h
+++ b/src/core/debug.h
@@ -2,7 +2,6 @@
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
 #pragma once
 
-#include "streaming.h"
 #include "extension.h"
 #include <vector>
 

--- a/src/core/enum-helpers.h
+++ b/src/core/enum-helpers.h
@@ -37,10 +37,15 @@ namespace librealsense {
         return false;                                                                                                  \
     }
 
+// For rs2_option, these make use of the registry
+LRS_EXTENSION_API std::string const & get_string( rs2_option value );
+bool is_valid( rs2_option value );
+std::ostream & operator<<( std::ostream & out, rs2_option option );
+bool try_parse( const std::string & option_name, rs2_option & result );
+
 RS2_ENUM_HELPERS( rs2_stream, STREAM )
 RS2_ENUM_HELPERS( rs2_format, FORMAT )
 RS2_ENUM_HELPERS( rs2_distortion, DISTORTION )
-RS2_ENUM_HELPERS( rs2_option, OPTION )
 RS2_ENUM_HELPERS( rs2_camera_info, CAMERA_INFO )
 RS2_ENUM_HELPERS_CUSTOMIZED( rs2_frame_metadata_value, 0, RS2_FRAME_METADATA_COUNT - 1, std::string const & )
 RS2_ENUM_HELPERS( rs2_timestamp_domain, TIMESTAMP_DOMAIN )

--- a/src/core/enum-helpers.h
+++ b/src/core/enum-helpers.h
@@ -1,0 +1,72 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <librealsense2/hpp/rs_types.hpp>
+
+
+namespace librealsense {
+
+
+// Require the last enumerator value to be in format of RS2_#####_COUNT
+#define RS2_ENUM_HELPERS( TYPE, PREFIX ) RS2_ENUM_HELPERS_CUSTOMIZED( TYPE, 0, RS2_##PREFIX##_COUNT - 1, const char * )
+
+// This macro can be used directly if needed to support enumerators with no RS2_#####_COUNT last value
+#define RS2_ENUM_HELPERS_CUSTOMIZED( TYPE, FIRST, LAST, STRTYPE )                                                      \
+    LRS_EXTENSION_API STRTYPE get_string( TYPE value );                                                                \
+    inline bool is_valid( TYPE value ) { return value >= FIRST && value <= LAST; }                                     \
+    inline std::ostream & operator<<( std::ostream & out, TYPE value )                                                 \
+    {                                                                                                                  \
+        if( is_valid( value ) )                                                                                        \
+            return out << get_string( value );                                                                         \
+        else                                                                                                           \
+            return out << (int)value;                                                                                  \
+    }                                                                                                                  \
+    inline bool try_parse( const std::string & str, TYPE & res )                                                       \
+    {                                                                                                                  \
+        for( int i = FIRST; i <= LAST; i++ )                                                                           \
+        {                                                                                                              \
+            auto v = static_cast< TYPE >( i );                                                                         \
+            if( str == get_string( v ) )                                                                               \
+            {                                                                                                          \
+                res = v;                                                                                               \
+                return true;                                                                                           \
+            }                                                                                                          \
+        }                                                                                                              \
+        return false;                                                                                                  \
+    }
+
+RS2_ENUM_HELPERS( rs2_stream, STREAM )
+RS2_ENUM_HELPERS( rs2_format, FORMAT )
+RS2_ENUM_HELPERS( rs2_distortion, DISTORTION )
+RS2_ENUM_HELPERS( rs2_option, OPTION )
+RS2_ENUM_HELPERS( rs2_camera_info, CAMERA_INFO )
+RS2_ENUM_HELPERS_CUSTOMIZED( rs2_frame_metadata_value, 0, RS2_FRAME_METADATA_COUNT - 1, std::string const & )
+RS2_ENUM_HELPERS( rs2_timestamp_domain, TIMESTAMP_DOMAIN )
+RS2_ENUM_HELPERS( rs2_calib_target_type, CALIB_TARGET )
+RS2_ENUM_HELPERS( rs2_sr300_visual_preset, SR300_VISUAL_PRESET )
+RS2_ENUM_HELPERS( rs2_extension, EXTENSION )
+RS2_ENUM_HELPERS( rs2_exception_type, EXCEPTION_TYPE )
+RS2_ENUM_HELPERS( rs2_log_severity, LOG_SEVERITY )
+RS2_ENUM_HELPERS( rs2_notification_category, NOTIFICATION_CATEGORY )
+RS2_ENUM_HELPERS( rs2_playback_status, PLAYBACK_STATUS )
+RS2_ENUM_HELPERS( rs2_matchers, MATCHER )
+RS2_ENUM_HELPERS( rs2_sensor_mode, SENSOR_MODE )
+RS2_ENUM_HELPERS( rs2_l500_visual_preset, L500_VISUAL_PRESET )
+RS2_ENUM_HELPERS( rs2_calibration_type, CALIBRATION_TYPE )
+RS2_ENUM_HELPERS_CUSTOMIZED( rs2_calibration_status,
+                             RS2_CALIBRATION_STATUS_FIRST,
+                             RS2_CALIBRATION_STATUS_LAST,
+                             const char * )
+RS2_ENUM_HELPERS_CUSTOMIZED( rs2_ambient_light,
+                             RS2_AMBIENT_LIGHT_NO_AMBIENT,
+                             RS2_AMBIENT_LIGHT_LOW_AMBIENT,
+                             const char * )
+RS2_ENUM_HELPERS_CUSTOMIZED( rs2_digital_gain, RS2_DIGITAL_GAIN_HIGH, RS2_DIGITAL_GAIN_LOW, const char * )
+RS2_ENUM_HELPERS( rs2_host_perf_mode, HOST_PERF )
+RS2_ENUM_HELPERS( rs2_emitter_frequency_mode, EMITTER_FREQUENCY )
+RS2_ENUM_HELPERS( rs2_depth_auto_exposure_mode, DEPTH_AUTO_EXPOSURE )
+
+
+}  // namespace librealsense

--- a/src/core/motion.h
+++ b/src/core/motion.h
@@ -23,7 +23,7 @@ namespace librealsense
 
     MAP_EXTENSION(RS2_EXTENSION_POSE_PROFILE, librealsense::pose_stream_profile_interface);
 
-    class pose_sensor_interface : public recordable<pose_sensor_interface>
+    class pose_sensor_interface
     {
     public:
         virtual bool export_relocalization_map(std::vector<uint8_t>& lmap_buf) const  = 0;
@@ -35,7 +35,7 @@ namespace librealsense
     };
     MAP_EXTENSION(RS2_EXTENSION_POSE_SENSOR, librealsense::pose_sensor_interface);
 
-    class wheel_odometry_interface : public recordable<wheel_odometry_interface>
+    class wheel_odometry_interface
     {
     public:
         virtual bool load_wheel_odometery_config(const std::vector<uint8_t>& odometry_config_buf) const = 0;

--- a/src/core/options.h
+++ b/src/core/options.h
@@ -2,11 +2,18 @@
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
 #pragma once
 
-#include <map>
 #include <librealsense2/h/rs_option.h>
 #include "extension.h"
-#include "../types.h"
+#include <src/basics.h>
+#include "enum-helpers.h"
+#include <src/librealsense-exception.h>
+
 #include <rsutils/string/from.h>
+#include <map>
+#include <vector>
+#include <functional>
+#include <memory>
+
 
 namespace librealsense
 {

--- a/src/core/processing.h
+++ b/src/core/processing.h
@@ -5,6 +5,7 @@
 #include "frame-holder.h"
 #include "options.h"
 #include "info.h"
+#include <src/types.h>
 #include <vector>
 #include <memory>
 

--- a/src/core/roi.h
+++ b/src/core/roi.h
@@ -2,10 +2,10 @@
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
 #pragma once
 
+#include "extension.h"
+#include <src/librealsense-exception.h>
 #include <memory>
 
-#include "extension.h"
-#include "../types.h"           // exception
 
 namespace librealsense
 {
@@ -41,7 +41,7 @@ namespace librealsense
         region_of_interest_method& get_roi_method() const override
         {
             if (!_roi_method.get())
-                throw librealsense::not_implemented_exception("Region-of-interest is not implemented for this device!");
+                throw not_implemented_exception("Region-of-interest is not implemented for this device!");
             return *_roi_method;
         }
 

--- a/src/core/roi.h
+++ b/src/core/roi.h
@@ -31,6 +31,8 @@ namespace librealsense
     public:
         virtual region_of_interest_method& get_roi_method() const = 0;
         virtual void set_roi_method(std::shared_ptr<region_of_interest_method> roi_method) = 0;
+
+        virtual ~roi_sensor_interface() = default;
     };
 
     class roi_sensor_base : public roi_sensor_interface

--- a/src/core/streaming.h
+++ b/src/core/streaming.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "options.h"
-#include "../types.h"
 #include "../depth-sensor.h"
 #include "../color-sensor.h"
 #include "../composite-frame.h"
@@ -13,11 +12,6 @@
 
 namespace librealsense
 {
-    namespace platform
-    {
-        class time_source;
-    }
-
     class sensor_interface;
     class archive_interface;
     class device_interface;

--- a/src/dds/rs-dds-depth-sensor-proxy.h
+++ b/src/dds/rs-dds-depth-sensor-proxy.h
@@ -23,16 +23,6 @@ public:
 
     // Needed by abstract interfaces
     float get_depth_scale() const override { return get_option( RS2_OPTION_DEPTH_UNITS ).query(); }
-
-    void create_snapshot( std::shared_ptr< depth_sensor > & snapshot ) const override
-    {
-        snapshot = std::make_shared< depth_sensor_snapshot >( get_depth_scale() );
-    }
-
-    void enable_recording( std::function< void( const depth_sensor & ) > recording_function ) override
-    {
-        // does not change over time
-    }
 };
 
 

--- a/src/depth-sensor.h
+++ b/src/depth-sensor.h
@@ -6,7 +6,7 @@
 #include "core/extension.h"
 
 namespace librealsense {
-class depth_sensor : public recordable< depth_sensor >
+class depth_sensor
 {
 public:
     virtual float get_depth_scale() const = 0;
@@ -15,41 +15,8 @@ public:
 
 MAP_EXTENSION( RS2_EXTENSION_DEPTH_SENSOR, librealsense::depth_sensor );
 
-class depth_sensor_snapshot
-    : public virtual depth_sensor
-    , public extension_snapshot
-{
-public:
-    depth_sensor_snapshot( float depth_units )
-        : m_depth_units( depth_units )
-    {
-    }
-    float get_depth_scale() const override { return m_depth_units; }
-
-    void update( std::shared_ptr< extension_snapshot > ext ) override
-    {
-        if( auto api = As< depth_sensor >( ext ) )
-        {
-            m_depth_units = api->get_depth_scale();
-        }
-    }
-    void create_snapshot( std::shared_ptr< depth_sensor > & snapshot ) const override
-    {
-        snapshot = std::make_shared< depth_sensor_snapshot >( *this );
-    }
-    void
-    enable_recording( std::function< void( const depth_sensor & ) > recording_function ) override
-    {
-        // empty
-    }
-
-protected:
-    float m_depth_units;
-};
-
 class depth_stereo_sensor
     : public virtual depth_sensor
-    , public recordable< depth_stereo_sensor >
 {
 public:
     virtual float get_stereo_baseline_mm() const = 0;
@@ -57,41 +24,5 @@ public:
 
 MAP_EXTENSION( RS2_EXTENSION_DEPTH_STEREO_SENSOR, librealsense::depth_stereo_sensor );
 
-class depth_stereo_sensor_snapshot
-    : public depth_stereo_sensor
-    , public depth_sensor_snapshot
-{
-public:
-    depth_stereo_sensor_snapshot( float depth_units, float stereo_bl_mm )
-        : depth_sensor_snapshot( depth_units )
-        , m_stereo_baseline_mm( stereo_bl_mm )
-    {
-    }
 
-    float get_stereo_baseline_mm() const override { return m_stereo_baseline_mm; }
-
-    void update( std::shared_ptr< extension_snapshot > ext ) override
-    {
-        depth_sensor_snapshot::update( ext );
-
-        if( auto api = As< depth_stereo_sensor >( ext ) )
-        {
-            m_stereo_baseline_mm = api->get_stereo_baseline_mm();
-        }
-    }
-
-    void create_snapshot( std::shared_ptr< depth_stereo_sensor > & snapshot ) const override
-    {
-        snapshot = std::make_shared< depth_stereo_sensor_snapshot >( *this );
-    }
-
-    void enable_recording(
-        std::function< void( const depth_stereo_sensor & ) > recording_function ) override
-    {
-        // empty
-    }
-
-private:
-    float m_stereo_baseline_mm;
-};
 }  // namespace librealsense

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -130,7 +130,11 @@ namespace librealsense
         return result;
     }
 
-    class d400_depth_sensor : public synthetic_sensor, public video_sensor_interface, public depth_stereo_sensor, public roi_sensor_base
+    class d400_depth_sensor
+        : public synthetic_sensor
+        , public video_sensor_interface
+        , public depth_stereo_sensor
+        , public roi_sensor_base
     {
     public:
         explicit d400_depth_sensor(d400_device* owner,
@@ -300,26 +304,6 @@ namespace librealsense
         std::shared_ptr<hdr_config> get_hdr_config() { return _hdr_cfg; }
 
         float get_stereo_baseline_mm() const override { return _owner->get_stereo_baseline_mm(); }
-
-        void create_snapshot(std::shared_ptr<depth_sensor>& snapshot) const override
-        {
-            snapshot = std::make_shared<depth_sensor_snapshot>(get_depth_scale());
-        }
-
-        void create_snapshot(std::shared_ptr<depth_stereo_sensor>& snapshot) const override
-        {
-            snapshot = std::make_shared<depth_stereo_sensor_snapshot>(get_depth_scale(), get_stereo_baseline_mm());
-        }
-
-        void enable_recording(std::function<void(const depth_sensor&)> recording_function) override
-        {
-            //does not change over time
-        }
-
-        void enable_recording(std::function<void(const depth_stereo_sensor&)> recording_function) override
-        {
-            //does not change over time
-        }
 
         float get_preset_max_value() const override
         {
@@ -899,8 +883,10 @@ namespace librealsense
 
             if (!val_in_range(_pid, { ds::RS457_PID }))
             {
-                depth_sensor.register_option(RS2_OPTION_STEREO_BASELINE, std::make_shared<const_value_option>("Distance in mm between the stereo imagers",
-                        rsutils::lazy< float >( [this]() { return get_stereo_baseline_mm(); } ) ) );
+                depth_sensor.register_option( RS2_OPTION_STEREO_BASELINE,
+                                              std::make_shared< const_value_option >(
+                                                  "Distance in mm between the stereo imagers",
+                                                  rsutils::lazy< float >( [this]() { return get_stereo_baseline_mm(); } ) ) );
             }
 
             if (advanced_mode && _fw_version >= firmware_version("5.6.3.0"))

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -1155,15 +1155,6 @@ namespace librealsense
         }
     }
 
-    void d400_device::create_snapshot(std::shared_ptr<debug_interface>& snapshot) const
-    {
-        //TODO: Implement
-    }
-    void d400_device::enable_recording(std::function<void(const debug_interface&)> record_action)
-    {
-        //TODO: Implement
-    }
-
     // Check if need change camera name due to number modifications on one device PID.
     void update_device_name(std::string& device_name, const ds::ds_caps cap)
     {

--- a/src/ds/d400/d400-device.h
+++ b/src/ds/d400/d400-device.h
@@ -53,8 +53,6 @@ namespace librealsense
 
         void hardware_reset() override;
 
-        void create_snapshot(std::shared_ptr<debug_interface>& snapshot) const override;
-        void enable_recording(std::function<void(const debug_interface&)> record_action) override;
         platform::usb_spec get_usb_spec() const;
         virtual double get_device_time_ms() override;
 

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -265,26 +265,6 @@ namespace librealsense
 
         float get_stereo_baseline_mm() const override { return _owner->get_stereo_baseline_mm(); }
 
-        void create_snapshot(std::shared_ptr<depth_sensor>& snapshot) const override
-        {
-            snapshot = std::make_shared<depth_sensor_snapshot>(get_depth_scale());
-        }
-
-        void create_snapshot(std::shared_ptr<depth_stereo_sensor>& snapshot) const override
-        {
-            snapshot = std::make_shared<depth_stereo_sensor_snapshot>(get_depth_scale(), get_stereo_baseline_mm());
-        }
-
-        void enable_recording(std::function<void(const depth_sensor&)> recording_function) override
-        {
-            //does not change over time
-        }
-
-        void enable_recording(std::function<void(const depth_stereo_sensor&)> recording_function) override
-        {
-            //does not change over time
-        }
-
         float get_preset_max_value() const override
         {
             return static_cast<float>(RS2_RS400_VISUAL_PRESET_MEDIUM_DENSITY);

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -762,15 +762,6 @@ namespace librealsense
             register_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR, usb_type_str);
     }
 
-    void d500_device::create_snapshot(std::shared_ptr<debug_interface>& snapshot) const
-    {
-        //TODO: Implement
-    }
-    void d500_device::enable_recording(std::function<void(const debug_interface&)> record_action)
-    {
-        //TODO: Implement
-    }
-
     platform::usb_spec d500_device::get_usb_spec() const
     {
         if(!supports_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -59,8 +59,6 @@ namespace librealsense
 
         void hardware_reset() override;
 
-        void create_snapshot(std::shared_ptr<debug_interface>& snapshot) const override;
-        void enable_recording(std::function<void(const debug_interface&)> record_action) override;
         platform::usb_spec get_usb_spec() const;
         virtual double get_device_time_ms() override;
 

--- a/src/global_timestamp_reader.h
+++ b/src/global_timestamp_reader.h
@@ -107,7 +107,7 @@ namespace librealsense
         bool _ts_is_ready;
     };
 
-    class global_time_interface : public recordable<global_time_interface>
+    class global_time_interface
     {
     protected:
         std::shared_ptr<time_diff_keeper> _tf_keeper;
@@ -117,9 +117,8 @@ namespace librealsense
         ~global_time_interface() { _tf_keeper.reset(); }
         void enable_time_diff_keeper(bool is_enable);
         virtual double get_device_time_ms() = 0; // Returns time in miliseconds.
-        virtual void create_snapshot(std::shared_ptr<global_time_interface>& snapshot) const override {}
-        virtual void enable_recording(std::function<void(const global_time_interface&)> record_action) override {}
     };
+
     MAP_EXTENSION(RS2_EXTENSION_GLOBAL_TIMER, librealsense::global_time_interface);
 
 }

--- a/src/media/playback/playback_device.cpp
+++ b/src/media/playback/playback_device.cpp
@@ -768,9 +768,11 @@ bool playback_device::try_extend_snapshot(std::shared_ptr<extension_snapshot>& e
         return false;
     }
 
+    // NOTE: the extensions listed here may not all have a base of recordable<>, but a snapshot of which is nonetheless
+    // created by ros_reader. I.e., any snapshot created by ros_reader needs to be listed here, even if the extension is
+    // not recordable!
     switch (extension_type)
     {
-    case RS2_EXTENSION_DEBUG:   return try_extend<debug_interface>(e, ext);
     case RS2_EXTENSION_INFO:    return try_extend<info_interface>(e, ext);
     case RS2_EXTENSION_OPTIONS: return try_extend<options_interface>(e, ext);
     case RS2_EXTENSION_VIDEO:   return try_extend<video_sensor_interface>(e, ext);

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -242,31 +242,19 @@ device_serializer::snapshot_collection librealsense::record_device::get_extensio
     for (int i = 0; i < static_cast<int>(RS2_EXTENSION_COUNT ); ++i)
     {
         rs2_extension ext = static_cast<rs2_extension>(i);
+        // Most extensions are unsupported; those that derive from recordable<> need to be added here:
         switch (ext)
         {
-            case RS2_EXTENSION_DEBUG           : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEBUG          >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_INFO            : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_INFO           >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_OPTIONS         : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_OPTIONS        >::type>(extendable, snapshots); break;
-            //case RS2_EXTENSION_VIDEO           : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_VIDEO          >::type>(extendable, snapshots); break;
-            //case RS2_EXTENSION_ROI             : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_ROI            >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_DEPTH_SENSOR    : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEPTH_SENSOR   >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_L500_DEPTH_SENSOR: break;  // deprecated
-            case RS2_EXTENSION_DEPTH_STEREO_SENSOR: try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEPTH_STEREO_SENSOR   >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_COLOR_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_COLOR_SENSOR   >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_MOTION_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_MOTION_SENSOR   >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_FISHEYE_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_FISHEYE_SENSOR   >::type>(extendable, snapshots); break;
-                //case RS2_EXTENSION_ADVANCED_MODE   : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_ADVANCED_MODE  >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_RECOMMENDED_FILTERS: try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_RECOMMENDED_FILTERS   >::type>(extendable, snapshots); break;
-            case RS2_EXTENSION_VIDEO_FRAME     : break;
-            case RS2_EXTENSION_MOTION_FRAME    : break;
-            case RS2_EXTENSION_COMPOSITE_FRAME : break;
-            case RS2_EXTENSION_POINTS          : break;
-            case RS2_EXTENSION_RECORD          : break;
-            case RS2_EXTENSION_PLAYBACK        : break;
-            case RS2_EXTENSION_COUNT           : break;
-            case RS2_EXTENSION_UNKNOWN         : break;
-            default:
-                LOG_WARNING("Extensions type is unhandled: " << get_string(ext));
+        case RS2_EXTENSION_INFO:
+            try_add_snapshot< T, ExtensionToType< RS2_EXTENSION_INFO >::type >( extendable, snapshots );
+            break;
+        case RS2_EXTENSION_OPTIONS         : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_OPTIONS        >::type>(extendable, snapshots); break;
+        case RS2_EXTENSION_DEPTH_SENSOR    : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEPTH_SENSOR   >::type>(extendable, snapshots); break;
+        case RS2_EXTENSION_DEPTH_STEREO_SENSOR: try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEPTH_STEREO_SENSOR   >::type>(extendable, snapshots); break;
+        case RS2_EXTENSION_COLOR_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_COLOR_SENSOR   >::type>(extendable, snapshots); break;
+        case RS2_EXTENSION_MOTION_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_MOTION_SENSOR   >::type>(extendable, snapshots); break;
+        case RS2_EXTENSION_FISHEYE_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_FISHEYE_SENSOR   >::type>(extendable, snapshots); break;
+        case RS2_EXTENSION_RECOMMENDED_FILTERS: try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_RECOMMENDED_FILTERS   >::type>(extendable, snapshots); break;
         }
     }
     return snapshots;
@@ -371,8 +359,11 @@ bool librealsense::record_device::extend_to(rs2_extension extension_type, void**
         *ext = this;
         return true;
     case RS2_EXTENSION_OPTIONS         : return extend_to_aux<RS2_EXTENSION_OPTIONS        >(m_device, ext);
-    case RS2_EXTENSION_ADVANCED_MODE   : return extend_to_aux<RS2_EXTENSION_ADVANCED_MODE  >(m_device, ext);
-    case RS2_EXTENSION_DEBUG           : return extend_to_aux<RS2_EXTENSION_DEBUG          >(m_device, ext);
+
+    case RS2_EXTENSION_ADVANCED_MODE   :
+        *ext = As< typename ExtensionToType< RS2_EXTENSION_ADVANCED_MODE >::type >( m_device ).get();
+        return *ext;
+
     //Other cases are not extensions that we expect a device to have.
     default:
         LOG_WARNING("Extensions type is unhandled: " << get_string(extension_type));

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -249,9 +249,6 @@ device_serializer::snapshot_collection librealsense::record_device::get_extensio
             try_add_snapshot< T, ExtensionToType< RS2_EXTENSION_INFO >::type >( extendable, snapshots );
             break;
         case RS2_EXTENSION_OPTIONS         : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_OPTIONS        >::type>(extendable, snapshots); break;
-        case RS2_EXTENSION_COLOR_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_COLOR_SENSOR   >::type>(extendable, snapshots); break;
-        case RS2_EXTENSION_MOTION_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_MOTION_SENSOR   >::type>(extendable, snapshots); break;
-        case RS2_EXTENSION_FISHEYE_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_FISHEYE_SENSOR   >::type>(extendable, snapshots); break;
         case RS2_EXTENSION_RECOMMENDED_FILTERS: try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_RECOMMENDED_FILTERS   >::type>(extendable, snapshots); break;
         }
     }

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -214,7 +214,7 @@ void librealsense::record_device::try_add_snapshot(T* extendable, device_seriali
             if (snapshot != nullptr)
             {
                 snapshots[TypeToExtension<Ext>::value] = snapshot;
-                LOG_INFO("Added snapshot of type: " << TypeToExtension<Ext>::to_string());
+                LOG_INFO("Added snapshot of type: " << TypeToExtension<Ext>::to_string() << "  to: " << extendable->get_info( RS2_CAMERA_INFO_NAME ) );
             }
             else
             {

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -249,8 +249,6 @@ device_serializer::snapshot_collection librealsense::record_device::get_extensio
             try_add_snapshot< T, ExtensionToType< RS2_EXTENSION_INFO >::type >( extendable, snapshots );
             break;
         case RS2_EXTENSION_OPTIONS         : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_OPTIONS        >::type>(extendable, snapshots); break;
-        case RS2_EXTENSION_DEPTH_SENSOR    : try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEPTH_SENSOR   >::type>(extendable, snapshots); break;
-        case RS2_EXTENSION_DEPTH_STEREO_SENSOR: try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_DEPTH_STEREO_SENSOR   >::type>(extendable, snapshots); break;
         case RS2_EXTENSION_COLOR_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_COLOR_SENSOR   >::type>(extendable, snapshots); break;
         case RS2_EXTENSION_MOTION_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_MOTION_SENSOR   >::type>(extendable, snapshots); break;
         case RS2_EXTENSION_FISHEYE_SENSOR:        try_add_snapshot<T, ExtensionToType<RS2_EXTENSION_FISHEYE_SENSOR   >::type>(extendable, snapshots); break;

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -180,7 +180,9 @@ bool librealsense::record_sensor::extend_to(rs2_extension extension_type, void**
     case RS2_EXTENSION_MOTION_SENSOR:
         *ext = As< typename ExtensionToType< RS2_EXTENSION_MOTION_SENSOR >::type >( &m_sensor );
         return *ext;
-    case RS2_EXTENSION_FISHEYE_SENSOR:      return extend_to_aux<RS2_EXTENSION_FISHEYE_SENSOR   >(&m_sensor, ext);
+    case RS2_EXTENSION_FISHEYE_SENSOR:
+        *ext = As< typename ExtensionToType< RS2_EXTENSION_FISHEYE_SENSOR >::type >( &m_sensor );
+        return *ext;
     case RS2_EXTENSION_POSE_SENSOR:         return extend_to_aux<RS2_EXTENSION_POSE_SENSOR   >(&m_sensor, ext);
 
     //Other extensions are not expected to be extensions of a sensor

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -177,7 +177,9 @@ bool librealsense::record_sensor::extend_to(rs2_extension extension_type, void**
     case RS2_EXTENSION_COLOR_SENSOR:
         *ext = As< typename ExtensionToType< RS2_EXTENSION_COLOR_SENSOR >::type >( &m_sensor );
         return *ext;
-    case RS2_EXTENSION_MOTION_SENSOR:       return extend_to_aux<RS2_EXTENSION_MOTION_SENSOR   >(&m_sensor, ext);
+    case RS2_EXTENSION_MOTION_SENSOR:
+        *ext = As< typename ExtensionToType< RS2_EXTENSION_MOTION_SENSOR >::type >( &m_sensor );
+        return *ext;
     case RS2_EXTENSION_FISHEYE_SENSOR:      return extend_to_aux<RS2_EXTENSION_FISHEYE_SENSOR   >(&m_sensor, ext);
     case RS2_EXTENSION_POSE_SENSOR:         return extend_to_aux<RS2_EXTENSION_POSE_SENSOR   >(&m_sensor, ext);
 

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -133,26 +133,6 @@ bool librealsense::record_sensor::is_streaming() const
     return m_sensor.is_streaming();
 }
 
-template <rs2_extension E, typename P>
-bool librealsense::record_sensor::extend_to_aux(P* p, void** ext)
-{
-    using EXT_TYPE = typename ExtensionToType<E>::type;
-    auto ptr = As<EXT_TYPE>(p);
-    if (!ptr)
-        return false;
-
-
-    if (auto recordable = As<librealsense::recordable<EXT_TYPE>>(p))
-    {
-        recordable->enable_recording([this](const EXT_TYPE& ext1) {
-            record_snapshot<EXT_TYPE>(E, ext1);
-        });
-    }
-
-    *ext = ptr;
-    return true;
-}
-
 bool librealsense::record_sensor::extend_to(rs2_extension extension_type, void** ext)
 {
     /**************************************************************************************
@@ -183,7 +163,9 @@ bool librealsense::record_sensor::extend_to(rs2_extension extension_type, void**
     case RS2_EXTENSION_FISHEYE_SENSOR:
         *ext = As< typename ExtensionToType< RS2_EXTENSION_FISHEYE_SENSOR >::type >( &m_sensor );
         return *ext;
-    case RS2_EXTENSION_POSE_SENSOR:         return extend_to_aux<RS2_EXTENSION_POSE_SENSOR   >(&m_sensor, ext);
+    case RS2_EXTENSION_POSE_SENSOR:
+        *ext = As< typename ExtensionToType< RS2_EXTENSION_POSE_SENSOR >::type >( &m_sensor );
+        return *ext;
 
     //Other extensions are not expected to be extensions of a sensor
     default:

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -168,8 +168,12 @@ bool librealsense::record_sensor::extend_to(rs2_extension extension_type, void**
     case RS2_EXTENSION_INFO:    // [[fallthrough]]
         *ext = this;
         return true;
-    case RS2_EXTENSION_DEPTH_SENSOR    : return extend_to_aux<RS2_EXTENSION_DEPTH_SENSOR   >(&m_sensor, ext);
-    case RS2_EXTENSION_DEPTH_STEREO_SENSOR: return extend_to_aux<RS2_EXTENSION_DEPTH_STEREO_SENSOR   >(&m_sensor, ext);
+    case RS2_EXTENSION_DEPTH_SENSOR:
+        *ext = As< typename ExtensionToType< RS2_EXTENSION_DEPTH_SENSOR >::type >( &m_sensor );
+        return *ext;
+    case RS2_EXTENSION_DEPTH_STEREO_SENSOR:
+        *ext = As< typename ExtensionToType< RS2_EXTENSION_DEPTH_STEREO_SENSOR >::type >( &m_sensor );
+        return *ext;
     case RS2_EXTENSION_COLOR_SENSOR:        return extend_to_aux<RS2_EXTENSION_COLOR_SENSOR   >(&m_sensor, ext);
     case RS2_EXTENSION_MOTION_SENSOR:       return extend_to_aux<RS2_EXTENSION_MOTION_SENSOR   >(&m_sensor, ext);
     case RS2_EXTENSION_FISHEYE_SENSOR:      return extend_to_aux<RS2_EXTENSION_FISHEYE_SENSOR   >(&m_sensor, ext);

--- a/src/media/record/record_sensor.cpp
+++ b/src/media/record/record_sensor.cpp
@@ -174,7 +174,9 @@ bool librealsense::record_sensor::extend_to(rs2_extension extension_type, void**
     case RS2_EXTENSION_DEPTH_STEREO_SENSOR:
         *ext = As< typename ExtensionToType< RS2_EXTENSION_DEPTH_STEREO_SENSOR >::type >( &m_sensor );
         return *ext;
-    case RS2_EXTENSION_COLOR_SENSOR:        return extend_to_aux<RS2_EXTENSION_COLOR_SENSOR   >(&m_sensor, ext);
+    case RS2_EXTENSION_COLOR_SENSOR:
+        *ext = As< typename ExtensionToType< RS2_EXTENSION_COLOR_SENSOR >::type >( &m_sensor );
+        return *ext;
     case RS2_EXTENSION_MOTION_SENSOR:       return extend_to_aux<RS2_EXTENSION_MOTION_SENSOR   >(&m_sensor, ext);
     case RS2_EXTENSION_FISHEYE_SENSOR:      return extend_to_aux<RS2_EXTENSION_FISHEYE_SENSOR   >(&m_sensor, ext);
     case RS2_EXTENSION_POSE_SENSOR:         return extend_to_aux<RS2_EXTENSION_POSE_SENSOR   >(&m_sensor, ext);

--- a/src/media/record/record_sensor.h
+++ b/src/media/record/record_sensor.h
@@ -54,7 +54,6 @@ namespace librealsense
 
     private /*methods*/:
         template <typename T> void record_snapshot(rs2_extension extension_type, const librealsense::recordable<T>& snapshot);
-        template <rs2_extension E, typename P> bool extend_to_aux(P* p, void** ext);
         void record_frame(frame_holder holder);
         void enable_sensor_hooks();
         void disable_sensor_hooks();

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -895,8 +895,6 @@ namespace librealsense
         , public extension_snapshot
     {
     public:
-        color_sensor_snapshot() {}
-
         void update( std::shared_ptr< extension_snapshot > ext ) override {}
     };
 
@@ -905,8 +903,14 @@ namespace librealsense
         , public extension_snapshot
     {
     public:
-        motion_sensor_snapshot() {}
+        void update( std::shared_ptr< extension_snapshot > ext ) override {}
+    };
 
+    class fisheye_sensor_snapshot
+        : public virtual fisheye_sensor
+        , public extension_snapshot
+    {
+    public:
         void update( std::shared_ptr< extension_snapshot > ext ) override {}
     };
 

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -888,6 +888,21 @@ namespace librealsense
         sensor_extensions[RS2_EXTENSION_RECOMMENDED_FILTERS] = proccesing_blocks;
     }
 
+    namespace {
+
+    class color_sensor_snapshot
+        : public virtual color_sensor
+        , public extension_snapshot
+    {
+    public:
+        color_sensor_snapshot() {}
+
+        void update( std::shared_ptr< extension_snapshot > ext ) override {}
+    };
+
+    }  // namespace
+
+
     void ros_reader::add_sensor_extension(snapshot_collection & sensor_extensions, std::string sensor_name)
     {
         if (is_color_sensor(sensor_name))

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -784,6 +784,60 @@ namespace librealsense
         return true;
     }
 
+    namespace {
+
+    class depth_sensor_snapshot
+        : public virtual depth_sensor
+        , public extension_snapshot
+    {
+    public:
+        depth_sensor_snapshot( float depth_units )
+            : m_depth_units( depth_units )
+        {
+        }
+        float get_depth_scale() const override { return m_depth_units; }
+
+        void update( std::shared_ptr< extension_snapshot > ext ) override
+        {
+            if( auto api = As< depth_sensor >( ext ) )
+            {
+                m_depth_units = api->get_depth_scale();
+            }
+        }
+
+    protected:
+        float m_depth_units;
+    };
+
+    class depth_stereo_sensor_snapshot
+        : public depth_stereo_sensor
+        , public depth_sensor_snapshot
+    {
+    public:
+        depth_stereo_sensor_snapshot( float depth_units, float stereo_bl_mm )
+            : depth_sensor_snapshot( depth_units )
+            , m_stereo_baseline_mm( stereo_bl_mm )
+        {
+        }
+
+        float get_stereo_baseline_mm() const override { return m_stereo_baseline_mm; }
+
+        void update( std::shared_ptr< extension_snapshot > ext ) override
+        {
+            depth_sensor_snapshot::update( ext );
+
+            if( auto api = As< depth_stereo_sensor >( ext ) )
+            {
+                m_stereo_baseline_mm = api->get_stereo_baseline_mm();
+            }
+        }
+
+    private:
+        float m_stereo_baseline_mm;
+    };
+
+    }  // namespace
+
     void ros_reader::update_sensor_options(const rosbag::Bag& file, uint32_t sensor_index, const nanoseconds& time, uint32_t file_version, snapshot_collection& sensor_extensions, uint32_t version)
     {
         if (version == legacy_file_format::file_version())

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -900,6 +900,16 @@ namespace librealsense
         void update( std::shared_ptr< extension_snapshot > ext ) override {}
     };
 
+    class motion_sensor_snapshot
+        : public virtual motion_sensor
+        , public extension_snapshot
+    {
+    public:
+        motion_sensor_snapshot() {}
+
+        void update( std::shared_ptr< extension_snapshot > ext ) override {}
+    };
+
     }  // namespace
 
 

--- a/src/media/ros/ros_writer.cpp
+++ b/src/media/ros/ros_writer.cpp
@@ -398,14 +398,6 @@ namespace librealsense
             }
             break;
         }
-        case RS2_EXTENSION_DEBUG:
-            break;
-            //case RS2_EXTENSION_OPTION:
-            //{
-            //    auto option = SnapshotAs<RS2_EXTENSION_OPTION>(snapshot);
-            //    write_sensor_option({ device_id, sensor_id }, timestamp, *option);
-            //    break;
-            //}
         case RS2_EXTENSION_OPTIONS:
         {
             auto options = SnapshotAs<RS2_EXTENSION_OPTIONS>(snapshot);

--- a/src/media/ros/ros_writer.cpp
+++ b/src/media/ros/ros_writer.cpp
@@ -405,14 +405,6 @@ namespace librealsense
             break;
         }
 
-        case RS2_EXTENSION_VIDEO:
-        case RS2_EXTENSION_ROI:
-        case RS2_EXTENSION_DEPTH_SENSOR:
-        case RS2_EXTENSION_COLOR_SENSOR:
-        case RS2_EXTENSION_MOTION_SENSOR:
-        case RS2_EXTENSION_FISHEYE_SENSOR:
-        case RS2_EXTENSION_DEPTH_STEREO_SENSOR:
-            break;
         case RS2_EXTENSION_VIDEO_PROFILE:
         {
             auto profile = SnapshotAs<RS2_EXTENSION_VIDEO_PROFILE>(snapshot);

--- a/src/option.h
+++ b/src/option.h
@@ -60,14 +60,17 @@ namespace librealsense
     class const_value_option : public readonly_option, public extension_snapshot
     {
     public:
-        const_value_option(std::string desc, float val)
-            : _val( rsutils::lazy< float >( [val]() { return val; } ) )
-            , _desc( std::move( desc ) )
+        const_value_option( std::string const & desc, float val )
+            : _val( [val]() { return val; } )
+            , _desc( desc )
         {
         }
 
-        const_value_option( std::string desc, rsutils::lazy< float > val )
-            : _val(std::move(val)), _desc(std::move(desc)) {}
+        const_value_option( std::string const & desc, rsutils::lazy< float > && val )
+            : _val( std::move( val ) )
+            , _desc( desc )
+        {
+        }
 
         float query() const override { return *_val; }
         option_range get_range() const override { return { *_val, *_val, 0, *_val }; }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -718,11 +718,6 @@ void log_callback_end( uint32_t fps,
         return _raw_sensor->is_opened();
     }
 
-    void motion_sensor::create_snapshot(std::shared_ptr<motion_sensor>& snapshot) const
-    {
-        snapshot = std::make_shared<motion_sensor_snapshot>();
-    }
-
     void fisheye_sensor::create_snapshot(std::shared_ptr<fisheye_sensor>& snapshot) const
     {
         snapshot = std::make_shared<fisheye_sensor_snapshot>();

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -718,11 +718,6 @@ void log_callback_end( uint32_t fps,
         return _raw_sensor->is_opened();
     }
 
-    void fisheye_sensor::create_snapshot(std::shared_ptr<fisheye_sensor>& snapshot) const
-    {
-        snapshot = std::make_shared<fisheye_sensor_snapshot>();
-    }
-
     format_conversion sensor_base::get_format_conversion() const
     {
         return _owner->get_format_conversion();

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -146,35 +146,13 @@ namespace librealsense
     MAP_EXTENSION(RS2_EXTENSION_MOTION_SENSOR, librealsense::motion_sensor);
 
 
-    class fisheye_sensor : public recordable<fisheye_sensor>
+    class fisheye_sensor
     {
     public:
         virtual ~fisheye_sensor() = default;
-
-        void create_snapshot(std::shared_ptr<fisheye_sensor>& snapshot) const override;
-        void enable_recording(std::function<void(const fisheye_sensor&)> recording_function) override {};
     };
 
     MAP_EXTENSION(RS2_EXTENSION_FISHEYE_SENSOR, librealsense::fisheye_sensor);
-
-    class fisheye_sensor_snapshot : public virtual fisheye_sensor, public extension_snapshot
-    {
-    public:
-        fisheye_sensor_snapshot() {}
-
-        void update(std::shared_ptr<extension_snapshot> ext) override
-        {
-        }
-
-        void create_snapshot(std::shared_ptr<fisheye_sensor>& snapshot) const  override
-        {
-            snapshot = std::make_shared<fisheye_sensor_snapshot>(*this);
-        }
-        void enable_recording(std::function<void(const fisheye_sensor&)> recording_function) override
-        {
-            //empty
-        }
-    };
 
     // Base class for anything that is the target of a synthetic_sensor
     //

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -137,36 +137,13 @@ namespace librealsense
 
     class processing_block;
 
-    class motion_sensor : public recordable<motion_sensor>
+    class motion_sensor
     {
     public:
         virtual ~motion_sensor() = default;
-
-        void create_snapshot(std::shared_ptr<motion_sensor>& snapshot) const override;
-        void enable_recording(std::function<void(const motion_sensor&)> recording_function) override {};
     };
 
     MAP_EXTENSION(RS2_EXTENSION_MOTION_SENSOR, librealsense::motion_sensor);
-
-    class motion_sensor_snapshot : public virtual motion_sensor, public extension_snapshot
-    {
-    public:
-        motion_sensor_snapshot() {}
-
-        void update(std::shared_ptr<extension_snapshot> ext) override
-        {
-        }
-
-        void create_snapshot(std::shared_ptr<motion_sensor>& snapshot) const  override
-        {
-            snapshot = std::make_shared<motion_sensor_snapshot>(*this);
-        }
-
-        void enable_recording(std::function<void(const motion_sensor&)> recording_function) override
-        {
-            //empty
-        }
-    };
 
 
     class fisheye_sensor : public recordable<fisheye_sensor>

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -83,7 +83,6 @@ namespace librealsense
     software_sensor::software_sensor( std::string const & name, software_device * owner )
         : sensor_base( name, owner, &_pbs )
         , _stereo_extension( [this]() { return stereo_extension( this ); } )
-        , _depth_extension( [this]() { return depth_extension( this ); } )
         , _metadata_map{}  // to all 0's
     {
         // At this time (and therefore for backwards compatibility) no register_metadata is required for SW sensors,
@@ -163,7 +162,8 @@ namespace librealsense
         {
             if (supports_option(RS2_OPTION_DEPTH_UNITS))
             {
-                *ptr = &(*_depth_extension);
+                auto & ext = *_stereo_extension;
+                *ptr = static_cast< depth_sensor * >( &ext );
                 return true;
             }
         }
@@ -357,9 +357,7 @@ namespace librealsense
 
     void software_sensor::add_read_only_option(rs2_option option, float val)
     {
-        register_option( option,
-                         std::make_shared< const_value_option >( "bypass sensor read only option",
-                                                                 rsutils::lazy< float >( [=]() { return val; } ) ) );
+        register_option( option, std::make_shared< const_value_option >( "bypass sensor read only option", val ) );
     }
 
     void software_sensor::update_read_only_option(rs2_option option, float val)

--- a/src/software-device.h
+++ b/src/software-device.h
@@ -157,32 +157,11 @@ namespace librealsense
                 return _owner->get_option(RS2_OPTION_STEREO_BASELINE).query();
             }
 
-            void create_snapshot(std::shared_ptr<depth_stereo_sensor>& snapshot) const override {}
-            void enable_recording(std::function<void(const depth_stereo_sensor&)> recording_function) override {}
-
-            void create_snapshot(std::shared_ptr<depth_sensor>& snapshot) const override {}
-            void enable_recording(std::function<void(const depth_sensor&)> recording_function) override {}
-        private:
-            software_sensor* _owner;
-        };
-
-        class depth_extension : public depth_sensor
-        {
-        public:
-            depth_extension(software_sensor* owner) : _owner(owner) {}
-
-            float get_depth_scale() const override {
-                return _owner->get_option(RS2_OPTION_DEPTH_UNITS).query();
-            }
-
-            void create_snapshot(std::shared_ptr<depth_sensor>& snapshot) const override {}
-            void enable_recording(std::function<void(const depth_sensor&)> recording_function) override {}
         private:
             software_sensor* _owner;
         };
 
         rsutils::lazy< stereo_extension > _stereo_extension;
-        rsutils::lazy< depth_extension > _depth_extension;
 
         software_recommended_proccesing_blocks _pbs;
     };

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -226,9 +226,4 @@ namespace librealsense
         auto from = reinterpret_cast<uint8_t const*>(src);
         std::copy(from, from + size, reinterpret_cast<uint8_t*>(dst));
     }
-
-    void color_sensor::create_snapshot(std::shared_ptr<color_sensor>& snapshot) const
-    {
-        snapshot = std::make_shared<color_sensor_snapshot>();
-    }
 }

--- a/src/types.h
+++ b/src/types.h
@@ -11,6 +11,7 @@
 
 #include <librealsense2/hpp/rs_types.hpp>
 
+#include "core/enum-helpers.h"
 #include <rsutils/concurrency/concurrency.h>
 #include "librealsense-exception.h"
 #include <rsutils/easylogging/easyloggingpp.h>
@@ -246,70 +247,6 @@ namespace librealsense
     };
 
     typedef float float_4[4];
-
-    /////////////////////////////
-    // Enumerated type support //
-    /////////////////////////////
-
-// Require the last enumerator value to be in format of RS2_#####_COUNT
-#define RS2_ENUM_HELPERS( TYPE, PREFIX )                                                           \
-    RS2_ENUM_HELPERS_CUSTOMIZED( TYPE, 0, RS2_##PREFIX##_COUNT - 1, const char * )
-
-// This macro can be used directly if needed to support enumerators with no RS2_#####_COUNT last value
-#define RS2_ENUM_HELPERS_CUSTOMIZED( TYPE, FIRST, LAST, STRTYPE )                                  \
-    LRS_EXTENSION_API STRTYPE get_string( TYPE value );                                            \
-    inline bool is_valid( TYPE value ) { return value >= FIRST && value <= LAST; }                 \
-    inline std::ostream & operator<<( std::ostream & out, TYPE value )                             \
-    {                                                                                              \
-        if( is_valid( value ) )                                                                    \
-            return out << get_string( value );                                                     \
-        else                                                                                       \
-            return out << (int)value;                                                              \
-    }                                                                                              \
-    inline bool try_parse( const std::string & str, TYPE & res )                                   \
-    {                                                                                              \
-        for( int i = FIRST; i <= LAST; i++ )                                                       \
-        {                                                                                          \
-            auto v = static_cast< TYPE >( i );                                                     \
-            if( str == get_string( v ) )                                                           \
-            {                                                                                      \
-                res = v;                                                                           \
-                return true;                                                                       \
-            }                                                                                      \
-        }                                                                                          \
-        return false;                                                                              \
-    }
-
-    // For rs2_option, these make use of the registry
-    LRS_EXTENSION_API std::string const & get_string( rs2_option value );
-    bool is_valid( rs2_option value );
-    std::ostream & operator<<( std::ostream & out, rs2_option option );
-    bool try_parse( const std::string & option_name, rs2_option & result );
-
-    RS2_ENUM_HELPERS(rs2_stream, STREAM)
-    RS2_ENUM_HELPERS(rs2_format, FORMAT)
-    RS2_ENUM_HELPERS(rs2_distortion, DISTORTION)
-    RS2_ENUM_HELPERS(rs2_camera_info, CAMERA_INFO)
-    RS2_ENUM_HELPERS_CUSTOMIZED(rs2_frame_metadata_value, 0, RS2_FRAME_METADATA_COUNT - 1, std::string const & )
-    RS2_ENUM_HELPERS(rs2_timestamp_domain, TIMESTAMP_DOMAIN)
-    RS2_ENUM_HELPERS(rs2_calib_target_type, CALIB_TARGET)
-    RS2_ENUM_HELPERS(rs2_sr300_visual_preset, SR300_VISUAL_PRESET)
-    RS2_ENUM_HELPERS(rs2_extension, EXTENSION)
-    RS2_ENUM_HELPERS(rs2_exception_type, EXCEPTION_TYPE)
-    RS2_ENUM_HELPERS(rs2_log_severity, LOG_SEVERITY)
-    RS2_ENUM_HELPERS(rs2_notification_category, NOTIFICATION_CATEGORY)
-    RS2_ENUM_HELPERS(rs2_playback_status, PLAYBACK_STATUS)
-    RS2_ENUM_HELPERS(rs2_matchers, MATCHER)
-    RS2_ENUM_HELPERS(rs2_sensor_mode, SENSOR_MODE)
-    RS2_ENUM_HELPERS(rs2_l500_visual_preset, L500_VISUAL_PRESET)
-    RS2_ENUM_HELPERS(rs2_calibration_type, CALIBRATION_TYPE)
-    RS2_ENUM_HELPERS_CUSTOMIZED(rs2_calibration_status, RS2_CALIBRATION_STATUS_FIRST, RS2_CALIBRATION_STATUS_LAST, const char * )
-    RS2_ENUM_HELPERS_CUSTOMIZED(rs2_ambient_light, RS2_AMBIENT_LIGHT_NO_AMBIENT, RS2_AMBIENT_LIGHT_LOW_AMBIENT, const char * )
-    RS2_ENUM_HELPERS_CUSTOMIZED(rs2_digital_gain, RS2_DIGITAL_GAIN_HIGH, RS2_DIGITAL_GAIN_LOW, const char * )
-    RS2_ENUM_HELPERS(rs2_host_perf_mode, HOST_PERF)
-    RS2_ENUM_HELPERS(rs2_emitter_frequency_mode, EMITTER_FREQUENCY)
-    RS2_ENUM_HELPERS(rs2_depth_auto_exposure_mode, DEPTH_AUTO_EXPOSURE)
-
 
     ////////////////////////////////////////////
     // World's tiniest linear algebra library //

--- a/tools/recorder/rs-record.cpp
+++ b/tools/recorder/rs-record.cpp
@@ -20,12 +20,19 @@ int main(int argc, char * argv[]) try
 {
     // Parse command line arguments
     CmdLine cmd("librealsense rs-record example tool", ' ');
-    ValueArg<int>    time("t", "Time", "Amount of time to record (in seconds)", false, 10, "");
+    SwitchArg debug_arg( "", "debug", "Turn on LibRS debug logs" );
+    ValueArg<double>    time("t", "Time", "Amount of time to record (in seconds)", false, 10., "");
     ValueArg<std::string> out_file("f", "FullFilePath", "the file where the data will be saved to", false, "test.bag", "");
 
+    cmd.add(debug_arg);
     cmd.add(time);
     cmd.add(out_file);
     cmd.parse(argc, argv);
+
+#ifdef BUILD_EASYLOGGINGPP
+    bool const debugging = debug_arg.getValue();
+    rs2::log_to_console( debugging ? RS2_LOG_SEVERITY_DEBUG : RS2_LOG_SEVERITY_ERROR );
+#endif
 
     rs2::pipeline pipe;
     rs2::config cfg;
@@ -49,7 +56,8 @@ int main(int argc, char * argv[]) try
 
     auto t = std::chrono::system_clock::now();
     auto t0 = t;
-    while(t - t0 <= std::chrono::seconds(time.getValue())) {
+    while( t - t0 <= std::chrono::milliseconds( (unsigned)( time.getValue() * 1000 ) ) )
+    {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         t = std::chrono::system_clock::now();
     }

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -39,16 +39,19 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         test.check_equal( len(sensors), 3 )
         sensor = dev.first_depth_sensor()
         if test.check( sensor ):
+            test.check( rs.depth_sensor( sensor ))
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'Stereo Module' )
             test.check_equal( len(sensor.get_stream_profiles()), 104 ) # As measured running rs-sensor-control example
         sensor = dev.first_color_sensor()
         if test.check( sensor ):
+            test.check( rs.color_sensor( sensor ))
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'RGB Camera' )
             test.check_equal( len(sensor.get_stream_profiles()), 160 ) # As measured running rs-sensor-control example
         sensor = dev.first_motion_sensor()
         if test.check( sensor ):
+            test.check( rs.motion_sensor( sensor ))
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'Motion Module' )
             test.check_equal( len(sensor.get_stream_profiles()), 2 ) # Only the Gyro profiles


### PR DESCRIPTION
Many of the recordable<>-derived snapshots were not actually written to the rosbags, and so were just cluttering code.
Recordable is now only left in option, options, and stream-profile. These may need work too, but this is good for now.

Small refactoring in some spots, but overall removes and simplifies code. 