### PR TITLE
Singleton backend/device-watcher

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/api.h"
         "${CMAKE_CURRENT_LIST_DIR}/archive.h"
         "${CMAKE_CURRENT_LIST_DIR}/backend.h"
+        "${CMAKE_CURRENT_LIST_DIR}/backend-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/backend-device-group.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/platform-device-info.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/device-watcher.h"

--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -7,6 +7,7 @@
 #include "platform/platform-device-info.h"
 #include "platform/device-watcher.h"
 
+#include "backend-device.h"
 #include "ds/d400/d400-info.h"
 #include "ds/d500/d500-info.h"
 #include "fw-update/fw-update-factory.h"
@@ -15,6 +16,13 @@
 #include <rsutils/shared-ptr-singleton.h>
 #include <rsutils/signal.h>
 #include <rsutils/json.h>
+
+
+namespace librealsense {
+namespace platform {
+std::shared_ptr< backend > create_backend();
+}  // namespace platform
+}  // namespace librealsense
 
 
 namespace {
@@ -135,6 +143,17 @@ public:
 
 
 static rsutils::shared_ptr_singleton< device_watcher_singleton > backend_device_watcher;
+
+
+std::shared_ptr< platform::backend > backend_device::get_backend()
+{
+    auto singleton = the_backend.get();
+    if( ! singleton )
+        // Whoever is calling us, they are expecting a backend to exist, but it does not!
+        throw std::runtime_error( "backend not created yet!" );
+
+    return singleton->get();
+}
 
 
 backend_device_factory::backend_device_factory( context & ctx, callback && cb )

--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -12,6 +12,8 @@
 #include "fw-update/fw-update-factory.h"
 #include "platform-camera.h"
 
+#include <rsutils/shared-ptr-singleton.h>
+#include <rsutils/signal.h>
 #include <rsutils/json.h>
 
 
@@ -77,56 +79,111 @@ subtract_sets( const std::vector< std::shared_ptr< librealsense::platform::platf
 namespace librealsense {
 
 
-backend_device_factory::backend_device_factory( context & ctx, callback && cb )
-    : _device_watcher( ctx.get_backend().create_device_watcher() )
-    , _context( ctx )
+// This singleton creates the actual backend; as long as someone holds it, the backend will stay alive.
+// The instance is held below by the device-watcher. I.e., the device-watcher triggers creation of the
+// backend!
+//
+class backend_singleton
 {
-    assert( _device_watcher->is_stopped() );
-    _device_watcher->start(
-        [this, cb = std::move( cb )]( platform::backend_device_group const & old,
-                                      platform::backend_device_group const & curr )
-        {
-            auto old_list = create_devices_from_group( old, RS2_PRODUCT_LINE_ANY );
-            auto new_list = create_devices_from_group( curr, RS2_PRODUCT_LINE_ANY );
+    std::shared_ptr< platform::backend > const _backend;
 
-            std::vector< rs2_device_info > devices_removed;
-            for( auto & device_removed : subtract_sets( old_list, new_list ) )
-            {
-                devices_removed.push_back( { _context.shared_from_this(), device_removed } );
-                LOG_DEBUG( "Device disconnected: " << device_removed->get_address() );
-            }
+public:
+    backend_singleton()
+        : _backend( platform::create_backend() )
+    {
+    }
 
-            std::vector< rs2_device_info > devices_added;
-            for( auto & device_added : subtract_sets( new_list, old_list ) )
-            {
-                devices_added.push_back( { _context.shared_from_this(), device_added } );
-                LOG_DEBUG( "Device connected: " << device_added->get_address() );
-            }
+    std::shared_ptr< platform::backend > get() const { return _backend; }
+};
 
-            if( devices_removed.size() + devices_added.size() )
-            {
-                cb( devices_removed, devices_added );
-            }
-        } );
+
+static rsutils::shared_ptr_singleton< backend_singleton > the_backend;
+
+
+// The device-watcher is also a singleton: we don't need multiple agents of notifications. It is held alive by the
+// device-factory below, which is held per context. I.e., as long as the context is alive, we'll stay alive and the
+// backend-singleton will stay alive.
+// 
+// We are responsible for exposing the single notification from the platform-device-watcher to several subscribers:
+// one device-watcher, but many contexts, each with further subscriptions.
+//
+class device_watcher_singleton
+{
+    // The device-watcher keeps a direct pointer to the backend instance, so we have to make sure it stays alive!
+    std::shared_ptr< backend_singleton > const _backend;
+    std::shared_ptr< platform::device_watcher > const _device_watcher;
+    rsutils::signal< platform::backend_device_group const &, platform::backend_device_group const & > _callbacks;
+
+public:
+    device_watcher_singleton()
+        : _backend( the_backend.instance() )
+        , _device_watcher( _backend->get()->create_device_watcher() )
+    {
+        assert( _device_watcher->is_stopped() );
+        _device_watcher->start(
+            [this]( platform::backend_device_group const & old, platform::backend_device_group const & curr )
+            { _callbacks.raise( old, curr ); } );
+    }
+
+    rsutils::subscription subscribe( platform::device_changed_callback && cb )
+    {
+        return _callbacks.subscribe( std::move( cb ) );
+    }
+
+    std::shared_ptr< platform::backend > const get_backend() const { return _backend->get(); }
+};
+
+
+static rsutils::shared_ptr_singleton< device_watcher_singleton > backend_device_watcher;
+
+
+backend_device_factory::backend_device_factory( context & ctx, callback && cb )
+    : _context( ctx )
+    , _device_watcher( backend_device_watcher.instance() )
+    , _dtor( _device_watcher->subscribe(
+          [this, cb = std::move( cb )]( platform::backend_device_group const & old,
+                                        platform::backend_device_group const & curr )
+          {
+              auto old_list = create_devices_from_group( old, RS2_PRODUCT_LINE_ANY );
+              auto new_list = create_devices_from_group( curr, RS2_PRODUCT_LINE_ANY );
+
+              std::vector< rs2_device_info > devices_removed;
+              for( auto & device_removed : subtract_sets( old_list, new_list ) )
+              {
+                  devices_removed.push_back( { _context.shared_from_this(), device_removed } );
+                  LOG_DEBUG( "Device disconnected: " << device_removed->get_address() );
+              }
+
+              std::vector< rs2_device_info > devices_added;
+              for( auto & device_added : subtract_sets( new_list, old_list ) )
+              {
+                  devices_added.push_back( { _context.shared_from_this(), device_added } );
+                  LOG_DEBUG( "Device connected: " << device_added->get_address() );
+              }
+
+              if( devices_removed.size() + devices_added.size() )
+              {
+                  cb( devices_removed, devices_added );
+              }
+          } ) )
+{
 }
 
 
 backend_device_factory::~backend_device_factory()
 {
-    if( _device_watcher )
-        _device_watcher->stop();
 }
 
 
 std::vector< std::shared_ptr< device_info > > backend_device_factory::query_devices( unsigned requested_mask ) const
 {
-    if( (requested_mask & RS2_PRODUCT_LINE_SW_ONLY) || (_context.get_device_mask() & RS2_PRODUCT_LINE_SW_ONLY) )
+    if( ( requested_mask & RS2_PRODUCT_LINE_SW_ONLY ) || ( _context.get_device_mask() & RS2_PRODUCT_LINE_SW_ONLY ) )
         return {};  // We don't carry any software devices
 
-    auto & backend = _context.get_backend();
-    platform::backend_device_group group( backend.query_uvc_devices(),
-                                          backend.query_usb_devices(),
-                                          backend.query_hid_devices() );
+    auto backend = _device_watcher->get_backend();
+    platform::backend_device_group group( backend->query_uvc_devices(),
+                                          backend->query_usb_devices(),
+                                          backend->query_hid_devices() );
     auto devices = create_devices_from_group( group, requested_mask );
     return { devices.begin(), devices.end() };
 }

--- a/src/backend-device-factory.h
+++ b/src/backend-device-factory.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <functional>
+#include <rsutils/subscription.h>
 #include <memory>
 #include <vector>
 
@@ -16,10 +16,10 @@ namespace librealsense {
 
 class device_info;
 class context;
+class device_watcher_singleton;
 
 
 namespace platform {
-class device_watcher;
 struct backend_device_group;
 class platform_device_info;
 }  // namespace platform
@@ -38,12 +38,13 @@ class platform_device_info;
 class backend_device_factory
 {
     context & _context;
-    std::shared_ptr< platform::device_watcher > const _device_watcher;
+    std::shared_ptr< device_watcher_singleton > const _device_watcher;
+    rsutils::subscription const _dtor;  // raii generic code, used to automatically unsubscribe our callback
 
+public:
     using callback = std::function< void( std::vector< rs2_device_info > & rs2_devices_info_removed,
                                           std::vector< rs2_device_info > & rs2_devices_info_added ) >;
 
-public:
     backend_device_factory( context &, callback && );
     ~backend_device_factory();
 

--- a/src/backend-device.h
+++ b/src/backend-device.h
@@ -4,25 +4,32 @@
 #pragma once
 
 #include <src/device.h>
+#include <memory>
 
 
 namespace librealsense {
 
 
-// Common base class for all Stereo devices
+namespace platform {
+class backend;
+}
+
+
+// Common base class for all backend devices (i.e., those that require a platform backend)
 //
-class ds_device : public virtual device
+class backend_device : public virtual device
 {
     typedef device super;
 
 protected:
-    ds_device( std::shared_ptr< const device_info > const & dev_info, bool device_changed_notifications = true )
+    backend_device( std::shared_ptr< const device_info > const & dev_info, bool device_changed_notifications = true )
         : super( dev_info, device_changed_notifications )
     {
     }
 
 public:
     uint16_t get_pid() const { return _pid; }
+    std::shared_ptr< platform::backend > get_backend();
 
 protected:
     uint16_t _pid = 0;

--- a/src/backend.h
+++ b/src/backend.h
@@ -53,8 +53,6 @@ namespace librealsense
             virtual ~backend() = default;
         };
 
-        std::shared_ptr<backend> create_backend();
-
     }
 
     double monotonic_to_realtime(double monotonic);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -42,14 +42,13 @@ using json = nlohmann::json;
 namespace librealsense
 {
     context::context( json const & settings )
-        : _backend( platform::create_backend() )
-        , _settings( settings )
+        : _settings( settings )
         , _device_mask( rsutils::json::get< unsigned >( settings, "device-mask", RS2_PRODUCT_LINE_ANY ) )
         , _devices_changed_callback( nullptr, []( rs2_devices_changed_callback * ) {} )
         , _backend_device_factory(
-            *this,
-            [this]( std::vector< rs2_device_info > & removed, std::vector< rs2_device_info > & added )
-            { invoke_devices_changed_callbacks( removed, added ); } )
+              *this,
+              [this]( std::vector< rs2_device_info > & removed, std::vector< rs2_device_info > & added )
+              { invoke_devices_changed_callbacks( removed, added ); } )
     {
         static bool version_logged = false;
         if( ! version_logged )
@@ -57,7 +56,6 @@ namespace librealsense
             version_logged = true;
             LOG_DEBUG( "Librealsense VERSION: " << RS2_API_VERSION_STR );
         }
-
 
 #ifdef BUILD_WITH_DDS
         nlohmann::json dds_settings
@@ -116,7 +114,7 @@ namespace librealsense
         // The normal bits enable, so enable only those that are on
         mask &= mask_in_settings & ~RS2_PRODUCT_LINE_SW_ONLY;
         // But the above turned off the SW-only bits, so turn them back on again
-        if( (mask_in_settings & RS2_PRODUCT_LINE_SW_ONLY) || (requested_mask & RS2_PRODUCT_LINE_SW_ONLY) )
+        if( ( mask_in_settings & RS2_PRODUCT_LINE_SW_ONLY ) || ( requested_mask & RS2_PRODUCT_LINE_SW_ONLY ) )
             mask |= RS2_PRODUCT_LINE_SW_ONLY;
         return mask;
     }

--- a/src/context.h
+++ b/src/context.h
@@ -81,7 +81,7 @@ namespace librealsense
         static unsigned combine_device_masks( unsigned requested_mask, unsigned mask_in_settings );
 
         std::vector<std::shared_ptr<device_info>> query_devices(int mask) const;
-        const platform::backend& get_backend() const { return *_backend; }
+        const platform::backend& get_backend() const { return *_backend_device_factory.get_backend(); }
 
         uint64_t register_internal_device_callback(devices_changed_callback_ptr callback);
         void unregister_internal_device_callback(uint64_t cb_id);
@@ -100,8 +100,6 @@ namespace librealsense
         void invoke_devices_changed_callbacks( std::vector<rs2_device_info> & rs2_devices_info_removed,
                                                std::vector<rs2_device_info> & rs2_devices_info_added );
         void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
-
-        std::shared_ptr<platform::backend> _backend;
 
         std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;

--- a/src/context.h
+++ b/src/context.h
@@ -4,8 +4,7 @@
 #pragma once
 
 #include "backend-device-factory.h"
-#include "device-info.h"
-#include "types.h"
+#include "types.h"  // devices_changed_callback_ptr
 
 #include <rsutils/lazy.h>
 #include <nlohmann/json.hpp>
@@ -49,19 +48,11 @@ namespace realdds {
 
 namespace librealsense
 {
-    class device;
-    class context;
     class playback_device_info;
     class stream_interface;
 
-    namespace platform {
-        class backend;
-        class device_watcher;
-    }
-
     class context : public std::enable_shared_from_this<context>
     {
-        context();
     public:
         explicit context( nlohmann::json const & );
         explicit context( char const * json_settings );
@@ -81,7 +72,6 @@ namespace librealsense
         static unsigned combine_device_masks( unsigned requested_mask, unsigned mask_in_settings );
 
         std::vector<std::shared_ptr<device_info>> query_devices(int mask) const;
-        const platform::backend& get_backend() const { return *_backend_device_factory.get_backend(); }
 
         uint64_t register_internal_device_callback(devices_changed_callback_ptr callback);
         void unregister_internal_device_callback(uint64_t cb_id);

--- a/src/dds/rs-dds-device-info.h
+++ b/src/dds/rs-dds-device-info.h
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include <src/context.h>  // device_info, context
+#include <src/context.h>
+#include <src/device-info.h>
 
 #include <memory>
 

--- a/src/ds/CMakeLists.txt
+++ b/src/ds/CMakeLists.txt
@@ -18,7 +18,6 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/advanced_mode/advanced_mode.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/ds-calib-parsers.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/ds-device-common.h"
-        "${CMAKE_CURRENT_LIST_DIR}/ds-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds-motion-common.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds-color-common.h"
         "${CMAKE_CURRENT_LIST_DIR}/ds-active-common.h"

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -43,7 +43,6 @@ namespace librealsense
     void d400_color::create_color_device(std::shared_ptr<context> ctx, const platform::backend_device_group& group)
     {
         using namespace ds;
-        auto&& backend = ctx->get_backend();
 
         _color_calib_table_raw = [this]()
         {
@@ -82,7 +81,7 @@ namespace librealsense
                 info = color_devs_info[1];
             else
                 info = color_devs_info.front();
-            auto uvcd = backend.create_uvc_device(info);
+            auto uvcd = get_backend()->create_uvc_device( info );
             //auto ftr = std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(d400_timestamp_reader_metadata), _tf_keeper, enable_global_time_option));
             auto raw_color_ep = std::make_shared<uvc_sensor>("Raw RGB Camera",
                 uvcd,

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -462,11 +462,9 @@ namespace librealsense
     {
         using namespace ds;
 
-        auto&& backend = ctx->get_backend();
-
         std::vector<std::shared_ptr<platform::uvc_device>> depth_devices;
         for (auto&& info : filter_by_mi(all_device_infos, 0)) // Filter just mi=0, DEPTH
-            depth_devices.push_back(backend.create_uvc_device(info));
+            depth_devices.push_back( get_backend()->create_uvc_device( info ) );
 
         std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
         frame_timestamp_reader* timestamp_reader_from_metadata;
@@ -499,7 +497,7 @@ namespace librealsense
     }
 
     d400_device::d400_device( std::shared_ptr< const d400_info > const & dev_info )
-        : ds_device(dev_info), global_time_interface(),
+        : backend_device(dev_info), global_time_interface(),
           auto_calibrated(),
           _device_capabilities(ds::ds_caps::CAP_UNDEFINED),
           _depth_stream(new stream(RS2_STREAM_DEPTH)),
@@ -516,7 +514,6 @@ namespace librealsense
     {
         using namespace ds;
 
-        auto&& backend = ctx->get_backend();
         auto& raw_sensor = get_raw_depth_sensor();
         _pid = group.uvc_devices.front().pid;
         // to be changed for D457
@@ -537,10 +534,10 @@ namespace librealsense
         }
         else
         {
-            if (!mipi_sensor)
-                _hw_monitor = std::make_shared<hw_monitor>(
-                std::make_shared<locked_transfer>(
-                    backend.create_usb_device(group.usb_devices.front()), raw_sensor));
+            if( ! mipi_sensor )
+                _hw_monitor = std::make_shared< hw_monitor >( std::make_shared< locked_transfer >(
+                    get_backend()->create_usb_device( group.usb_devices.front() ),
+                    raw_sensor ) );
         }
         set_hw_monitor_for_auto_calib(_hw_monitor);
 
@@ -1212,11 +1209,9 @@ namespace librealsense
     {
         using namespace ds;
 
-        auto&& backend = ctx->get_backend();
-
         std::vector<std::shared_ptr<platform::uvc_device>> depth_devices;
-        for (auto&& info : filter_by_mi(all_device_infos, 0)) // Filter just mi=0, DEPTH
-            depth_devices.push_back(backend.create_uvc_device(info));
+        for( auto & info : filter_by_mi( all_device_infos, 0 ) )  // Filter just mi=0, DEPTH
+            depth_devices.push_back( get_backend()->create_uvc_device( info ) );
 
         std::unique_ptr< frame_timestamp_reader > d400_timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> d400_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(d400_timestamp_reader_backup)));

--- a/src/ds/d400/d400-device.h
+++ b/src/ds/d400/d400-device.h
@@ -16,7 +16,7 @@
 #include "d400-options.h"
 
 #include "ds/ds-device-common.h"
-#include "ds/ds-device.h"
+#include "backend-device.h"
 
 namespace librealsense
 {
@@ -24,7 +24,7 @@ namespace librealsense
     class d400_thermal_monitor;
 
     class d400_device
-        : public virtual ds_device
+        : public virtual backend_device
         , public debug_interface
         , public global_time_interface
         , public updatable

--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -43,7 +43,7 @@ namespace librealsense
     public:
         rs400_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_nonmonochrome( dev_info )
             , ds_advanced_mode_base( d400_device::_hw_monitor, get_depth_sensor() )
@@ -82,7 +82,7 @@ namespace librealsense
     public:
         rs405u_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device(dev_info, register_device_notifications),
-            ds_device( dev_info, register_device_notifications ),
+            backend_device( dev_info, register_device_notifications ),
             ds5u_device(dev_info),
             ds_advanced_mode_base(d400_device::_hw_monitor, get_depth_sensor()),
             firmware_logger_device(dev_info, d400_device::_hw_monitor,
@@ -133,7 +133,7 @@ namespace librealsense
     public:
         rs410_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_nonmonochrome( dev_info )
             , d400_active( dev_info )
@@ -172,7 +172,7 @@ namespace librealsense
     public:
         rs415_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_nonmonochrome( dev_info )
             , d400_active( dev_info )
@@ -213,7 +213,7 @@ namespace librealsense
     public:
         rs416_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_nonmonochrome( dev_info )
             , d400_active( dev_info )
@@ -267,7 +267,7 @@ namespace librealsense
     public:
         rs416_rgb_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_nonmonochrome( dev_info )
             , d400_active( dev_info )
@@ -321,7 +321,7 @@ namespace librealsense
     public:
         rs420_mm_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_motion( dev_info )
             , ds_advanced_mode_base( d400_device::_hw_monitor, get_depth_sensor() )
@@ -369,7 +369,7 @@ namespace librealsense
     public:
         rs420_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , ds_advanced_mode_base( d400_device::_hw_monitor, get_depth_sensor() )
             , firmware_logger_device(
@@ -407,7 +407,7 @@ namespace librealsense
     public:
         rs430_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , ds_advanced_mode_base( d400_device::_hw_monitor, get_depth_sensor() )
@@ -446,7 +446,7 @@ namespace librealsense
     public:
         rs430i_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , ds_advanced_mode_base( d400_device::_hw_monitor, get_depth_sensor() )
@@ -490,7 +490,7 @@ namespace librealsense
     public:
         rs430_mm_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , d400_motion( dev_info )
@@ -541,7 +541,7 @@ namespace librealsense
     public:
         rs435_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , d400_color( dev_info )
@@ -583,7 +583,7 @@ namespace librealsense
     public:
         rs457_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , d400_color( dev_info )
@@ -617,7 +617,7 @@ namespace librealsense
     public:
         rs430_rgb_mm_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , d400_color( dev_info )
@@ -660,7 +660,7 @@ namespace librealsense
     public:
         rs435i_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , d400_color( dev_info )
@@ -878,7 +878,7 @@ namespace librealsense
     public:
         rs465_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_active( dev_info )
             , d400_color( dev_info )
@@ -919,7 +919,7 @@ namespace librealsense
     public:
         rs400_imu_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_motion( dev_info )
             , ds_advanced_mode_base( d400_device::_hw_monitor, get_depth_sensor() )
@@ -949,7 +949,7 @@ namespace librealsense
     public:
         rs405_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_color( dev_info )
             , d400_nonmonochrome( dev_info )
@@ -1036,7 +1036,7 @@ namespace librealsense
     public:
         rs455_device( std::shared_ptr< const d400_info > const & dev_info, bool register_device_notifications )
             : device( dev_info, register_device_notifications )
-            , ds_device( dev_info, register_device_notifications )
+            , backend_device( dev_info, register_device_notifications )
             , d400_device( dev_info )
             , d400_nonmonochrome( dev_info )
             , d400_active( dev_info )

--- a/src/ds/d400/d400-motion.cpp
+++ b/src/ds/d400/d400-motion.cpp
@@ -46,11 +46,9 @@ namespace librealsense
             return nullptr;
         }
 
-        auto&& backend = ctx->get_backend();
-
         std::vector<std::shared_ptr<platform::uvc_device>> imu_devices;
         for (auto&& info : filter_by_mi(all_uvc_infos, 4)) // Filter just mi=4, IMU
-            imu_devices.push_back(backend.create_uvc_device(info));
+            imu_devices.push_back( get_backend()->create_uvc_device( info ) );
 
         std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata(new ds_timestamp_reader_from_metadata_mipi_motion(std::move(timestamp_reader_backup)));
@@ -170,11 +168,16 @@ namespace librealsense
             return;
 
         std::unique_ptr< frame_timestamp_reader > ds_timestamp_reader_backup( new ds_timestamp_reader() );
-        auto&& backend = ctx->get_backend();
         std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(ds_timestamp_reader_backup)));
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
-        auto raw_fisheye_ep = std::make_shared<uvc_sensor>("FishEye Sensor", backend.create_uvc_device(fisheye_infos.front()),
-                                std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(ds_timestamp_reader_metadata), _tf_keeper, enable_global_time_option)), this);
+        auto raw_fisheye_ep
+            = std::make_shared< uvc_sensor >( "FishEye Sensor",
+                                              get_backend()->create_uvc_device( fisheye_infos.front() ),
+                                              std::unique_ptr< frame_timestamp_reader >( new global_timestamp_reader(
+                                                  std::move( ds_timestamp_reader_metadata ),
+                                                  _tf_keeper,
+                                                  enable_global_time_option ) ),
+                                              this );
         auto fisheye_ep = std::make_shared<ds_fisheye_sensor>(raw_fisheye_ep, this);
         
         _ds_motion_common->assign_fisheye_ep(raw_fisheye_ep, fisheye_ep, enable_global_time_option);

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -43,7 +43,6 @@ namespace librealsense
     void d500_color::create_color_device(std::shared_ptr<context> ctx, const platform::backend_device_group& group)
     {
         using namespace ds;
-        auto&& backend = ctx->get_backend();
 
         _color_calib_table_raw = [this]()
         {
@@ -61,10 +60,14 @@ namespace librealsense
         std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(ds_timestamp_reader_backup)));
 
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
-        auto raw_color_ep = std::make_shared<uvc_sensor>("Raw RGB Camera",
-            backend.create_uvc_device(color_devs_info.front()),
-            std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(ds_timestamp_reader_metadata), _tf_keeper, enable_global_time_option)),
-            this);
+        auto raw_color_ep = std::make_shared< uvc_sensor >(
+            "Raw RGB Camera",
+            get_backend()->create_uvc_device( color_devs_info.front() ),
+            std::unique_ptr< frame_timestamp_reader >(
+                new global_timestamp_reader( std::move( ds_timestamp_reader_metadata ),
+                                             _tf_keeper,
+                                             enable_global_time_option ) ),
+            this );
 
         auto color_ep = std::make_shared<d500_color_sensor>(this,
             raw_color_ep,

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -346,11 +346,9 @@ namespace librealsense
     {
         using namespace ds;
 
-        auto&& backend = ctx->get_backend();
-
         std::vector<std::shared_ptr<platform::uvc_device>> depth_devices;
-        for (auto&& info : filter_by_mi(all_device_infos, 0)) // Filter just mi=0, DEPTH
-            depth_devices.push_back(backend.create_uvc_device(info));
+        for( auto & info : filter_by_mi( all_device_infos, 0 ) )  // Filter just mi=0, DEPTH
+            depth_devices.push_back( get_backend()->create_uvc_device( info ) );
 
         std::unique_ptr< frame_timestamp_reader > timestamp_reader_backup( new ds_timestamp_reader() );
         std::unique_ptr<frame_timestamp_reader> timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(timestamp_reader_backup)));
@@ -376,7 +374,7 @@ namespace librealsense
     }
 
     d500_device::d500_device( std::shared_ptr< const d500_info > const & dev_info )
-        : ds_device(dev_info), global_time_interface(),
+        : backend_device(dev_info), global_time_interface(),
           _device_capabilities(ds::ds_caps::CAP_UNDEFINED),
           _depth_stream(new stream(RS2_STREAM_DEPTH)),
           _left_ir_stream(new stream(RS2_STREAM_INFRARED, 1)),
@@ -393,7 +391,6 @@ namespace librealsense
     {
         using namespace ds;
 
-        auto&& backend = ctx->get_backend();
         auto& raw_sensor = get_raw_depth_sensor();
         _pid = group.uvc_devices.front().pid;
 
@@ -412,9 +409,9 @@ namespace librealsense
         }
         else
         {
-            _hw_monitor = std::make_shared<hw_monitor_extended_buffers>(
-                std::make_shared<locked_transfer>(
-                    backend.create_usb_device(group.usb_devices.front()), raw_sensor));
+            _hw_monitor = std::make_shared< hw_monitor_extended_buffers >(
+                std::make_shared< locked_transfer >( get_backend()->create_usb_device( group.usb_devices.front() ),
+                                                     raw_sensor ) );
         }
 
         _ds_device_common = std::make_shared<ds_device_common>(this, _hw_monitor);

--- a/src/ds/d500/d500-device.h
+++ b/src/ds/d500/d500-device.h
@@ -17,7 +17,7 @@
 #include "ds/ds-options.h"
 
 #include "ds/ds-device-common.h"
-#include "ds/ds-device.h"
+#include "backend-device.h"
 
 #include <rsutils/lazy.h>
 
@@ -34,7 +34,7 @@ namespace librealsense
     }
 
     class d500_device
-        : public virtual ds_device
+        : public virtual backend_device
         , public debug_interface
         , public global_time_interface
         , public updatable

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -42,7 +42,7 @@ class d555e_device
 public:
     d555e_device( std::shared_ptr< const d500_info > dev_info )
         : device( dev_info )
-        , ds_device( dev_info )
+        , backend_device( dev_info )
         , d500_device( dev_info )
         , d500_active( dev_info )
         , d500_color( dev_info )

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -72,11 +72,16 @@ namespace librealsense
             return;
 
         std::unique_ptr< frame_timestamp_reader > ds_timestamp_reader_backup( new ds_timestamp_reader() );
-        auto&& backend = ctx->get_backend();
         std::unique_ptr<frame_timestamp_reader> ds_timestamp_reader_metadata(new ds_timestamp_reader_from_metadata(std::move(ds_timestamp_reader_backup)));
         auto enable_global_time_option = std::shared_ptr<global_time_option>(new global_time_option());
-        auto raw_fisheye_ep = std::make_shared<uvc_sensor>("FishEye Sensor", backend.create_uvc_device(fisheye_infos.front()),
-                                std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(ds_timestamp_reader_metadata), _tf_keeper, enable_global_time_option)), this);
+        auto raw_fisheye_ep
+            = std::make_shared< uvc_sensor >( "FishEye Sensor",
+                                              get_backend()->create_uvc_device( fisheye_infos.front() ),
+                                              std::unique_ptr< frame_timestamp_reader >( new global_timestamp_reader(
+                                                  std::move( ds_timestamp_reader_metadata ),
+                                                  _tf_keeper,
+                                                  enable_global_time_option ) ),
+                                              this );
         auto fisheye_ep = std::make_shared<ds_fisheye_sensor>(raw_fisheye_ep, this);
 
         _ds_motion_common->assign_fisheye_ep(raw_fisheye_ep, fisheye_ep, enable_global_time_option);

--- a/src/ds/ds-active-common.cpp
+++ b/src/ds/ds-active-common.cpp
@@ -10,7 +10,7 @@ namespace librealsense
 
     ds_active_common::ds_active_common(uvc_sensor& raw_depth_ep,
         synthetic_sensor& depth_ep,
-        ds_device* owner,
+        backend_device* owner,
         ds_caps device_capabilities,
         std::shared_ptr<hw_monitor> hw_monitor,
         firmware_version fw_version) :

--- a/src/ds/ds-active-common.h
+++ b/src/ds/ds-active-common.h
@@ -10,14 +10,14 @@
 
 namespace librealsense
 {
-    class ds_device;
+    class backend_device;
 
     class ds_active_common
     {
     public:
         ds_active_common(uvc_sensor& raw_color_ep,
             synthetic_sensor& color_ep,
-            ds_device* owner, 
+            backend_device* owner, 
             ds::ds_caps device_capabilities,
             std::shared_ptr<hw_monitor> hw_monitor,
             firmware_version firmware_version);
@@ -26,7 +26,7 @@ namespace librealsense
     private:
         uvc_sensor& _raw_depth_ep;
         synthetic_sensor& _depth_ep;
-        ds_device* _owner;
+        backend_device* _owner;
         ds::ds_caps _device_capabilities;
         std::shared_ptr<hw_monitor> _hw_monitor;
         firmware_version _fw_version;

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -261,7 +261,7 @@ namespace librealsense
         return auto_exposure;
     }
 
-    ds_motion_common::ds_motion_common(ds_device* owner,
+    ds_motion_common::ds_motion_common( backend_device * owner,
         firmware_version fw_version,
         const ds::ds_caps& device_capabilities,
         std::shared_ptr<hw_monitor> hwm) :
@@ -472,12 +472,16 @@ namespace librealsense
         }
         _fps_and_sampling_frequency_per_rs2_stream[RS2_STREAM_ACCEL] = fps_and_frequency_map;
 
-        auto raw_hid_ep = std::make_shared<hid_sensor>(ctx->get_backend().create_hid_device(all_hid_infos.front()),
-            std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(iio_hid_ts_reader), tf_keeper, enable_global_time_option)),
-            std::unique_ptr<frame_timestamp_reader>(new global_timestamp_reader(std::move(custom_hid_ts_reader), tf_keeper, enable_global_time_option)),
+        auto raw_hid_ep = std::make_shared< hid_sensor >(
+            _owner->get_backend()->create_hid_device( all_hid_infos.front() ),
+            std::unique_ptr< frame_timestamp_reader >(
+                new global_timestamp_reader( std::move( iio_hid_ts_reader ), tf_keeper, enable_global_time_option ) ),
+            std::unique_ptr< frame_timestamp_reader >( new global_timestamp_reader( std::move( custom_hid_ts_reader ),
+                                                                                    tf_keeper,
+                                                                                    enable_global_time_option ) ),
             _fps_and_sampling_frequency_per_rs2_stream,
             _sensor_name_and_hid_profiles,
-            _owner);
+            _owner );
 
         auto hid_ep = std::make_shared<ds_motion_sensor>("Motion Module", raw_hid_ep, _owner);
 

