### PR TITLE
Fix dependencies in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,6 @@
 
 <!-- This file is only used to enable the building librealsense2 -->
 <!-- as a debian package for use with ROS 2 (http://ros.org) -->
-<!-- via ament_cmake (which invokes cmake) -->
 
 <package format="2">
   <name>librealsense2</name>
@@ -20,7 +19,7 @@
 
   <license>Apache License, Version 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
 
   <build_depend>pkg-config</build_depend>
 
@@ -36,6 +35,6 @@
   <depend>opengl</depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>cmake</build_type>
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <build_depend>libssl-dev</build_depend>
   <build_depend>libudev-dev</build_depend>
   <build_depend>dkms</build_depend>
+  <build_depend>git</build_depend>
   <build_depend>udev</build_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -31,6 +31,10 @@
   <build_depend>git</build_depend>
   <build_depend>udev</build_depend>
 
+  <depend>libx11</depend>
+  <depend>libglfw3-dev</depend>
+  <depend>opengl</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
This is a rebase of #12343 onto the `development` branch.
There were several missing build and exec dependencies.
Further, building doesn't require ament_cmake. cmake is sufficient.