### PR TITLE
Clean up types.h a little

### DIFF
--- a/src/core/enum-helpers.h
+++ b/src/core/enum-helpers.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include <src/basics.h>
 #include <librealsense2/hpp/rs_types.hpp>
+
+
+#define UNKNOWN_VALUE "UNKNOWN"
 
 
 namespace librealsense {

--- a/src/core/enum-helpers.h
+++ b/src/core/enum-helpers.h
@@ -7,10 +7,10 @@
 #include <librealsense2/hpp/rs_types.hpp>
 
 
-#define UNKNOWN_VALUE "UNKNOWN"
-
-
 namespace librealsense {
+
+
+constexpr static char const * UNKNOWN_VALUE = "UNKNOWN";
 
 
 // Require the last enumerator value to be in format of RS2_#####_COUNT

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -5,7 +5,9 @@
 #include "json_loader.hpp"
 #include "ds/d400/d400-color.h"
 #include "ds/d500/d500-color.h"
+
 #include <rsutils/string/from.h>
+#include <rsutils/string/hexdump.h>
 
 namespace librealsense
 {
@@ -128,8 +130,10 @@ namespace librealsense
                     default_450_high_res(p);
                     break;
                 default:
-                    throw invalid_value_exception( rsutils::string::from() << "apply_preset(...) failed! Given device doesn't support Default Preset (pid=0x" <<
-                        std::hex << device_pid << ")");
+                    throw invalid_value_exception(
+                        rsutils::string::from()
+                        << "apply_preset(...) failed! Given device doesn't support Default Preset (pid=0x"
+                        << rsutils::string::hexdump( device_pid ) << ")" );
                     break;
                 }
             case ds::RS405U_PID:
@@ -147,8 +151,8 @@ namespace librealsense
             default:
                 throw invalid_value_exception(
                     rsutils::string::from()
-                    << "apply_preset(...) failed! Given device doesn't support Default Preset (pid=0x" << std::hex
-                    << device_pid << ")" );
+                    << "apply_preset(...) failed! Given device doesn't support Default Preset (pid=0x"
+                    << rsutils::string::hexdump( device_pid ) << ")" );
                 break;
             }
             break;

--- a/src/ds/advanced_mode/rs_advanced_mode.cpp
+++ b/src/ds/advanced_mode/rs_advanced_mode.cpp
@@ -9,9 +9,15 @@
 #include "core/advanced_mode.h"
 #include "api.h"
 
-#define STRCASE(T, X) case RS2_##T##_##X: {\
-        static std::string s##T##_##X##_str = make_less_screamy(#X);\
-        return s##T##_##X##_str.c_str(); }
+#include <rsutils/string/make-less-screamy.h>
+
+
+
+#define STRCASE( T, X )                                                                                                \
+    case RS2_##T##_##X: {                                                                                              \
+        static std::string s##T##_##X##_str = rsutils::string::make_less_screamy( #X );                                \
+        return s##T##_##X##_str.c_str();                                                                               \
+    }
 
 namespace librealsense
 {

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -31,6 +31,7 @@
 #include <src/fw-update/fw-update-unsigned.h>
 #include <nlohmann/json.hpp>
 
+#include <rsutils/string/hexdump.h>
 #include <regex>
 #include <iterator>
 
@@ -634,7 +635,7 @@ namespace librealsense
             }
             
 
-            pid_hex_str = hexify(_pid);
+            pid_hex_str = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( _pid );
 
             if ((_pid == RS416_PID || _pid == RS416_RGB_PID) && _fw_version >= firmware_version("5.12.0.1"))
             {

--- a/src/ds/d400/d400-private.cpp
+++ b/src/ds/d400/d400-private.cpp
@@ -256,7 +256,7 @@ namespace librealsense
                 intrin(1, 1) * height / 2.f,
                 RS2_DISTORTION_INVERSE_BROWN_CONRADY  // The coefficients shall be use for undistort
             };
-            librealsense::copy(calc_intrinsic.coeffs, table->distortion, sizeof(table->distortion));
+            std::memcpy(calc_intrinsic.coeffs, table->distortion, sizeof(table->distortion));
             //LOG_DEBUG(endl << array2str((float_4&)(calc_intrinsic.fx, calc_intrinsic.fy, calc_intrinsic.ppx, calc_intrinsic.ppy)) << endl);
 
             static rs2_intrinsics ref{};

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -29,6 +29,8 @@
 #include "hdr-config.h"
 #include "../common/fw/firmware-version.h"
 #include "fw-update/fw-update-unsigned.h"
