### PR TITLE
Options registry for non-built-in DDS options

### DIFF
--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -121,8 +121,19 @@ extern "C" {
         RS2_OPTION_COUNT /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
     } rs2_option;
 
-    // This function is being deprecated. For existing options it will return option name, but for future API additions the user should call rs2_get_option_name instead.
+    /**
+    * Returns the option name if the option exists, or "UNKNOWN" otherwise.
+    * See rs2_option_from_string() for the reverse.
+    * \param[in] option    the option identifier
+    */
     const char* rs2_option_to_string(rs2_option option);
+
+    /**
+    * Get the specific rs2_option identifier given its name if found, or RS2_OPTION_COUNT if not.
+    * See rs2_option_to_string() for the reverse.
+    * \param[in] option_name    the case-sensitive option name
+    */
+    rs2_option rs2_option_from_string( const char * option_name );
 
     /** \brief For SR300 devices: provides optimized settings (presets) for specific types of usage. */
     typedef enum rs2_sr300_visual_preset
@@ -276,10 +287,10 @@ extern "C" {
     const char* rs2_get_option_name(const rs2_options* options, rs2_option option, rs2_error** error);
 
     /**
-   * get the specific option from options list
-   * \param[in] i    the index of the option
-   * \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
-   */
+    * get the specific option from options list
+    * \param[in] i    the index of the option
+    * \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    */
     rs2_option rs2_get_option_from_list(const rs2_options_list* options, int i, rs2_error** error);
 
     /**

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -231,7 +231,7 @@ namespace librealsense
             devices.hid_devices = _backend->query_hid_devices();
         }
         auto const list = create_devices( devices, _playback_devices, mask );
-        LOG_INFO( "Found " << list.size() << " RealSense devices (mask 0x" << std::hex << mask << ")" );
+        LOG_INFO( "Found " << list.size() << " RealSense devices (mask 0x" << std::hex << mask << std::dec << ")" );
         for( auto & item : list )
             LOG_INFO( "... " << item->get_address() );
         return list;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/motion.h"
         "${CMAKE_CURRENT_LIST_DIR}/video.h"
         "${CMAKE_CURRENT_LIST_DIR}/options.h"
+        "${CMAKE_CURRENT_LIST_DIR}/options-registry.h"
+        "${CMAKE_CURRENT_LIST_DIR}/options-registry.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/info.h"
         "${CMAKE_CURRENT_LIST_DIR}/extension.h"
         "${CMAKE_CURRENT_LIST_DIR}/processing.h"

--- a/src/core/options-registry.cpp
+++ b/src/core/options-registry.cpp
@@ -1,0 +1,122 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include "options-registry.h"
+#include "basics.h"
+#include <src/librealsense-exception.h>
+#include <vector>
+#include <mutex>
+#include <map>
+
+
+namespace librealsense {
+
+
+LRS_EXTENSION_API std::string const & get_string( rs2_option );
+
+
+namespace by_name {
+
+
+static std::map< std::string, rs2_option > _option_by_name = []()
+{
+    // Automatically add all our known options into the option names -- that way, no duplicate custom option
+    // can be added...
+    std::map< std::string, rs2_option > map;
+    for( auto option = rs2_option( 0 ); option < RS2_OPTION_COUNT; option = rs2_option( option + 1 ) )
+        map[get_string( option )] = option;
+    return std::move( map );
+}();
+static std::vector< std::string > _name_by_index;
+static std::mutex _mutex;
+
+
+inline size_t option_to_index( rs2_option by_name_option )
+{
+    return -by_name_option - 1;
+}
+
+
+inline rs2_option index_to_option( size_t index )
+{
+    return rs2_option( -( int( index ) + 1 ) );
+}
+
+
+inline size_t new_index()
+{
+    // _name_by_index and _option_by_name do not have the same size:
+    // _option_by_name is also populated with non-registered options names!
+    auto const index = _name_by_index.size();
+    // We have to return strings by reference, which means we cannot control access simply with a mutex!
+    // The mutex will still be able to control registration, but otherwise we want to ensure that the names stay
+    // inviolable after registered, so the name-by-index vector cannot be allowed to grow beyond a certain limit.
+    if( index >= 1000 )
+        throw std::runtime_error( "reached option limit of 1000" );
+    _name_by_index.reserve( 1000 );
+    return index;
+}
+
+
+}  // namespace by_name
+
+
+rs2_option options_registry::register_option_by_name( std::string const & option_name, bool ok_if_there )
+{
+    if( option_name.empty() )
+        throw invalid_value_exception( "cannot register an empty option name" );
+
+    std::lock_guard< std::mutex > lock( by_name::_mutex );
+    auto const index = by_name::new_index();
+    auto const option = by_name::index_to_option( index );
+    auto it_new = by_name::_option_by_name.emplace( option_name, option );
+    if( ! it_new.second )
+    {
+        if( ! ok_if_there )
+            throw invalid_value_exception( "option '" + option_name + "' was already registered" );
+        return it_new.first->second;
+    }
+    by_name::_name_by_index.push_back( option_name );
+    LOG_DEBUG( "        new option registered: '" << option_name << "' = " << int( option ) );
+    return option;
+}
+
+
+rs2_option options_registry::find_option_by_name( std::string const & option_name )
+{
+    // Both regular and by-name options are supported
+    std::lock_guard< std::mutex > lock( by_name::_mutex );
+    auto it = by_name::_option_by_name.find( option_name );
+    if( it == by_name::_option_by_name.end() )
+        return RS2_OPTION_COUNT;
+    return it->second;
+}
+
+
+bool options_registry::is_option_registered( rs2_option const option )
+{
+    if( option >= 0 )
+        return false;
+
+    auto const index = by_name::option_to_index( option );
+    if( index >= by_name::_name_by_index.size() )
+        return false;
+
+    return true;
+}
+
+
+std::string const & options_registry::get_registered_option_name( rs2_option const option )
+{
+    if( option >= 0 )
+        throw invalid_value_exception( "option " + std::to_string( option ) + " is not registered" );
+
+    auto const index = by_name::option_to_index( option );
+    if( index >= by_name::_name_by_index.size() )
+        throw invalid_value_exception( "bad option " + std::to_string( option ) );
+
+    return by_name::_name_by_index[index];
+}
+
+
+}  // namespace librealsense

--- a/src/core/options-registry.h
+++ b/src/core/options-registry.h
@@ -1,0 +1,30 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <librealsense2/h/rs_option.h>
+#include <string>
+
+
+namespace librealsense {
+
+
+class options_registry
+{
+public:
+    // Register a custom option. Option names are unique and case-sensitive. By default, will throw if the option
+    // already exists.
+    static rs2_option register_option_by_name( std::string const & option_name, bool ok_if_there = false );
+
+    // True if register_option_by_name() was called (i.e., a custom option)
+    static bool is_option_registered( rs2_option );
+
+    // Map from option-name to option - works for both custom and built-in options
+    static rs2_option find_option_by_name( std::string const & option_name );
+
+    // Returns the name of the option - works only if option is custom, otherwise returns the empty string
+    static std::string const & get_registered_option_name( rs2_option );
+};
+
+
+}  // namespace librealsense

--- a/src/core/options.h
+++ b/src/core/options.h
@@ -40,7 +40,7 @@ namespace librealsense
         virtual const option& get_option(rs2_option id) const = 0;
         virtual bool supports_option(rs2_option id) const = 0;
         virtual std::vector<rs2_option> get_supported_options() const = 0;
-        virtual const char* get_option_name(rs2_option) const = 0;
+        virtual std::string const & get_option_name(rs2_option) const = 0;
         virtual ~options_interface() = default;
     };
 
@@ -116,7 +116,7 @@ namespace librealsense
 
         std::vector<rs2_option> get_supported_options() const override;
 
-        virtual const char* get_option_name(rs2_option option) const override
+        virtual std::string const & get_option_name(rs2_option option) const override
         {
             return get_string(option);
         }

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -191,7 +191,8 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
             sensor_info.proxy->add_dds_stream( sidx, stream );
             _stream_name_to_owning_sensor[stream->name()] = sensor_info.proxy;
             type_and_index_to_dds_stream_sidx.insert( { type_and_index, sidx }  );
-            LOG_DEBUG( sidx.to_string() << " " << stream->sensor_name() << " : " << stream->name() );
+            LOG_DEBUG( sidx.to_string() << " " << get_string( sensor_info.type ) << " '" << stream->sensor_name()
+                                        << "' : '" << stream->name() << "' " << get_string( stream_type ) );
 
             software_sensor & sensor = get_software_sensor( sensor_info.sensor_index );
             auto video_stream = std::dynamic_pointer_cast< realdds::dds_video_stream >( stream );

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -126,7 +126,7 @@ const char* librealsense::uvc_pu_option::get_description() const
     case RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE: return "Enable / disable auto-white-balance";
     case RS2_OPTION_POWER_LINE_FREQUENCY: return "Power Line Frequency";
     case RS2_OPTION_AUTO_EXPOSURE_PRIORITY: return "Restrict Auto-Exposure to enforce constant FPS rate. Turn ON to remove the restrictions (may result in FPS drop)";
-    default: return _ep.get_option_name(_id);
+    default: return _ep.get_option_name( _id ).c_str();
     }
 }
 

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -140,6 +140,7 @@ EXPORTS
     rs2_format_to_string
     rs2_distortion_to_string
     rs2_option_to_string
+    rs2_option_from_string
     rs2_camera_info_to_string
     rs2_frame_metadata_to_string
     rs2_frame_metadata_value_to_string

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -671,7 +671,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(nullptr, options)
 const char* rs2_get_option_name(const rs2_options* options,rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    return options->options->get_option_name(option);
+    return options->options->get_option_name(option).c_str();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, option, options)
 

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -2,7 +2,7 @@
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 #include "types.h"
-#include "core/options.h"
+#include "core/options-registry.h"
 
 
 #define STRX( X ) make_less_screamy( #X )
@@ -703,7 +703,19 @@ const char * get_string( rs2_l500_visual_preset value )
 const char * rs2_stream_to_string( rs2_stream stream ) { return librealsense::get_string( stream ); }
 const char * rs2_format_to_string( rs2_format format ) { return librealsense::get_string( format ); }
 const char * rs2_distortion_to_string( rs2_distortion distortion ) { return librealsense::get_string( distortion ); }
-const char * rs2_option_to_string( rs2_option option ) { return librealsense::get_string( option ).c_str(); }
+
+const char * rs2_option_to_string( rs2_option option )
+{
+    return librealsense::get_string( option ).c_str();
+}
+
+rs2_option rs2_option_from_string( char const * option_name )
+{
+    return option_name
+        ? librealsense::options_registry::find_option_by_name( option_name )
+        : RS2_OPTION_COUNT;
+}
+
 const char * rs2_camera_info_to_string( rs2_camera_info info ) { return librealsense::get_string( info ); }
 const char * rs2_timestamp_domain_to_string( rs2_timestamp_domain info ) { return librealsense::get_string( info ); }
 const char * rs2_notification_category_to_string( rs2_notification_category category ) { return librealsense::get_string( category ); }

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -2,6 +2,8 @@
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 #include "types.h"
+#include "core/options.h"
+
 
 #define STRX( X ) make_less_screamy( #X )
 #define STRCASE( T, X )                                                                                                \
@@ -310,114 +312,151 @@ const char * get_string( rs2_log_severity value )
 #undef CASE
 }
 
-const char * get_string( rs2_option value )
+std::string const & get_string_( rs2_option value )
 {
-#define CASE( X ) STRCASE( OPTION, X )
-    switch( value )
+    static auto str_array = []()
     {
-    CASE( BACKLIGHT_COMPENSATION )
-    CASE( BRIGHTNESS )
-    CASE( CONTRAST )
-    CASE( EXPOSURE )
-    CASE( GAIN )
-    CASE( GAMMA )
-    CASE( HUE )
-    CASE( SATURATION )
-    CASE( SHARPNESS )
-    CASE( WHITE_BALANCE )
-    CASE( ENABLE_AUTO_EXPOSURE )
-    CASE( ENABLE_AUTO_WHITE_BALANCE )
-    CASE( LASER_POWER )
-    CASE( ACCURACY )
-    CASE( MOTION_RANGE )
-    CASE( FILTER_OPTION )
-    CASE( CONFIDENCE_THRESHOLD )
-    CASE( FRAMES_QUEUE_SIZE )
-    CASE( VISUAL_PRESET )
-    CASE( TOTAL_FRAME_DROPS )
-    CASE( EMITTER_ENABLED )
-    case RS2_OPTION_AUTO_EXPOSURE_MODE:  return "Fisheye Auto Exposure Mode";
-    CASE( POWER_LINE_FREQUENCY )
-    CASE( ASIC_TEMPERATURE )
-    CASE( ERROR_POLLING_ENABLED )
-    CASE( PROJECTOR_TEMPERATURE )
-    CASE( OUTPUT_TRIGGER_ENABLED )
-    CASE( MOTION_MODULE_TEMPERATURE )
-    CASE( DEPTH_UNITS )
-    CASE( ENABLE_MOTION_CORRECTION )
-    CASE( AUTO_EXPOSURE_PRIORITY )
-    CASE( HISTOGRAM_EQUALIZATION_ENABLED )
-    CASE( MIN_DISTANCE )
-    CASE( MAX_DISTANCE )
-    CASE( COLOR_SCHEME )
-    CASE( TEXTURE_SOURCE )
-    CASE( FILTER_MAGNITUDE )
-    CASE( FILTER_SMOOTH_ALPHA )
-    CASE( FILTER_SMOOTH_DELTA )
-    CASE( STEREO_BASELINE )
-    CASE( HOLES_FILL )
-    CASE( AUTO_EXPOSURE_CONVERGE_STEP )
-    CASE( INTER_CAM_SYNC_MODE )
-    CASE( STREAM_FILTER )
-    CASE( STREAM_FORMAT_FILTER )
-    CASE( STREAM_INDEX_FILTER )
-    CASE( EMITTER_ON_OFF )
-    CASE( ZERO_ORDER_POINT_X )
-    CASE( ZERO_ORDER_POINT_Y )
-    case RS2_OPTION_LLD_TEMPERATURE:        return "LDD temperature";
-    CASE( MC_TEMPERATURE )
-    CASE( MA_TEMPERATURE )
-    CASE( APD_TEMPERATURE )
-    CASE( HARDWARE_PRESET )
-    CASE( GLOBAL_TIME_ENABLED )
-    CASE( ENABLE_MAPPING )
-    CASE( ENABLE_RELOCALIZATION )
-    CASE( ENABLE_POSE_JUMPING )
-    CASE( ENABLE_DYNAMIC_CALIBRATION )
-    CASE( DEPTH_OFFSET )
-    CASE( LED_POWER )
-    CASE( ZERO_ORDER_ENABLED )
-    CASE( ENABLE_MAP_PRESERVATION )
-    CASE( FREEFALL_DETECTION_ENABLED )
-    case RS2_OPTION_AVALANCHE_PHOTO_DIODE:  return "Receiver Gain";
-    CASE( POST_PROCESSING_SHARPENING )
-    CASE( PRE_PROCESSING_SHARPENING )
-    CASE( NOISE_FILTERING )
-    CASE( INVALIDATION_BYPASS )
-    // CASE(AMBIENT_LIGHT) // Deprecated - replaced by "DIGITAL_GAIN" option
-    CASE( DIGITAL_GAIN )
-    CASE( SENSOR_MODE )
-    CASE( EMITTER_ALWAYS_ON )
-    CASE( THERMAL_COMPENSATION )
-    CASE( TRIGGER_CAMERA_ACCURACY_HEALTH )
-    CASE( RESET_CAMERA_ACCURACY_HEALTH )
-    CASE( HOST_PERFORMANCE )
-    CASE( HDR_ENABLED )
-    CASE( SEQUENCE_NAME )
-    CASE( SEQUENCE_SIZE )
-    CASE( SEQUENCE_ID )
-    CASE( HUMIDITY_TEMPERATURE )
-    CASE( ENABLE_MAX_USABLE_RANGE )
-    case RS2_OPTION_ALTERNATE_IR:           return "Alternate IR";
-    CASE( NOISE_ESTIMATION )
-    case RS2_OPTION_ENABLE_IR_REFLECTIVITY: return "Enable IR Reflectivity";
-    CASE( AUTO_EXPOSURE_LIMIT )
-    CASE( AUTO_GAIN_LIMIT )
-    CASE( AUTO_RX_SENSITIVITY )
-    CASE( TRANSMITTER_FREQUENCY )
-    CASE( VERTICAL_BINNING )
-    CASE( RECEIVER_SENSITIVITY )
-    CASE( AUTO_EXPOSURE_LIMIT_TOGGLE )
-    CASE( AUTO_GAIN_LIMIT_TOGGLE )
-    CASE( EMITTER_FREQUENCY )
-    case RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE:  return "Auto Exposure Mode";
-    CASE( LEFT_IR_TEMPERATURE )
-    default:
-        assert( ! is_valid( value ) );
-        return UNKNOWN_VALUE;
-    }
+        std::vector< std::string > arr( RS2_OPTION_COUNT );
+#define CASE( X ) STRARR( arr, OPTION, X );
+        CASE( BACKLIGHT_COMPENSATION )
+        CASE( BRIGHTNESS )
+        CASE( CONTRAST )
+        CASE( EXPOSURE )
+        CASE( GAIN )
+        CASE( GAMMA )
+        CASE( HUE )
+        CASE( SATURATION )
+        CASE( SHARPNESS )
+        CASE( WHITE_BALANCE )
+        CASE( ENABLE_AUTO_EXPOSURE )
+        CASE( ENABLE_AUTO_WHITE_BALANCE )
+        CASE( LASER_POWER )
+        CASE( ACCURACY )
+        CASE( MOTION_RANGE )
+        CASE( FILTER_OPTION )
+        CASE( CONFIDENCE_THRESHOLD )
+        CASE( FRAMES_QUEUE_SIZE )
+        CASE( VISUAL_PRESET )
+        CASE( TOTAL_FRAME_DROPS )
+        CASE( EMITTER_ENABLED )
+        arr[RS2_OPTION_AUTO_EXPOSURE_MODE] = "Fisheye Auto Exposure Mode";
+        CASE( POWER_LINE_FREQUENCY )
+        CASE( ASIC_TEMPERATURE )
+        CASE( ERROR_POLLING_ENABLED )
+        CASE( PROJECTOR_TEMPERATURE )
+        CASE( OUTPUT_TRIGGER_ENABLED )
+        CASE( MOTION_MODULE_TEMPERATURE )
+        CASE( DEPTH_UNITS )
+        CASE( ENABLE_MOTION_CORRECTION )
+        CASE( AUTO_EXPOSURE_PRIORITY )
+        CASE( HISTOGRAM_EQUALIZATION_ENABLED )
+        CASE( MIN_DISTANCE )
+        CASE( MAX_DISTANCE )
+        CASE( COLOR_SCHEME )
+        CASE( TEXTURE_SOURCE )
+        CASE( FILTER_MAGNITUDE )
+        CASE( FILTER_SMOOTH_ALPHA )
+        CASE( FILTER_SMOOTH_DELTA )
+        CASE( STEREO_BASELINE )
+        CASE( HOLES_FILL )
+        CASE( AUTO_EXPOSURE_CONVERGE_STEP )
+        CASE( INTER_CAM_SYNC_MODE )
+        CASE( STREAM_FILTER )
+        CASE( STREAM_FORMAT_FILTER )
+        CASE( STREAM_INDEX_FILTER )
+        CASE( EMITTER_ON_OFF )
+        CASE( ZERO_ORDER_POINT_X )
+        CASE( ZERO_ORDER_POINT_Y )
+        arr[RS2_OPTION_LLD_TEMPERATURE] = "LDD temperature";
+        CASE( MC_TEMPERATURE )
+        CASE( MA_TEMPERATURE )
+        CASE( APD_TEMPERATURE )
+        CASE( HARDWARE_PRESET )
+        CASE( GLOBAL_TIME_ENABLED )
+        CASE( ENABLE_MAPPING )
+        CASE( ENABLE_RELOCALIZATION )
+        CASE( ENABLE_POSE_JUMPING )
+        CASE( ENABLE_DYNAMIC_CALIBRATION )
+        CASE( DEPTH_OFFSET )
+        CASE( LED_POWER )
+        CASE( ZERO_ORDER_ENABLED )
+        CASE( ENABLE_MAP_PRESERVATION )
+        CASE( FREEFALL_DETECTION_ENABLED )
+        arr[RS2_OPTION_AVALANCHE_PHOTO_DIODE] = "Receiver Gain";
+        CASE( POST_PROCESSING_SHARPENING )
+        CASE( PRE_PROCESSING_SHARPENING )
+        CASE( NOISE_FILTERING )
+        CASE( INVALIDATION_BYPASS )
+        // CASE(AMBIENT_LIGHT) // Deprecated - replaced by "DIGITAL_GAIN" option
+        CASE( DIGITAL_GAIN )
+        CASE( SENSOR_MODE )
+        CASE( EMITTER_ALWAYS_ON )
+        CASE( THERMAL_COMPENSATION )
+        CASE( TRIGGER_CAMERA_ACCURACY_HEALTH )
+        CASE( RESET_CAMERA_ACCURACY_HEALTH )
+        CASE( HOST_PERFORMANCE )
+        CASE( HDR_ENABLED )
+        CASE( SEQUENCE_NAME )
+        CASE( SEQUENCE_SIZE )
+        CASE( SEQUENCE_ID )
+        CASE( HUMIDITY_TEMPERATURE )
+        CASE( ENABLE_MAX_USABLE_RANGE )
+        arr[RS2_OPTION_ALTERNATE_IR] = "Alternate IR";
+        CASE( NOISE_ESTIMATION )
+        arr[RS2_OPTION_ENABLE_IR_REFLECTIVITY] = "Enable IR Reflectivity";
+        CASE( AUTO_EXPOSURE_LIMIT )
+        CASE( AUTO_GAIN_LIMIT )
+        CASE( AUTO_RX_SENSITIVITY )
+        CASE( TRANSMITTER_FREQUENCY )
+        CASE( VERTICAL_BINNING )
+        CASE( RECEIVER_SENSITIVITY )
+        CASE( AUTO_EXPOSURE_LIMIT_TOGGLE )
+        CASE( AUTO_GAIN_LIMIT_TOGGLE )
+        CASE( EMITTER_FREQUENCY )
+        arr[RS2_OPTION_DEPTH_AUTO_EXPOSURE_MODE] = "Auto Exposure Mode";
+        CASE( LEFT_IR_TEMPERATURE )
 #undef CASE
+        return arr;
+    }();
+    if( value >= 0 && value < RS2_OPTION_COUNT )
+        return str_array[value];
+    return unknown_value_str;
 }
+
+std::string const & get_string( rs2_option const option )
+{
+    if( options_registry::is_option_registered( option ) )
+        return options_registry::get_registered_option_name( option );
+    return get_string_( option );
+}
+
+
+bool is_valid( rs2_option option )
+{
+    return options_registry::is_option_registered( option )
+        || option >= 0 && option < RS2_OPTION_COUNT;
+}
+
+
+std::ostream & operator<<( std::ostream & out, rs2_option option )
+{
+    if( options_registry::is_option_registered( option ) )
+        return out << options_registry::get_registered_option_name( option );
+    if( option >= 0 && option < RS2_OPTION_COUNT )
+        return out << get_string_( option );
+    return out << (int)option;
+}
+
+
+bool try_parse( std::string const & option_name, rs2_option & res )
+{
+    auto const option = options_registry::find_option_by_name( option_name );
+    if( RS2_OPTION_COUNT == option )
+        return false;
+    res = option;
+    return true;
+}
+
 
 const char * get_string( rs2_format value )
 {
@@ -664,7 +703,7 @@ const char * get_string( rs2_l500_visual_preset value )
 const char * rs2_stream_to_string( rs2_stream stream ) { return librealsense::get_string( stream ); }
 const char * rs2_format_to_string( rs2_format format ) { return librealsense::get_string( format ); }
 const char * rs2_distortion_to_string( rs2_distortion distortion ) { return librealsense::get_string( distortion ); }
-const char * rs2_option_to_string( rs2_option option ) { return librealsense::get_string( option ); }
+const char * rs2_option_to_string( rs2_option option ) { return librealsense::get_string( option ).c_str(); }
 const char * rs2_camera_info_to_string( rs2_camera_info info ) { return librealsense::get_string( info ); }
 const char * rs2_timestamp_domain_to_string( rs2_timestamp_domain info ) { return librealsense::get_string( info ); }
 const char * rs2_notification_category_to_string( rs2_notification_category category ) { return librealsense::get_string( category ); }

--- a/src/types.h
+++ b/src/types.h
@@ -269,7 +269,7 @@ namespace librealsense
 
 // This macro can be used directly if needed to support enumerators with no RS2_#####_COUNT last value
 #define RS2_ENUM_HELPERS_CUSTOMIZED( TYPE, FIRST, LAST, STRTYPE )                                  \
-    LRS_EXTENSION_API STRTYPE get_string( TYPE value );                                       \
+    LRS_EXTENSION_API STRTYPE get_string( TYPE value );                                            \
     inline bool is_valid( TYPE value ) { return value >= FIRST && value <= LAST; }                 \
     inline std::ostream & operator<<( std::ostream & out, TYPE value )                             \
     {                                                                                              \
@@ -292,10 +292,15 @@ namespace librealsense
         return false;                                                                              \
     }
 
+    // For rs2_option, these make use of the registry
+    LRS_EXTENSION_API std::string const & get_string( rs2_option value );
+    bool is_valid( rs2_option value );
+    std::ostream & operator<<( std::ostream & out, rs2_option option );
+    bool try_parse( const std::string & option_name, rs2_option & result );
+
     RS2_ENUM_HELPERS(rs2_stream, STREAM)
     RS2_ENUM_HELPERS(rs2_format, FORMAT)
     RS2_ENUM_HELPERS(rs2_distortion, DISTORTION)
-    RS2_ENUM_HELPERS(rs2_option, OPTION)
     RS2_ENUM_HELPERS(rs2_camera_info, CAMERA_INFO)
     RS2_ENUM_HELPERS_CUSTOMIZED(rs2_frame_metadata_value, 0, RS2_FRAME_METADATA_COUNT - 1, std::string const & )
     RS2_ENUM_HELPERS(rs2_timestamp_domain, TIMESTAMP_DOMAIN)

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -564,7 +564,10 @@ PYBIND11_MODULE(NAME, m) {
     using realdds::dds_option_range;
     py::class_< dds_option_range >( m, "dds_option_range" )
         .def( py::init<>() )
-        .def( py::init<>( []( float n, float x, float s, float def ) { return dds_option_range{ n, x, s, def }; } ) )
+        .def( py::init<>(
+            []( float min, float max, float step, float def ) {
+                return dds_option_range{ min, max, step, def };
+            } ) )
         .def_readwrite( "min", &dds_option_range::min )
         .def_readwrite( "max", &dds_option_range::max )
         .def_readwrite( "step", &dds_option_range::step )

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -564,6 +564,7 @@ PYBIND11_MODULE(NAME, m) {
     using realdds::dds_option_range;
     py::class_< dds_option_range >( m, "dds_option_range" )
         .def( py::init<>() )
+        .def( py::init<>( []( float n, float x, float s, float def ) { return dds_option_range{ n, x, s, def }; } ) )
         .def_readwrite( "min", &dds_option_range::min )
         .def_readwrite( "max", &dds_option_range::max )
         .def_readwrite( "step", &dds_option_range::step )

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -374,17 +374,12 @@ int stream_name_to_index( std::string const & type_string )
     return index;
 }
 
-rs2_option option_name_to_type( const std::string & name, const rs2::sensor & sensor )
+rs2_option option_name_to_id( const std::string & name )
 {
-    for( size_t i = 0; i < static_cast< size_t >( RS2_OPTION_COUNT ); i++ )
-    {
-        if( name.compare( sensor.get_option_name( static_cast< rs2_option >( i ) ) ) == 0 )
-        {
-            return static_cast< rs2_option >( i );
-        }
-    }
-
-    throw std::runtime_error( "Option '" + name + "' type not found" );
+    auto option_id = rs2_option_from_string( name.c_str() );
+    if( RS2_OPTION_COUNT == option_id )
+        throw std::runtime_error( "Option '" + name + "' not found" );
+    return option_id;
 }
 
 
@@ -729,8 +724,7 @@ void lrs_device_controller::set_option( const std::shared_ptr< realdds::dds_opti
         throw std::runtime_error( "no stream '" + option->owner_name() + "' in device" );
     auto server = it->second;
     auto & sensor = _rs_sensors[server->sensor_name()];
-    rs2_option opt_type = option_name_to_type( option->get_name(), sensor );
-    sensor.set_option( opt_type, new_value );
+    sensor.set_option( option_name_to_id( option->get_name() ), new_value );
 }
 
 
@@ -741,8 +735,7 @@ float lrs_device_controller::query_option( const std::shared_ptr< realdds::dds_o
         throw std::runtime_error( "no stream '" + option->owner_name() + "' in device" );
     auto server = it->second;
     auto & sensor = _rs_sensors[server->sensor_name()];
-    rs2_option opt_type = option_name_to_type( option->get_name(), sensor );
-    return sensor.get_option( opt_type );
+    return sensor.get_option( option_name_to_id( option->get_name() ) );
 }
 
 

--- a/unit-tests/dds/test-librs-options.py
+++ b/unit-tests/dds/test-librs-options.py
@@ -1,0 +1,66 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#test:donotrun:!dds
+#test:retries 2
+
+from rspy import log, test
+with test.remote.fork( nested_indent=None ) as remote:
+    if remote is None:  # we're the fork
+        import pyrealdds as dds
+        dds.debug( log.is_debug_on() )
+
+        with test.closure( 'Start the server participant' ):
+            participant = dds.participant()
+            participant.init( 123, 'server' )
+
+        with test.closure( 'Create the server' ):
+            device_info = dds.message.device_info()
+            device_info.name = 'Options device'
+            device_info.topic_root = 'librs-options/device'
+            s1p1 = dds.video_stream_profile( 9, dds.video_encoding.rgb, 10, 10 )
+            s1profiles = [s1p1]
+            s1 = dds.color_stream_server( 's1', 'sensor' )
+            s1.init_profiles( s1profiles, 0 )
+            options = []
+            option = dds.dds_option( 'Backlight Compensation', 'RGB Camera' )
+            option.set_range( dds.dds_option_range( 0, 1, 1, 0 ) )
+            option.set_description( 'Backlight custom description' )
+            options.append( option )
+            option = dds.dds_option( 'Custom Option', 'RGB Camera' )
+            option.set_range( dds.dds_option_range( 0, 1, 1, 0 ) )
+            option.set_description( 'Something' )
+            options.append( option )
+            s1.init_options( options )
+            server = dds.device_server( participant, device_info.topic_root )
+            server.init( [s1], [], {} )
+
+        with test.closure( 'Broadcast the device', on_fail=test.ABORT ):
+            server.broadcast( device_info )
+
+        raise StopIteration()  # quit the remote
+
+
+    ###############################################################################################################
+    # The client is LibRS
+    #
+    import pyrealsense2 as rs
+    if log.is_debug_on():
+        rs.log_to_console( rs.log_severity.debug )
+    from dds import wait_for_devices
+
+    with test.closure( 'Initialize librealsense context', on_fail=test.ABORT ):
+        context = rs.context( { 'dds': { 'domain': 123, 'participant': 'client' }} )
+        only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any)
+
+    with test.closure( 'Find the server', on_fail=test.ABORT ):
+        dev = wait_for_devices( context, only_sw_devices, n=1. )
+        for s in dev.query_sensors():
+            break
+        options = test.info( "supported options", s.get_supported_options() )
+        test.check_equal( len(options), 3 )  # 'Frames Queue Size' gets added to all sensors!!?!?!
+
+    dev = None
+    context = None
+
+test.print_results()

--- a/unit-tests/dds/test-streaming.py
+++ b/unit-tests/dds/test-streaming.py
@@ -2,6 +2,7 @@
 # Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
+#test:retries 2
 
 import pyrealdds as dds
 from rspy import log, test

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -484,6 +484,7 @@ def info( name, value, persistent = False ):
     """
     global test_info
     test_info[name] = Information(value, persistent)
+    return value
 
 
 def reset_info(persistent = False):

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -76,7 +76,7 @@ if '--nested' in sys.argv:
     sys.argv.pop( nested_index )
     # Use a special prompt when interactive mode is requested (-i)
     if sys.flags.interactive and not hasattr( sys, 'ps1' ):
-        sys.ps1 = '___\n'  # sys.ps2 will get the default '...'
+        sys.ps1 = '___ready\n'  # sys.ps2 will get the default '...'
 
 
 def set_env_vars( env_vars ):
@@ -598,7 +598,7 @@ class closure:
         return True  # otherwise the exception will keep propagating
 
 
-def print_results_and_exit():
+def print_results():
     """
     Used to print the results of the tests in the file. The format has to agree with the expected format in check_log()
     in run-unit-tests and with the C++ format using Catch
@@ -613,10 +613,14 @@ def print_results_and_exit():
         log.out("assertions:", n_assertions, "|", passed, "passed |", n_failed_assertions, "failed")
         sys.exit(1)
     log.out("All tests passed (" + str(n_assertions) + " assertions in " + str(n_tests) + " test cases)")
+
+
+def print_results_and_exit():
+    print_results()
     sys.exit(0)
 
 
-def nested_cmd( script, nested_indent = 'svr', interactive = False, cwd = None ):
+def nested_cmd( script, nested_indent='svr', interactive=False, cwd=None ):
     """
     Builds the command list for running a nested script, given the current context etc.
 
@@ -654,7 +658,7 @@ def nested_cmd( script, nested_indent = 'svr', interactive = False, cwd = None )
     if log.is_color_on():
         cmd += ['--color']
     #
-    cmd += ['--nested', nested_indent]
+    cmd += ['--nested', nested_indent or '']
     #
     return cmd
 
@@ -741,27 +745,23 @@ class remote:
         It is in danger of HANGING UP our own process because readline blocks forever! To avoid this
         please follow the usage guidelines in the class notes.
         """
-        nested_prefix = f'[{self._nested_indent}] '
+        nested_prefix = self._nested_indent and f'[{self._nested_indent}] ' or ''
         for line in iter( self._process.stdout.readline, '' ):
             # NOTE: line will include the terminating \n EOL
             # NOTE: so readline will return '' (with no EOL) when EOF is reached - the "sentinel"
             #       2nd argument to iter() - and we'll break out of the loop
-            if line == '___\n':
+            if line == '___ready\n':
                 log.d( self._name, self._exception and 'raised an error' or 'is ready' )
-                if self._on_ready:  # a queue of callbacks
-                    callback = self._on_ready.pop(0)
-                    if callback:
-                        callback()
                 if self._events:
                     event = self._events.pop(0)
                     if event:
                         event.set()
                 else:
-                    # We raise the error here only as a last resort: we prefer handling it over to
+                    # We raise the error here only as a last resort: we prefer handing it over to
                     # the waiting thread on the event!
                     self._raise_if_needed()
                 continue
-            if line.find( nested_prefix ) < 0:  # there could be color codes in the line
+            if not nested_prefix or line.find( nested_prefix ) < 0:  # there could be color codes in the line
                 if self._exception:
                     self._exception.append( line[:-1] )
                     # We cannot raise an error here -- it'll just exit the thread and not be
@@ -790,52 +790,47 @@ class remote:
         self._thread = threading.Thread( target = remote._output_reader, args=(self,) )
         #
         # We allow waiting until the script is ready for input: see wait_until_ready()
-        self._initialized_event = threading.Event()
-        def set_initialized():
-            nonlocal self
-            self._initialized_event = None
-            self._raise_if_needed()
-        self._on_ready = [ set_initialized ]
-        self._events = [ self._initialized_event ]
+        import threading
+        self._ready = threading.Event()
+        self._events = [ self._ready ]
         #
         self._thread.start()
 
-    def _raise_if_needed( self, how='raise' ):
+    def _raise_if_needed( self, on_fail=RAISE ):
         if self._exception:
             what = f'[{self._name}] ' + self._exception.pop()
             while self._exception and ( what.startswith( 'Invoked with:' ) or what.startswith( '  ' ) or what.startswith( '\n' )):
                 what = self._exception.pop() + '\n  ' + what
             self._exception = None
-            if how == RAISE:
+            if on_fail == RAISE:
                 raise remote.Error( what )
             print_stack_( traceback.format_stack()[:-2] )
             log.out( f'      {what}' )
-            if how == ABORT:
+            if on_fail == ABORT:
                 self.wait()
                 abort()
-            if how == LOG:
+            if on_fail == LOG:
                 pass
             else:
                 raise ValueError( f'invalid failure handler "{how}" should be raise, abort, or log' )
 
 
-    def wait_until_ready( self, timeout=10 ):
+    def wait_until_ready( self, timeout=10, on_fail=RAISE ):
         """
         The initial script can take a bit of time to load and run, and more if it does something "heavy". The user may want
         to wait until it's "ready" to take input...
         """
-        if not self._initialized_event.wait( timeout ):
-            raise RuntimeError( f'{self._name} timeout' )
+        if not self._ready.wait( timeout ):
+            raise RuntimeError( f'{self._name} timed out' )
+        self._raise_if_needed( on_fail=on_fail )
         if not self.is_running():
             raise RuntimeError( f'{self._name} exited with status {self._status}' )
 
-    def run( self, command, on_ready=None, timeout=5, on_fail=RAISE ):
+    def run( self, command, timeout=5, on_fail=RAISE ):
         """
-        Run in a command asynchronously in the remote process: returns immediately without waiting for the command to
-        finish.
+        Run a command asynchronously in the remote process
         :param command: the line, as if you typed it in an interactive shell
-        :param on_ready: a callback that will be called when the command finishes
-        :param timeout: if not None, how long to wait for the command to finish
+        :param timeout: if not None, how long to wait for the command to finish; otherwise returns immediately
         :param on_fail: how to handle exceptions on the server
                         'raise' to raise them as remote.Error()
                         'abort' to test.abort()
@@ -843,16 +838,13 @@ class remote:
         """
         log.d( self._name, 'running:', command )
         assert self._interactive
-        self._on_ready.append( on_ready )  # even if None
-        import threading
-        event = timeout and threading.Event() or None
-        self._events.append( event )
+        self._events.append( self._ready )
+        self._ready.clear()
         self._process.stdin.write( command + '\n' )
         self._process.stdin.flush()
-        if event:
-            if not event.wait( timeout ):
-                raise RuntimeError( f'{self._name} command timed out' )
-            self._raise_if_needed( on_fail )
+        if timeout:
+            self.wait_until_ready( timeout=timeout, on_fail=on_fail )
+
 
     def wait( self, timeout=10 ):
         """
@@ -889,9 +881,8 @@ class remote:
             except subprocess.TimeoutExpired:
                 log.d( self._name, 'process terminate timed out; no status' )
             finally:
-                if self._initialized_event is not None:
-                    # Unexpected, but known to happen (process terminated while we're waiting for it to be ready)
-                    self._initialized_event.set()
+                # Unexpected, but known to happen (process terminated while we're waiting for it to be ready)
+                self._ready.set()
 
     def stop( self ):
         """
@@ -899,8 +890,59 @@ class remote:
         If you want to wait until it finishes and all stdout is consumed, use wait()
         """
         if self.is_running():
-            log.d( 'stopping', self_name, 'process' )
+            log.d( 'stopping', self._name, 'process' )
             self._terminate()
             self._thread.join()
             self._thread = None
 
+
+    class fork:
+        """
+        Using the remote is nice, but the two scripts live separately which could be annoying.
+        Instead, we could do something similar to a 'fork' in Linux, e.g.:
+
+        from rspy import log, test
+        with test.remote.fork() as remote:
+            if remote is None:
+                log.i( "This is the forked code" )
+                raise StopIteration()  # skip to the end of the with statement
+            log.i( "This is the parent code" )
+        """
+
+        def __init__( self, script=None, **kwargs ):
+            # We add a 'forked' to the command-line of the forked process
+            if log.nested is not None:
+                self._instance = None
+            else:
+                self._instance = remote( script or sys.argv[0], **kwargs )
+                #self._instance._cmd += ['forked']
+
+        def __enter__( self ):
+            """
+            Called when entering a 'with' statement. We automatically start and wait until ready:
+            """
+            if self._instance is not None:
+                try:
+                    self._instance.start()
+                    self._instance.wait_until_ready()
+                except:
+                    if not self.__exit__( *sys.exc_info() ):
+                        raise
+            return self._instance  # return the remote; None if we're the fork
+
+        def __exit__( self, exc_type, exc_value, traceback ):
+            """
+            Called when exiting scope of a 'with' statement, so we can properly clean up.
+            """
+            if exc_type is None:
+                if self._instance is not None:
+                    self._instance.wait()
+            elif exc_type is StopIteration:
+                # A StopIteration can be used to get out of the 'with' statement easily
+                #
+                # "If an exception is supplied, and the method wishes to suppress the exception (i.e.,
+                # prevent it from being propagated), it should return a true value."
+                # https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers
+                return True  # otherwise the exception will keep propagating
+            elif self._instance is not None:
+                self._instance.stop()

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -34,6 +34,17 @@ void init_c_files(py::module &m) {
     BIND_ENUM(m, rs2_calib_target_type, RS2_CALIB_TARGET_COUNT, "Calibration target type.")
 
     BIND_ENUM(m, rs2_option, RS2_OPTION_COUNT, "Defines general configuration controls. These can generally be mapped to camera UVC controls, and can be set / queried at any time unless stated otherwise.")
+    py_rs2_option.attr( "__repr__" ) = py::cpp_function(
+        []( const py::object & arg) -> py::str
+        {
+            auto type = py::type::handle_of( arg );
+            py::object type_name = type.attr( "__name__" );
+            py::int_ arg_int( arg );
+            py::str enum_name( rs2_option_to_string( rs2_option( (int) arg_int ) ) );
+            return py::str( "<{} {} '{}'>" ).format( std::move( type_name ), arg_int, enum_name );
+        },
+        py::name( "__repr__" ),
+        py::is_method( py_rs2_option ) );
     // Force binding of deprecated (renamed) options that we still want to expose for backwards compatibility
     py_rs2_option.value("ambient_light", RS2_OPTION_AMBIENT_LIGHT);
     py_rs2_option.value( "lld_temperature", RS2_OPTION_LLD_TEMPERATURE );

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -33,9 +33,10 @@ void init_c_files(py::module &m) {
     BIND_ENUM(m, rs2_frame_metadata_value, RS2_FRAME_METADATA_COUNT, "Per-Frame-Metadata is the set of read-only properties that might be exposed for each individual frame.")
     BIND_ENUM(m, rs2_calib_target_type, RS2_CALIB_TARGET_COUNT, "Calibration target type.")
 
-    BIND_ENUM(m, rs2_option, RS2_OPTION_COUNT, "Defines general configuration controls. These can generally be mapped to camera UVC controls, and can be set / queried at any time unless stated otherwise.")
+    BIND_ENUM(m, rs2_option, RS2_OPTION_COUNT+1, "Defines general configuration controls. These can generally be mapped to camera UVC controls, and can be set / queried at any time unless stated otherwise.")
+    // Without __repr__ and __str__, we get the default 'enum_base' showing '???'
     py_rs2_option.attr( "__repr__" ) = py::cpp_function(
-        []( const py::object & arg) -> py::str
+        []( const py::object & arg ) -> py::str
         {
             auto type = py::type::handle_of( arg );
             py::object type_name = type.attr( "__name__" );
@@ -45,9 +46,18 @@ void init_c_files(py::module &m) {
         },
         py::name( "__repr__" ),
         py::is_method( py_rs2_option ) );
+    py_rs2_option.attr( "__str__" ) = py::cpp_function(
+        []( const py::object & arg ) -> py::str {
+            py::int_ arg_int( arg );
+            return rs2_option_to_string( rs2_option( (int) arg_int ) );
+        },
+        py::name( "name" ),
+        py::is_method( py_rs2_option ) );
     // Force binding of deprecated (renamed) options that we still want to expose for backwards compatibility
     py_rs2_option.value("ambient_light", RS2_OPTION_AMBIENT_LIGHT);
     py_rs2_option.value( "lld_temperature", RS2_OPTION_LLD_TEMPERATURE );
+
+    m.def( "option_from_string", &rs2_option_from_string );
 
     BIND_ENUM(m, rs2_l500_visual_preset, RS2_L500_VISUAL_PRESET_COUNT, "For L500 devices: provides optimized settings (presets) for specific types of usage.")
     BIND_ENUM(m, rs2_rs400_visual_preset, RS2_RS400_VISUAL_PRESET_COUNT, "For D400 devices: provides optimized settings (presets) for specific types of usage.")


### PR DESCRIPTION
New options can now be registered by their name/string:
* Options must have unique names/strings
* New options (custom options) have negative values
* DDS sensor options register automatically, so DDS devices can now have freedom from librealsense built-in options
* Added `rs2_option_from_string`, the reverse of `rs2_option_to_string`
* Support in Python

Various other minor changes along the way. I recommend to just review by commit...

Tracked by [LRS-864]