### PR TITLE
Deadlock test & unit-test-config now listens to donotrun

### DIFF
--- a/unit-tests/live/test-deadlock.cpp
+++ b/unit-tests/live/test-deadlock.cpp
@@ -1,0 +1,45 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+// See RSDSO-19304 or Github #10482 for background
+
+//#test:device D400*
+
+// The deadlock causes this test to time out but we don't want to wait the full 200 seconds
+//#test:timeout 12
+
+//#test:donotrun:!nightly
+
+#include "live-common.h"
+#include <chrono>
+
+using namespace rs2;
+
+
+TEST_CASE( "deadlock after hw reset", "[live]" )
+{
+    rs2::context ctx( "{\"dds\":0}" );
+
+    rs2::device_list list = ctx.query_devices();
+    test::log.i( list.size(), "RealSense devices connected" );
+
+    test::log.i( "Resetting" );
+    for( uint32_t dev_idx = 0; dev_idx < list.size(); dev_idx++ )
+        list[dev_idx].hardware_reset();
+
+    test::log.i( "Sleeping 6 seconds" );
+    std::this_thread::sleep_for( std::chrono::seconds( 6 ) );
+
+    list = ctx.query_devices();
+    test::log.i( list.size(), "devices after reset" );
+
+    test::log.i( "This caused deadlock" );
+    for( uint32_t dev_idx = 0; dev_idx < list.size(); dev_idx++ )
+    {
+        rs2::device dev;
+        dev = list[dev_idx];
+
+        // Add 500 ms delay to avoid deadlock
+        //std::this_thread::sleep_for( std::chrono::milliseconds( 500 ));
+    }
+}

--- a/unit-tests/unit-test-config.py
+++ b/unit-tests/unit-test-config.py
@@ -243,6 +243,9 @@ def process_cpp( dir, builddir ):
                 if config.configurations:
                     continue
 
+            if config.donotrun:
+                continue
+
             # Build the list of files we want in the project:
             # At a minimum, we have the original file, plus any common files
             filelist = [ dir + '/' + f ]


### PR DESCRIPTION
Following #12275, this adds the test that was used to reproduce:
* even with one device.
* only on Linux

Made it only run on the nightly.
Tried with Python, but failed to reproduce.

On the way, made unit-test-config actually pay attention to the `donotrun` directives in our unit-tests (so, for example, nightly tests aren't even build in non-nightly builds).

Tracked on [RSDSO-19304]