+
+#include <rsutils/string/hexdump.h>
 #include <nlohmann/json.hpp>
 #include <vector>
 #include <string>
@@ -494,7 +496,7 @@ namespace librealsense
                 []() {return std::make_shared<y16i_to_y10msby10msb>(); }
             );
                 
-            pid_hex_str = hexify(_pid);
+            pid_hex_str = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( _pid );
 
             _is_locked = _ds_device_common->is_locked(GVD, is_camera_locked_offset);
 

--- a/src/ds/d500/d500-private.cpp
+++ b/src/ds/d500/d500-private.cpp
@@ -228,7 +228,9 @@ namespace librealsense
             intrinsics.ppx = rect_params[2];
             intrinsics.ppy = rect_params[3];
             intrinsics.model = table->rgb_coefficients_table.distortion_model;
-            librealsense::copy(intrinsics.coeffs, table->rgb_coefficients_table.distortion_coeffs, sizeof(intrinsics.coeffs));
+            std::memcpy( intrinsics.coeffs,
+                         table->rgb_coefficients_table.distortion_coeffs,
+                         sizeof( intrinsics.coeffs ) );
 
             update_table_to_correct_fisheye_distortion(const_cast<ds::d500_rgb_calibration_table&>(*table), intrinsics);
 

--- a/src/ds/ds-calib-parsers.cpp
+++ b/src/ds/ds-calib-parsers.cpp
@@ -189,7 +189,7 @@ namespace librealsense
         if (_valid_extrinsic)
         {
             // extrinsic from calibration table, by user custom calibration, The extrinsic is stored as array of floats / little-endian
-            librealsense::copy(&_extr, &_calib_table.module_info.dm_v2_calib_table.depth_to_imu, sizeof(rs2_extrinsics));
+            std::memcpy( &_extr, &_calib_table.module_info.dm_v2_calib_table.depth_to_imu, sizeof( rs2_extrinsics ) );
         }
         else
         {
@@ -300,7 +300,7 @@ namespace librealsense
         if (_valid_extrinsic)
         {
             // only in case valid extrinsic is available in calibration data by calibration script in future or user custom calibration
-            librealsense::copy(&_extr, &imu_calib_table.depth_to_imu, sizeof(rs2_extrinsics));
+            std::memcpy( &_extr, &imu_calib_table.depth_to_imu, sizeof( rs2_extrinsics ) );
         }
         else
         {

--- a/src/ds/ds-private.cpp
+++ b/src/ds/ds-private.cpp
@@ -35,7 +35,7 @@ namespace librealsense
             intrinsics.height = height;
             intrinsics.width = width;
 
-            librealsense::copy(intrinsics.coeffs, table->distortion, sizeof(table->distortion));
+            std::memcpy( intrinsics.coeffs, table->distortion, sizeof( table->distortion ) );
 
             LOG_DEBUG(endl << array2str((float_4&)(intrinsics.fx, intrinsics.fy, intrinsics.ppx, intrinsics.ppy)) << endl);
 

--- a/src/fw-update/fw-update-device.cpp
+++ b/src/fw-update/fw-update-device.cpp
@@ -7,6 +7,8 @@
 #include "../device-info.h"
 #include "ds/d400/d400-private.h"
 
+#include <rsutils/string/hexdump.h>
+
 #include <chrono>
 #include <stdexcept>
 #include <algorithm>
@@ -112,7 +114,10 @@ namespace librealsense
 
     update_device::update_device( std::shared_ptr< const device_info > const & dev_info,
                                   std::shared_ptr< platform::usb_device > const & usb_device )
-        : _dev_info(dev_info), _usb_device(usb_device), _physical_port( usb_device->get_info().id), _pid(hexify(usb_device->get_info().pid))
+        : _dev_info( dev_info )
+        , _usb_device( usb_device )
+        , _physical_port( usb_device->get_info().id )
+        , _pid( rsutils::string::from() << std::uppercase << rsutils::string::hexdump( usb_device->get_info().pid ) )
     {
         if (auto messenger = _usb_device->open(FW_UPDATE_INTERFACE_NUMBER))
         {

--- a/src/hid/hid-device.cpp
+++ b/src/hid/hid-device.cpp
@@ -4,6 +4,10 @@
 #include <queue>
 #include "hid-device.h"
 
+#include <rsutils/string/from.h>
+#include <rsutils/string/hexdump.h>
+
+
 const int USB_REQUEST_COUNT = 1;
 
 namespace librealsense
@@ -20,8 +24,8 @@ namespace librealsense
                 if(info.cls != RS2_USB_CLASS_HID)
                     continue;
                 platform::hid_device_info device_info;
-                device_info.vid = hexify(info.vid);
-                device_info.pid = hexify(info.pid);
+                device_info.vid = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( info.vid );
+                device_info.pid = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( info.pid );
                 device_info.unique_id = info.unique_id;
                 device_info.device_path = info.unique_id;//the device unique_id is the USB port
 

--- a/src/hw-monitor.cpp
+++ b/src/hw-monitor.cpp
@@ -55,7 +55,7 @@ namespace librealsense
 
         if (dataLength)
         {
-            librealsense::copy(writePtr + cur_index, data, dataLength);
+            std::memcpy( writePtr + cur_index, data, dataLength );
             cur_index += dataLength;
         }
 
@@ -112,7 +112,7 @@ namespace librealsense
             //    throw invalid_value_exception("bulk transfer failed - user buffer too small");
 
             inSize = std::min(res.size(),inSize); // For D457 only
-            librealsense::copy(in, res.data(), inSize);
+            std::memcpy( in, res.data(), inSize );
         }
     }
 
@@ -126,10 +126,10 @@ namespace librealsense
             throw invalid_value_exception("received incomplete response to usb command");
 
         details.receivedCommandDataLength -= 4;
-        librealsense::copy(details.receivedOpcode.data(), outputBuffer, 4);
+        std::memcpy( details.receivedOpcode.data(), outputBuffer, 4 );
 
         if (details.receivedCommandDataLength > 0)
-            librealsense::copy(details.receivedCommandData.data(), outputBuffer + 4, details.receivedCommandDataLength);
+            std::memcpy( details.receivedCommandData.data(), outputBuffer + 4, details.receivedCommandDataLength );
     }
 
     void hw_monitor::send_hw_monitor_command(hwmon_cmd_details& details) const
@@ -182,8 +182,10 @@ namespace librealsense
         if( !newCommand.require_response )
             return std::vector<uint8_t>();
 
-        librealsense::copy(newCommand.receivedOpcode, details.receivedOpcode.data(), 4);
-        librealsense::copy(newCommand.receivedCommandData, details.receivedCommandData.data(), details.receivedCommandDataLength);
+        std::memcpy( newCommand.receivedOpcode, details.receivedOpcode.data(), 4 );
+        std::memcpy( newCommand.receivedCommandData,
+                     details.receivedCommandData.data(),
+                     details.receivedCommandDataLength );
         newCommand.receivedCommandDataLength = details.receivedCommandDataLength;
 
         // endian?
@@ -243,7 +245,7 @@ namespace librealsense
         command command(gvd_cmd);
         auto data = send(command);
         auto minSize = std::min(sz, data.size());
-        librealsense::copy(gvd, data.data(), minSize);
+        std::memcpy( gvd, data.data(), minSize );
     }
 
     bool hw_monitor::is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const
