### PR TITLE
Actual FPS simplification & unit change [API change]

### DIFF
--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -1083,12 +1083,12 @@ void frame_drops_dashboard::process_frame(rs2::frame f)
         {
             auto last = stream_to_time[f.get_profile().unique_id()];
 
-            long long fps = f.get_profile().fps();
+            double fps = (double)f.get_profile().fps();
 
-            if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
-                fps = f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
+            if( f.supports_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) )
+                fps = f.get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.;
 
-            if (1000.f * (ts - last) > 1.5f * (1000.f / fps)) {
+            if (1000. * (ts - last) > 1.5 * (1000. / fps)) {
                 drops++;
             }
         }

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -805,7 +805,7 @@ namespace rs2
                                     "Frame Timestamp is normalized represetation of when the frame was taken.\n"
                                     "It's a property of every frame, so when exact creation time is not provided by "
                                     "the hardware, an approximation will be used.\n"
-                                    "Clock Domain feilds helps to interpret the meaning of timestamp\n"
+                                    "Clock Domain fields helps to interpret the meaning of timestamp\n"
                                     "Timestamp is measured in milliseconds, and is allowed to roll-over (reset to "
                                     "zero) in some situations" } );
         stream_details.push_back(
@@ -891,11 +891,12 @@ namespace rs2
               "When AE is set On, the value is controlled by firmware. Integer value" },
             { RS2_FRAME_METADATA_AUTO_EXPOSURE, "Auto Exposure Mode indicator. Zero corresponds to AE switched off. " },
             { RS2_FRAME_METADATA_WHITE_BALANCE, "White Balance setting as a color temperature. Kelvin degrees" },
-            { RS2_FRAME_METADATA_TIME_OF_ARRIVAL, "Time of arrival in system clock " },
+            { RS2_FRAME_METADATA_TIME_OF_ARRIVAL, "Time of arrival in system clock" },
             { RS2_FRAME_METADATA_TEMPERATURE,
               "Temperature of the device, measured at the time of the frame capture. Celsius degrees " },
             { RS2_FRAME_METADATA_BACKEND_TIMESTAMP, "Timestamp get from uvc driver. usec" },
-            { RS2_FRAME_METADATA_ACTUAL_FPS, "Actual hardware FPS. May differ from requested due to Auto-Exposure" },
+            { RS2_FRAME_METADATA_ACTUAL_FPS, "Hardware FPS * 1000 =\n"
+              "1000000 * (frame-number - prev-frame-number) / (timestamp - prev-timestamp)" },
             { RS2_FRAME_METADATA_FRAME_LASER_POWER_MODE,
               "Laser power mode. Zero corresponds to Laser power switched off and one for switched on." },
             { RS2_FRAME_METADATA_EXPOSURE_PRIORITY,
@@ -912,10 +913,10 @@ namespace rs2
             {
                 auto val = (rs2_frame_metadata_value)i;
                 std::string name = rs2_frame_metadata_to_string( val );
-                std::string desc = "";
+                std::string desc;
                 if( descriptions.find( val ) != descriptions.end() )
                     desc = descriptions[val];
-                stream_details.push_back( { name, rsutils::string::from() << kvp.second, desc } );
+                stream_details.push_back( { name, rsutils::string::from( kvp.second ), desc } );
             }
         }
 

--- a/doc/frame_metadata.md
+++ b/doc/frame_metadata.md
@@ -87,7 +87,7 @@ GAIN_LEVEL|16
 AUTO_EXPOSURE|1  
 TIME_OF_ARRIVAL|1523871918775
 BACKEND_TIMESTAMP|1523871918741
-ACTUAL_FPS|30
+ACTUAL_FPS|30000
 
  - `rs-config-ui` includes a checkbox in the upper-right corner of  stream's canvas, clicking on which will bring up an overlay window with the metadata attributes available.  
 

--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -39,7 +39,7 @@ typedef enum rs2_frame_metadata_value
     RS2_FRAME_METADATA_TIME_OF_ARRIVAL                      , /**< Time of arrival in system clock */
     RS2_FRAME_METADATA_TEMPERATURE                          , /**< Temperature of the device, measured at the time of the frame capture. Celsius degrees */
     RS2_FRAME_METADATA_BACKEND_TIMESTAMP                    , /**< Timestamp get from uvc driver. usec*/
-    RS2_FRAME_METADATA_ACTUAL_FPS                           , /**< Actual fps */
+    RS2_FRAME_METADATA_ACTUAL_FPS                           , /**< Actual fps, times 1000 (30.1 fps would be 30100 in the metadata) */
     RS2_FRAME_METADATA_FRAME_LASER_POWER                    , /**< Laser power value 0-360. */
     RS2_FRAME_METADATA_FRAME_LASER_POWER_MODE               , /**< Laser power mode. Zero corresponds to Laser power switched off and one for switched on. deprecated, replaced by RS2_FRAME_METADATA_FRAME_EMITTER_MODE*/
     RS2_FRAME_METADATA_EXPOSURE_PRIORITY                    , /**< Exposure priority. */

