### PR TITLE
Simplify time-service usage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,7 +109,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/platform/hid-device-info.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/playback-device-info.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/stream-profile.h"
-        "${CMAKE_CURRENT_LIST_DIR}/platform/time-service.h"
+        "${CMAKE_CURRENT_LIST_DIR}/core/time-service.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/uvc-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/uvc-device-info.h"
         "${CMAKE_CURRENT_LIST_DIR}/context.h"

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -13,31 +13,30 @@ namespace librealsense
    
     std::shared_ptr<archive_interface> make_archive(rs2_extension type,
         std::atomic<uint32_t>* in_max_frame_queue_size,
-        std::shared_ptr<platform::time_service> ts,
         std::shared_ptr<metadata_parser_map> parsers)
     {
         switch (type)
         {
         case RS2_EXTENSION_VIDEO_FRAME:
-            return std::make_shared<frame_archive<video_frame>>(in_max_frame_queue_size, ts, parsers);
+            return std::make_shared<frame_archive<video_frame>>(in_max_frame_queue_size, parsers);
 
         case RS2_EXTENSION_COMPOSITE_FRAME:
-            return std::make_shared<frame_archive<composite_frame>>(in_max_frame_queue_size, ts, parsers);
+            return std::make_shared<frame_archive<composite_frame>>(in_max_frame_queue_size, parsers);
 
         case RS2_EXTENSION_MOTION_FRAME:
-            return std::make_shared<frame_archive<motion_frame>>(in_max_frame_queue_size, ts, parsers);
+            return std::make_shared<frame_archive<motion_frame>>(in_max_frame_queue_size, parsers);
 
         case RS2_EXTENSION_POINTS:
-            return std::make_shared<frame_archive<points>>(in_max_frame_queue_size, ts, parsers);
+            return std::make_shared<frame_archive<points>>(in_max_frame_queue_size, parsers);
 
         case RS2_EXTENSION_DEPTH_FRAME:
-            return std::make_shared<frame_archive<depth_frame>>(in_max_frame_queue_size, ts, parsers);
+            return std::make_shared<frame_archive<depth_frame>>(in_max_frame_queue_size, parsers);
 
         case RS2_EXTENSION_POSE_FRAME:
-            return std::make_shared<frame_archive<pose_frame>>(in_max_frame_queue_size, ts, parsers);
+            return std::make_shared<frame_archive<pose_frame>>(in_max_frame_queue_size, parsers);
 
         case RS2_EXTENSION_DISPARITY_FRAME:
-            return std::make_shared<frame_archive<disparity_frame>>(in_max_frame_queue_size, ts, parsers);
+            return std::make_shared<frame_archive<disparity_frame>>(in_max_frame_queue_size, parsers);
 
         default:
             throw std::runtime_error("Requested frame type is not supported!");

--- a/src/archive.h
+++ b/src/archive.h
@@ -11,9 +11,6 @@
 namespace librealsense
 {
     struct frame_additional_data;
-    namespace platform {
-        class time_service;
-    }
 
     class archive_interface
     {
@@ -37,7 +34,6 @@ namespace librealsense
 
     std::shared_ptr<archive_interface> make_archive(rs2_extension type,
         std::atomic<uint32_t>* in_max_frame_queue_size,
-        std::shared_ptr<platform::time_service> ts,
         std::shared_ptr<metadata_parser_map> parsers);
 
 }

--- a/src/backend.h
+++ b/src/backend.h
@@ -22,8 +22,6 @@ const uint8_t MAX_META_DATA_SIZE          = 0xff; // UVC Metadata total length
 
 namespace librealsense
 {
-    class time_service;
-
     namespace platform
     {
         class device_watcher;
@@ -43,8 +41,6 @@ namespace librealsense
 
             virtual std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const = 0;
             virtual std::vector<hid_device_info> query_hid_devices() const = 0;
-
-            virtual std::shared_ptr<time_service> create_time_service() const = 0;
 
             virtual std::shared_ptr<device_watcher> create_device_watcher() const = 0;
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -22,11 +22,12 @@ const uint8_t MAX_META_DATA_SIZE          = 0xff; // UVC Metadata total length
 
 namespace librealsense
 {
+    class time_service;
+
     namespace platform
     {
         class device_watcher;
         class hid_device;
-        class time_service;
         class uvc_device;
         class command_transfer;
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -149,8 +149,6 @@ namespace librealsense
         }
 #endif //BUILD_WITH_DDS
 
-        environment::get_instance().set_time_service(_backend->create_time_service());
-
         _device_watcher = _backend->create_device_watcher();
         assert(_device_watcher->is_stopped());
     }
@@ -162,8 +160,6 @@ namespace librealsense
         _settings = settings;
 
         _backend = platform::create_backend();  // standard type
-
-        environment::get_instance().set_time_service( _backend->create_time_service() );
 
         _device_watcher = _backend->create_device_watcher();
         assert( _device_watcher->is_stopped() );

--- a/src/core/time-service.h
+++ b/src/core/time-service.h
@@ -13,16 +13,10 @@ namespace librealsense {
 
 class time_service
 {
-public:
-    virtual double get_time() const = 0;
-    virtual ~time_service() = default;
-};
+    time_service() = delete;  // not for instantiation
 
-
-class os_time_service : public time_service
-{
 public:
-    rs2_time_t get_time() const override
+    static rs2_time_t get_time()
     {
         return std::chrono::duration< double, std::milli >( std::chrono::system_clock::now().time_since_epoch() )
             .count();

--- a/src/core/time-service.h
+++ b/src/core/time-service.h
@@ -9,7 +9,6 @@
 
 
 namespace librealsense {
-namespace platform {
 
 
 class time_service
@@ -31,5 +30,4 @@ public:
 };
 
 
-}  // namespace platform
 }  // namespace librealsense

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -66,7 +66,7 @@ namespace librealsense
                 color_devs_info = group.uvc_devices;
             else
                 color_devs_info = color_devs_info_mi3;
-            std::unique_ptr<frame_timestamp_reader> d400_timestamp_reader_backup(new ds_timestamp_reader(backend.create_time_service()));
+            std::unique_ptr< frame_timestamp_reader > d400_timestamp_reader_backup( new ds_timestamp_reader() );
             frame_timestamp_reader* timestamp_reader_from_metadata;
             if (ds::RS457_PID != _pid)
                 timestamp_reader_from_metadata = new ds_timestamp_reader_from_metadata(std::move(d400_timestamp_reader_backup));

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -467,7 +467,7 @@ namespace librealsense
         for (auto&& info : filter_by_mi(all_device_infos, 0)) // Filter just mi=0, DEPTH
             depth_devices.push_back(backend.create_uvc_device(info));
 
-        std::unique_ptr<frame_timestamp_reader> timestamp_reader_backup(new ds_timestamp_reader(backend.create_time_service()));
+        std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
         frame_timestamp_reader* timestamp_reader_from_metadata;
         if (all_device_infos.front().pid != RS457_PID)
             timestamp_reader_from_metadata = new ds_timestamp_reader_from_metadata(std::move(timestamp_reader_backup));
@@ -1217,7 +1217,7 @@ namespace librealsense
         for (auto&& info : filter_by_mi(all_device_infos, 0)) // Filter just mi=0, DEPTH
             depth_devices.push_back(backend.create_uvc_device(info));
 
-        std::unique_ptr<frame_timestamp_reader> d400_timestamp_reader_backup(new ds_timestamp_reader(backend.create_time_service()));
+        std::unique_ptr< frame_timestamp_reader > d400_timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> d400_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(d400_timestamp_reader_backup)));
 
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());

--- a/src/ds/d400/d400-motion.cpp
+++ b/src/ds/d400/d400-motion.cpp
@@ -51,7 +51,7 @@ namespace librealsense
         for (auto&& info : filter_by_mi(all_uvc_infos, 4)) // Filter just mi=4, IMU
             imu_devices.push_back(backend.create_uvc_device(info));
 
-        std::unique_ptr<frame_timestamp_reader> timestamp_reader_backup(new ds_timestamp_reader(backend.create_time_service()));
+        std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata(new ds_timestamp_reader_from_metadata_mipi_motion(std::move(timestamp_reader_backup)));
 
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
@@ -168,7 +168,7 @@ namespace librealsense
         if (!is_fisheye_avaialable)
             return;
 
-        std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_backup(new ds_timestamp_reader(environment::get_instance().get_time_service()));
+        std::unique_ptr< frame_timestamp_reader > ds_timestamp_reader_backup( new ds_timestamp_reader() );
         auto&& backend = ctx->get_backend();
         std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(ds_timestamp_reader_backup)));
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -56,7 +56,7 @@ namespace librealsense
 
         std::vector<platform::uvc_device_info> color_devs_info = filter_by_mi(group.uvc_devices, 3);
 
-        std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_backup(new ds_timestamp_reader(backend.create_time_service()));
+        std::unique_ptr< frame_timestamp_reader > ds_timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(ds_timestamp_reader_backup)));
 
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -351,7 +351,7 @@ namespace librealsense
         for (auto&& info : filter_by_mi(all_device_infos, 0)) // Filter just mi=0, DEPTH
             depth_devices.push_back(backend.create_uvc_device(info));
 