@@ -251,7 +253,7 @@ namespace librealsense
         std::vector<unsigned char> gvd(HW_MONITOR_BUFFER_SIZE);
         get_gvd(gvd.size(), gvd.data(), gvd_cmd);
         bool value;
-        librealsense::copy(&value, gvd.data() + offset, 1);
+        std::memcpy( &value, gvd.data() + offset, 1 );
         return value;
     }
 }

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -6,6 +6,8 @@
 #include "uvc-sensor.h"
 #include <mutex>
 #include "platform/command-transfer.h"
+#include <string>
+
 
 namespace librealsense
 {
@@ -296,7 +298,7 @@ namespace librealsense
                   require_response(cmd.require_response),
                   receivedCommandDataLength(0)
             {
-                librealsense::copy(data, cmd.data.data(), sizeOfSendCommandData);
+                std::memcpy( data, cmd.data.data(), sizeOfSendCommandData );
             }
         };
 

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1296,7 +1296,7 @@ namespace librealsense
         {
             uint32_t device_fourcc = id;
             char fourcc_buff[sizeof(device_fourcc)+1];
-            librealsense::copy(fourcc_buff, &device_fourcc, sizeof(device_fourcc));
+            std::memcpy( fourcc_buff, &device_fourcc, sizeof( device_fourcc ) );
             fourcc_buff[sizeof(device_fourcc)] = 0;
             return fourcc_buff;
         }

