### PR TITLE
enable unit-test-config --live

### DIFF
--- a/common/utilities/imgui/wrap.cpp
+++ b/common/utilities/imgui/wrap.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include "wrap.h"
 #include <rsutils/string/split.h>
-#include "../third-party/imgui/imgui.h"
+#include <third-party/imgui/imgui.h>
 
 namespace utilities {
 namespace imgui {

--- a/unit-tests/py/rspy/libci.py
+++ b/unit-tests/py/rspy/libci.py
@@ -193,7 +193,7 @@ class TestConfigFromText( TestConfig ):
                 #      0      |            1             | USE
                 #      1      |            0             | USE
                 #      1      |            1             | IGNORE
-                if not_context == (directive_context in self._context):
+                if not_context == (self._context and directive_context in self._context):
                     # log.d( "directive", line['line'], "ignored because of context mismatch with running context",
                     #       self._context)
                     continue

--- a/unit-tests/rsutils/concurrency/test-scq.cpp
+++ b/unit-tests/rsutils/concurrency/test-scq.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 #include <unit-tests/test.h>
 #include <rsutils/time/timer.h>
 #include <rsutils/concurrency/concurrency.h>

--- a/unit-tests/rsutils/imgui/test-wrap.cpp
+++ b/unit-tests/rsutils/imgui/test-wrap.cpp
@@ -1,6 +1,7 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
 //#cmake:add-file ../../../common/utilities/imgui/wrap.cpp
 
 #include "common.h"

--- a/unit-tests/rsutils/number/stabilized/test-multi-threading.cpp
+++ b/unit-tests/rsutils/number/stabilized/test-multi-threading.cpp
@@ -1,9 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 #include <thread>
 #include <chrono>
-#include "../../../test.h"
+#include <unit-tests/test.h>
 #include <rsutils/number/stabilized-value.h>
 
 using namespace rsutils::number;

--- a/unit-tests/rsutils/string/test-string-to-value.cpp
+++ b/unit-tests/rsutils/string/test-string-to-value.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 #include "common.h"
 #include <rsutils/string/string-utilities.h>
 #include <ostream>

--- a/unit-tests/rsutils/string/test-trim-newlines.cpp
+++ b/unit-tests/rsutils/string/test-trim-newlines.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 #include "common.h"
 #include <rsutils/string/trim-newlines.h>
 

--- a/unit-tests/rsutils/time/test-periodic_timer.cpp
+++ b/unit-tests/rsutils/time/test-periodic_timer.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 // Unit Test Goals:
 // Test the timer utility classes: stopwatch, timer, periodic_timer.
 

--- a/unit-tests/rsutils/time/test-stopwatch.cpp
+++ b/unit-tests/rsutils/time/test-stopwatch.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 // Unit Test Goals:
 // Test the timer utility classes: stopwatch, timer, periodic_timer.
 

--- a/unit-tests/rsutils/time/test-timer.cpp
+++ b/unit-tests/rsutils/time/test-timer.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 // Unit Test Goals:
 // Test the timer utility classes: stopwatch, timer, periodic_timer.
 

--- a/unit-tests/rsutils/time/test-waiting-on.cpp
+++ b/unit-tests/rsutils/time/test-waiting-on.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 #include <rsutils/string/chrono.h>  // must be before catch.h!
 #include <unit-tests/catch.h>
 #include <rsutils/time/waiting-on.h>

--- a/unit-tests/rsutils/time/test-work_week.cpp
+++ b/unit-tests/rsutils/time/test-work_week.cpp
@@ -1,6 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
+//#cmake:dependencies rsutils
+
 #include "common.h"
 #include <rsutils/time/work-week.h>
 #include <ctime>

--- a/unit-tests/test.h
+++ b/unit-tests/test.h
@@ -3,8 +3,11 @@
 
 #pragma once
 
+#ifdef LIBCI_DEPENDENCY_realsense2
 #include <librealsense2/rs.hpp>
+#endif
 #include "catch.h"
+#include <sstream>
 
 
 namespace test {

--- a/unit-tests/unit-test-default-main.cpp
+++ b/unit-tests/unit-test-default-main.cpp
@@ -59,8 +59,11 @@ int main( int argc, char * argv[] )
     if( ret )
         return ret;  // >0 == Error code
 
+#ifdef LIBCI_DEPENDENCY_realsense2
+    // rs2::log_to_console() is only available if realsense2 is a dependency of ours
     if( rslog )
         rs2::log_to_console( RS2_LOG_SEVERITY_DEBUG );
+#endif
 
     return session.run();
 }


### PR DESCRIPTION
Continuation of #12223:
This actually does make use of `cmake:dependencies` in the `rsutils` unit-tests that should not depend on `librealsense`. This makes a big difference when actually testing these utilities.

The major thing here, though, is that LibCI will no longer even see non-live tests: `unit-test-config --live` will use only live tests (and requires `--context ...` to be passed in, otherwise it's not accurate).

I am waiting on [a separate PR](https://github.com/IntelRealSense/librealsense-deploy/pull/173) that will actually pass those flags in. It cannot be merged until this PR is merged and then reflected in all branches.

Tracked on [LRS-894]