### PR TITLE
Enable D457 FW update on LibCI

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -3,6 +3,7 @@
 
 # we want this test to run first so that all tests run with updated FW versions, so we give it priority 0
 #test:priority 0
+#test:donotrun:gha
 #test:device each(D400*)
 
 import sys


### PR DESCRIPTION
The rs-fw-update tool now supports D457, enable the test for it on LibCI

Also, do not run on GHA, there is no need
Tracked on [LRS-738]