--- a/src/mf/mf-uvc.cpp
+++ b/src/mf/mf-uvc.cpp
@@ -362,13 +362,13 @@ namespace librealsense
 
                 auto pStruct = next_struct;
                 cfg.step.resize(option_range_size);
-                librealsense::copy(cfg.step.data(), pStruct, field_width);
+                std::memcpy( cfg.step.data(), pStruct, field_width );
                 pStruct += length;
                 cfg.min.resize(option_range_size);
-                librealsense::copy(cfg.min.data(), pStruct, field_width);
+                std::memcpy( cfg.min.data(), pStruct, field_width );
                 pStruct += length;
                 cfg.max.resize(option_range_size);
-                librealsense::copy(cfg.max.data(), pStruct, field_width);
+                std::memcpy( cfg.max.data(), pStruct, field_width );
                 return;
             }
             case KSPROPERTY_MEMBER_VALUES:
@@ -386,7 +386,7 @@ namespace librealsense
                     }
 
                     cfg.def.resize(option_range_size);
-                    librealsense::copy(cfg.def.data(), next_struct, field_width);
+                    std::memcpy( cfg.def.data(), next_struct, field_width );
                 }
                 return;
             }

--- a/src/proc/color-formats-converter.cpp
+++ b/src/proc/color-formats-converter.cpp
@@ -232,7 +232,7 @@ namespace librealsense
                     src[16], src[18], src[20], src[22],
                     src[24], src[26], src[28], src[30],
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -246,7 +246,7 @@ namespace librealsense
                     0, src[16], 0, src[18], 0, src[20], 0, src[22],
                     0, src[24], 0, src[26], 0, src[28], 0, src[30],
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy(dst, out, sizeof out);
                 dst += sizeof out;
                 continue;
             }
@@ -295,7 +295,7 @@ namespace librealsense
                     r[12], g[12], b[12], r[13], g[13], b[13],
                     r[14], g[14], b[14], r[15], g[15], b[15],
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -312,7 +312,7 @@ namespace librealsense
                     b[12], g[12], r[12], b[13], g[13], r[13],
                     b[14], g[14], r[14], b[15], g[15], r[15],
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -329,7 +329,7 @@ namespace librealsense
                     r[12], g[12], b[12], 255, r[13], g[13], b[13], 255,
                     r[14], g[14], b[14], 255, r[15], g[15], b[15], 255,
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -346,7 +346,7 @@ namespace librealsense
                     b[12], g[12], r[12], 255, b[13], g[13], r[13], 255,
                     b[14], g[14], r[14], 255, b[15], g[15], r[15], 255,
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -362,7 +362,7 @@ namespace librealsense
         {
             // grabbing matching y,u,v values
             uint8_t y[16] = { 0 };
-            librealsense::copy(y, &y_one_line[y_pix], 16);
+            std::memcpy( y, &y_one_line[y_pix], 16 );
 
             uint8_t u[16] = {
                 uv_one_line[uv_pix + 0], uv_one_line[uv_pix + 0], uv_one_line[uv_pix + 2], uv_one_line[uv_pix + 2],
@@ -407,7 +407,7 @@ namespace librealsense
                     r[12], g[12], b[12], r[13], g[13], b[13],
                     r[14], g[14], b[14], r[15], g[15], b[15]
                 };
-                librealsense::copy(*dst, out, sizeof(out));
+                std::memcpy( *dst, out, sizeof( out ) );
                 *dst += sizeof out;
                 continue;
             }
@@ -424,7 +424,7 @@ namespace librealsense
                     b[12], g[12], r[12], b[13], g[13], r[13],
                     b[14], g[14], r[14], b[15], g[15], r[15],
                 };
-                librealsense::copy(*dst, out, sizeof out);
+                std::memcpy( *dst, out, sizeof out );
                 *dst += sizeof out;
                 continue;
             }
@@ -441,7 +441,7 @@ namespace librealsense
                     r[12], g[12], b[12], 255, r[13], g[13], b[13], 255,
                     r[14], g[14], b[14], 255, r[15], g[15], b[15], 255,
                 };
-                librealsense::copy(*dst, out, sizeof out);
+                std::memcpy( *dst, out, sizeof out );
                 *dst += sizeof out;
                 continue;
             }
