### PR TITLE
Cherry pick #11892 -  Ignore ae mode in drops on set test

### DIFF
--- a/unit-tests/live/options/test-drops-on-set.py
+++ b/unit-tests/live/options/test-drops-on-set.py
@@ -108,7 +108,7 @@ if product_line == "L500":
 # inter_cam_sync_mode --> frame drops are expected during inter_cam_sync_mode change
 # emitter_frequency   --> Not allowed to be set during streaming
 if product_line == "D400":
-    options_to_ignore = [rs.option.visual_preset, rs.option.inter_cam_sync_mode, rs.option.emitter_frequency]
+    options_to_ignore = [rs.option.visual_preset, rs.option.inter_cam_sync_mode, rs.option.emitter_frequency, rs.option.auto_exposure_mode]
 
 def test_option_changes(sensor):
     global options_to_ignore

--- a/unit-tests/live/options/test-drops-on-set.py
+++ b/unit-tests/live/options/test-drops-on-set.py
@@ -107,6 +107,7 @@ if product_line == "L500":
 # visual_preset       --> frame drops are expected during visual_preset change
 # inter_cam_sync_mode --> frame drops are expected during inter_cam_sync_mode change
 # emitter_frequency   --> Not allowed to be set during streaming
+# auto_exposure_mode  --> Not allowed to be set during streaming
 if product_line == "D400":
     options_to_ignore = [rs.option.visual_preset, rs.option.inter_cam_sync_mode, rs.option.emitter_frequency, rs.option.auto_exposure_mode]
 


### PR DESCRIPTION
This addition was only in development, this function is blocked while streaming and should be ignored on this test