-        std::unique_ptr<frame_timestamp_reader> timestamp_reader_backup(new ds_timestamp_reader(backend.create_time_service()));
+        std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(timestamp_reader_backup)));
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
         auto raw_depth_ep = std::make_shared<uvc_sensor>("Raw Depth Sensor", std::make_shared<platform::multi_pins_uvc_device>(depth_devices),

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -71,7 +71,7 @@ namespace librealsense
         if (!is_fisheye_avaialable)
             return;
 
-        std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_backup(new ds_timestamp_reader(environment::get_instance().get_time_service()));
+        std::unique_ptr< frame_timestamp_reader > ds_timestamp_reader_backup( new ds_timestamp_reader() );
         auto&& backend = ctx->get_backend();
         std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(ds_timestamp_reader_backup)));
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());

--- a/src/ds/ds-timestamp.cpp
+++ b/src/ds/ds-timestamp.cpp
@@ -288,8 +288,8 @@ namespace librealsense
         _backup_timestamp_reader->reset();
     }
 
-    ds_timestamp_reader::ds_timestamp_reader(std::shared_ptr<time_service> ts)
-        : counter(pins), _ts(ts)
+    ds_timestamp_reader::ds_timestamp_reader()
+        : counter(pins)
     {
         reset();
     }
@@ -305,8 +305,7 @@ namespace librealsense
 
     rs2_time_t ds_timestamp_reader::get_frame_timestamp(const std::shared_ptr<frame_interface>& frame)
     {
-        std::lock_guard<std::recursive_mutex> lock(_mtx);
-        return _ts->get_time();
+        return environment::get_instance().get_time_service()->get_time();
     }
 
     unsigned long long ds_timestamp_reader::get_frame_counter(const std::shared_ptr<frame_interface>& frame) const

