### PR TITLE
[RDK-2860] Upgrade librealsense sdk version to 2.54.2

### DIFF
--- a/src/terminal-parser.cpp
+++ b/src/terminal-parser.cpp
@@ -32,12 +32,6 @@ namespace librealsense
 
         auto raw_data = build_raw_command_data(command, params);
 
-        for (auto b : raw_data)
-        {
-            cout << hex << fixed << setfill('0') << setw(2) << (int)b << " ";
-        }
-        cout << endl;
-
         return raw_data;
     }
 


### PR DESCRIPTION
This PR upgrades the librealsense version to 2.54.2. It also removes an unnecessary `cout` statement that causes build issues.