### PR TITLE
Context callback changes and device mutex removal

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "context.h"
+#include "types.h"  // notification
 #include "core/extension.h"
 #include "device.h"
 #include <rsutils/string/from.h>

--- a/src/context.h
+++ b/src/context.h
@@ -76,7 +76,6 @@ namespace librealsense
     private:
         void invoke_devices_changed_callbacks( std::vector<rs2_device_info> & rs2_devices_info_removed,
                                                std::vector<rs2_device_info> & rs2_devices_info_added );
-        void raise_devices_changed(const std::vector<rs2_device_info>& removed, const std::vector<rs2_device_info>& added);
 
         std::map< std::string, std::weak_ptr< device_info > > _user_devices;
         std::map<uint64_t, devices_changed_callback_ptr> _devices_changed_callbacks;
@@ -86,7 +85,6 @@ namespace librealsense
 
         std::vector< std::shared_ptr< device_factory > > _factories;
 
-        devices_changed_callback_ptr _devices_changed_callback;
         std::mutex _devices_changed_callbacks_mtx;
     };
 

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -3,14 +3,16 @@
 
 #include "rsdds-device-factory.h"
 #include "context.h"
-
 #include "rs-dds-device-info.h"
+
+#include <librealsense2/h/rs_context.h>  // RS2_PRODUCT_LINE_...
 
 #include <realdds/dds-device-watcher.h>
 #include <realdds/dds-participant.h>
 #include <realdds/dds-device.h>
 #include <realdds/topics/device-info-msg.h>
 
+#include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/shared-ptr-singleton.h>
 #include <rsutils/os/executable-name.h>
 #include <rsutils/string/slice.h>

--- a/src/device.h
+++ b/src/device.h
@@ -54,7 +54,7 @@ public:
 
     std::pair<uint32_t, rs2_extrinsics> get_extrinsics(const stream_interface& stream) const override;
 
-    bool is_valid() const override { return _is_valid; }
+    bool is_valid() const override { return *_is_alive; }
 
     void tag_profiles(stream_profiles profiles) const override;
 
@@ -81,11 +81,9 @@ protected:
 private:
     std::vector<std::shared_ptr<sensor_interface>> _sensors;
     std::shared_ptr< const device_info > _dev_info;
-    std::atomic< bool > _is_valid;
+    std::shared_ptr< std::atomic< bool > > _is_alive;
     rsutils::subscription _device_change_subscription;
     rsutils::lazy< std::vector< tagged_profile > > _profiles_tags;
-
-    std::shared_ptr< bool > _is_alive; // Ensures object can be accessed
 };
 
 

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -5,7 +5,14 @@
 
 #include "context.h"
 #include "device.h"
+#include <librealsense2/h/rs_context.h>  // RS2_PRODUCT_LINE_...
+
 #include <limits>
+#include <mutex>
+#include <condition_variable>
+#include <vector>
+#include <memory>
+
 
 namespace librealsense
 {
@@ -52,7 +59,7 @@ namespace librealsense
         std::condition_variable _cv;
         std::vector<std::shared_ptr<device_info>> _device_list;
         int _camera_index = 0;
-        uint64_t _device_changes_callback_id;
+        rsutils::subscription _device_change_subscription;
         int _mask;
     };
 }

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -92,6 +92,7 @@ struct rs2_sensor : public rs2_options
 struct rs2_context
 {
     std::shared_ptr<librealsense::context> ctx;
+    mutable rsutils::subscription devices_changed_subscription;
 };
 
 struct rs2_device_hub
@@ -824,7 +825,7 @@ void rs2_set_devices_changed_callback(const rs2_context* context, rs2_devices_ch
     librealsense::devices_changed_callback_ptr cb(
         new librealsense::devices_changed_callback(callback, user),
         [](rs2_devices_changed_callback* p) { delete p; });
-    context->ctx->set_devices_changed_callback(std::move(cb));
+    context->devices_changed_subscription = context->ctx->on_device_changes( cb );
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, context, callback, user)
 
@@ -882,7 +883,7 @@ void rs2_set_devices_changed_callback_cpp(rs2_context* context, rs2_devices_chan
                                               } };
 
     VALIDATE_NOT_NULL(context);
-    context->ctx->set_devices_changed_callback( callback_ptr );
+    context->devices_changed_subscription = context->ctx->on_device_changes( callback_ptr );
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, context, callback)
 

--- a/src/rscore/device-factory.h
+++ b/src/rscore/device-factory.h
@@ -39,8 +39,8 @@ protected:
 public:
     // Callbacks take this form.
     //
-    using callback = std::function< void( std::vector< rs2_device_info > & devices_removed,
-                                          std::vector< rs2_device_info > & devices_added ) >;
+    using callback = std::function< void( std::vector< rs2_device_info > const & devices_removed,
+                                          std::vector< rs2_device_info > const & devices_added ) >;
 
     virtual ~device_factory() = default;
 

--- a/third-party/rsutils/include/rsutils/signal.h
+++ b/third-party/rsutils/include/rsutils/signal.h
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <functional>
 #include <memory>
+#include <vector>
 
 
 namespace rsutils {

--- a/third-party/rsutils/include/rsutils/subscription.h
+++ b/third-party/rsutils/include/rsutils/subscription.h
@@ -44,6 +44,11 @@ public:
         return *this;
     }
 
+    // Return true if the subscription is active, meaning subscription-needs-to-be-cancelled-if-alive:
+    // The signal/subscription source may already be gone but we won't know that until we try to cancel, so active does
+    // not mean the source is alive! I.e., if true then a subscription was made and cancel() will get called.
+    bool is_active() const { return _d; }
+
     // Unsubscribing is "canceling" the subscription. Will not throw if we've already cancelled.
     void cancel()
     {


### PR DESCRIPTION
This is an **API-breaking** change:
* a context is created
* `rs2_set_devices_changed_callback` is called
* the context is destroyed with `rs2_delete_context`

**Before**: as long as the internal context object was held alive (by a device etc.), the callback was still callable, possibly even when unintended (requiring the user to set an "empty" callback as a workaround)

**Now**: when delete-context is called, the callback is unsubscribed and no longer happens. I.e., **you now have to hold the context if you want callbacks from it**. This is the correct behavior.

Changes:
* simplify context callback handling; only a single function remains, `on_device_changes()`
* make use of `rsutils::signal` (we handle multiple callbacks), and remove mutex in context
* simpler & more robust `device::is_valid()` implementation, without a mutex around it

Everything together solves the deadlock in #11933. A test will be added separately to regressions.

Tracked on [RSDSO-19304]