--- a/src/ds/ds-timestamp.cpp
+++ b/src/ds/ds-timestamp.cpp
@@ -305,7 +305,7 @@ namespace librealsense
 
     rs2_time_t ds_timestamp_reader::get_frame_timestamp(const std::shared_ptr<frame_interface>& frame)
     {
-        return environment::get_instance().get_time_service()->get_time();
+        return time_service::get_time();
     }
 
     unsigned long long ds_timestamp_reader::get_frame_counter(const std::shared_ptr<frame_interface>& frame) const

--- a/src/ds/ds-timestamp.cpp
+++ b/src/ds/ds-timestamp.cpp
@@ -288,7 +288,7 @@ namespace librealsense
         _backup_timestamp_reader->reset();
     }
 
-    ds_timestamp_reader::ds_timestamp_reader(std::shared_ptr<platform::time_service> ts)
+    ds_timestamp_reader::ds_timestamp_reader(std::shared_ptr<time_service> ts)
         : counter(pins), _ts(ts)
     {
         reset();

--- a/src/ds/ds-timestamp.h
+++ b/src/ds/ds-timestamp.h
@@ -69,10 +69,9 @@ namespace librealsense
     {
         static const int pins = 2;
         mutable std::vector<int64_t> counter;
-        std::shared_ptr<time_service> _ts;
         mutable std::recursive_mutex _mtx;
     public:
-        ds_timestamp_reader(std::shared_ptr<time_service> ts);
+        ds_timestamp_reader();
 
         void reset() override;
 

--- a/src/ds/ds-timestamp.h
+++ b/src/ds/ds-timestamp.h
@@ -69,10 +69,10 @@ namespace librealsense
     {
         static const int pins = 2;
         mutable std::vector<int64_t> counter;
-        std::shared_ptr<platform::time_service> _ts;
+        std::shared_ptr<time_service> _ts;
         mutable std::recursive_mutex _mtx;
     public:
-        ds_timestamp_reader(std::shared_ptr<platform::time_service> ts);
+        ds_timestamp_reader(std::shared_ptr<time_service> ts);
 
         void reset() override;
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2,7 +2,6 @@
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
 
 #include "environment.h"
-#include "core/time-service.h"
 
 namespace librealsense
 {
@@ -236,8 +235,7 @@ namespace librealsense
 
 
     environment::environment()
-        : _ts( std::make_shared< os_time_service >() )
-        , _stream_id( 0 )
+        : _stream_id( 0 )
     {
     }
 
@@ -251,15 +249,5 @@ namespace librealsense
     extrinsics_graph& environment::get_extrinsics_graph()
     {
         return _extrinsics;
-    }
-
-    void environment::set_time_service(std::shared_ptr<time_service> ts)
-    {
-        _ts = ts;
-    }
-
-    std::shared_ptr<time_service> environment::get_time_service()
-    {
-        return _ts;
     }
 }

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
 
 #include "environment.h"
+#include "core/time-service.h"
 
 namespace librealsense
 {
@@ -231,6 +232,13 @@ namespace librealsense
         }
 
         return nullptr;
+    }
+
+
+    environment::environment()
+        : _ts( std::make_shared< os_time_service >() )
+        , _stream_id( 0 )
+    {
     }
 
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -245,12 +245,12 @@ namespace librealsense
         return _extrinsics;
     }
 
-    void environment::set_time_service(std::shared_ptr<platform::time_service> ts)
+    void environment::set_time_service(std::shared_ptr<time_service> ts)
     {
         _ts = ts;
     }
 
-    std::shared_ptr<platform::time_service> environment::get_time_service()
+    std::shared_ptr<time_service> environment::get_time_service()
     {
         return _ts;
     }

--- a/src/environment.h
+++ b/src/environment.h
@@ -93,9 +93,7 @@ namespace librealsense
     };
 
 
