### PR TITLE
Eth misc

### DIFF
--- a/common/metadata-helper.cpp
+++ b/common/metadata-helper.cpp
@@ -54,6 +54,8 @@ namespace rs2
 
     class windows_metadata_helper : public metadata_helper
     {
+        using super = metadata_helper;
+
     public:
         static bool parse_device_id(const std::string& id, device_id* res)
         {
@@ -239,11 +241,13 @@ namespace rs2
 
         bool is_enabled(std::string id) const override
         {
-            bool res = false;
-
             device_id did;
-            if (parse_device_id(id, &did))
-                foreach_device_path({ did }, [&res, did](const device_id&, std::wstring path) {
+            if( ! parse_device_id( id, &did ) )
+                // If it's not parsed, it's not a valid USB device; return the default
+                return super::is_enabled( id );
+
+            bool res = false;
+            foreach_device_path({ did }, [&res, did](const device_id&, std::wstring path) {
 
                 HKEY key;
                 if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, path.c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &key) == ERROR_SUCCESS)

--- a/common/metadata-helper.h
+++ b/common/metadata-helper.h
@@ -25,7 +25,7 @@ namespace rs2
 
         static bool can_support_metadata(const std::string& product)
         {
-            return product == "D400";
+            return product == "D400" || product == "D500";
         }
 
         // This is the command-line parameter that gets passed to another process (running as admin) in order to enable metadata -- see WinMain

--- a/scripts/realsense_metadata_win10.ps1
+++ b/scripts/realsense_metadata_win10.ps1
@@ -77,7 +77,8 @@ $MultiPinDevices =
     "USB\VID_8086&PID_0B5B&MI_00",# D405
     "USB\VID_8086&PID_0B5C&MI_00",# D455
     "USB\VID_8086&PID_0B64&MI_00",# L515
-    "USB\VID_8086&PID_0B68&MI_00" # L535
+    "USB\VID_8086&PID_0B68&MI_00",# L535
+    "USB\VID_8086&PID_0B56&MI_00" # D555e
 
 #Inhibit system warnings and erros, such as permissions or missing values
 $ErrorActionPreference = "silentlycontinue"

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -343,7 +343,12 @@ void dds_device::impl::open( const dds_stream_profiles & profiles )
         { "stream-profiles", stream_profiles },
     };
 
-    write_control_message( j );
+    nlohmann::json reply;
+    write_control_message( j, &reply );
+
+    if( rsutils::json::get( reply, status_key, status_ok ) != status_ok )
+        throw std::runtime_error( "failed to open stream: "
+                                  + rsutils::json::get< std::string >( reply, explanation_key, "no explanation" ) );
 }
 
 

--- a/unit-tests/dds/metadata-server.py
+++ b/unit-tests/dds/metadata-server.py
@@ -22,6 +22,11 @@ color_stream.init_profiles( d435i.color_stream_profiles(), 0 )
 color_stream.init_options( [] )
 color_stream.set_intrinsics( d435i.color_stream_intrinsics() )
 
+def on_control( server, id, control, reply ):
+    # the control has already been output to debug by the calling code, as will the reply
+    return True  # otherwise the control will be flagged as error
+
+device_server.on_control( on_control )
 device_server.init( [color_stream], [], {} )
 
 


### PR DESCRIPTION
* wait for a reply for dds-device open-streams
  * Without this, `open-streams` is received after the stream is already open
* add eth PID to windows metadata script
* add D500 to metadata helper (missing from dev branch)
* metadata_helper::is_enabled() now returns true if not a USB device

Tracked on [LRS-871]