### PR TITLE
Setting preset does not update color options for D500

### DIFF
--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -208,7 +208,10 @@ namespace librealsense
         rsutils::lazy< bool > _amplitude_factor_support;
 
         preset get_all() const;
-        void set_all(const preset& p);
+        void set_all( const preset & p );
+        void set_all_depth( const preset & p );
+        void set_all_color( const preset & p );
+        bool should_set_color_preset() const;
 
         std::vector<uint8_t> send_receive(const std::vector<uint8_t>& input) const;
 

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -4,9 +4,8 @@
 #include "core/advanced_mode.h"
 #include "json_loader.hpp"
 #include "ds/d400/d400-color.h"
-
+#include "ds/d500/d500-color.h"
 #include <rsutils/string/from.h>
-
 
 namespace librealsense
 {
@@ -42,18 +41,23 @@ namespace librealsense
         if (is_enabled())
             register_to_visual_preset_option();
 
-        _color_sensor = [this]() {
-            auto& dev = _depth_sensor.get_device();
-            for (size_t i = 0; i < dev.get_sensors_count(); ++i)
+        _color_sensor = [this]() -> synthetic_sensor *
+        {
+            auto & dev = _depth_sensor.get_device();
+            for( size_t i = 0; i < dev.get_sensors_count(); ++i )
             {
-                if (auto s = dynamic_cast<const d400_color_sensor*>(&(dev.get_sensor(i))))
+                if( auto s = dynamic_cast< const d400_color_sensor * >( &( dev.get_sensor( i ) ) ) )
                 {
-                    return const_cast<d400_color_sensor*>(s);
+                    return const_cast< d400_color_sensor * >( s );
+                }
+                if( auto s = dynamic_cast< const d500_color_sensor * >( &( dev.get_sensor( i ) ) ) )
+                {
+                    return const_cast< d500_color_sensor * >( s );
                 }
             }
-            return (d400_color_sensor*)nullptr;
+            return nullptr;
         };
-        
+
         _amplitude_factor_support = [this]() {
             auto fw_ver = firmware_version(_depth_sensor.get_device().get_info(rs2_camera_info::RS2_CAMERA_INFO_FIRMWARE_VERSION));
             return (fw_ver >= firmware_version("5.11.9.0"));
@@ -753,15 +757,18 @@ namespace librealsense
         return p;
     }
 
-    void ds_advanced_mode_base::set_all(const preset& p)
+    void ds_advanced_mode_base::set_all( const preset & p )
+    {
+        set_all_depth( p );
+        if( should_set_color_preset() )
+            set_all_color( p );
+    }
+
+    void ds_advanced_mode_base::set_all_depth(const preset& p)
     {
         set(p.depth_controls, advanced_mode_traits<STDepthControlGroup>::group);
         set(p.rsm           , advanced_mode_traits<STRsm>::group);
         set(p.rsvc          , advanced_mode_traits<STRauSupportVectorControl>::group);
-        set(p.color_control , advanced_mode_traits<STColorControl>::group);
-        set(p.rctc          , advanced_mode_traits<STRauColorThresholdsControl>::group);
-        set(p.sctc          , advanced_mode_traits<STSloColorThresholdsControl>::group);
-        set(p.spc           , advanced_mode_traits<STSloPenaltyControl>::group);
         set(p.hdad          , advanced_mode_traits<STHdad>::group);
 
         // Setting auto-white-balance control before colorCorrection parameters
@@ -784,6 +791,14 @@ namespace librealsense
             set_depth_gain(p.depth_gain);
             set_depth_exposure(p.depth_exposure);
         }
+    }
+
+    void ds_advanced_mode_base::set_all_color( const preset & p )
+    {
+        set( p.color_control, advanced_mode_traits< STColorControl >::group );
+        set( p.rctc         , advanced_mode_traits< STRauColorThresholdsControl >::group );
+        set( p.sctc         , advanced_mode_traits< STSloColorThresholdsControl >::group );
+        set( p.spc          , advanced_mode_traits< STSloPenaltyControl >::group );
 
         set_color_auto_exposure(p.color_auto_exposure);
         if (p.color_auto_exposure.was_set && p.color_auto_exposure.auto_exposure == 0)
@@ -806,6 +821,13 @@ namespace librealsense
 
         // TODO: W/O due to a FW bug of power_line_frequency control on Windows OS
         //set_color_power_line_frequency(p.color_power_line_frequency);
+    }
+
+    bool ds_advanced_mode_base::should_set_color_preset() const
+    {
+        auto product_line = _depth_sensor.get_device().get_info( rs2_camera_info::RS2_CAMERA_INFO_PRODUCT_LINE );
+
+        return product_line != "D500";
     }
 
     std::vector<uint8_t> ds_advanced_mode_base::send_receive(const std::vector<uint8_t>& input) const

--- a/unit-tests/live/options/test-presets.py
+++ b/unit-tests/live/options/test-presets.py
@@ -1,6 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
+# test:donotrun:gha
 
 import pyrealsense2 as rs
 from rspy import test

--- a/unit-tests/live/options/test-presets.py
+++ b/unit-tests/live/options/test-presets.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
-# test:donotrun:gha
+# test:device each(D400*)
 
 import pyrealsense2 as rs
 from rspy import test

--- a/unit-tests/live/options/test-presets.py
+++ b/unit-tests/live/options/test-presets.py
@@ -34,16 +34,16 @@ with test.closure( 'save/load preset' ):
     test.check( am_dev.get_depth_control().textureCountThreshold != 250 )
 
 with test.closure( 'setting color options' ):
-    color_sensor.set_option( rs.option.hue, 123 )
-    test.check( color_sensor.get_option( rs.option.hue ) == 123 )
+    color_sensor.set_option( rs.option.gain, 123 )
+    test.check( color_sensor.get_option( rs.option.gain ) == 123 )
     
     depth_sensor.set_option( rs.option.visual_preset, int(rs.rs400_visual_preset.default ) )
     if product_line == "D400":
         # D400 devices set color options as part of preset setting
-        test.check( color_sensor.get_option( rs.option.hue ) != 123 )
+        test.check( color_sensor.get_option( rs.option.gain ) != 123 )
     elif product_line == "D500":
         # D500 devices do not set color options as part of preset setting
-        test.check( color_sensor.get_option( rs.option.hue ) == 123 )
+        test.check( color_sensor.get_option( rs.option.gain ) == 123 )
     else:
         raise RuntimeError( 'unsupported product line' )
     

--- a/unit-tests/live/options/test-presets.py
+++ b/unit-tests/live/options/test-presets.py
@@ -1,0 +1,50 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+
+import pyrealsense2 as rs
+from rspy import test
+from rspy import log
+
+dev = test.find_first_device_or_exit()
+depth_sensor = dev.first_depth_sensor()
+color_sensor = dev.first_color_sensor()
+product_line = dev.get_info(rs.camera_info.product_line)
+
+
+with test.closure( 'visual preset support', on_fail=test.ABORT ): # No use continuing the test if there is no preset support
+    test.check( depth_sensor.supports(rs.option.visual_preset) )
+
+with test.closure( 'set presets' ):
+    depth_sensor.set_option( rs.option.visual_preset, float(rs.rs400_visual_preset.high_accuracy ) )
+    test.check_equal( depth_sensor.get_option( rs.option.visual_preset ), float( rs.rs400_visual_preset.high_accuracy ) )
+    depth_sensor.set_option( rs.option.visual_preset, float(rs.rs400_visual_preset.default ) )
+    test.check_equal( depth_sensor.get_option( rs.option.visual_preset ), float( rs.rs400_visual_preset.default ) )
+
+with test.closure( 'save/load preset' ):
+    am_dev = rs.rs400_advanced_mode(dev)
+    saved_values = am_dev.serialize_json()
+    depth_control_group = am_dev.get_depth_control()
+    depth_control_group.textureCountThreshold = 250
+    am_dev.set_depth_control( depth_control_group )
+    test.check_equal( depth_sensor.get_option( rs.option.visual_preset ), float( rs.rs400_visual_preset.custom ) )
+    
+    am_dev.load_json( saved_values )
+    test.check( am_dev.get_depth_control().textureCountThreshold != 250 )
+
+with test.closure( 'setting color options' ):
+    color_sensor.set_option( rs.option.hue, 123 )
+    test.check( color_sensor.get_option( rs.option.hue ) == 123 )
+    
+    depth_sensor.set_option( rs.option.visual_preset, float(rs.rs400_visual_preset.default ) )
+    if product_line == "D400":
+        # D400 devices set color options as part of preset setting
+        test.check( color_sensor.get_option( rs.option.hue ) != 123 )
+    elif product_line == "D500":
+        # D500 devices do not set color options as part of preset setting
+        test.check( color_sensor.get_option( rs.option.hue ) == 123 )
+    else:
+        raise RuntimeError( 'unsupported product line' )
+    
+    
+test.print_results_and_exit()

--- a/unit-tests/live/options/test-presets.py
+++ b/unit-tests/live/options/test-presets.py
@@ -17,10 +17,10 @@ with test.closure( 'visual preset support', on_fail=test.ABORT ): # No use conti
     test.check( depth_sensor.supports(rs.option.visual_preset) )
 
 with test.closure( 'set presets' ):
-    depth_sensor.set_option( rs.option.visual_preset, float(rs.rs400_visual_preset.high_accuracy ) )
-    test.check_equal( depth_sensor.get_option( rs.option.visual_preset ), float( rs.rs400_visual_preset.high_accuracy ) )
-    depth_sensor.set_option( rs.option.visual_preset, float(rs.rs400_visual_preset.default ) )
-    test.check_equal( depth_sensor.get_option( rs.option.visual_preset ), float( rs.rs400_visual_preset.default ) )
+    depth_sensor.set_option( rs.option.visual_preset, int(rs.rs400_visual_preset.high_accuracy ) )
+    test.check( depth_sensor.get_option( rs.option.visual_preset ) == rs.rs400_visual_preset.high_accuracy )
+    depth_sensor.set_option( rs.option.visual_preset, int(rs.rs400_visual_preset.default ) )
+    test.check( depth_sensor.get_option( rs.option.visual_preset ) == rs.rs400_visual_preset.default )
 
 with test.closure( 'save/load preset' ):
     am_dev = rs.rs400_advanced_mode(dev)
@@ -28,7 +28,7 @@ with test.closure( 'save/load preset' ):
     depth_control_group = am_dev.get_depth_control()
     depth_control_group.textureCountThreshold = 250
     am_dev.set_depth_control( depth_control_group )
-    test.check_equal( depth_sensor.get_option( rs.option.visual_preset ), float( rs.rs400_visual_preset.custom ) )
+    test.check( depth_sensor.get_option( rs.option.visual_preset ) == rs.rs400_visual_preset.custom )
     
     am_dev.load_json( saved_values )
     test.check( am_dev.get_depth_control().textureCountThreshold != 250 )
@@ -37,7 +37,7 @@ with test.closure( 'setting color options' ):
     color_sensor.set_option( rs.option.hue, 123 )
     test.check( color_sensor.get_option( rs.option.hue ) == 123 )
     
-    depth_sensor.set_option( rs.option.visual_preset, float(rs.rs400_visual_preset.default ) )
+    depth_sensor.set_option( rs.option.visual_preset, int(rs.rs400_visual_preset.default ) )
     if product_line == "D400":
         # D400 devices set color options as part of preset setting
         test.check( color_sensor.get_option( rs.option.hue ) != 123 )


### PR DESCRIPTION
There were 2 design options:
1. Adding API to `device_interface` and each concrete device type will implement if color options need setting.
2. Handle preset logic in `advanced_mode` deciding based on device type. Might need to update `advanced_mode` module for future devices.

I selected option number 2.