-    namespace platform {
-        class time_service;
-    }
+    class time_service;
 
 
     class environment
@@ -107,8 +105,8 @@ namespace librealsense
 
         int generate_stream_id() { return _stream_id.fetch_add(1); }
 
-        void set_time_service(std::shared_ptr<platform::time_service> ts);
-        std::shared_ptr<platform::time_service> get_time_service();
+        void set_time_service(std::shared_ptr<time_service> ts);
+        std::shared_ptr<time_service> get_time_service();
 
         environment(const environment&) = delete;
         environment(const environment&&) = delete;
@@ -118,7 +116,7 @@ namespace librealsense
 
         extrinsics_graph _extrinsics;
         std::atomic<int> _stream_id;
-        std::shared_ptr<platform::time_service> _ts;
+        std::shared_ptr<time_service> _ts;
 
         environment(){_stream_id = 0;}
 

--- a/src/environment.h
+++ b/src/environment.h
@@ -112,13 +112,13 @@ namespace librealsense
         environment(const environment&&) = delete;
         environment operator=(const environment&) = delete;
         environment operator=(const environment&&) = delete;
-    private:
 
+    private:
         extrinsics_graph _extrinsics;
         std::atomic<int> _stream_id;
         std::shared_ptr<time_service> _ts;
 
-        environment(){_stream_id = 0;}
+        environment();
 
     };
 }

--- a/src/environment.h
+++ b/src/environment.h
@@ -93,9 +93,6 @@ namespace librealsense
     };
 
 
