### PR TITLE
fix pybackend missing udev watcher

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -148,6 +148,18 @@ if(APPLE)
 endif()
 endif()
 
+if(${BACKEND} STREQUAL RS2_USE_V4L2_BACKEND)
+    if(UDEV_FOUND)
+        target_sources( pybackend2
+            PRIVATE
+                ../../src/linux/udev-device-watcher.cpp
+                ../../src/linux/udev-device-watcher.h
+            )
+        target_link_libraries( pybackend2 PRIVATE udev )
+        target_compile_definitions( pybackend2 PRIVATE -DUSING_UDEV )
+    endif()
+endif()
+
 install(TARGETS pybackend2 pyrealsense2
     EXPORT pyrealsense2Targets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
Pybackend compiled, but didn't actually load in Linux because of missing udev-watcher!

`ImportError: /home/administrator/eran/librs/build/Release/pybackend2.cpython-39-x86_64-linux-gnu.so: undefined symbol: _ZN12librealsense19udev_device_watcherC1EPKNS_8platform7backendE`

Tracked on [LRS-938]