### PR TITLE
remove context knowledge of playback devices

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -5,7 +5,6 @@
 
 #include "types.h"  // devices_changed_callback_ptr
 
-#include <rsutils/lazy.h>
 #include <nlohmann/json.hpp>
 #include <vector>
 #include <map>
@@ -39,8 +38,6 @@ struct rs2_stream_profile
 
 namespace librealsense
 {
-    class playback_device_info;
-    class stream_interface;
     class device_factory;
 
     class context : public std::enable_shared_from_this<context>
@@ -69,11 +66,11 @@ namespace librealsense
         void unregister_internal_device_callback(uint64_t cb_id);
         void set_devices_changed_callback(devices_changed_callback_ptr callback);
 
-        std::shared_ptr<playback_device_info> add_device(const std::string& file);
-        void remove_device(const std::string& file);
+        // Let the context maintain a list of custom devices. These can be anything, like playback devices or devices
+        // maintained by the user.
+        void add_device( std::shared_ptr< device_info > const & );
+        void remove_device( std::shared_ptr< device_info > const & );
 
-        void add_software_device(std::shared_ptr<device_info> software_device);
-        
         const nlohmann::json & get_settings() const { return _settings; }
 
     private:
@@ -81,7 +78,7 @@ namespace librealsense
                                                std::vector<rs2_device_info> & rs2_devices_info_added );
         void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
 
-        std::map<std::string, std::weak_ptr<device_info>> _playback_devices;
+        std::map< std::string, std::weak_ptr< device_info > > _user_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
 
         nlohmann::json _settings; // Save operation settings
@@ -90,9 +87,7 @@ namespace librealsense
         std::vector< std::shared_ptr< device_factory > > _factories;
 
         devices_changed_callback_ptr _devices_changed_callback;
-        std::map<int, std::weak_ptr<const stream_interface>> _streams;
-        std::map< int, std::map< int, std::weak_ptr< rsutils::lazy< rs2_extrinsics > > > > _extrinsics;
-        std::mutex _streams_mutex, _devices_changed_callbacks_mtx;
+        std::mutex _devices_changed_callbacks_mtx;
     };
 
 }

--- a/src/pipeline/config.cpp
+++ b/src/pipeline/config.cpp
@@ -253,7 +253,9 @@ namespace librealsense
                     return pdev->create_device();
             }
 
-            return ctx->add_device(file)->create_device();
+            auto dev_info = std::make_shared< playback_device_info >( ctx, file );
+            ctx->add_device( dev_info );
+            return dev_info->create_device();
         }
 
         std::shared_ptr<device_interface> config::resolve_device_requests(std::shared_ptr<pipeline> pipe, const std::chrono::milliseconds& timeout)

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1551,7 +1551,8 @@ rs2_device* rs2_context_add_device(rs2_context* ctx, const char* file, rs2_error
     VALIDATE_NOT_NULL(ctx);
     VALIDATE_NOT_NULL(file);
 
-    auto dev_info = ctx->ctx->add_device(file);
+    auto dev_info = std::make_shared< playback_device_info >( ctx->ctx, file );
+    ctx->ctx->add_device( dev_info );
     return new rs2_device{ dev_info->create_device() };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, ctx, file)
@@ -1564,7 +1565,7 @@ void rs2_context_add_software_device(rs2_context* ctx, rs2_device* dev, rs2_erro
     
     auto dev_info = std::make_shared< software_device_info >( ctx->ctx );
     dev_info->set_device( std::dynamic_pointer_cast< software_device >( dev->device ) );
-    ctx->ctx->add_software_device( dev_info );
+    ctx->ctx->add_device( dev_info );
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, ctx, dev)
 
@@ -1572,7 +1573,10 @@ void rs2_context_remove_device(rs2_context* ctx, const char* file, rs2_error** e
 {
     VALIDATE_NOT_NULL(ctx);
     VALIDATE_NOT_NULL(file);
-    ctx->ctx->remove_device(file);
+    // The context uses the address from the device-info to maintain the list of devices. I.e., we need a device-info
+    // that uses a device-info that is_same_as() the one created above, in rs2_context_add_device:
+    auto dev_info = std::make_shared< playback_device_info >( ctx->ctx, file );
+    ctx->ctx->remove_device( dev_info );
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, ctx, file)
 


### PR DESCRIPTION
After this, context will hopefully be free to move to rscore... (assuming types.h doesn't prove problematic)

Tracked on [LRS-920]