--- a/src/algo.cpp
+++ b/src/algo.cpp
@@ -80,10 +80,14 @@ auto_exposure_mechanism::auto_exposure_mechanism(option& gain_option, option& ex
 
                 double values[2] = {};
 
-                values[0] = frame->supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE) ?
-                            static_cast<double>(frame->get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE)) : _exposure_option.query();
-                values[1] = frame->supports_frame_metadata(RS2_FRAME_METADATA_GAIN_LEVEL) ?
-                            static_cast<double>(frame->get_frame_metadata(RS2_FRAME_METADATA_GAIN_LEVEL)) : _gain_option.query();
+                rs2_metadata_type actual_exposure_md;
+                values[0] = frame->find_metadata( RS2_FRAME_METADATA_ACTUAL_EXPOSURE, &actual_exposure_md )
+                              ? static_cast< double >( actual_exposure_md )
+                              : _exposure_option.query();
+                rs2_metadata_type gain_level_md;
+                values[1] = frame->find_metadata( RS2_FRAME_METADATA_GAIN_LEVEL, &gain_level_md )
+                              ? static_cast< double >( gain_level_md )
+                              : _gain_option.query();
 
                 values[0] /= 1000.; // Fisheye exposure value by extension control-
                                     // is in units of MicroSeconds, from FW version 5.6.3.0

--- a/src/composite-frame.h
+++ b/src/composite-frame.h
@@ -39,13 +39,9 @@ public:
     // In the next section we make the composite frame "look and feel" like the first of its
     // children
     frame_header const & get_header() const override { return first()->get_header(); }
-    rs2_metadata_type get_frame_metadata( const rs2_frame_metadata_value & frame_metadata ) const override
+    bool find_metadata( rs2_frame_metadata_value frame_metadata, rs2_metadata_type * p_output_value ) const override
     {
-        return first()->get_frame_metadata( frame_metadata );
-    }
-    bool supports_frame_metadata( const rs2_frame_metadata_value & frame_metadata ) const override
-    {
-        return first()->supports_frame_metadata( frame_metadata );
+        return first()->find_metadata( frame_metadata, p_output_value );
     }
     int get_frame_data_size() const override { return first()->get_frame_data_size(); }
     const uint8_t * get_frame_data() const override { return first()->get_frame_data(); }

--- a/src/core/frame-interface.h
+++ b/src/core/frame-interface.h
@@ -21,8 +21,8 @@ class frame_interface
 {
 public:
     virtual frame_header const & get_header() const = 0;
-    virtual rs2_metadata_type get_frame_metadata( const rs2_frame_metadata_value & frame_metadata ) const = 0;
-    virtual bool supports_frame_metadata( const rs2_frame_metadata_value & frame_metadata ) const = 0;
+
+    virtual bool find_metadata( rs2_frame_metadata_value, rs2_metadata_type * p_output_value ) const = 0;
     virtual int get_frame_data_size() const = 0;
     virtual const uint8_t * get_frame_data() const = 0;
     virtual rs2_time_t get_frame_timestamp() const = 0;
@@ -31,7 +31,7 @@ public:
     virtual unsigned long long get_frame_number() const = 0;
 
     virtual void set_timestamp_domain( rs2_timestamp_domain timestamp_domain ) = 0;
-    virtual rs2_time_t get_frame_system_time() const = 0;
+    virtual rs2_time_t get_frame_system_time() const = 0;  // TIME_OF_ARRIVAL
     virtual std::shared_ptr< stream_profile_interface > get_stream() const = 0;
     virtual void set_stream( std::shared_ptr< stream_profile_interface > sp ) = 0;
 

--- a/src/ds/d400/d400-auto-calibration.cpp
+++ b/src/ds/d400/d400-auto-calibration.cpp
@@ -1270,13 +1270,16 @@ namespace librealsense
     {
         try
         {
+            auto fi = (frame_interface *)f;
             std::vector<uint8_t> res;
-            rs2_metadata_type frame_counter = ((frame_interface*)f)->get_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER);
-            rs2_metadata_type frame_ts = ((frame_interface*)f)->get_frame_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP);
+            rs2_metadata_type frame_counter;
+            if( ! fi->find_metadata( RS2_FRAME_METADATA_FRAME_COUNTER, &frame_counter ) )
+                throw invalid_value_exception( "missing FRAME_COUNTER" );
+            rs2_metadata_type frame_ts;
+            if( ! fi->find_metadata( RS2_FRAME_METADATA_FRAME_TIMESTAMP, &frame_ts ) )
+                throw invalid_value_exception( "missing FRAME_TIMESTAMP" );
             bool tare_fc_workaround = (_action == auto_calib_action::RS2_OCC_ACTION_TARE_CALIB); //Tare calib shall use rolling frame counter
-            bool mipi_sku = ((frame_interface*)f)->supports_frame_metadata(RS2_FRAME_METADATA_CALIB_INFO);
-            if (mipi_sku)
-                frame_counter = ((frame_interface*)f)->get_frame_metadata(RS2_FRAME_METADATA_CALIB_INFO);
+            bool mipi_sku = fi->find_metadata( RS2_FRAME_METADATA_CALIB_INFO, &frame_counter );
 
             if (_interactive_state == interactive_calibration_state::RS2_OCC_STATE_WAIT_TO_CAMERA_START)
             {

--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -1345,7 +1345,7 @@ namespace librealsense
         std::vector<stream_interface*> streams = { _depth_stream.get() , _left_ir_stream.get() , _right_ir_stream.get(), _color_stream.get() };
         std::vector<stream_interface*> mm_streams = { _accel_stream.get(), _gyro_stream.get()};
         streams.insert(streams.end(), mm_streams.begin(), mm_streams.end());
-        if (frame.frame->supports_frame_metadata(RS2_FRAME_METADATA_FRAME_COUNTER))
+        if( frame.frame->find_metadata( RS2_FRAME_METADATA_FRAME_COUNTER, nullptr ) )
         {
             return matcher_factory::create(RS2_MATCHER_DLR_C, streams);
         }

--- a/src/ds/ds-color-common.cpp
+++ b/src/ds/ds-color-common.cpp
@@ -77,8 +77,7 @@ namespace librealsense
     void ds_color_common::register_metadata()
     {
         _color_ep.register_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP, make_uvc_header_parser(&platform::uvc_header::timestamp));
-        _color_ep.register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS, std::make_shared<ds_md_attribute_actual_fps>(false, [](const rs2_metadata_type& param)
-            {return param * 100; })); //the units of the exposure of the RGB sensor are 100 microseconds so the md_attribute_actual_fps need the lambda to convert it to microseconds
+        _color_ep.register_metadata(RS2_FRAME_METADATA_ACTUAL_FPS, std::make_shared<ds_md_attribute_actual_fps>());
 
         // attributes of md_capture_timing
         auto md_prop_offset = offsetof(metadata_raw, mode) +

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -223,6 +223,18 @@ unsigned long long frame::get_frame_number() const
     return additional_data.frame_number;
 }
 
