### PR TITLE
add rs2_device_is_connected, rs2::device::is_connected

### DIFF
--- a/include/librealsense2/h/rs_device.h
+++ b/include/librealsense2/h/rs_device.h
@@ -55,6 +55,12 @@ rs2_device* rs2_create_device(const rs2_device_list* info_list, int index, rs2_e
 void rs2_delete_device(rs2_device* device);
 
 /**
+* \param[in]  device    Realsense device to query
+* \return               True if device is still present in the system
+*/
+int rs2_device_is_connected( const rs2_device * device, rs2_error ** error );
+
+/**
 * Retrieve camera specific information, like versions of various internal components.
 * \param[in]  device    The RealSense device
 * \param[in]  info      Camera info type to retrieve

--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -91,7 +91,6 @@ namespace rs2
         void hardware_reset()
         {
             rs2_error* e = nullptr;
-
             rs2_hardware_reset(_dev.get(), &e);
             error::handle(e);
         }
@@ -110,6 +109,8 @@ namespace rs2
         }
         device() : _dev(nullptr) {}
 
+        // Note: this checks the validity of rs2::device (i.e., if it's connected to a realsense device), and does
+        // NOT reflect the current condition (connected/disconnected). Use is_connected() for that.
         operator bool() const
         {
             return _dev != nullptr;
@@ -123,6 +124,14 @@ namespace rs2
             return (
                 std::strcmp( get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ), other.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ) )
                 < 0 );
+        }
+
+        bool is_connected() const
+        {
+            rs2_error * e = nullptr;
+            bool connected = rs2_device_is_connected( _dev.get(), &e );
+            error::handle( e );
+            return connected;
         }
 
         template<class T>

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -18,6 +18,7 @@ EXPORTS
     rs2_delete_device_list
     rs2_create_device
     rs2_delete_device
+    rs2_device_is_connected
 
     rs2_query_sensors
     rs2_get_sensors_count

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -311,6 +311,7 @@ NOEXCEPT_RETURN(, device)
 int rs2_device_is_connected( const rs2_device * device, rs2_error ** error ) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL( device );
+    VALIDATE_NOT_NULL( device->device );
     return device->device->is_valid();
 }
 HANDLE_EXCEPTIONS_AND_RETURN( 0, device )

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -308,6 +308,13 @@ void rs2_delete_device(rs2_device* device) BEGIN_API_CALL
 }
 NOEXCEPT_RETURN(, device)
 
+int rs2_device_is_connected( const rs2_device * device, rs2_error ** error ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( device );
+    return device->device->is_valid();
+}
+HANDLE_EXCEPTIONS_AND_RETURN( 0, device )
+
 rs2_sensor* rs2_create_sensor(const rs2_sensor_list* list, int index, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(list);

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -2,24 +2,25 @@
 # Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
 import sys, os, re, platform
+
+def usage():
+    ourname = os.path.basename( sys.argv[0] )
+    print( 'Syntax: devices [actions|flags]' )
+    print( '        Control the LibRS devices connected' )
+    print( 'Actions (only one)' )
+    print( '        --list         Enumerate devices (default action)' )
+    print( '        --recycle      Recycle all' )
+    print( 'Flags:' )
+    print( '        --all          Enable all port [requires acroname]' )
+    print( '        --port <#>     Enable only this port [requires acroname]' )
+    print( '        --ports        Show physical port for each device (rather than the RS string)' )
+    sys.exit(2)
+
 try:
     from rspy import log
 except ModuleNotFoundError:
     if __name__ != '__main__':
         raise
-    #
-    def usage():
-        ourname = os.path.basename( sys.argv[0] )
-        print( 'Syntax: devices [actions|flags]' )
-        print( '        Control the LibRS devices connected' )
-        print( 'Actions (only one)' )
-        print( '        --list         Enumerate devices (default action)' )
-        print( '        --recycle      Recycle all' )
-        print( 'Flags:' )
-        print( '        --all          Enable all port [requires acroname]' )
-        print( '        --port <#>     Enable only this port [requires acroname]' )
-        print( '        --ports        Show physical port for each device (rather than the RS string)' )
-        sys.exit(2)
     #
     # We need to tell Python where to look for rspy
     rspy_dir = os.path.dirname( os.path.abspath( __file__ ))
@@ -787,7 +788,7 @@ if __name__ == '__main__':
                     handle = printer(device)
                     ))
         elif action == 'recycle':
-            log.f( 'Not implemented yet' )
+            acroname.recycle_ports()
     finally:
         #
         # Disconnect from the Acroname -- if we don't it'll crash on Linux...

--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -29,6 +29,7 @@ void init_device(py::module &m) {
         .def(py::init<>())
         .def("__nonzero__", &rs2::device::operator bool) // Called to implement truth value testing in Python 2
         .def("__bool__", &rs2::device::operator bool) // Called to implement truth value testing in Python 3
+        .def( "is_connected", &rs2::device::is_connected )
         .def(BIND_DOWNCAST(device, debug_protocol))
         .def(BIND_DOWNCAST(device, playback))
         .def(BIND_DOWNCAST(device, recorder))


### PR DESCRIPTION
The `device_interface::is_valid()` function is only exposed today through `device_hub::is_connected()`, which calls it directly without any more logic.

This exposes the same functionality via direct access in `rs2::device` and `rs2_device_is_connected`.

Tracked on [LRS-895]