### PR TITLE
Fix pybind arg names

### DIFF
--- a/wrappers/python/pyrsutil.cpp
+++ b/wrappers/python/pyrsutil.cpp
@@ -51,7 +51,7 @@ void init_util(py::module &m) {
     };
 
     m.def("rs2_project_color_pixel_to_depth_pixel", cp_to_dp, "Given pixel coordinates of the color image and a minimum and maximum depth, compute the corresponding pixel coordinates in the depth image. Returns [-1 -1] on failure.",
-          "data"_a, "depth_scale"_a, "depth_min"_a, "depth_max"_a, "depth_intrin"_a, "color_intrin"_a, "depth_to_color"_a,
-          "color_to_depth"_a, "from_pixel"_a);
+          "data"_a, "depth_scale"_a, "depth_min"_a, "depth_max"_a, "depth_intrin"_a, "color_intrin"_a, "color_to_depth"_a,
+          "depth_to_color"_a, "from_pixel"_a);
     /** end rsutil.h **/
 }


### PR DESCRIPTION
There was a previous fix #11273 to fix the internal ordering, but that was never propagated to the actual pybind function definitiion.