### PR TITLE
SW device depth-units per sensor's DEPTH_UNITS, if set

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -404,7 +404,13 @@ return __p.invoke(func);\
     #define VALIDATE_FIXED_SIZE(ARG, SIZE) if((ARG) != (SIZE)) { std::ostringstream ss; ss << "Unsupported size provided { " << ARG << " }," " expecting { " << SIZE << " }"; throw librealsense::invalid_value_exception(ss.str()); }
     #define VALIDATE_NOT_NULL(ARG) if(!(ARG)) throw std::runtime_error("null pointer passed for argument \"" #ARG "\"");
     #define VALIDATE_ENUM(ARG) if(!librealsense::is_valid(ARG)) { std::ostringstream ss; ss << "invalid enum value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
-    #define VALIDATE_OPTION(OBJ, OPT_ID) if(!OBJ->options->supports_option(OPT_ID)) { std::ostringstream ss; ss << "object doesn't support option #" << std::to_string(OPT_ID); throw librealsense::invalid_value_exception(ss.str()); }
+#define VALIDATE_OPTION( OBJ, OPT_ID )                                                                                 \
+    if( ! OBJ->options->supports_option( OPT_ID ) )                                                                    \
+    {                                                                                                                  \
+        std::ostringstream ss;                                                                                         \
+        ss << "object doesn't support option " << librealsense::get_string( OPT_ID );                                  \
+        throw librealsense::invalid_value_exception( ss.str() );                                                       \
+    }
     #define VALIDATE_RANGE(ARG, MIN, MAX) if((ARG) < (MIN) || (ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
     #define VALIDATE_LE(ARG, MAX) if((ARG) > (MAX)) { std::ostringstream ss; ss << "out of range value for argument \"" #ARG "\""; throw std::runtime_error(ss.str()); }
     #define VALIDATE_GT(ARG, MIN) if((ARG) <= (MIN)) { std::ostringstream ss; ss << "value is below allowed min for argument \"" #ARG "\""; throw std::runtime_error(ss.str()); }

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -307,7 +307,16 @@ namespace librealsense
         data.timestamp = software_frame.timestamp;
         data.timestamp_domain = software_frame.domain;
         data.frame_number = software_frame.frame_number;
-        data.depth_units = software_frame.depth_units;
+
+        // Depth units, if not provided by the user, should default to the current sensor value of DEPTH_UNITS:
+        if( vid_profile->get_stream_type() != RS2_STREAM_DEPTH )
+            data.depth_units = 0;
+        else if( software_frame.depth_units )
+            data.depth_units = software_frame.depth_units;
+        else if( auto opt = get_option_handler( RS2_OPTION_DEPTH_UNITS ) )
+            data.depth_units = opt->query();
+        else
+            data.depth_units = 0.f;
 
         auto frame
             = allocate_new_video_frame( vid_profile, software_frame.stride, software_frame.bpp, std::move( data ) );

--- a/unit-tests/sw-dev/sw.py
+++ b/unit-tests/sw-dev/sw.py
@@ -10,7 +10,7 @@ fps = 30
 w = 640
 h = 480
 bpp = 2  # bytes
-pixels = bytearray( b'\x00' * ( w * h * bpp ))  # Dummy data
+pixels = bytearray( b'\x69' * ( w * h * bpp ))  # Dummy data
 domain = rs.timestamp_domain.hardware_clock     # For either depth/color
 
 global_frame_number = 0
@@ -63,6 +63,18 @@ class sensor:
 
     def set( self, key:rs.frame_metadata_value, value ):
         self._handle.set_metadata( key, value )
+
+    def add_option( self, option:rs.option, option_range, writable=True ):
+        self._handle.add_option( option, option_range, writable )
+
+    def supports( self, option:rs.option ):
+        return self._handle.supports( option )
+
+    def get_option( self, option:rs.option ):
+        return self._handle.get_option( option )
+
+    def set_option( self, option:rs.option, value ):
+        self._handle.set_option( option, value )
 
     def publish( self, frame ):
         if str(frame.profile) not in self._profiles_str:

--- a/unit-tests/sw-dev/test-units.py
+++ b/unit-tests/sw-dev/test-units.py
@@ -1,0 +1,55 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+import pyrealsense2 as rs
+from rspy import log, test
+import sw
+
+    
+with sw.sensor( "Stereo Module" ) as sensor:
+    depth = sensor.video_stream( "Depth", rs.stream.depth, rs.format.z16 )
+    sensor.start( depth )
+
+    with test.closure( "By default, frames do not have units" ):
+        f = depth.frame()
+        test.check_equal( f.depth_units, 0. )
+
+    # Publish it
+    f = sensor.publish( f )
+
+    with test.closure( "rs.stream.depth should generate depth-frames", on_fail=test.ABORT ):
+        df = rs.depth_frame( f )
+        test.check( df )
+
+    with test.closure( "No DEPTH_UNITS; Units should be 0" ):
+        test.check_false( sensor.supports( rs.option.depth_units ) )
+        test.check_equal( df.get_units(), 0. )
+        test.check_equal( df.get_distance( 0, 0 ), 0. )
+
+    with test.closure( "Set the sensor DEPTH_UNITS" ):
+        sensor.add_option( rs.option.depth_units, rs.option_range( 0, 1, 0.000001, 0.001 ), True )
+        #test.check_equal( sensor.get_option( rs.option.depth_units ), 0.001 )   it's not set yet
+        sensor.set_option( rs.option.depth_units, 0.001 )
+
+    with test.closure( "Frame units should not change after the fact" ):
+        sensor.set_option( rs.option.depth_units, 0.001 )
+        test.check_equal( df.get_units(), 0. )
+        test.check_equal( df.get_distance( 0, 0 ), 0. )
+
+    with test.closure( "But if we generate a new frame..." ):
+        f = depth.frame()
+        test.check_equal( f.depth_units, 0. )
+
+    # Publish it
+    f = sensor.publish( f )
+    df = rs.depth_frame( f )
+
+    with test.closure( "New frame should pick up DEPTH_UNITS" ):
+        test.check_approx_abs( df.get_units(), 0.001, 0.00000001 )
+        test.check_approx_abs( df.get_distance( 0, 0 ), 26.985, 0.000001 )
+
+
+#
+#############################################################################################
+test.print_results_and_exit()
+

--- a/wrappers/python/pyrs_internal.cpp
+++ b/wrappers/python/pyrs_internal.cpp
@@ -42,13 +42,7 @@ void init_internal(py::module &m) {
     py::class_< rs2_software_video_frame >( m,
                                             "software_video_frame",
                                             "All the parameters required to define a video frame" )
-        .def( py::init( []() {
-            rs2_software_video_frame f;
-            f.deleter = nullptr;
-            f.pixels = nullptr;
-            f.profile = nullptr;
-            return f;
-        } ) )  // guarantee deleter is set to nullptr
+        .def( py::init( []() { return rs2_software_video_frame{ 0 }; } ) )
         .def_property(
             "pixels",
             []( const rs2_software_video_frame & self ) {
@@ -100,6 +94,7 @@ void init_internal(py::module &m) {
         .def_readwrite("timestamp", &rs2_software_video_frame::timestamp)
         .def_readwrite("domain", &rs2_software_video_frame::domain)
         .def_readwrite("frame_number", &rs2_software_video_frame::frame_number)
+        .def_readwrite("depth_units", &rs2_software_video_frame::depth_units)
         .def_property(
             "profile",
             []( const rs2_software_video_frame & self ) {
@@ -127,7 +122,8 @@ void init_internal(py::module &m) {
 
     py::class_<rs2_software_motion_frame> software_motion_frame(m, "software_motion_frame", "All the parameters "
                                                                 "required to define a motion frame.");
-    software_motion_frame.def(py::init([]() { rs2_software_motion_frame f{}; f.deleter = nullptr; return f; })) // guarantee deleter is set to nullptr
+    software_motion_frame  //
+        .def( py::init( []() { return rs2_software_motion_frame{ 0 }; } ) )
         .def_property("data", [](const rs2_software_motion_frame& self) -> rs2_vector {
             auto data = reinterpret_cast<const float*>(self.data);
             return rs2_vector{ data[0], data[1], data[2] };
@@ -148,7 +144,8 @@ void init_internal(py::module &m) {
 
     py::class_<rs2_software_pose_frame> software_pose_frame(m, "software_pose_frame", "All the parameters "
                                                             "required to define a pose frame.");
-    software_pose_frame.def(py::init([]() { rs2_software_pose_frame f{}; f.deleter = nullptr; return f; })) // guarantee deleter is set to nullptr
+    software_pose_frame  //
+        .def( py::init( []() { return rs2_software_pose_frame{ 0 }; } ) )
         .def_property(
             "data",
             []( const rs2_software_pose_frame & self ) -> rs2_pose {

--- a/wrappers/python/pyrs_types.cpp
+++ b/wrappers/python/pyrs_types.cpp
@@ -36,6 +36,14 @@ void init_types(py::module &m) {
 
     py::class_<rs2::option_range> option_range(m, "option_range"); // No docstring in C++
     option_range.def(py::init<>())
+        .def( py::init(
+                  []( float min, float max, float step, float default_value ) {
+                      return rs2::option_range{ min, max, step, default_value };
+                  } ),
+              "min"_a,
+              "max"_a,
+              "step"_a,
+              "default"_a )
         .def_readwrite("min", &rs2::option_range::min)
         .def_readwrite("max", &rs2::option_range::max)
         .def_readwrite("default", &rs2::option_range::def)


### PR DESCRIPTION
Goes along with #12193:
* Fixes initialization in Python of software frames (all types)
* If SW sensor now has `DEPTH_UNITS` set and no `depth_units` are set in the frame (when creating the frame), then the frame will pick up the sensor's depth units
* If a sensor changes its depth units after the frame exists, it will not see the new value
* Added a unit-test

Tracked on [DSO-19246]