### PR TITLE
remove rs2 structs from context.h

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -3,7 +3,6 @@
 
 
 #pragma once
-#include "context.h"
 #include "types.h"  // notification
 #include "core/extension.h"
 #include "device.h"

--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -133,17 +133,17 @@ backend_device_factory::backend_device_factory( context & ctx, callback && cb )
               auto old_list = create_devices_from_group( old, RS2_PRODUCT_LINE_ANY );
               auto new_list = create_devices_from_group( curr, RS2_PRODUCT_LINE_ANY );
 
-              std::vector< rs2_device_info > devices_removed;
+              std::vector< std::shared_ptr< device_info > > devices_removed;
               for( auto & device_removed : subtract_sets( old_list, new_list ) )
               {
-                  devices_removed.push_back( { _context.shared_from_this(), device_removed } );
+                  devices_removed.push_back( device_removed );
                   LOG_DEBUG( "Device disconnected: " << device_removed->get_address() );
               }
 
-              std::vector< rs2_device_info > devices_added;
+              std::vector< std::shared_ptr< device_info > > devices_added;
               for( auto & device_added : subtract_sets( new_list, old_list ) )
               {
-                  devices_added.push_back( { _context.shared_from_this(), device_added } );
+                  devices_added.push_back( device_added );
                   LOG_DEBUG( "Device connected: " << device_added->get_address() );
               }
 

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -111,14 +111,14 @@ rsdds_device_factory::rsdds_device_factory( context & ctx, callback && cb )
         _subscription = _watcher_singleton->subscribe(
             [this, cb = std::move( cb )]( std::shared_ptr< realdds::dds_device > const & dev, bool added )
             {
-                std::vector< rs2_device_info > infos_added;
-                std::vector< rs2_device_info > infos_removed;
+                std::vector< std::shared_ptr< device_info > > infos_added;
+                std::vector< std::shared_ptr< device_info > > infos_removed;
                 auto ctx = _context.shared_from_this();
                 auto dev_info = std::make_shared< dds_device_info >( ctx, dev );
                 if( added )
-                    infos_added.push_back( { ctx, dev_info } );
+                    infos_added.push_back( dev_info );
                 else
-                    infos_removed.push_back( { ctx, dev_info } );
+                    infos_removed.push_back( dev_info );
                 cb( infos_removed, infos_added );
             } );
     }

--- a/src/ds/d400/d400-active.cpp
+++ b/src/ds/d400/d400-active.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 
 #include "device.h"
-#include "context.h"
 #include "image.h"
 #include "metadata-parser.h"
 

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -2,7 +2,6 @@
 // Copyright(c) 2016 Intel Corporation. All Rights Reserved.
 
 #include <src/device.h>
-#include <src/context.h>
 #include <src/image.h>
 #include <src/metadata-parser.h>
 #include <src/metadata.h>

--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 
 #include "device.h"
-#include "context.h"
 #include "image.h"
 #include "metadata-parser.h"
 

--- a/src/ds/d400/d400-nonmonochrome.cpp
+++ b/src/ds/d400/d400-nonmonochrome.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 
 #include "device.h"
-#include "context.h"
 #include "image.h"
 #include "metadata-parser.h"
 

--- a/src/ds/d500/d500-active.cpp
+++ b/src/ds/d500/d500-active.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 
 #include "device.h"
-#include "context.h"
 #include "image.h"
 #include "metadata-parser.h"
 

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -2,7 +2,6 @@
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
 #include "device.h"
-#include "context.h"
 #include "image.h"
 #include "metadata-parser.h"
 #include "metadata.h"

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 
 #include "device.h"
-#include "context.h"
 #include "image.h"
 #include "metadata-parser.h"
 

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -4,7 +4,6 @@
 #include "ds-motion-common.h"
 
 #include "algo.h"
-#include "context.h"
 #include "hid-sensor.h"
 #include "environment.h"
 #include "metadata.h"

--- a/src/ds/ds-timestamp.cpp
+++ b/src/ds/ds-timestamp.cpp
@@ -10,7 +10,6 @@
 #include <iterator>
 
 #include "device.h"
-#include "context.h"
 #include "image.h"
 #include "metadata.h"
 

--- a/src/fw-update/fw-update-factory.h
+++ b/src/fw-update/fw-update-factory.h
@@ -5,10 +5,11 @@
 
 #include "platform/platform-device-info.h"
 #include "core/streaming.h"