+double frame::calc_actual_fps() const
+{
+    auto const dt = ( additional_data.timestamp - additional_data.last_timestamp );
+    if( dt > 0. && additional_data.frame_number > additional_data.last_frame_number )
+    {
+        auto const n_frames = additional_data.frame_number - additional_data.last_frame_number;
+        return 1000. * n_frames / dt;
+    }
+
+    return 0.;  // Unknown actual FPS
+}
+
 rs2_time_t frame::get_frame_system_time() const
 {
     return additional_data.system_time;

--- a/src/frame.h
+++ b/src/frame.h
@@ -51,6 +51,9 @@ public:
         additional_data.timestamp_domain = timestamp_domain;
     }
 
+    // Return FPS calculated as (1000*d_frames/d_timestamp), or 0 if this cannot be estimated
+    double calc_actual_fps() const;
+
     rs2_time_t get_frame_system_time() const override;
 
     std::shared_ptr< stream_profile_interface > get_stream() const override { return stream; }

--- a/src/frame.h
+++ b/src/frame.h
@@ -38,8 +38,7 @@ public:
 
     virtual ~frame() { on_release.reset(); }
     frame_header const & get_header() const override { return additional_data; }
-    rs2_metadata_type get_frame_metadata( const rs2_frame_metadata_value & frame_metadata ) const override;
-    bool supports_frame_metadata( const rs2_frame_metadata_value & frame_metadata ) const override;
+    bool find_metadata( rs2_frame_metadata_value, rs2_metadata_type * p_output_value ) const override;
     int get_frame_data_size() const override;
     const uint8_t * get_frame_data() const override;
     rs2_time_t get_frame_timestamp() const override;

--- a/src/hid-sensor.cpp
+++ b/src/hid-sensor.cpp
@@ -221,6 +221,9 @@ void hid_sensor::start( frame_callback_ptr callback )
                                         << rs2_timestamp_domain_to_string( timestamp_domain ) << ",last_frame_number,"
                                         << last_frame_number << ",last_timestamp," << last_timestamp );
 
+            if( frame_counter <= last_frame_number )
+                LOG_INFO( "Frame counter reset" );
+
             last_frame_number = frame_counter;
             last_timestamp = timestamp;
             frame_holder frame

