### PR TITLE
fix update_device::get_device_info

### DIFF
--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -1179,19 +1179,11 @@ namespace librealsense
                 {
                     hwm_devices.push_back(hwm);
                 }
-                else
-                {
-                    LOG_DEBUG("d400_try_fetch_usb_device(...) failed.");
-                }
 
                 auto info = std::make_shared<d400_info>( ctx, std::move( devices ), std::move( hwm_devices ), std::move( hids ) );
                 chosen.insert(chosen.end(), devices.begin(), devices.end());
                 results.push_back(info);
 
-            }
-            else
-            {
-                LOG_WARNING("DS5 group_devices is empty.");
             }
         }
 

--- a/src/ds/d400/d400-fw-update-device.cpp
+++ b/src/ds/d400/d400-fw-update-device.cpp
@@ -6,8 +6,10 @@
 
 namespace librealsense
 {
-    ds_update_device::ds_update_device(std::shared_ptr<context> const & ctx, std::shared_ptr<platform::usb_device> const & usb_device)
-        : update_device(ctx, usb_device), _product_line("D400")
+ds_update_device::ds_update_device( std::shared_ptr< const device_info > const & dev_info,
+                                    std::shared_ptr< platform::usb_device > const & usb_device )
+    : update_device( dev_info, usb_device )
+    , _product_line( "D400" )
     {
         auto info = usb_device->get_info();
         _name = ds::rs400_sku_names.find(info.pid) != ds::rs400_sku_names.end() ? ds::rs400_sku_names.at(info.pid) : "unknown";        

--- a/src/ds/d400/d400-fw-update-device.h
+++ b/src/ds/d400/d400-fw-update-device.h
@@ -10,7 +10,7 @@ namespace librealsense
     class ds_update_device : public update_device
     {
     public:
-        ds_update_device( std::shared_ptr< context > const & ctx,
+        ds_update_device( std::shared_ptr< const device_info > const &,
                           std::shared_ptr< platform::usb_device > const & usb_device );
         virtual ~ds_update_device() = default;
 

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -109,9 +109,9 @@ namespace librealsense
         return false;
     }
 
-    update_device::update_device( std::shared_ptr< context > const & ctx,
+    update_device::update_device( std::shared_ptr< const device_info > const & dev_info,
                                   std::shared_ptr< platform::usb_device > const & usb_device )
-        : _context(ctx), _usb_device(usb_device), _physical_port( usb_device->get_info().id), _pid(hexify(usb_device->get_info().pid))
+        : _dev_info(dev_info), _usb_device(usb_device), _physical_port( usb_device->get_info().id), _pid(hexify(usb_device->get_info().pid))
     {
         if (auto messenger = _usb_device->open(FW_UPDATE_INTERFACE_NUMBER))
         {
@@ -242,12 +242,12 @@ namespace librealsense
 
     std::shared_ptr<context> update_device::get_context() const
     {
-        return _context;
+        return _dev_info->get_context();
     }
 
     std::shared_ptr< const device_info > update_device::get_device_info() const
     {
-        throw std::runtime_error("update_device does not support get_device_data API");//TODO_MK
+        return _dev_info;
     }
 
     std::pair<uint32_t, rs2_extrinsics> update_device::get_extrinsics(const stream_interface& stream) const

--- a/src/fw-update/fw-update-device.h
+++ b/src/fw-update/fw-update-device.h
@@ -97,7 +97,7 @@ namespace librealsense
     class update_device : public update_device_interface
     {
     public:
-        update_device( std::shared_ptr< context > const & ctx,
+        update_device( std::shared_ptr< const device_info > const &,
                        std::shared_ptr< platform::usb_device > const & usb_device );
         virtual ~update_device();
 
@@ -146,7 +146,7 @@ namespace librealsense
         void read_device_info(std::shared_ptr<platform::usb_messenger> messenger);
 
 
-        const std::shared_ptr<context> _context;
+        const std::shared_ptr< const device_info > _dev_info;
         const platform::rs_usb_device _usb_device;
         std::vector<uint8_t> _serial_number_buffer;
         std::string _highest_fw_version;

--- a/src/fw-update/fw-update-factory.cpp
+++ b/src/fw-update/fw-update-factory.cpp
@@ -52,9 +52,9 @@ namespace librealsense
                 if (!usb)
                     continue;
                 if (ds::RS_RECOVERY_PID == info.pid)
-                    return std::make_shared<ds_update_device>(get_context(), usb);
+                    return std::make_shared< ds_update_device >( shared_from_this(), usb );
                 if (ds::RS_USB2_RECOVERY_PID == info.pid)
-                    return std::make_shared<ds_update_device>(get_context(), usb);
+                    return std::make_shared< ds_update_device >( shared_from_this(), usb );
             }
         }
         throw std::runtime_error( rsutils::string::from()

--- a/src/fw-update/fw-update-factory.h
+++ b/src/fw-update/fw-update-factory.h
@@ -11,6 +11,8 @@ namespace librealsense
 {
     class fw_update_info : public platform::platform_device_info
     {
+        typedef platform::platform_device_info super;
+
     public:
         std::shared_ptr< device_interface > create_device() override;
 
@@ -19,6 +21,8 @@ namespace librealsense
 
         explicit fw_update_info(std::shared_ptr<context> ctx, platform::usb_device_info const & dfu)
             : platform_device_info( ctx, { { dfu } } ) {}
+
+        std::string get_address() const override { return "recovery:" + super::get_address(); }
 
     private:
         const char* RECOVERY_MESSAGE = "Selected RealSense device is in recovery mode!\nEither perform a firmware update or reconnect the camera to fall-back to last working firmware if available!";

--- a/src/platform/platform-device-info.h
+++ b/src/platform/platform-device-info.h
@@ -37,7 +37,7 @@ public:
         for( auto & d : _group.uvc_devices )
             return d.device_path;
         for( auto & d : _group.usb_devices )
-            return d.serial;
+            return d.id;
         throw std::runtime_error( "non-standard platform-device-info" );
     }
 

--- a/src/platform/uvc-device-info.h
+++ b/src/platform/uvc-device-info.h
@@ -27,7 +27,7 @@ struct uvc_device_info
     bool has_metadata_node = false;
     std::string metadata_node_id;
 
-    operator std::string()
+    operator std::string() const
     {
         std::ostringstream s;
         s << "id- " << id << "\nvid- " << std::hex << vid << "\npid- " << std::hex << pid << "\nmi- " << std::dec << mi

--- a/src/types.h
+++ b/src/types.h
@@ -867,7 +867,7 @@ namespace librealsense
         uint16_t mi;
         std::string unique_id;
 
-        operator std::string()
+        operator std::string() const
         {
             std::stringstream s;
 

--- a/unit-tests/dds/dds.py
+++ b/unit-tests/dds/dds.py
@@ -77,9 +77,17 @@ def wait_for_devices( context, mask, n=1, timeout=3, throw=None ):
         #
         devices = context.query_devices( mask )
         if len(devices) >= n:
-            if not exact or len(devices) == n:
+            if not exact:
+                return devices
+            if len(devices) == n:
+                if n == 1:
+                    return devices[0]
                 return devices
     if throw:
         raise TimeoutError( f'timeout waiting for {n} device(s)' )
     log.d( f'timeout waiting for {n} device(s)' )
+    if exact and n == 1:
+        if devices:
+            return device[0]
+        return None
     return devices

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -31,7 +31,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D435i" ):
         remote.run( 'instance = broadcast_device( d435i, d435i.device_info )' )
-        dds.wait_for_devices( context, only_sw_devices, n=1. )
+        dev = dds.wait_for_devices( context, only_sw_devices, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d435i.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d435i.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d435i.device_info.topic_root )
@@ -59,7 +59,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D405" ):
         remote.run( 'instance = broadcast_device( d405, d405.device_info )' )
-        dds.wait_for_devices( context, only_sw_devices, n=1. )
+        dev = dds.wait_for_devices( context, only_sw_devices, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d405.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d405.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d405.device_info.topic_root )
@@ -77,7 +77,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D455" ):
         remote.run( 'instance = broadcast_device( d455, d455.device_info )' )
-        dds.wait_for_devices( context, only_sw_devices, n=1. )
+        dev = dds.wait_for_devices( context, only_sw_devices, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d455.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d455.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d455.device_info.topic_root )

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -142,7 +142,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         from dds import wait_for_devices
         context = rs.context( { 'dds': { 'domain': 123, 'participant': 'librs' }} )
         only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
-        device = wait_for_devices( context, only_sw_devices, n=1. )[0]
+        device = wait_for_devices( context, only_sw_devices, n=1. )
         sensors = device.sensors
         test.check_equal( len(sensors), 1, on_fail=test.RAISE )
         sensor = sensors[0]


### PR DESCRIPTION
This was causing FW updates to cause problems (which is why only the nightlies failed).
The `get_device_info()` function for the `update_device` was throwing an exception, and this threw everything into disarray.

¯\\\_(ツ)\_/¯