--- a/src/ds/ds-motion-common.h
+++ b/src/ds/ds-motion-common.h
@@ -111,12 +111,12 @@ namespace librealsense
         struct backend_device_group;
     }
 
-    class ds_device;
+    class backend_device;
 
     class ds_motion_common
     {
     public:
-        ds_motion_common(ds_device* owner,
+        ds_motion_common( backend_device * owner,
             firmware_version fw_version,
             const ds::ds_caps& device_capabilities,
             std::shared_ptr<hw_monitor> hwm);
@@ -164,7 +164,7 @@ namespace librealsense
         friend class ds_motion_sensor;
         friend class ds_fisheye_sensor;
 
-        ds_device * _owner;
+        backend_device * _owner;
         firmware_version _fw_version;
         ds::ds_caps _device_capabilities;
         std::shared_ptr<hw_monitor> _hw_monitor;

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -4,6 +4,7 @@
 #include "fw-update-device.h"
 #include "../types.h"
 #include "../context.h"
+#include "../device-info.h"
 #include "ds/d400/d400-private.h"
 
 #include <chrono>

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -65,10 +65,12 @@ platform_camera::platform_camera( std::shared_ptr< const device_info > const & d
                                   const std::vector< platform::uvc_device_info > & uvc_infos,
                                   bool register_device_notifications )
     : device( dev_info, register_device_notifications )
+    , backend_device( dev_info, register_device_notifications )
 {
     std::vector< std::shared_ptr< platform::uvc_device > > devs;
-    for( auto && info : uvc_infos )
-        devs.push_back( dev_info->get_context()->get_backend().create_uvc_device( info ) );
+    auto backend = get_backend();
+    for( auto & info : uvc_infos )
+        devs.push_back( backend->create_uvc_device( info ) );
 
     std::unique_ptr< frame_timestamp_reader > host_timestamp_reader_backup( new ds_timestamp_reader() );
     auto raw_color_ep = std::make_shared< uvc_sensor >(

--- a/src/platform-camera.h
+++ b/src/platform-camera.h
@@ -3,14 +3,14 @@
 
 #pragma once
 
-#include "device.h"
+#include "backend-device.h"
 #include "platform/platform-device-info.h"
 
 
 namespace librealsense {
 
 
-class platform_camera : public device
+class platform_camera : public backend_device
 {
 public:
     platform_camera( std::shared_ptr< const device_info > const & dev_info,

--- a/wrappers/python/pybackend.cpp
+++ b/wrappers/python/pybackend.cpp
@@ -35,6 +35,12 @@ using namespace pybind11::literals;
 using namespace librealsense;
 using namespace pybackend2;
 
+namespace librealsense {
+namespace platform {
+std::shared_ptr< backend > create_backend();
+}  // namespace platform
+}  // namespace librealsense
+
 
 // Prevents expensive copies of pixel buffers into python
 PYBIND11_MAKE_OPAQUE(std::vector<uint8_t>)


### PR DESCRIPTION
* Backend and the device-watcher are now both singletons, as it should be
* Still, they are automatically destroyed (so the watcher stops watching, etc.) when they're no longer needed (when the last context its devices are removed) - and also automatically created when they're needed
* Removed `create_backend()` from the `backend.h` header, so it's not possible for others to call it
* Removed `context.get_backend()` - the backend is now only for `backend_device` objects
* Renamed `ds_device` (recently added by myself) as `backend_device` and moved out of `ds/`

The backend is now mostly separate from the rest of librealsense and can be theoretically moved into its own module.

Tracked on [LRS-891]