### PR TITLE
use RS2_API_FULL_VERSION_STR in tools

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -10,7 +10,7 @@
 #endif
 
 #include <librealsense2/hpp/rs_types.hpp>  // rs2_devices_changed_callback
-#include <librealsense2/rs.h>              // RS2_API_VERSION_STR
+#include <librealsense2/rs.h>              // RS2_API_FULL_VERSION_STR
 #include <src/librealsense-exception.h>
 
 #include <rsutils/easylogging/easyloggingpp.h>
@@ -29,7 +29,7 @@ namespace librealsense
         if( ! version_logged )
         {
             version_logged = true;
-            LOG_DEBUG( "Librealsense VERSION: " << RS2_API_VERSION_STR );
+            LOG_DEBUG( "Librealsense VERSION: " << RS2_API_FULL_VERSION_STR );
         }
 
         _factories.push_back( std::make_shared< backend_device_factory >(

--- a/tools/benchmark/rs-benchmark.cpp
+++ b/tools/benchmark/rs-benchmark.cpp
@@ -222,7 +222,7 @@ int main(int argc, char** argv) try
         return EXIT_SUCCESS;
     }
 
-    CmdLine cmd("librealsense rs-benchmark tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-benchmark tool", ' ', RS2_API_FULL_VERSION_STR);
     cmd.parse(argc, argv);
 
     glfwInit();

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -300,7 +300,7 @@ void output_modes( std::vector< stream_profile > const & profiles, bool verbose,
 
 int main(int argc, char** argv) try
 {
-    CmdLine cmd("librealsense rs-enumerate-devices tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-enumerate-devices tool", ' ', RS2_API_FULL_VERSION_STR);
 
     SwitchArg debug_arg( "", "debug", "Turn on LibRS debug logs" );
     SwitchArg short_view_arg("s", "short", "Provide a one-line summary of the devices");

--- a/tools/fw-logger/rs-fw-logger.cpp
+++ b/tools/fw-logger/rs-fw-logger.cpp
@@ -28,7 +28,7 @@ string datetime_string()
 int main(int argc, char* argv[])
 {
     int default_polling_interval_ms = 100;
-    CmdLine cmd("librealsense rs-fw-logger example tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-fw-logger example tool", ' ', RS2_API_FULL_VERSION_STR);
     ValueArg<string> sn_arg("s", "sn", "camera serial number", false, "", "camera serial number");
     ValueArg<string> xml_arg("l", "load", "Full file path of HW Logger Events XML file", false, "", "Load HW Logger Events XML file");
     ValueArg<string> out_arg("o", "out", "Full file path of output file", false, "", "Print Fw logs to output file");

--- a/tools/fw-update/rs-fw-update.cpp
+++ b/tools/fw-update/rs-fw-update.cpp
@@ -220,7 +220,7 @@ try
 
     bool done = false;
 
-    CmdLine cmd("librealsense rs-fw-update tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-fw-update tool", ' ', RS2_API_FULL_VERSION_STR);
 
     SwitchArg list_devices_arg("l", "list_devices", "List all available devices");
     SwitchArg recover_arg("r", "recover", "Recover all connected devices which are in recovery mode");

--- a/tools/terminal/rs-terminal.cpp
+++ b/tools/terminal/rs-terminal.cpp
@@ -164,7 +164,7 @@ rs2::device wait_for_device(const rs2::device_hub& hub, bool print_info = true)
 
 int main(int argc, char** argv)
 {
-    CmdLine cmd("librealsense rs-terminal tool", ' ', RS2_API_VERSION_STR);
+    CmdLine cmd("librealsense rs-terminal tool", ' ', RS2_API_FULL_VERSION_STR);
     SwitchArg debug_arg( "", "debug", "Turn on LibRS debug logs" );
     ValueArg<string> xml_arg("l", "load", "Full file path of commands XML file", false, "", "Load commands XML file");
     ValueArg<int> device_id_arg("d", "deviceId", "Device ID could be obtain from rs-enumerate-devices example", false, 0, "Select a device to work with");


### PR DESCRIPTION
Tools just show a --version like 2.55.0 which isn't helpful, especially during development. Add the build component.

Tracked on [LRS-940]