@@ -458,7 +458,7 @@ namespace librealsense
                     b[12], g[12], r[12], 255, b[13], g[13], r[13], 255,
                     b[14], g[14], r[14], 255, b[15], g[15], r[15], 255,
                 };
-                librealsense::copy(*dst, out, sizeof out);
+                std::memcpy( *dst, out, sizeof out );
                 *dst += sizeof out;
                 continue;
             }
@@ -700,7 +700,7 @@ namespace librealsense
                 // fill the destination with y values
                 // while y is on 2 lines, and uv on the third line
                 auto start_of_y = src + k * width;
-                librealsense::copy(dst, start_of_y, 2 * width);
+                std::memcpy( dst, start_of_y, 2 * width );
                 dst += 2 * width;
             }
             return;
@@ -720,7 +720,7 @@ namespace librealsense
                     {
                         y[dst_idx] = start_of_y[src_idx + pix] << 8;
                     }
-                    librealsense::copy(dst, y, sizeof y);
+                    std::memcpy( dst, y, sizeof y );
                     dst += sizeof y;
                 }
             }
@@ -986,7 +986,7 @@ namespace librealsense
                     r[12], g[12], b[12], r[13], g[13], b[13],
                     r[14], g[14], b[14], r[15], g[15], b[15],
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -1003,7 +1003,7 @@ namespace librealsense
                     b[12], g[12], r[12], b[13], g[13], r[13],
                     b[14], g[14], r[14], b[15], g[15], r[15],
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -1020,7 +1020,7 @@ namespace librealsense
                     r[12], g[12], b[12], 255, r[13], g[13], b[13], 255,
                     r[14], g[14], b[14], 255, r[15], g[15], b[15], 255,
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -1037,7 +1037,7 @@ namespace librealsense
                     b[12], g[12], r[12], 255, b[13], g[13], r[13], 255,
                     b[14], g[14], r[14], 255, b[15], g[15], r[15], 255,
                 };
-                librealsense::copy(dst, out, sizeof out);
+                std::memcpy( dst, out, sizeof out );
                 dst += sizeof out;
                 continue;
             }
@@ -1077,7 +1077,7 @@ namespace librealsense
         if (uncompressed_rgb)
         {
             auto uncompressed_size = w * h * bpp;
-            librealsense::copy(dest[0], uncompressed_rgb, uncompressed_size);
+            std::memcpy( dest[0], uncompressed_rgb, uncompressed_size );
             stbi_image_free(uncompressed_rgb);
         }
         else
@@ -1093,7 +1093,7 @@ namespace librealsense
         auto in = reinterpret_cast<const uint8_t *>(source);
         auto out = reinterpret_cast<uint8_t *>(dest[0]);
 
-        librealsense::copy(out, in, count * 3);
+        std::memcpy( out, in, count * 3 );
         for (auto i = 0; i < count; i++)
         {
             std::swap(out[i * 3], out[i * 3 + 2]);

--- a/src/proc/depth-formats-converter.cpp
+++ b/src/proc/depth-formats-converter.cpp
@@ -22,7 +22,7 @@ namespace librealsense
 #else
         for (int i = 0; i < count; ++i) *out_ir++ = *in++ >> 2;
 #endif
-        librealsense::copy(dest[0], in, count * 2);
+        std::memcpy( dest[0], in, count * 2 );
     }
 
     void unpack_z16_y16_from_sr300_inzi(byte * const dest[], const byte * source, int width, int height, int actual_size)
@@ -36,7 +36,7 @@ namespace librealsense
 #else
         for (int i = 0; i < count; ++i) *out_ir++ = *in++ << 6;
 #endif
-        librealsense::copy(dest[0], in, count * 2);
+        std::memcpy( dest[0], in, count * 2 );
     }
 
     void unpack_inzi(rs2_format dst_ir_format, byte * const d[], const byte * s, int width, int height, int actual_size)
@@ -83,7 +83,7 @@ namespace librealsense
     void copy_raw10(byte * const dest[], const byte * source, int width, int height, int actual_size)
     {
         auto count = width * height; // num of pixels
-        librealsense::copy(dest[0], source, size_t(5.0 * (count / 4.0)));
+        std::memcpy( dest[0], source, size_t( 5.0 * ( count / 4.0 ) ) );
     }
 
     void unpack_y10bpack(byte * const dest[], const byte * source, int width, int height, int actual_size)

