### PR TITLE
rsdds-device-factory : rscore/device-factory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/device.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/device-info.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/device_hub.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/rscore/device-factory.h"
         "${CMAKE_CURRENT_LIST_DIR}/environment.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/error-handling.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/firmware_logger_device.cpp"

--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -124,7 +124,7 @@ std::shared_ptr< platform::backend > backend_device::get_backend()
 
 
 backend_device_factory::backend_device_factory( context & ctx, callback && cb )
-    : _context( ctx )
+    : super( ctx )
     , _device_watcher( backend_device_watcher.instance() )
     , _dtor( _device_watcher->subscribe(
           [this, cb = std::move( cb )]( platform::backend_device_group const & old,

--- a/src/backend-device-factory.h
+++ b/src/backend-device-factory.h
@@ -3,19 +3,13 @@
 
 #pragma once
 
+#include <rscore/device-factory.h>
 #include <rsutils/subscription.h>
-#include <memory>
-#include <vector>
-
-
-struct rs2_device_info;
 
 
 namespace librealsense {
 
 
-class device_info;
-class context;
 class device_watcher_singleton;
 
 
@@ -35,23 +29,21 @@ class platform_device_info;
 // manages these device-info objects such that lifetime is tracked and updated appropriately, without the caller's
 // knowledge.
 //
-class backend_device_factory
+class backend_device_factory : public device_factory
 {
-    context & _context;
+    typedef device_factory super;
+
     std::shared_ptr< device_watcher_singleton > const _device_watcher;
     rsutils::subscription const _dtor;  // raii generic code, used to automatically unsubscribe our callback
 
 public:
-    using callback = std::function< void( std::vector< rs2_device_info > & rs2_devices_info_removed,
-                                          std::vector< rs2_device_info > & rs2_devices_info_added ) >;
-
     backend_device_factory( context &, callback && );
     ~backend_device_factory();
 
     // Query any subset of available devices and return them as device-info objects
     // Devices will match both the requested mask and the device-mask from the context settings
     //
-    std::vector< std::shared_ptr< device_info > > query_devices( unsigned mask ) const;
+    std::vector< std::shared_ptr< device_info > > query_devices( unsigned mask ) const override;
 
 private:
     std::vector< std::shared_ptr< platform::platform_device_info > >

--- a/src/context.h
+++ b/src/context.h
@@ -4,6 +4,9 @@
 #pragma once
 
 #include "backend-device-factory.h"
+#ifdef BUILD_WITH_DDS
+#include "dds/rsdds-device-factory.h"
+#endif
 #include "types.h"  // devices_changed_callback_ptr
 
 #include <rsutils/lazy.h>
@@ -36,14 +39,6 @@ struct rs2_stream_profile
     librealsense::stream_profile_interface* profile;
     std::shared_ptr<librealsense::stream_profile_interface> clone;
 };
-
-
-#ifdef BUILD_WITH_DDS
-namespace realdds {
-    class dds_device_watcher;
-    class dds_participant;
-}  // namespace realdds
-#endif
 
 
 namespace librealsense
@@ -93,16 +88,13 @@ namespace librealsense
 
         std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
-#ifdef BUILD_WITH_DDS
-        std::shared_ptr< realdds::dds_participant > _dds_participant;
-        std::shared_ptr< realdds::dds_device_watcher > _dds_watcher;
-
-        void start_dds_device_watcher();
-#endif
 
         nlohmann::json _settings; // Save operation settings
         unsigned const _device_mask;
         backend_device_factory _backend_device_factory;
+#ifdef BUILD_WITH_DDS
+        rsdds_device_factory _dds_device_factory;
+#endif
 
         devices_changed_callback_ptr _devices_changed_callback;
         std::map<int, std::weak_ptr<const stream_interface>> _streams;

--- a/src/context.h
+++ b/src/context.h
@@ -3,10 +3,6 @@
 
 #pragma once
 
-#include "backend-device-factory.h"
-#ifdef BUILD_WITH_DDS
-#include "dds/rsdds-device-factory.h"
-#endif
 #include "types.h"  // devices_changed_callback_ptr
 
 #include <rsutils/lazy.h>
@@ -45,6 +41,7 @@ namespace librealsense
 {
     class playback_device_info;
     class stream_interface;
+    class device_factory;
 
     class context : public std::enable_shared_from_this<context>
     {
@@ -72,8 +69,6 @@ namespace librealsense
         void unregister_internal_device_callback(uint64_t cb_id);
         void set_devices_changed_callback(devices_changed_callback_ptr callback);
 
-        void query_software_devices( std::vector< std::shared_ptr< device_info > > & list, unsigned requested_mask ) const;
-
         std::shared_ptr<playback_device_info> add_device(const std::string& file);
         void remove_device(const std::string& file);
 
@@ -91,10 +86,8 @@ namespace librealsense
 
         nlohmann::json _settings; // Save operation settings
         unsigned const _device_mask;
-        backend_device_factory _backend_device_factory;
-#ifdef BUILD_WITH_DDS
-        rsdds_device_factory _dds_device_factory;
-#endif
+
+        std::vector< std::shared_ptr< device_factory > > _factories;
 
         devices_changed_callback_ptr _devices_changed_callback;
         std::map<int, std::weak_ptr<const stream_interface>> _streams;

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -79,7 +79,7 @@ static std::mutex domain_context_by_id_mutex;
 
 
 rsdds_device_factory::rsdds_device_factory( context & ctx, callback && cb )
-    : _context( ctx )
+    : super( ctx )
 {
     nlohmann::json dds_settings = rsutils::json::get< nlohmann::json >( _context.get_settings(),
                                                                         std::string( "dds", 3 ),

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -1,0 +1,169 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include "rsdds-device-factory.h"
+#include "context.h"
+
+#include "rs-dds-device-info.h"
+
+#include <realdds/dds-device-watcher.h>
+#include <realdds/dds-participant.h>
+#include <realdds/dds-device.h>
+#include <realdds/topics/device-info-msg.h>
+
+#include <rsutils/shared-ptr-singleton.h>
+#include <rsutils/os/executable-name.h>
+#include <rsutils/string/slice.h>
+#include <rsutils/string/from.h>
+#include <rsutils/signal.h>
+#include <rsutils/json.h>
+
+#include <mutex>
+
+
+namespace librealsense {
+
+
+// The device-watcher is a singleton per domain. It is held alive by the device-factory below, which is held per
+// context. I.e., as long as a context is alive, it stays alive alongside the participant.
+//
+// We are responsible for exposing the single notification from the dds-device-watcher to several subscribers:
+// one device-watcher to many contexts, each with further subscriptions.
+//
+class rsdds_watcher_singleton
+{
+    std::shared_ptr< realdds::dds_device_watcher > const _device_watcher;
+    using signal = rsutils::signal< std::shared_ptr< realdds::dds_device > const &, bool /*added*/ >;
+    signal _callbacks;
+
+public:
+    rsdds_watcher_singleton( std::shared_ptr< realdds::dds_participant > const & participant )
+        : _device_watcher( std::make_shared< realdds::dds_device_watcher >( participant ) )
+    {
+        assert( _device_watcher->is_stopped() );
+
+        _device_watcher->on_device_added(
+            [this]( std::shared_ptr< realdds::dds_device > const & dev )
+            {
+                dev->wait_until_ready();  // make sure handshake is complete
+                _callbacks.raise( dev, true );
+            } );
+
+        _device_watcher->on_device_removed( [this]( std::shared_ptr< realdds::dds_device > const & dev )
+                                            { _callbacks.raise( dev, false ); } );
+
+        _device_watcher->start();
+    }
+
+    rsutils::subscription subscribe( signal::callback && cb ) { return _callbacks.subscribe( std::move( cb ) ); }
+
+    std::shared_ptr< realdds::dds_device_watcher > const get_device_watcher() const { return _device_watcher; }
+};
+
+
+// We manage one participant and device-watcher per domain:
+// Two contexts with the same domain-id will share the same participant and watcher, while a third context on a
+// different domain will have its own.
+//
+struct domain_context
+{
+    rsutils::shared_ptr_singleton< realdds::dds_participant > participant;
+    rsutils::shared_ptr_singleton< rsdds_watcher_singleton > device_watcher;
+};
+//
+// Domains are mapped by ID:
+// Two contexts with the same participant name on different domain-ids are using two different participants!
+//
+static std::map< realdds::dds_domain_id, domain_context > domain_context_by_id;
+static std::mutex domain_context_by_id_mutex;
+
+
+rsdds_device_factory::rsdds_device_factory( context & ctx, callback && cb )
+    : _context( ctx )
+{
+    nlohmann::json dds_settings = rsutils::json::get< nlohmann::json >( _context.get_settings(),
+                                                                        std::string( "dds", 3 ),
+                                                                        nlohmann::json::object() );
+    if( dds_settings.is_object() )
+    {
+        auto domain_id = rsutils::json::get< realdds::dds_domain_id >( dds_settings, std::string( "domain", 6 ), 0 );
+        std::string participant_name = rsutils::json::get< std::string >( dds_settings,
+                                                                          std::string( "participant", 11 ),
+                                                                          rsutils::os::executable_name() );
+
+        std::lock_guard< std::mutex > lock( domain_context_by_id_mutex );
+        auto & domain = domain_context_by_id[domain_id];
+        _participant = domain.participant.instance();
+        if( ! _participant->is_valid() )
+        {
+            _participant->init( domain_id, participant_name, std::move( dds_settings ) );
+        }
+        else if( rsutils::json::has_value( dds_settings, std::string( "participant", 11 ) )
+                 && participant_name != _participant->name() )
+        {
+            throw std::runtime_error( rsutils::string::from()
+                                      << "A DDS participant '" << _participant->name() << "' already exists in domain "
+                                      << domain_id << "; cannot create '" << participant_name << "'" );
+        }
+        _watcher_singleton = domain.device_watcher.instance( _participant );
+        _subscription = _watcher_singleton->subscribe(
+            [this, cb = std::move( cb )]( std::shared_ptr< realdds::dds_device > const & dev, bool added )
+            {
+                std::vector< rs2_device_info > infos_added;
+                std::vector< rs2_device_info > infos_removed;
+                auto ctx = _context.shared_from_this();
+                auto dev_info = std::make_shared< dds_device_info >( ctx, dev );
+                if( added )
+                    infos_added.push_back( { ctx, dev_info } );
+                else
+                    infos_removed.push_back( { ctx, dev_info } );
+                cb( infos_removed, infos_added );
+            } );
+    }
+}
+
+
+rsdds_device_factory::~rsdds_device_factory() {}
+
+
+std::vector< std::shared_ptr< device_info > > rsdds_device_factory::query_devices( unsigned requested_mask ) const
+{
+    std::vector< std::shared_ptr< device_info > > list;
+    if( _watcher_singleton )
+    {
+        unsigned const mask = context::combine_device_masks( requested_mask, _context.get_device_mask() );
+
+        _watcher_singleton->get_device_watcher()->foreach_device(
+            [&]( std::shared_ptr< realdds::dds_device > const & dev ) -> bool
+            {
+                if( ! dev->is_ready() )
+                {
+                    LOG_DEBUG( "device '" << dev->device_info().debug_name() << "' is not ready" );
+                    return true;
+                }
+                if( dev->device_info().product_line == "D400" )
+                {
+                    if( ! ( mask & RS2_PRODUCT_LINE_D400 ) )
+                        return true;
+                }
+                else if( dev->device_info().product_line == "D500" )
+                {
+                    if( ! ( mask & RS2_PRODUCT_LINE_D500 ) )
+                        return true;
+                }
+                else if( ! ( mask & RS2_PRODUCT_LINE_NON_INTEL ) )
+                {
+                    return true;
+                }
+
+                std::shared_ptr< device_info > info
+                    = std::make_shared< dds_device_info >( _context.shared_from_this(), dev );
+                list.push_back( info );
+                return true;  // continue iteration
+            } );
+    }
+    return list;
+}
+
+
+}  // namespace librealsense

--- a/src/dds/rsdds-device-factory.h
+++ b/src/dds/rsdds-device-factory.h
@@ -3,12 +3,8 @@
 
 #pragma once
 
+#include <rscore/device-factory.h>
 #include <rsutils/subscription.h>
-#include <memory>
-#include <vector>
-
-
-struct rs2_device_info;
 
 
 namespace realdds {
@@ -19,8 +15,6 @@ class dds_participant;
 namespace librealsense {
 
 
-class device_info;
-class context;
 class rsdds_watcher_singleton;
 
 
@@ -31,24 +25,22 @@ class rsdds_watcher_singleton;
 //
 // Any devices created here will have a device-info that derives from dds_device_info.
 //
-class rsdds_device_factory
+class rsdds_device_factory : public device_factory
 {
-    context & _context;
+    typedef device_factory super;
+
     std::shared_ptr< realdds::dds_participant > _participant;
     std::shared_ptr< rsdds_watcher_singleton > _watcher_singleton;
     rsutils::subscription _subscription;
 
 public:
-    using callback = std::function< void( std::vector< rs2_device_info > & rs2_devices_info_removed,
-                                          std::vector< rs2_device_info > & rs2_devices_info_added ) >;
-
     rsdds_device_factory( context &, callback && );
     ~rsdds_device_factory();
 
     // Query any subset of available devices and return them as device-info objects
     // Devices will match both the requested mask and the device-mask from the context settings
     //
-    std::vector< std::shared_ptr< device_info > > query_devices( unsigned mask ) const;
+    std::vector< std::shared_ptr< device_info > > query_devices( unsigned mask ) const override;
 };
 
 

--- a/src/dds/rsdds-device-factory.h
+++ b/src/dds/rsdds-device-factory.h
@@ -1,0 +1,55 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <rsutils/subscription.h>
+#include <memory>
+#include <vector>
+
+
+struct rs2_device_info;
+
+
+namespace realdds {
+class dds_participant;
+}
+
+
+namespace librealsense {
+
+
+class device_info;
+class context;
+class rsdds_watcher_singleton;
+
+
+// This factory creates "rsdds devices", or RealSense device proxies around a realdds device core.
+//
+// The factory abstracts away platform-specific concepts such that all the user has to do is supply a callback to know
+// when changes in the list of devices have been made.
+//
+// Any devices created here will have a device-info that derives from dds_device_info.
+//
+class rsdds_device_factory
+{
+    context & _context;
+    std::shared_ptr< realdds::dds_participant > _participant;
+    std::shared_ptr< rsdds_watcher_singleton > _watcher_singleton;
+    rsutils::subscription _subscription;
+
+public:
+    using callback = std::function< void( std::vector< rs2_device_info > & rs2_devices_info_removed,
+                                          std::vector< rs2_device_info > & rs2_devices_info_added ) >;
+
+    rsdds_device_factory( context &, callback && );
+    ~rsdds_device_factory();
+
+    // Query any subset of available devices and return them as device-info objects
+    // Devices will match both the requested mask and the device-mask from the context settings
+    //
+    std::vector< std::shared_ptr< device_info > > query_devices( unsigned mask ) const;
+};
+
+
+}  // namespace librealsense

--- a/src/ds/d400/d400-options.h
+++ b/src/ds/d400/d400-options.h
@@ -63,7 +63,7 @@ namespace librealsense
         virtual float query() const override;
         virtual option_range get_range() const override;
         virtual bool is_enabled() const override { return true; }
-        virtual bool is_read_only() const { return _sensor && _sensor->is_opened(); }
+        virtual bool is_read_only() const override { return _sensor && _sensor->is_opened(); }
         virtual const char* get_description() const override
         {
             return "Exposure limit is in microseconds. If the requested exposure limit is greater than frame time, it will be set to frame time at runtime. Setting will not take effect until next streaming session.";
@@ -87,7 +87,7 @@ namespace librealsense
         virtual float query() const override;
         virtual option_range get_range() const override;
         virtual bool is_enabled() const override { return true; }
-        virtual bool is_read_only() const { return _sensor && _sensor->is_opened(); }
+        virtual bool is_read_only() const override { return _sensor && _sensor->is_opened(); }
         virtual const char* get_description() const override
         {
             return "Gain limits ranges from 16 to 248. If the requested gain limit is less than 16, it will be set to 16. If the requested gain limit is greater than 248, it will be set to 248. Setting will not take effect until next streaming session.";

--- a/src/ds/ds-options.h
+++ b/src/ds/ds-options.h
@@ -201,7 +201,7 @@ namespace librealsense
         virtual float query() const override;
         virtual option_range get_range() const override;
         virtual bool is_enabled() const override { return true; }
-        virtual bool is_read_only() const { return _sensor && _sensor->is_opened(); }
+        virtual bool is_read_only() const override { return _sensor && _sensor->is_opened(); }
         const char* get_description() const override;
 
         void enable_recording(std::function<void(const option &)> record_action) override

--- a/src/rscore/device-factory.h
+++ b/src/rscore/device-factory.h
@@ -1,0 +1,57 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <functional>
+
+
+struct rs2_device_info;
+
+
+namespace librealsense {
+
+
+class device_info;
+class context;
+
+
+// Interface for device factories, allowing for:
+//      - notification callbacks for any device additions and removals
+//      - querying of current devices in the system
+// 
+// A device factory is contained by a context, 1:1. I.e., multiple factory instances may exist at once, each for a
+// different context.
+//
+
+class device_factory
+{
+protected:
+    context & _context;
+
+    device_factory( context & ctx )
+        : _context( ctx )
+    {
+    }
+
+public:
+    // Callbacks take this form.
+    //
+    using callback = std::function< void( std::vector< rs2_device_info > & devices_removed,
+                                          std::vector< rs2_device_info > & devices_added ) >;
+
+    virtual ~device_factory() = default;
+
+    // Query any subset of available devices and return them as device-info objects from which actual devices can be
+    // created as needed.
+    // 
+    // Devices will match both the requested mask and the device-mask from the context settings. See
+    // RS2_PRODUCT_LINE_... defines for possible values.
+    //
+    virtual std::vector< std::shared_ptr< device_info > > query_devices( unsigned mask ) const = 0;
+};
+
+
+}  // namespace librealsense

--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -85,6 +85,10 @@ public:
     //
     dds_guid const & guid() const;
 
+    // Returns the domain-ID for this participant
+    //
+    dds_domain_id domain_id() const;
+
     // Returns this participant's name from the QoS
     //
     rsutils::string::slice name() const;

--- a/third-party/realdds/include/realdds/dds-topic-reader.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader.h
@@ -39,6 +39,8 @@ protected:
 
     eprosima::fastdds::dds::DataReader * _reader = nullptr;
 
+    int _n_writers = 0;
+
 public:
     dds_topic_reader( std::shared_ptr< dds_topic > const & topic );
     dds_topic_reader( std::shared_ptr< dds_topic > const & topic, std::shared_ptr< dds_subscriber > const & subscriber );
@@ -48,6 +50,7 @@ public:
     eprosima::fastdds::dds::DataReader * operator->() const { return get(); }
 
     bool is_running() const { return ( get() != nullptr ); }
+    bool has_writers() const { return _n_writers > 0; }
 
     std::shared_ptr< dds_topic > const & topic() const { return _topic; }
 

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -268,6 +268,12 @@ dds_guid const & dds_participant::guid() const
 }
 
 
+dds_domain_id dds_participant::domain_id() const
+{
+    return get()->get_domain_id();
+}
+
+
 rsutils::string::slice dds_participant::name() const
 {
     auto & string_255 = get()->get_qos().name();

--- a/third-party/realdds/src/dds-topic-reader.cpp
+++ b/third-party/realdds/src/dds-topic-reader.cpp
@@ -112,6 +112,7 @@ void dds_topic_reader::on_subscription_matched(
     eprosima::fastdds::dds::DataReader *, eprosima::fastdds::dds::SubscriptionMatchedStatus const & info )
 {
     // Called when the subscriber is matched (un)with a Writer
+    _n_writers = info.current_count;
     if( _on_subscription_matched )
         _on_subscription_matched( info );
 }

--- a/third-party/rsutils/include/rsutils/signal.h
+++ b/third-party/rsutils/include/rsutils/signal.h
@@ -33,7 +33,9 @@ using subscription_slot = int;
 template< typename... Args >
 class signal
 {
+public:
     using callback = std::function< void( Args... ) >;
+private:
     using map = std::map< subscription_slot, callback >;
 
     // We use a shared_ptr to control lifetime: only while it's alive can we remove subscriptions


### PR DESCRIPTION
* separate DDS code into `rsdds-device-factory`
* provide a `rscore/device-factory.h` base class `device_factory` as base for both the above and `backend_device_factory`
* `context` now just stores a vector of `device_factory` objects

Plus some misc changes and a warning fix.

The location of `device-factory.h` is temporary: I am simply trying to minimize effects of later moving of files into their individual libraries.

Tracked on [LRS-919]