--- a/src/media/ros/ros_writer.cpp
+++ b/src/media/ros/ros_writer.cpp
@@ -106,9 +106,9 @@ namespace librealsense
         for (int i = 0; i < static_cast<rs2_frame_metadata_value>(rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT); i++)
         {
             rs2_frame_metadata_value type = static_cast<rs2_frame_metadata_value>(i);
-            if (frame->supports_frame_metadata(type))
+            rs2_metadata_type md;
+            if (frame->find_metadata(type, &md))
             {
-                auto md = frame->get_frame_metadata(type);
                 diagnostic_msgs::KeyValue md_msg;
                 md_msg.key = librealsense::get_string(type);
                 md_msg.value = std::to_string(md);

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -333,11 +333,7 @@ namespace librealsense
                 // In case of frame counter reset fallback to fps from the stream configuration
                 return false;
             if( p_value )
-            {
-                if( frm.additional_data.frame_number <= frm.additional_data.last_frame_number )
-                    LOG_INFO( "Frame counter reset" );  // TODO: this is not a good place!
                 *p_value = fps;
-            }
             return true;
         }
     };

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -345,7 +345,7 @@ namespace librealsense
     class actual_fps_calculator
     {
     public:
-        double get_fps(const librealsense::frame & frm)
+        static double get_fps( const librealsense::frame & frm )
         {
             // A computation involving unsigned operands can never overflow (ISO/IEC 9899:1999 (E) \A76.2.5/9)
             // In case of frame counter reset fallback use fps from the stream configuration
@@ -373,67 +373,15 @@ namespace librealsense
     class ds_md_attribute_actual_fps : public md_attribute_parser_base
     {
     public:
-        ds_md_attribute_actual_fps(bool discrete = true, attrib_modifyer  exposure_mod = [](const rs2_metadata_type& param) {return param; })
-            : _fps_values{ 6, 15, 30, 60, 90 } , _exposure_modifyer(exposure_mod), _discrete(discrete)
-        {}
-
-        rs2_metadata_type get(const librealsense::frame & frm) const override
+        rs2_metadata_type get( const librealsense::frame & frm ) const override
         {
-            if (frm.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE))
-            {
-                if (frm.get_stream()->get_format() == RS2_FORMAT_Y16 &&
-                    frm.get_stream()->get_stream_type() == RS2_STREAM_INFRARED) //calibration mode
-                {
-                    if (std::find(_fps_values.begin(), _fps_values.end(), 25) == _fps_values.end())
-                    {
-                        _fps_values.push_back(25);
-                        std::sort(_fps_values.begin(), _fps_values.end());
-                    }
-
-                }
-
-                auto exp = frm.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_EXPOSURE);
-
-                auto exp_in_micro = _exposure_modifyer(exp);
-                if (exp_in_micro > 0)
-                {
-                    auto fps = 1000000. / exp_in_micro;
-
-                    if (_discrete)
-                    {
-                        if (fps >= _fps_values.back())
-                        {
-                            fps = static_cast<double>(_fps_values.back());
-                        }
-                        else
-                        {
-                            for (size_t i = 0; i < _fps_values.size() - 1; i++)
-                            {
-                                if (fps < _fps_values[i + 1])
-                                {
-                                    fps = static_cast<double>(_fps_values[i]);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    return rs2_metadata_type( std::min( fps, (double)frm.get_stream()->get_framerate() ) * 1000 );
-                }
-            }
-
-            return rs2_metadata_type( _fps_calculator.get_fps( frm ) * 1000 );
+            return rs2_metadata_type( actual_fps_calculator::get_fps( frm ) * 1000 );
         }
 
         bool supports(const librealsense::frame & frm) const override
         {
             return true;
         }
-
-    private:
-        mutable actual_fps_calculator _fps_calculator;
-        mutable std::vector<uint32_t> _fps_values;
-        attrib_modifyer _exposure_modifyer;
-        bool _discrete;
     };
 
     /**\brief A helper function to create a specialized parser for RS4xx sensor timestamp*/

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -18,8 +18,7 @@ namespace librealsense
     class md_attribute_parser_base
     {
     public:
-        virtual rs2_metadata_type get(const frame& frm) const = 0;
-        virtual bool supports(const frame& frm) const = 0;
+        virtual bool find( const frame & frm, rs2_metadata_type * p_value ) const = 0;
 
         virtual ~md_attribute_parser_base() = default;
     };
@@ -29,19 +28,24 @@ namespace librealsense
     {
     public:
         md_constant_parser(rs2_frame_metadata_value type) : _type(type) {}
-        rs2_metadata_type get(const frame& frm) const override
+
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
-            rs2_metadata_type v;
-            if (try_get(frm, v) == false)
+            const uint8_t * pos = frm.additional_data.metadata_blob.data();
+            while( pos <= frm.additional_data.metadata_blob.data() + frm.additional_data.metadata_blob.size() )
             {
-                throw invalid_value_exception("Frame does not support this type of metadata");
+                const rs2_frame_metadata_value * type = reinterpret_cast<const rs2_frame_metadata_value *>(pos);
+                pos += sizeof( rs2_frame_metadata_value );
+                if( _type == *type )
+                {
+                    const rs2_metadata_type * value = reinterpret_cast<const rs2_metadata_type *>(pos);
+                    if( p_value )
+                        memcpy( (void *) p_value, (const void *) value, sizeof( *value ) );
+                    return true;
+                }
+                pos += sizeof( rs2_metadata_type );
             }
-            return v;
-        }
-        bool supports(const frame& frm) const override
-        {
-            rs2_metadata_type v;
-            return try_get(frm, v);
+            return false;
         }
 
         static std::shared_ptr<metadata_parser_map> create_metadata_parser_map()
@@ -54,25 +58,8 @@ namespace librealsense
             }
             return md_parser_map;
         }
-    private:
-        bool try_get(const frame& frm, rs2_metadata_type& result) const
-        {
-            const uint8_t* pos = frm.additional_data.metadata_blob.data();
-            while( pos <= frm.additional_data.metadata_blob.data() + frm.additional_data.metadata_blob.size() )
-            {
-                const rs2_frame_metadata_value* type = reinterpret_cast< const rs2_frame_metadata_value* >( pos );
-                pos += sizeof( rs2_frame_metadata_value );
-                if( _type == *type )
-                {
-                    const rs2_metadata_type* value = reinterpret_cast< const rs2_metadata_type* >( pos );
-                    memcpy( (void*)&result, (const void*)value, sizeof( *value ) );
-                    return true;
-                }
-                pos += sizeof( rs2_metadata_type );
-            }
-            return false;
-        }
 
+    private:
         rs2_frame_metadata_value _type;
     };
 
@@ -88,20 +75,15 @@ namespace librealsense
         {
         }
 
-        rs2_metadata_type get( const frame & frm ) const override
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
             auto pmd = reinterpret_cast< metadata_array_value const * >( frm.additional_data.metadata_blob.data() );
             metadata_array_value const & value = pmd[_key];
             if( ! value.is_valid )
-                throw invalid_value_exception( "Frame does not support this type of metadata" );
-            return value.value;
-        }
-
-        bool supports(const frame& frm) const override
-        {
-            auto pmd = reinterpret_cast< metadata_array_value const * >( frm.additional_data.metadata_blob.data() );
-            metadata_array_value const & value = pmd[_key];
-            return value.is_valid;
+                return false;
+            if( p_value )
+                *p_value = value.value;
+            return true;
         }
     };
 