-    class time_service;
-
-
     class environment
     {
     public:
@@ -105,9 +102,6 @@ namespace librealsense
 
         int generate_stream_id() { return _stream_id.fetch_add(1); }
 
-        void set_time_service(std::shared_ptr<time_service> ts);
-        std::shared_ptr<time_service> get_time_service();
-
         environment(const environment&) = delete;
         environment(const environment&&) = delete;
         environment operator=(const environment&) = delete;
@@ -116,9 +110,7 @@ namespace librealsense
     private:
         extrinsics_graph _extrinsics;
         std::atomic<int> _stream_id;
-        std::shared_ptr<time_service> _ts;
 
         environment();
-
     };
 }

--- a/src/frame-archive.h
+++ b/src/frame-archive.h
@@ -20,7 +20,6 @@ namespace librealsense
         std::atomic<bool> recycle_frames;
         int pending_frames = 0;
         std::recursive_mutex mutex;
-        std::shared_ptr<platform::time_service> _time_service;
 
         std::weak_ptr<sensor_interface> _sensor;
         std::shared_ptr<sensor_interface> get_sensor() const override { return _sensor.lock(); }
@@ -140,12 +139,11 @@ namespace librealsense
         friend class frame;
 
     public:
-        explicit frame_archive(std::atomic<uint32_t>* in_max_frame_queue_size,
-            std::shared_ptr<platform::time_service> ts,
-            std::shared_ptr<metadata_parser_map> parsers)
-            : max_frame_queue_size(in_max_frame_queue_size),
-            recycle_frames(true), mutex(), _time_service(ts),
-            _metadata_parsers(parsers)
+        explicit frame_archive( std::atomic< uint32_t > * in_max_frame_queue_size,
+                                std::shared_ptr< metadata_parser_map > const & parsers )
+            : max_frame_queue_size( in_max_frame_queue_size )
+            , recycle_frames( true )
+            , _metadata_parsers( parsers )
         {
             published_frames_count = 0;
         }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -2712,10 +2712,6 @@ namespace librealsense
             });
             return results;
         }
-        std::shared_ptr<time_service> v4l_backend::create_time_service() const
-        {
-            return std::make_shared<os_time_service>();
-        }
 
         std::shared_ptr<device_watcher> v4l_backend::create_device_watcher() const
         {

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -3,7 +3,7 @@
 
 #include "backend-v4l2.h"
 #include <src/platform/command-transfer.h>
-#include <src/platform/time-service.h>
+#include <src/core/time-service.h>
 #include "backend-hid.h"
 #include "backend.h"
 #include "types.h"

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -501,7 +501,6 @@ namespace librealsense
             std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const override;
             std::vector<hid_device_info> query_hid_devices() const override;
 
-            std::shared_ptr<time_service> create_time_service() const override;
             std::shared_ptr<device_watcher> create_device_watcher() const override;
         };
     }

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -176,11 +176,6 @@ namespace librealsense
             return devices;
         }
 