--- a/src/proc/motion-transform.cpp
+++ b/src/proc/motion-transform.cpp
@@ -26,7 +26,7 @@ namespace librealsense
             res = float3{ float(hid->x), float(hid->y), float(hid->z) } *float(factor);
         }
 
-        librealsense::copy(dest[0], &res, sizeof(float3));
+        std::memcpy( dest[0], &res, sizeof( float3 ) );
     }
 
     // The Accelerometer input format: signed int 16bit. data units 1LSB=0.001g;

--- a/src/proc/rotation-transform.cpp
+++ b/src/proc/rotation-transform.cpp
@@ -55,7 +55,7 @@ namespace librealsense
             for (int j = 0; j < width; ++j)
             {
                 auto out_index = (((height_out - j) * width_out) - i - 1) * SIZE;
-                librealsense::copy((void*)(&out[out_index]), &(source[(row_offset + j) * SIZE]), SIZE);
+                std::memcpy( &out[out_index], &( source[( row_offset + j ) * SIZE] ), SIZE );
             }
         }
     }

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -17,7 +17,7 @@
 #define STRARR( ARRAY, T, X ) ARRAY[RS2_##T##_##X] = STRX( X )
 
 
-static std::string const unknown_value_str( UNKNOWN_VALUE );
+static std::string const unknown_value_str( librealsense::UNKNOWN_VALUE );
 
 
 namespace librealsense {

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -1,11 +1,14 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2021 Intel Corporation. All Rights Reserved.
 
-#include "types.h"
 #include "core/options-registry.h"
+#include "core/enum-helpers.h"
+
+#include <rsutils/string/make-less-screamy.h>
+#include <cassert>
 
 
-#define STRX( X ) make_less_screamy( #X )
+#define STRX( X ) rsutils::string::make_less_screamy( #X )
 #define STRCASE( T, X )                                                                                                \
     case RS2_##T##_##X: {                                                                                              \
         static const std::string s##T##_##X##_str = STRX( X );                                                         \

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -9,8 +9,7 @@
 #include <fstream>
 #include <cmath>
 
-#include "core/streaming.h"
-#include "../include/librealsense2/hpp/rs_processing.hpp"
+#include <librealsense2/hpp/rs_processing.hpp>
 
 const double SQRT_DBL_EPSILON = sqrt(std::numeric_limits<double>::epsilon());
 
@@ -219,11 +218,5 @@ namespace librealsense
     notifications_callback_ptr notifications_processor::get_callback() const
     {
         return _callback;
-    }
-
-    void copy(void* dst, void const* src, size_t size)
-    {
-        auto from = reinterpret_cast<uint8_t const*>(src);
-        std::copy(from, from + size, reinterpret_cast<uint8_t*>(dst));
     }
 }

--- a/src/types.h
+++ b/src/types.h
@@ -58,7 +58,6 @@ using std::abs;
 #include "../common/android_helpers.h"
 #endif
 
-#define UNKNOWN_VALUE "UNKNOWN"
 
 namespace librealsense
 {
@@ -176,8 +175,6 @@ namespace librealsense
     }
 
     void copy(void* dst, void const* src, size_t size);
-
-    std::string make_less_screamy(const char* str);
 
     ///////////////////////
     // Logging mechanism //

--- a/src/types.h
+++ b/src/types.h
@@ -175,16 +175,6 @@ namespace librealsense
         return false;
     }
 
-    template<class T>
-    std::string hexify(const T& val)
-    {
-        static_assert((std::is_integral<T>::value), "hexify supports integral built-in types only");
-
-        std::ostringstream oss;
-        oss << std::setw(sizeof(T)*2) << std::setfill('0') << std::uppercase << std::hex << val;
-        return oss.str().c_str();
-    }
-
     void copy(void* dst, void const* src, size_t size);
 
     std::string make_less_screamy(const char* str);

--- a/src/types.h
+++ b/src/types.h
@@ -174,8 +174,6 @@ namespace librealsense
         return false;
     }
 
-    void copy(void* dst, void const* src, size_t size);
-
     ///////////////////////
     // Logging mechanism //
     ///////////////////////

--- a/third-party/rsutils/include/rsutils/string/make-less-screamy.h
+++ b/third-party/rsutils/include/rsutils/string/make-less-screamy.h
@@ -1,0 +1,23 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <string>
+
+
+namespace rsutils {
+namespace string {
+
+
+// Convert a typically all-uppercase, underscore-delimited identifier (e.g., "PRODUCT_LINE_D500") to a more
+// human-readable form (e.g., "Product Line D500").
+// 
+//      - underscores are replaced by spaces
+//      - letters are made lower-case; the beginning of a words upper-case
+//
+std::string make_less_screamy( std::string );
+
+
+}  // namespace string
+}  // namespace rsutils