@@ -113,13 +95,10 @@ namespace librealsense
     class md_time_of_arrival_parser : public md_attribute_parser_base
     {
     public:
-        rs2_metadata_type get(const frame& frm) const override
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
-            return (rs2_metadata_type)frm.get_frame_system_time();
-        }
-
-        bool supports(const frame& frm) const override
-        {
+            if( p_value )
+                *p_value = (rs2_metadata_type)frm.get_frame_system_time();
             return true;
         }
     };
@@ -141,25 +120,22 @@ namespace librealsense
         {
         }
 
-        rs2_metadata_type get(const librealsense::frame & frm) const override
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
-            auto s = reinterpret_cast<const S*>(((const uint8_t*)frm.additional_data.metadata_blob.data()) + _offset);
+            auto s = reinterpret_cast< const S * >( ( (const uint8_t *)frm.additional_data.metadata_blob.data() )
+                                                    + _offset );
 
-            if (!is_attribute_valid(s))
-                throw invalid_value_exception("metadata not available");
+            if( ! is_attribute_valid( s ) )
+                return false;
 
-            auto attrib = static_cast<rs2_metadata_type>((*s).*_md_attribute);
-            if( _modifyer )
-                attrib = _modifyer( attrib );
-            return attrib;
-        }
-
-        // Verifies that the parameter is both supported and available
-        bool supports(const librealsense::frame & frm) const override
-        {
-            auto s = reinterpret_cast<const S*>(((const uint8_t*)frm.additional_data.metadata_blob.data()) + _offset);
-
-            return is_attribute_valid(s);
+            if( p_value )
+            {
+                auto attrib = static_cast<rs2_metadata_type>((*s).*_md_attribute);
+                if( _modifyer )
+                    attrib = _modifyer( attrib );
+                *p_value = attrib;
+            }
+            return true;
         }
 
     protected:
@@ -215,18 +191,22 @@ namespace librealsense
         md_uvc_header_parser(Attribute St::* attribute_name, attrib_modifyer mod) :
             _md_attribute(attribute_name), _modifyer(mod){};
 
-        rs2_metadata_type get(const librealsense::frame & frm) const override
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
-            if (!supports(frm))
-                throw invalid_value_exception("UVC header is not available");
+            if( frm.additional_data.metadata_size < platform::uvc_header_size )
+                return false;
 
-            auto attrib =  static_cast<rs2_metadata_type>((*reinterpret_cast<const St*>((const uint8_t*)frm.additional_data.metadata_blob.data())).*_md_attribute);
-            if (_modifyer) attrib = _modifyer(attrib);
-            return attrib;
+            if( p_value )
+            {
+                auto attrib = static_cast< rs2_metadata_type >(
+                    ( *reinterpret_cast< const St * >( (const uint8_t *)frm.additional_data.metadata_blob.data() ) )
+                    .*_md_attribute );
+                if( _modifyer )
+                    attrib = _modifyer( attrib );
+                *p_value = attrib;
+            }
+            return true;
         }
-
-        bool supports(const librealsense::frame & frm) const override
-        { return (frm.additional_data.metadata_size >= platform::uvc_header_size); }
 
     private:
         md_uvc_header_parser() = delete;
@@ -252,20 +232,22 @@ namespace librealsense
         md_hid_header_parser(Attribute St::* attribute_name, attrib_modifyer mod) :
             _md_attribute(attribute_name), _modifyer(mod) {};
 
-        rs2_metadata_type get(const librealsense::frame & frm) const override
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
-            if (!supports(frm))
-                throw invalid_value_exception("HID header is not available");
+            if( frm.additional_data.metadata_size < hid_header_size )
+                return false;
 
-            auto attrib = static_cast<rs2_metadata_type>((*reinterpret_cast<const St*>((const uint8_t*)frm.additional_data.metadata_blob.data())).*_md_attribute);
-            attrib &= 0x00000000ffffffff;
-            if (_modifyer) attrib = _modifyer(attrib);
-            return attrib;
-        }
-
-        bool supports(const librealsense::frame & frm) const override
-        {
-            return (frm.additional_data.metadata_size >= hid_header_size);
+            if( p_value )
+            {
+                auto attrib = static_cast< rs2_metadata_type >(
+                    ( *reinterpret_cast< const St * >( (const uint8_t *)frm.additional_data.metadata_blob.data() ) )
+                    .*_md_attribute );
+                attrib &= 0x00000000ffffffff;
+                if( _modifyer )
+                    attrib = _modifyer( attrib );
+                *p_value = attrib;
+            }
+            return true;
         }
 
     private:
@@ -292,13 +274,12 @@ namespace librealsense
         md_additional_parser(Attribute St::* attribute_name) :
             _md_attribute(attribute_name) {};
 
-        rs2_metadata_type get(const librealsense::frame & frm) const override
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
-            return static_cast<rs2_metadata_type>(frm.additional_data.*_md_attribute);
+            if( p_value )
+                *p_value = static_cast< rs2_metadata_type >( frm.additional_data.*_md_attribute );
+            return true;
         }
-
-        bool supports(const librealsense::frame & frm) const override
-        { return true; }
 
     private:
         md_additional_parser() = delete;
@@ -330,33 +311,34 @@ namespace librealsense
 
         // The sensor's timestamp is defined as the middle of exposure time. Sensor_ts= Frame_ts - (Actual_Exposure/2)
         // For RS4xx the metadata payload holds only the (Actual_Exposure/2) offset, and the actual value needs to be calculated
