### PR TITLE
move all ExternalProjectTargets into '3rd Party'

### DIFF
--- a/CMake/external_catch2.cmake
+++ b/CMake/external_catch2.cmake
@@ -41,7 +41,7 @@ function(get_catch2)
 
     # place libraries with other 3rd-party projects
     set_target_properties( Catch2 Catch2WithMain PROPERTIES
-                           FOLDER "ExternalProjectTargets/catch2" )
+                           FOLDER "3rd Party/catch2" )
 
     message( STATUS "Fetching Catch2 - Done" )
 

--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -48,7 +48,7 @@ function(get_fastdds)
 
     # place FastDDS project with other 3rd-party projects
     set_target_properties(fastcdr fastrtps PROPERTIES
-                          FOLDER "ExternalProjectTargets/fastdds")
+                          FOLDER "3rd Party/fastdds")
 
     list(POP_BACK CMAKE_MESSAGE_INDENT) # Unindent outputs
 

--- a/CMake/external_libusb.cmake
+++ b/CMake/external_libusb.cmake
@@ -29,6 +29,8 @@ target_include_directories(usb INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINAR
 target_link_libraries(usb INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/libusb_install/lib/${CMAKE_STATIC_LIBRARY_PREFIX}usb${CMAKE_STATIC_LIBRARY_SUFFIX})
 set(USE_EXTERNAL_USB ON) # INTERFACE libraries can't have real deps, so targets that link with usb need to also depend on libusb
 
+set_target_properties( libusb PROPERTIES FOLDER "3rd Party")
+
 if (APPLE)
   find_library(corefoundation_lib CoreFoundation)
   find_library(iokit_lib IOKit)

--- a/CMake/external_pybind11.cmake
+++ b/CMake/external_pybind11.cmake
@@ -56,7 +56,7 @@ function(get_pybind11)
     add_subdirectory( "${CMAKE_BINARY_DIR}/third-party/pybind11"
                       "${CMAKE_BINARY_DIR}/third-party/pybind11/build" )
 
-    set_target_properties( pybind11 PROPERTIES FOLDER "ExternalProjectTargets" )
+    set_target_properties( pybind11 PROPERTIES FOLDER "3rd Party" )
 
     # Besides pybind11, any python module will also need to be installed using:
     #     install(

--- a/third-party/glfw/src/CMakeLists.txt
+++ b/third-party/glfw/src/CMakeLists.txt
@@ -95,7 +95,7 @@ set_target_properties(glfw PROPERTIES
                       VERSION ${GLFW_VERSION}
                       SOVERSION ${GLFW_VERSION_MAJOR}
                       POSITION_INDEPENDENT_CODE ON
-                      FOLDER "GLFW3")
+                      FOLDER "3rd Party")
 
 target_compile_definitions(glfw PRIVATE _GLFW_USE_CONFIG_H)
 target_include_directories(glfw PUBLIC


### PR DESCRIPTION
Today we have some projects, like GLFW3, outside any hierarchy in Visual Studio.
Others are in "ExternalProjectTargets", which isn't nice-looking.

This moves everything into `3rd Party`

Tracked on [LRS-939]