--- a/third-party/rsutils/src/make-less-screamy.cpp
+++ b/third-party/rsutils/src/make-less-screamy.cpp
@@ -1,0 +1,33 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include <string>
+
+
+namespace rsutils {
+namespace string {
+
+
+std::string make_less_screamy( std::string res )
+{
+    bool first = true;
+    for( char & ch : res )
+    {
+        if( ch != '_' )
+        {
+            if( ! first )
+                ch = tolower( ch );
+            first = false;
+        }
+        else
+        {
+            ch = ' ';
+            first = true;
+        }
+    }
+    return res;
+}
+
+
+}  // namespace string
+}  // namespace rsutils

--- a/unit-tests/py/rspy/acroname.py
+++ b/unit-tests/py/rspy/acroname.py
@@ -19,11 +19,12 @@ if __name__ == '__main__':
         print( '        Control the acroname USB hub' )
         print( 'Options:' )
         print( '        --enable       Enable all ports' )
+        print( '        --disable      Disable all ports' )
         print( '        --recycle      Recycle all ports' )
         sys.exit(2)
     try:
         opts,args = getopt.getopt( sys.argv[1:], '',
-            longopts = [ 'help', 'recycle', 'enable' ])
+            longopts = [ 'help', 'recycle', 'enable', 'disable' ])
     except getopt.GetoptError as err:
         print( '-F-', err )   # something like "option -a not recognized"
         usage()
@@ -96,7 +97,7 @@ def find_all_hubs():
     """
     from rspy import lsusb
     #
-    # 24ff:8013 = 
+    # 24ff:8013 =
     #   iManufacturer           Acroname Inc.
     #   iProduct                USBHub3p-3[A]
     hubs = set( lsusb.devices_by_vendor( '24ff' ))
@@ -314,6 +315,9 @@ if __name__ == '__main__':
         if opt in ('--enable'):
             connect()
             enable_ports()   # so ports() will return all
+        elif opt in ('--disable'):
+            connect()
+            disable_ports()
         elif opt in ('--recycle'):
             connect()
             enable_ports()   # so ports() will return all

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -758,12 +758,6 @@ if __name__ == '__main__':
         for opt,arg in opts:
             if opt in ('--list'):
                 action = 'list'
-            elif opt in ('--ports'):
-                printer = get_phys_port
-            elif opt in ('--all'):
-                if not acroname:
-                    log.f( 'No acroname available' )
-                acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
             elif opt in ('--port'):
                 if not acroname:
                     log.f( 'No acroname available' )
@@ -773,6 +767,12 @@ if __name__ == '__main__':
                 if len(ports) != len(str_ports):
                     log.f( 'Invalid ports', str_ports )
                 acroname.enable_ports( ports, disable_other_ports = True, sleep_on_change = MAX_ENUMERATION_TIME )
+            elif opt in ('--ports'):
+                printer = get_phys_port
+            elif opt in ('--all'):
+                if not acroname:
+                    log.f( 'No acroname available' )
+                acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
             elif opt in ('--recycle'):
                 action = 'recycle'
             else:

--- a/unit-tests/rsutils/string/test-hexarray.cpp
+++ b/unit-tests/rsutils/string/test-hexarray.cpp
@@ -89,6 +89,12 @@ TEST_CASE( "hexdump", "[hexarray]" )
 #pragma pack( pop )
         CHECK( to_string( hexdump( s ) ) == "04030201060578" );
     }
+    SECTION( "case" )
+    {
+        int i = 0x0a0b0c0d;
+        CHECK( to_string( hexdump( i ) ) == "0a0b0c0d" );
+        CHECK( ( from() << std::uppercase << hexdump( i ) ).str() == "0A0B0C0D" );
+    }
 }
 
 TEST_CASE( "hexdump of bytearray", "[hexarray]" )


### PR DESCRIPTION
* simpler `hexdump`; make sure it listens to `std::uppercase`
* remove hexify
* move `make_less_screamy` to rsutils
* `librealsense::copy` -> `std::memcpy`
* fixed couple of things with acroname and devices

Tracked on [LRS-923]