### PR TITLE
Fix GetDistance() issue for SoftwareDevice in C#

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Sensors/SoftwareSensor.cs
+++ b/wrappers/csharp/Intel.RealSense/Sensors/SoftwareSensor.cs
@@ -19,7 +19,7 @@ namespace Intel.RealSense
             NativeMethods.rs2_software_sensor_on_video_frame(Handle, f, out error);
         }
 
-        public void AddVideoFrame<T>(T[] pixels, int stride, int bpp, double timestamp, TimestampDomain domain, int frameNumber, VideoStreamProfile profile, float depthUnits = 0.001f)
+        public void AddVideoFrame<T>(T[] pixels, int stride, int bpp, double timestamp, TimestampDomain domain, int frameNumber, VideoStreamProfile profile, float depthUnits = 0f)
         {
             // TODO: avoid copy by adding void* user_data to native methods, so we can pass GCHandle.ToIntPtr() and free in deleter
             IntPtr hglobal = Marshal.AllocHGlobal(profile.Height * stride);

--- a/wrappers/csharp/Intel.RealSense/Sensors/SoftwareSensor.cs
+++ b/wrappers/csharp/Intel.RealSense/Sensors/SoftwareSensor.cs
@@ -19,7 +19,7 @@ namespace Intel.RealSense
             NativeMethods.rs2_software_sensor_on_video_frame(Handle, f, out error);
         }
 
-        public void AddVideoFrame<T>(T[] pixels, int stride, int bpp, double timestamp, TimestampDomain domain, int frameNumber, VideoStreamProfile profile)
+        public void AddVideoFrame<T>(T[] pixels, int stride, int bpp, double timestamp, TimestampDomain domain, int frameNumber, VideoStreamProfile profile, float depthUnits = 0.001f)
         {
             // TODO: avoid copy by adding void* user_data to native methods, so we can pass GCHandle.ToIntPtr() and free in deleter
             IntPtr hglobal = Marshal.AllocHGlobal(profile.Height * stride);
@@ -44,7 +44,8 @@ namespace Intel.RealSense
                 timestamp = timestamp,
                 domain = domain,
                 frame_number = frameNumber,
-                profile = profile.Handle
+                profile = profile.Handle,
+                depth_units = depthUnits
             });
         }
 

--- a/wrappers/csharp/Intel.RealSense/Types/SoftwareVideoFrame.cs
+++ b/wrappers/csharp/Intel.RealSense/Types/SoftwareVideoFrame.cs
@@ -19,5 +19,6 @@ namespace Intel.RealSense
         public TimestampDomain domain;
         public int frame_number;
         public IntPtr profile;
+        public float depth_units;
     }
 }

--- a/wrappers/csharp/tutorial/software-dev/Window.xaml.cs
+++ b/wrappers/csharp/tutorial/software-dev/Window.xaml.cs
@@ -188,11 +188,13 @@ namespace Intel.RealSense
 
                             depthData = depthData ?? new ushort[depthFrame.Width * depthFrame.Height];
                             depthFrame.CopyTo(depthData);
+                            // Construct SW depth frame for SW depth sensor and initialize Depth Unit
                             depth_sensor.AddVideoFrame(depthData, depthFrame.Stride, depthFrame.BitsPerPixel / 8, depthFrame.Timestamp,
-                                depthFrame.TimestampDomain, (int)depthFrame.Number, depth_profile);
+                                depthFrame.TimestampDomain, (int)depthFrame.Number, depth_profile, realDepthSensor.DepthScale);
 
                             colorData = colorData ?? new byte[colorFrame.Stride * colorFrame.Height];
                             colorFrame.CopyTo(colorData);
+                            // Construct SW color frame for SW color sensor
                             color_sensor.AddVideoFrame(colorData, colorFrame.Stride, colorFrame.BitsPerPixel / 8, colorFrame.Timestamp,
                                 colorFrame.TimestampDomain, (int)colorFrame.Number, color_profile);
                         }


### PR DESCRIPTION
Fix GetDistance() issue for SoftwareDevice in C#

changes:
add depth_units field to type SoftwareVideoFrame and class AddVideoFrame

Tracked on: [DSO-19246]
Original issue: #12170