-        std::shared_ptr<time_service> wmf_backend::create_time_service() const
-        {
-            return std::make_shared<os_time_service>();
-        }
-
         class win_event_device_watcher : public device_watcher
         {
         public:

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -7,7 +7,7 @@
 #include "mf-backend.h"
 #include "mf-uvc.h"
 #include "mf-hid.h"
-#include <src/platform/time-service.h>
+#include <src/core/time-service.h>
 #include <src/platform/device-watcher.h>
 #include <src/platform/command-transfer.h>
 #include "usb/usb-device.h"

--- a/src/mf/mf-backend.h
+++ b/src/mf/mf-backend.h
@@ -25,7 +25,6 @@ namespace librealsense
 
             std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const override;
             std::vector<hid_device_info> query_hid_devices() const override;
-            virtual std::shared_ptr<time_service> create_time_service() const override;
             std::shared_ptr<device_watcher> create_device_watcher() const override;
             std::string get_device_serial(uint16_t device_vid, uint16_t device_pid, const std::string& device_uid) const override;
 

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -69,8 +69,7 @@ platform_camera::platform_camera( std::shared_ptr< const device_info > const & d
     for( auto && info : uvc_infos )
         devs.push_back( dev_info->get_context()->get_backend().create_uvc_device( info ) );
 
-    std::unique_ptr< frame_timestamp_reader > host_timestamp_reader_backup(
-        new ds_timestamp_reader( environment::get_instance().get_time_service() ) );
+    std::unique_ptr< frame_timestamp_reader > host_timestamp_reader_backup( new ds_timestamp_reader() );
     auto raw_color_ep = std::make_shared< uvc_sensor >(
         "Raw RGB Camera",
         std::make_shared< platform::multi_pins_uvc_device >( devs ),

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -2497,7 +2497,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(, frame_ref, calib_type, target_dims, target_dims_s
 
 rs2_time_t rs2_get_time(rs2_error** error) BEGIN_API_CALL
 {
-    return environment::get_instance().get_time_service()->get_time();
+    return time_service::get_time();
 }
 NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(0)
 

--- a/src/rsusb-backend/rsusb-backend.cpp
+++ b/src/rsusb-backend/rsusb-backend.cpp
@@ -64,10 +64,5 @@ namespace librealsense
         {
             return query_hid_devices_info();
         }
-
-        std::shared_ptr<time_service> rs_backend::create_time_service() const
-        {
-            return std::make_shared<os_time_service>();
-        }
     }
 }

--- a/src/rsusb-backend/rsusb-backend.cpp
+++ b/src/rsusb-backend/rsusb-backend.cpp
@@ -8,7 +8,7 @@
 #include "../hid/hid-types.h"
 #include "../hid/hid-device.h"
 #include "../usb/usb-enumerator.h"
-#include "../platform/time-service.h"
+#include "../core/time-service.h"
 
 #include <chrono>
 #include <cctype> // std::tolower

--- a/src/rsusb-backend/rsusb-backend.h
+++ b/src/rsusb-backend/rsusb-backend.h
@@ -27,9 +27,6 @@ namespace librealsense
             // Not supported
             std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const override;
             std::vector<hid_device_info> query_hid_devices() const override;
-
-            // don't change
-            virtual std::shared_ptr<time_service> create_time_service() const override;
         };
     }
 }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -25,10 +25,10 @@ namespace librealsense {
 
 void log_callback_end( uint32_t fps,
                        rs2_time_t callback_start_time,
+                       rs2_time_t const current_time,
                        rs2_stream stream_type,
                        unsigned long long frame_number )
 {
-    auto current_time = environment::get_instance().get_time_service()->get_time();
     auto callback_warning_duration = 1000.f / ( fps + 1 );
     auto callback_duration = current_time - callback_start_time;
 
@@ -281,13 +281,14 @@ void log_callback_end( uint32_t fps,
         return pixels;
     }
 
-    std::shared_ptr<frame> sensor_base::generate_frame_from_data(const platform::frame_object& fo,
-        frame_timestamp_reader* timestamp_reader,
-        const rs2_time_t& last_timestamp,
-        const unsigned long long& last_frame_number,
-        std::shared_ptr<stream_profile_interface> profile)
+    std::shared_ptr< frame >
+    sensor_base::generate_frame_from_data( const platform::frame_object & fo,
+                                           rs2_time_t const system_time,
+                                           frame_timestamp_reader * timestamp_reader,
+                                           const rs2_time_t & last_timestamp,
+                                           const unsigned long long & last_frame_number,
+                                           std::shared_ptr< stream_profile_interface > profile )
     {
-        auto system_time = environment::get_instance().get_time_service()->get_time();
         auto fr = std::make_shared<frame>();
         
         fr->set_stream(profile);

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -104,11 +104,12 @@ namespace librealsense
 
         void sort_profiles( stream_profiles & );
 
-        std::shared_ptr<frame> generate_frame_from_data(const platform::frame_object& fo,
-            frame_timestamp_reader* timestamp_reader,
-            const rs2_time_t& last_timestamp,
-            const unsigned long long& last_frame_number,
-            std::shared_ptr<stream_profile_interface> profile);
+        std::shared_ptr< frame > generate_frame_from_data( const platform::frame_object & fo,
+                                                           rs2_time_t system_time,
+                                                           frame_timestamp_reader * timestamp_reader,
+                                                           const rs2_time_t & last_timestamp,
+                                                           const unsigned long long & last_frame_number,
+                                                           std::shared_ptr< stream_profile_interface > profile );
 
         inline int compute_frame_expected_size(int width, int height, int bpp) const
         {

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -66,7 +66,7 @@ namespace librealsense
 
         for (auto type : supported)
         {
-            _archive[type] = make_archive(type, &_max_publish_list_size, _ts, metadata_parsers);
+            _archive[type] = make_archive(type, &_max_publish_list_size, metadata_parsers);
         }
 
         _metadata_parsers = metadata_parsers;

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -46,10 +46,9 @@ namespace librealsense
         return std::make_shared<frame_queue_size>(&_max_publish_list_size, option_range{ 0, 32, 1, 16 });
     }
 
-    frame_source::frame_source(uint32_t max_publish_list_size)
-            : _callback(nullptr, [](rs2_frame_callback*) {}),
-              _max_publish_list_size(max_publish_list_size),
-              _ts(environment::get_instance().get_time_service())
+    frame_source::frame_source( uint32_t max_publish_list_size )
+        : _callback( nullptr, []( rs2_frame_callback * ) {} )
+        , _max_publish_list_size( max_publish_list_size )
     {}
 
     void frame_source::init(std::shared_ptr<metadata_parser_map> metadata_parsers)

--- a/src/source.h
+++ b/src/source.h
@@ -7,7 +7,7 @@
 #include "archive.h"
 #include "metadata-parser.h"
 #include "frame-archive.h"
-#include "platform/time-service.h"
+#include "core/time-service.h"
 
 
 namespace librealsense
@@ -64,7 +64,7 @@ namespace librealsense
 
         std::atomic<uint32_t> _max_publish_list_size;
         frame_callback_ptr _callback;
-        std::shared_ptr<platform::time_service> _ts;
+        std::shared_ptr<time_service> _ts;
         std::shared_ptr<metadata_parser_map> _metadata_parsers;
     };
 }

--- a/src/source.h
+++ b/src/source.h
@@ -48,7 +48,7 @@ namespace librealsense
         template<class T>
         void add_extension(rs2_extension ex)
         {
-            _archive[ex] = std::make_shared<frame_archive<T>>(&_max_publish_list_size, _ts, _metadata_parsers);
+            _archive[ex] = std::make_shared<frame_archive<T>>(&_max_publish_list_size, _metadata_parsers);
         }
 
         void set_max_publish_list_size(int qsize) {_max_publish_list_size = qsize; }

--- a/src/source.h
+++ b/src/source.h
@@ -41,7 +41,7 @@ namespace librealsense
 
         virtual ~frame_source() { flush(); }
 
-        double get_time() const { return _ts ? _ts->get_time() : 0; }
+        double get_time() const { return time_service::get_time(); }
 
         void set_sensor(const std::shared_ptr<sensor_interface>& s);
 
@@ -64,7 +64,6 @@ namespace librealsense
 
         std::atomic<uint32_t> _max_publish_list_size;
         frame_callback_ptr _callback;
-        std::shared_ptr<time_service> _ts;
         std::shared_ptr<metadata_parser_map> _metadata_parsers;
     };
 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -567,7 +567,7 @@ namespace librealsense
         else
             _fps[m] = f->get_stream()->get_framerate();
 
