### PR TITLE
clean up libusb_config when compiling python bindings

### DIFF
--- a/CMake/external_libusb.cmake
+++ b/CMake/external_libusb.cmake
@@ -1,4 +1,10 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
 include(ExternalProject)
+
+message( STATUS "Fetching libusb..." )
+
 
 ExternalProject_Add(
     libusb
@@ -34,3 +40,6 @@ if (APPLE)
   find_library(iokit_lib IOKit)
   target_link_libraries(usb INTERFACE objc ${corefoundation_lib} ${iokit_lib})
 endif()
+
+message( STATUS "Fetching libusb - Done" )
+

--- a/CMake/global_config.cmake
+++ b/CMake/global_config.cmake
@@ -64,7 +64,6 @@ macro(global_set_flags)
     endif()
 
     if(BUILD_PYTHON_BINDINGS)
-        include(libusb_config)
         include(CMake/external_pybind11.cmake)
     endif()
 
@@ -95,7 +94,6 @@ macro(global_target_config)
             ${ROSBAG_HEADER_DIRS}
             ${BOOST_INCLUDE_PATH}
             ${LZ4_INCLUDE_PATH}
-            ${LIBUSB_LOCAL_INCLUDE_PATH}
         PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
No need to configure libusb when we build Python...

Tracked on [LRS-937]