-        rs2_metadata_type get(const librealsense::frame & frm) const override
+        bool find( const librealsense::frame & frm, rs2_metadata_type * p_value ) const override
         {
-            return _frame_ts_parser->get(frm) - _sensor_ts_parser->get(frm);
-        };
-
-        bool supports(const librealsense::frame & frm) const override
-        {
-            return (_sensor_ts_parser->supports(frm) && _frame_ts_parser->supports(frm));
-        };
+            rs2_metadata_type frame_value, sensor_value;
+            if( ! _sensor_ts_parser->find( frm, &sensor_value ) || ! _frame_ts_parser->find( frm, &frame_value ) )
+                return false;
+            if( p_value )
+                *p_value = frame_value - sensor_value;
+            return true;
+        }
     };
 
 
     class ds_md_attribute_actual_fps : public md_attribute_parser_base
     {
     public:
-        rs2_metadata_type get( const librealsense::frame & frm ) const override
+        bool find( const librealsense::frame & frm, rs2_metadata_type * p_value ) const override
         {
-            if( frm.additional_data.frame_number <= frm.additional_data.last_frame_number )
-                LOG_INFO( "Frame counter reset" );
-
-            return rs2_metadata_type( frm.calc_actual_fps() * 1000 );
-        }
-
-        bool supports(const librealsense::frame & frm) const override
-        {
-            // In case of frame counter reset fallback use fps from the stream configuration
-            return rs2_metadata_type( frm.calc_actual_fps() * 1000 ) > 0;
+            auto fps = rs2_metadata_type( frm.calc_actual_fps() * 1000 );
+            if( fps <= 0. )
+                // In case of frame counter reset fallback to fps from the stream configuration
+                return false;
+            if( p_value )
+            {
+                if( frm.additional_data.frame_number <= frm.additional_data.last_frame_number )
+                    LOG_INFO( "Frame counter reset" );  // TODO: this is not a good place!
+                *p_value = fps;
+            }
+            return true;
         }
     };
 