-        auto const now = environment::get_instance().get_time_service()->get_time();
+        auto const now = time_service::get_time();
         //LOG_DEBUG( _name << ": _last_arrived[" << m->get_name() << "] = " << now );
         _last_arrived[m] = now;
     }

--- a/unit-tests/live/memory/test-extrinsics.cpp
+++ b/unit-tests/live/memory/test-extrinsics.cpp
@@ -18,7 +18,6 @@
 
 
 using namespace librealsense;
-using namespace librealsense::platform;
 
 constexpr int DELAY_INCREMENT_THRESHOLD = 4; //[%]
 constexpr int DELAY_INCREMENT_THRESHOLD_IMU = 8; //[%]

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -388,8 +388,7 @@ PYBIND11_MODULE(NAME, m) {
         .def("create_usb_device", &platform::backend::create_usb_device, "info"_a)
         .def("query_usb_devices", &platform::backend::query_usb_devices)
         .def("create_hid_device", &platform::backend::create_hid_device, "info"_a)
-        .def("query_hid_devices", &platform::backend::query_hid_devices)
-        .def("create_time_service", &platform::backend::create_time_service);
+        .def("query_hid_devices", &platform::backend::query_hid_devices);
 
     py::class_<platform::multi_pins_uvc_device, std::shared_ptr<platform::multi_pins_uvc_device>, platform::uvc_device> multi_pins_uvc_device(m, "multi_pins_uvc_device");
     multi_pins_uvc_device.def(py::init<std::vector<std::shared_ptr<platform::uvc_device>>&>())

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -61,10 +61,7 @@ PYBIND11_MODULE(NAME, m) {
                  .def_readwrite("def", &platform::control_range::def)
                  .def_readwrite("step", &platform::control_range::step);
 
-    py::class_<librealsense::time_service> time_service(m, "time_service");
-    time_service.def("get_time", &librealsense::time_service::get_time);
-
-    py::class_<librealsense::os_time_service, librealsense::time_service> os_time_service(m, "os_time_service");
+    m.def("get_time", &librealsense::time_service::get_time);
 
 #define BIND_RAW_RO_ARRAY(class, name, type, size) #name, [](const class &c) -> const std::array<type, size>& { return reinterpret_cast<const std::array<type, size>&>(c.name); }
 #define BIND_RAW_RW_ARRAY(class, name, type, size) BIND_RAW_RO_ARRAY(class, name, type, size), [](class &c, const std::array<type, size> &arr) { for (int i=0; i<size; ++i) c.name[i] = arr[i]; }

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -17,7 +17,7 @@ Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 #include "core/options.h"   // Workaround for the missing DLL_EXPORT template
 #include "core/info.h"   // Workaround for the missing DLL_EXPORT template
 #include "../src/backend.h"
-#include <src/platform/time-service.h>
+#include <src/core/time-service.h>
 #include <src/platform/command-transfer.h>
 #include <src/platform/hid-device.h>
 #include "pybackend_extras.h"
@@ -61,10 +61,10 @@ PYBIND11_MODULE(NAME, m) {
                  .def_readwrite("def", &platform::control_range::def)
                  .def_readwrite("step", &platform::control_range::step);
 
-    py::class_<platform::time_service> time_service(m, "time_service");
-    time_service.def("get_time", &platform::time_service::get_time);
+    py::class_<librealsense::time_service> time_service(m, "time_service");
+    time_service.def("get_time", &librealsense::time_service::get_time);
 
-    py::class_<platform::os_time_service, platform::time_service> os_time_service(m, "os_time_service");
+    py::class_<librealsense::os_time_service, librealsense::time_service> os_time_service(m, "os_time_service");
 
 #define BIND_RAW_RO_ARRAY(class, name, type, size) #name, [](const class &c) -> const std::array<type, size>& { return reinterpret_cast<const std::array<type, size>&>(c.name); }
 #define BIND_RAW_RW_ARRAY(class, name, type, size) BIND_RAW_RO_ARRAY(class, name, type, size), [](class &c, const std::array<type, size> &arr) { for (int i=0; i<size; ++i) c.name[i] = arr[i]; }


### PR DESCRIPTION
The class `time_service` was polymorphic before, and "created" by the `backend`.
The idea was nice, but in reality usage was mixed between the backend and the `environment`. I tried centralizing it in `context` but ran into difficulties requiring refactoring in other places, and in the end decided that it just wasn't worth the effort and code complexity:
* The backends (all of them) ended up using the default one in the environment (which is why mixing usage worked), so the polymorphism wasn't in use
* Its place in `environment` is really not good, as that's really used for the extrinsics information and we were abusing it

The code is now much simpler and easier to read/write. No weird backend usage in weird places, etc.

Tracked on [LRS-889]