-#include "context.h"
 
 namespace librealsense
 {
+    class context;
+
     class fw_update_info : public platform::platform_device_info
     {
         typedef platform::platform_device_info super;

--- a/src/gl/pointcloud-gl.cpp
+++ b/src/gl/pointcloud-gl.cpp
@@ -9,7 +9,7 @@
 #include "pointcloud-gl.h"
 #include "option.h"
 #include "environment.h"
-#include "context.h"
+#include "stream.h"
 
 #include <iostream>
 #include <chrono>

--- a/src/gl/upload.cpp
+++ b/src/gl/upload.cpp
@@ -10,7 +10,6 @@
 #include "colorizer-gl.h"
 #include "upload.h"
 #include "option.h"
-#include "context.h"
 
 #ifndef NOMINMAX
 #define NOMINMAX

--- a/src/media/playback/playback_sensor.cpp
+++ b/src/media/playback/playback_sensor.cpp
@@ -6,7 +6,6 @@
 #include "core/motion.h"
 #include <map>
 #include "types.h"
-#include "context.h"
 #include "ds/d400/d400-options.h"
 #include "media/ros/ros_reader.h"
 

--- a/src/pipeline/config.cpp
+++ b/src/pipeline/config.cpp
@@ -5,6 +5,8 @@
 #include "pipeline.h"
 #include "platform/platform-device-info.h"
 #include "media/playback/playback-device-info.h"
+#include "context.h"
+
 
 namespace librealsense
 {

--- a/src/proc/decimation-filter.cpp
+++ b/src/proc/decimation-filter.cpp
@@ -8,7 +8,7 @@
 #include <cmath>
 #include "environment.h"
 #include "option.h"
-#include "context.h"
+#include "stream.h"
 #include "core/video.h"
 #include "proc/synthetic-stream.h"
 #include "proc/decimation-filter.h"

--- a/src/proc/disparity-transform.cpp
+++ b/src/proc/disparity-transform.cpp
@@ -1,11 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 
-#include "../include/librealsense2/hpp/rs_sensor.hpp"
-#include "../include/librealsense2/hpp/rs_processing.hpp"
+#include <librealsense2/hpp/rs_sensor.hpp>
+#include <librealsense2/hpp/rs_processing.hpp>
 
 #include "option.h"
-#include "context.h"
+#include "stream.h"
 #include "ds/d400/d400-private.h"
 #include "core/video.h"
 #include "proc/synthetic-stream.h"

--- a/src/proc/hole-filling-filter.cpp
+++ b/src/proc/hole-filling-filter.cpp
@@ -6,7 +6,6 @@
 #include <librealsense2/hpp/rs_processing.hpp>
 #include "option.h"
 #include "environment.h"
-#include "context.h"
 #include "software-device.h"
 #include "proc/synthetic-stream.h"
 #include "proc/hole-filling-filter.h"

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -8,7 +8,6 @@
 #include <src/core/depth-frame.h>
 #include "option.h"
 #include "environment.h"
-#include "context.h"
 #include "../device.h"
 #include "../stream.h"
 #include <rsutils/string/from.h>

--- a/src/proc/spatial-filter.cpp
+++ b/src/proc/spatial-filter.cpp
@@ -5,7 +5,6 @@
 #include <librealsense2/hpp/rs_processing.hpp>
 #include "option.h"
 #include "environment.h"
-#include "context.h"
 #include "software-device.h"
 #include "proc/synthetic-stream.h"
 #include "proc/hole-filling-filter.h"

--- a/src/proc/sse/sse-pointcloud.cpp
+++ b/src/proc/sse/sse-pointcloud.cpp
@@ -8,7 +8,6 @@
 #include "../occlusion-filter.h"
 #include "sse-pointcloud.h"
 #include "../../option.h"
-#include "../../context.h"
 
 #include <iostream>
 

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -7,7 +7,6 @@
 #include "core/motion-frame.h"
 #include "core/depth-frame.h"
 #include "option.h"
-#include "context.h"
 #include "stream.h"
 #include "types.h"
 

--- a/src/proc/temporal-filter.cpp
+++ b/src/proc/temporal-filter.cpp
@@ -6,7 +6,6 @@
 #include "source.h"
 #include "option.h"
 #include "environment.h"
-#include "context.h"
 #include "proc/synthetic-stream.h"
 #include "proc/temporal-filter.h"
 

--- a/src/rscore/device-factory.h
+++ b/src/rscore/device-factory.h
@@ -8,9 +8,6 @@
 #include <functional>
 
 
-struct rs2_device_info;
-
-
 namespace librealsense {
 
 
@@ -39,8 +36,8 @@ protected:
 public:
     // Callbacks take this form.
     //
-    using callback = std::function< void( std::vector< rs2_device_info > const & devices_removed,
-                                          std::vector< rs2_device_info > const & devices_added ) >;
+    using callback = std::function< void( std::vector< std::shared_ptr< device_info > > const & devices_removed,
+                                          std::vector< std::shared_ptr< device_info > > const & devices_added ) >;
 
     virtual ~device_factory() = default;
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -11,6 +11,19 @@
 #include "environment.h"
 #include "platform/stream-profile.h"
 
+
+namespace librealsense
+{
+    class stream_profile_interface;
+}
+
+struct rs2_stream_profile
+{
+    librealsense::stream_profile_interface * profile;
+    std::shared_ptr< librealsense::stream_profile_interface > clone;
+};
+
+
 namespace librealsense
 {
     class stream : public stream_interface


### PR DESCRIPTION
The `rs2_device_list` struct, outside of `librealsense` namespace, was used all the way in the device factories.
* changed device-factories to use `std::vector< std::shared_ptr< device_info > >` instead
* changed `context::on_device_changes()` to accept a callback, rather than rs2 concepts
* removed `rs2_device_info` and changed `rs2_device_list` to also use `std::vector< std::shared_ptr< device_info > >`
* moved `rs2_device_list` into rs.cpp
* moved `rs2_stream_profile` into `stream.h` until the latter is refactored, too
* removed `context.h` includes where not needed

Tracked on [LRS-921]