--- a/src/proc/syncer-processing-block.cpp
+++ b/src/proc/syncer-processing-block.cpp
@@ -14,7 +14,7 @@ namespace librealsense
         : processing_block("syncer"), _matcher((new composite_identity_matcher({})))
         , _enable_opts(enable_opts.begin(), enable_opts.end())
     {
-        _matcher->set_callback( [this]( frame_holder f, syncronization_environment env ) {
+        _matcher->set_callback( []( frame_holder f, syncronization_environment const & env ) {
             if( env.log )
             {
                 LOG_DEBUG( "<-- queueing " << f );

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -919,7 +919,7 @@ int rs2_supports_frame_metadata(const rs2_frame* frame, rs2_frame_metadata_value
 {
     VALIDATE_NOT_NULL(frame);
     VALIDATE_ENUM(frame_metadata);
-    return ((frame_interface*)frame)->supports_frame_metadata(frame_metadata);
+    return ((frame_interface*)frame)->find_metadata( frame_metadata, nullptr );
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, frame, frame_metadata)
 
@@ -927,7 +927,13 @@ rs2_metadata_type rs2_get_frame_metadata(const rs2_frame* frame, rs2_frame_metad
 {
     VALIDATE_NOT_NULL(frame);
     VALIDATE_ENUM(frame_metadata);
-    return ((frame_interface*)frame)->get_frame_metadata(frame_metadata);
+    auto frame_ifc = (frame_interface *)frame;
+    rs2_metadata_type value;
+    if( frame_ifc->find_metadata( frame_metadata, &value ) )
+        return value;
+    throw invalid_value_exception( rsutils::string::from()
+                                   << get_string( frame_ifc->get_stream()->get_stream_type() )
+                                   << " frame does not support metadata \"" << get_string( frame_metadata ) << "\"" );
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, frame, frame_metadata)
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -526,10 +526,7 @@ namespace librealsense
         if (a->get_frame_timestamp_domain() == b->get_frame_timestamp_domain())
             return{ a->get_frame_timestamp(), b->get_frame_timestamp() };
         else
-        {
-            return{ (double)a->get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL),
-                    (double)b->get_frame_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL) };
-        }
+            return{ a->get_frame_system_time(), b->get_frame_system_time() };
     }
 
     timestamp_composite_matcher::timestamp_composite_matcher(
@@ -571,10 +568,9 @@ namespace librealsense
     double timestamp_composite_matcher::get_fps( frame_interface const * f )
     {
         double fps = 0.;
-        if(f->supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
-        {
-            fps = f->get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.;
-        }
+        rs2_metadata_type fps_md;
+        if( f->find_metadata( RS2_FRAME_METADATA_ACTUAL_FPS, &fps_md ) )
+            fps = fps_md / 1000.;
         if( fps )
         {
             //LOG_DEBUG( "fps " << fps << " from metadata" );

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -563,22 +563,17 @@ namespace librealsense
 
     void timestamp_composite_matcher::update_last_arrived(frame_holder& f, matcher* m)
     {
-        if(f->supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
-            _fps[m] = (uint32_t)f->get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
-        else
-            _fps[m] = f->get_stream()->get_framerate();
-
         auto const now = time_service::get_time();
         //LOG_DEBUG( _name << ": _last_arrived[" << m->get_name() << "] = " << now );
         _last_arrived[m] = now;
     }
 
-    unsigned int timestamp_composite_matcher::get_fps( frame_interface const * f )
+    double timestamp_composite_matcher::get_fps( frame_interface const * f )
     {
-        uint32_t fps = 0;
+        double fps = 0.;
         if(f->supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
         {
-            fps = (uint32_t)f->get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
+            fps = f->get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.;
         }
         if( fps )
         {
@@ -597,7 +592,7 @@ namespace librealsense
                                                        const frame_holder & f )
     {
         auto fps = get_fps( f );
-        auto gap = 1000.f / (float)fps;
+        auto gap = 1000. / fps;
 
         auto ts = f.frame->get_frame_timestamp();
         auto ne = ts + gap;
@@ -687,7 +682,7 @@ namespace librealsense
         {
             // Wait for the missing stream frame to arrive -- up to a cutout: anything more and we
             // let the frameset be ready without it...
-            auto gap = 1000.f / fps;
+            auto gap = 1000. / fps;
             // NOTE: the threshold is a function of the gap; the bigger it is, the more latency
             // between the streams we're willing to live with. Each gap is a frame so we are limited
             // by the number of frames we're willing to keep (which is our queue limit)
@@ -714,10 +709,17 @@ namespace librealsense
                                  fps );  // should be min fps to match behavior elsewhere?
     }
 
-    bool timestamp_composite_matcher::are_equivalent( double a, double b, unsigned int fps )
+    bool timestamp_composite_matcher::are_equivalent( double a, double b, double fps )
     {
-        float gap = 1000.f / fps;
-        return abs(a - b) < (gap / 2);
+        auto gap = 1000. / fps;
+        if( abs( a - b ) < (gap / 2) )
+        {
+            //LOG_DEBUG( "...     " << a << " == " << b << "  {diff}" << abs( a - b ) << " < " << (gap / 2) << "{gap/2}" );
+            return true;
+        }
+
+        //LOG_DEBUG( "...     " << a << " != " << b << "  {diff}" << abs( a - b ) << " >= " << ( gap / 2 ) << "{gap/2}" );
+        return false;
     }
 
     composite_identity_matcher::composite_identity_matcher(

--- a/src/sync.h
+++ b/src/sync.h
@@ -180,10 +180,8 @@ namespace librealsense
                                    const frame_holder & f ) override;
 
     private:
-        unsigned int get_fps( frame_interface const * f );
-        bool are_equivalent( double a, double b, unsigned int fps );
+        double get_fps( frame_interface const * f );
+        bool are_equivalent( double a, double b, double fps );
         std::map<matcher*, double> _last_arrived;
-        std::map<matcher*, unsigned int> _fps;
-
     };
 }

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -154,6 +154,9 @@ void uvc_sensor::open( const stream_profiles & requests )
                                << rs2_timestamp_domain_to_string( timestamp_domain ) << ",last_frame_number,"
                                << last_frame_number << ",last_timestamp," << last_timestamp );
 
+                    if( frame_counter <= last_frame_number )
+                        LOG_INFO( "Frame counter reset" );
+
                     last_frame_number = frame_counter;
                     last_timestamp = timestamp;
 

--- a/unit-tests/live/syncer/test-throughput.cpp
+++ b/unit-tests/live/syncer/test-throughput.cpp
@@ -90,7 +90,7 @@ TEST_CASE( "Syncer dynamic FPS - throughput test" )
                 if (!f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS) || !f.supports_frame_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP))
                     return;
                 auto frame_num = f.get_frame_number();
-                auto actual_fps = (float)f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS);
+                auto actual_fps = f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS) / 1000.f;
                 auto frame_arrival = f.get_frame_metadata(RS2_FRAME_METADATA_FRAME_TIMESTAMP); // usec
                 if (stream_type == "Infrared 1")
                     _ir_frames_arrival_info.push_back({ (float)frame_arrival, actual_fps });

--- a/unit-tests/unit-tests-live.cpp
+++ b/unit-tests/unit-tests-live.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Sync sanity", "[live][mayfail]") {
         }
 
         std::vector<std::vector<double>> all_timestamps;
-        auto actual_fps = fps;
+        auto actual_fps = float( fps );
 
         for (auto i = 0; i < 200; i++)
         {
@@ -61,7 +61,7 @@ TEST_CASE("Sync sanity", "[live][mayfail]") {
 
                 if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                 {
-                    auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                    auto val = f.get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.f;
                     if (val < actual_fps)
                         actual_fps = val;
                 }
@@ -98,7 +98,7 @@ TEST_CASE("Sync sanity", "[live][mayfail]") {
                 continue;
 
             std::sort(set_timestamps.begin(), set_timestamps.end());
-            REQUIRE(set_timestamps[set_timestamps.size() - 1] - set_timestamps[0] <= (float)1000 / (float)actual_fps);
+            REQUIRE(set_timestamps[set_timestamps.size() - 1] - set_timestamps[0] <= 1000.f / actual_fps);
         }
 
         CAPTURE(num_of_partial_sync_sets);
@@ -2801,13 +2801,13 @@ TEST_CASE("Auto-complete feature works", "[offline][util::config][using_pipeline
 //}
 
 
-void validate(std::vector<std::vector<stream_profile>> frames, std::vector<std::vector<double>> timestamps, device_profiles requests, int actual_fps)
+void validate(std::vector<std::vector<stream_profile>> frames, std::vector<std::vector<double>> timestamps, device_profiles requests, float actual_fps)
 {
     REQUIRE(frames.size() > 0);
 
     int successful = 0;
 
-    auto gap = (float)1000 / (float)actual_fps;
+    auto gap = 1000.f / actual_fps;
 
     auto ts = 0;
 
@@ -2957,7 +2957,7 @@ TEST_CASE("Pipeline wait_for_frames", "[live][pipeline][using_pipeline][!mayfail
             for (auto i = 0; i < 30; i++)
                 REQUIRE_NOTHROW(pipe.wait_for_frames(10000));
 
-            auto actual_fps = pipeline_default_configurations.at(PID).fps;
+            auto actual_fps = float( pipeline_default_configurations.at(PID).fps );
 
             while (frames.size() < 100)
             {
@@ -2970,7 +2970,7 @@ TEST_CASE("Pipeline wait_for_frames", "[live][pipeline][using_pipeline][!mayfail
                 {
                     if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                     {
-                        auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                        auto val = f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS) / 1000.f;
                         if (val < actual_fps)
                             actual_fps = val;
                     }
@@ -3024,7 +3024,7 @@ TEST_CASE("Pipeline poll_for_frames", "[live][pipeline][using_pipeline][!mayfail
             for (auto i = 0; i < 30; i++)
                 REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
 
-            auto actual_fps = pipeline_default_configurations.at(PID).fps;
+            auto actual_fps = float( pipeline_default_configurations.at(PID).fps );
             while (frames.size() < 100)
             {
                 frameset frame;
@@ -3036,7 +3036,7 @@ TEST_CASE("Pipeline poll_for_frames", "[live][pipeline][using_pipeline][!mayfail
                     {
                         if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                         {
-                            auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                            auto val = f.get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.f;
                             if (val < actual_fps)
                                 actual_fps = val;
                         }
@@ -3117,7 +3117,7 @@ TEST_CASE("Pipeline enable stream", "[live][pipeline][using_pipeline]") {
         for (auto i = 0; i < 30; i++)
             REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
 
-        auto actual_fps = dev_requests[PID].fps;
+        auto actual_fps = float( dev_requests[PID].fps );
 
         while (frames.size() < 100)
         {
@@ -3130,7 +3130,7 @@ TEST_CASE("Pipeline enable stream", "[live][pipeline][using_pipeline]") {
             {
                 if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                 {
-                    auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                    auto val = f.get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.f;
                     if (val < actual_fps)
                         actual_fps = val;
                 }
@@ -3211,7 +3211,7 @@ TEST_CASE("Pipeline enable stream auto complete", "[live][pipeline][using_pipeli
             for (auto i = 0; i < 30; i++)
                 REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
 
-            auto actual_fps = configurations[PID].fps;
+            auto actual_fps = float( configurations[PID].fps );
 
             while (frames.size() < 100)
             {
@@ -3223,7 +3223,7 @@ TEST_CASE("Pipeline enable stream auto complete", "[live][pipeline][using_pipeli
                 {
                     if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                     {
-                        auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                        auto val = f.get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.f;
                         if (val < actual_fps)
                             actual_fps = val;
                     }
@@ -3288,7 +3288,7 @@ TEST_CASE("Pipeline disable_all", "[live][pipeline][using_pipeline][!mayfail]") 
             for (auto i = 0; i < 30; i++)
                 REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
 
-            auto actual_fps = default_configurations[PID].fps;
+            auto actual_fps = float( default_configurations[PID].fps );
 
             while (frames.size() < 100)
             {
@@ -3300,7 +3300,7 @@ TEST_CASE("Pipeline disable_all", "[live][pipeline][using_pipeline][!mayfail]") 
                 {
                     if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                     {
-                        auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                        auto val = f.get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.f;
                         if (val < actual_fps)
                             actual_fps = val;
                     }
@@ -3367,7 +3367,7 @@ TEST_CASE("Pipeline disable stream", "[live][pipeline][using_pipeline]") {
             for (auto i = 0; i < 30; i++)
                 REQUIRE_NOTHROW(pipe.wait_for_frames(5000));
 
-            auto actual_fps = configurations[PID].fps;
+            auto actual_fps = float( configurations[PID].fps );
             while (frames.size() < 100)
             {
                 frameset frame;
@@ -3378,7 +3378,7 @@ TEST_CASE("Pipeline disable stream", "[live][pipeline][using_pipeline]") {
                 {
                     if (f.supports_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS))
                     {
-                        auto val = static_cast<int>(f.get_frame_metadata(RS2_FRAME_METADATA_ACTUAL_FPS));
+                        auto val = f.get_frame_metadata( RS2_FRAME_METADATA_ACTUAL_FPS ) / 1000.f;
                         if (val < actual_fps)
                             actual_fps = val;
                     }


### PR DESCRIPTION
`RS2_FRAME_METADATA_ACTUAL_FPS` is now really the actual FPS, same as shown in the viewer as `Hardware FPS`, although with better precision:

* Changes the units of ACTUAL_FPS metadata to be *1000 (e.g., 30.1 fps will be represented as 30100 in metadata)
    * This is **NOT backwards-compatible**!
    * This greatly improves syncer accuracy at lower FPS (see #12315)
    * NOTE: this likely has implications for rosbag recordings, in that the old values will not be *1000... when tested, they play just fine but show the old values
* Removes discrete mode for ACTUAL_FPS
    * This was used in non-color (i.e., Depth, IR, etc.) `d400_device` derivatives; actual FPS will now be correct
* Removes use of ACTUAL_EXPOSURE as predictor of actual FPS
* If ACTUAL_FPS cannot be calculated (missing previous frame time, or getting a value ~0) then ACTUAL_FPS value will be missing (i.e., supports() will return false; contrast with the previous behavior, which instead put the stream FPS there)
* Simplifies metadata parsers: joins the supports() and get() functions into single find()
* Likewise implements a single virtual `frame_interface::find_metadata()` to both check and get metadata - should save on performance, especially relevant in the syncer

Related to [RSDSO-19336]