### PR TITLE
revise dds metadata handling with overrides & depth-units

### DIFF
--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -103,10 +103,13 @@ config_file::config_file(std::string filename)
         if (!t.good()) return;
         std::string str((std::istreambuf_iterator<char>(t)),
                  std::istreambuf_iterator<char>());
-        auto j = json::parse(str);
-        for (json::iterator it = j.begin(); it != j.end(); ++it) 
+        if( ! str.empty() )
         {
-            _values[it.key()] = it.value().get<std::string>();
+            auto j = json::parse( str );
+            for( json::iterator it = j.begin(); it != j.end(); ++it )
+            {
+                _values[it.key()] = it.value().get< std::string >();
+            }
         }
     }
     catch(...)

--- a/src/dds/rs-dds-depth-sensor-proxy.cpp
+++ b/src/dds/rs-dds-depth-sensor-proxy.cpp
@@ -1,0 +1,63 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include "rs-dds-depth-sensor-proxy.h"
+#include "rs-dds-option.h"
+
+#include <src/librealsense-exception.h>
+#include <rsutils/json.h>
+
+
+namespace librealsense {
+
+
+static const std::string metadata_header_key( "header", 6 );
+static const std::string depth_units_key( "depth-units", 11 );
+
+
+float dds_depth_sensor_proxy::get_depth_scale() const
+{
+    if( auto opt = get_option_handler( RS2_OPTION_DEPTH_UNITS ) )
+    {
+        // We don't want to do a long control-reply cycle on a value that gets updated automatically
+        if( auto dds_option = std::dynamic_pointer_cast< rs_dds_option >( opt ) )
+            return dds_option->get_last_known_value();
+        else
+            return opt->query();
+    }
+    // Rather than throwing an exception, we try to be a little more helpful: without depth units, the depth image will
+    // show black, prompting bug reports. The D400 units min/max are taken from the HW, but the default is set to:
+    return 0.001f;
+}
+
+
+void dds_depth_sensor_proxy::add_no_metadata( frame * const f, streaming_impl & streaming )
+{
+    f->additional_data.depth_units = get_depth_scale();
+    super::add_no_metadata( f, streaming );
+}
+
+
+void dds_depth_sensor_proxy::add_frame_metadata( frame * const f, nlohmann::json && dds_md, streaming_impl & streaming )
+{
+    if( auto du = rsutils::json::nested( dds_md, metadata_header_key, depth_units_key ) )
+    {
+        try
+        {
+            f->additional_data.depth_units = rsutils::json::value< float >( du );
+        }
+        catch( nlohmann::json::exception const & )
+        {
+            f->additional_data.depth_units = get_depth_scale();
+        }
+    }
+    else
+    {
+        f->additional_data.depth_units = get_depth_scale();
+    }
+
+    super::add_frame_metadata( f, std::move( dds_md ), streaming );
+}
+
+
+}  // namespace librealsense

--- a/src/dds/rs-dds-depth-sensor-proxy.h
+++ b/src/dds/rs-dds-depth-sensor-proxy.h
@@ -14,16 +14,22 @@ class dds_depth_sensor_proxy
     : public dds_sensor_proxy
     , public depth_sensor
 {
+    using super = dds_sensor_proxy;
+
 public:
     dds_depth_sensor_proxy( std::string const & sensor_name,
                             software_device * owner,
                             std::shared_ptr< realdds::dds_device > const & dev )
-        : dds_sensor_proxy( sensor_name, owner, dev )
+        : super( sensor_name, owner, dev )
     {
     }
 
     // Needed by abstract interfaces
-    float get_depth_scale() const override { return get_option( RS2_OPTION_DEPTH_UNITS ).query(); }
+    float get_depth_scale() const override;
+
+protected:
+    void add_no_metadata( frame *, streaming_impl & ) override;
+    void add_frame_metadata( frame * const f, nlohmann::json && dds_md, streaming_impl & streaming ) override;
 };
 
 

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -9,6 +9,7 @@
 #include <realdds/dds-device.h>
 #include <realdds/dds-stream.h>
 #include <realdds/dds-trinsics.h>
+#include <realdds/dds-participant.h>
 
 #include <realdds/topics/device-info-msg.h>
 #include <realdds/topics/flexible-msg.h>
@@ -335,6 +336,17 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
         }
     }
     // TODO - need to register extrinsics group in dev?
+
+    // Use the default D400 matchers:
+    // Depth & IR matched by frame-number, time-stamp-matched to color.
+    // Motion streams will not get synced.
+    rs2_matchers matcher = RS2_MATCHER_DLR_C;
+    if( auto matcher_j = rsutils::json::nested( _dds_dev->participant()->settings(), "device", "matcher" ) )
+    {
+        if( ! matcher_j->is_string() || ! try_parse( matcher_j.string_ref(), matcher ) )
+            LOG_WARNING( "Invalid 'device/matcher' value " << matcher_j );
+    }
+    set_matcher_type( matcher );
 }
 
 

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -204,7 +204,7 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
             auto const & default_profile = profiles[stream->default_profile_index()];
             for( auto & profile : profiles )
             {
-                LOG_DEBUG( "    " << profile->details_to_string() );
+                //LOG_DEBUG( "    " << profile->details_to_string() );
                 if( video_stream )
                 {
                     auto video_profile = std::static_pointer_cast< realdds::dds_video_stream_profile >( profile );
@@ -244,17 +244,17 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
         // Set profile's ID based on the dds_stream's ID (index already set). Connect the profile to the extrinsics graph.
         for( auto & profile : sensor_info.second.proxy->get_stream_profiles() )
         {
-            if( auto p = std::dynamic_pointer_cast< librealsense::video_stream_profile_interface >( profile ) )
-            {
-                LOG_DEBUG( "    " << get_string( p->get_stream_type() ) << ' ' << p->get_stream_index() << ' '
-                                  << get_string( p->get_format() ) << ' ' << p->get_width() << 'x' << p->get_height()
-                                  << " @ " << p->get_framerate() );
-            }
-            else if( auto p = std::dynamic_pointer_cast<librealsense::motion_stream_profile_interface>( profile ) )
-            {
-                LOG_DEBUG( "    " << get_string( p->get_stream_type() ) << ' ' << p->get_stream_index() << ' '
-                                  << get_string( p->get_format() ) << " @ " << p->get_framerate() );
-            }
+            //if( auto p = std::dynamic_pointer_cast< librealsense::video_stream_profile_interface >( profile ) )
+            //{
+            //    LOG_DEBUG( "    " << get_string( p->get_stream_type() ) << ' ' << p->get_stream_index() << ' '
+            //                      << get_string( p->get_format() ) << ' ' << p->get_width() << 'x' << p->get_height()
+            //                      << " @ " << p->get_framerate() );
+            //}
+            //else if( auto p = std::dynamic_pointer_cast<librealsense::motion_stream_profile_interface>( profile ) )
+            //{
+            //    LOG_DEBUG( "    " << get_string( p->get_stream_type() ) << ' ' << p->get_stream_index() << ' '
+            //                      << get_string( p->get_format() ) << " @ " << p->get_framerate() );
+            //}
             sid_index type_and_index( profile->get_stream_type(), profile->get_stream_index() );
             
             auto & streams = sensor_info.second.proxy->streams();

--- a/src/dds/rs-dds-option.cpp
+++ b/src/dds/rs-dds-option.cpp
@@ -41,6 +41,13 @@ float rs_dds_option::query() const
 }
 
 
+float rs_dds_option::get_last_known_value() const
+{
+    return _dds_opt->get_value();
+}
+
+
+
 const char * rs_dds_option::get_description() const
 {
     return _dds_opt->get_description().c_str();

--- a/src/dds/rs-dds-option.h
+++ b/src/dds/rs-dds-option.h
@@ -37,6 +37,8 @@ public:
 
     void set( float value ) override;
 
+    float get_last_known_value() const;
+
     float query() const override;
 
     bool is_enabled() const override { return true; }

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -412,7 +412,11 @@ void dds_sensor_proxy::add_frame_metadata( frame * const f, nlohmann::json && dd
         std::string const & keystr = librealsense::get_string( key );
         try
         {
-            metadata[key] = { true, rsutils::json::get< rs2_metadata_type >( md, keystr ) };
+            if( auto value = rsutils::json::nested( md, keystr ) )
+            {
+                if( value->is_number_integer() )
+                    metadata[key] = { true, rsutils::json::get< rs2_metadata_type >( md, keystr ) };
+            }
         }
         catch( nlohmann::json::exception const & )
         {

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -39,7 +39,6 @@ static const std::string frame_number_key( "frame-number", 12 );
 static const std::string metadata_key( "metadata", 8 );
 static const std::string timestamp_key( "timestamp", 9 );
 static const std::string timestamp_domain_key( "timestamp-domain", 16 );
-static const std::string depth_units_key( "depth-units", 11 );
 static const std::string metadata_header_key( "header", 6 );
 
 
@@ -303,6 +302,7 @@ void dds_sensor_proxy::handle_video_data( realdds::topics::image_msg && dds_fram
     }
     else
     {
+        add_no_metadata( new_frame, streaming );
         invoke_new_frame( new_frame,
                           nullptr,    // pixels are already inside new_frame->data
                           nullptr );  // so no deleter is necessary
@@ -360,20 +360,20 @@ void dds_sensor_proxy::handle_new_metadata( std::string const & stream_name, nlo
 }
 
 
+void dds_sensor_proxy::add_no_metadata( frame * const f, streaming_impl & streaming )
+{
+    // Without MD, we have no way of knowing the frame-number - we assume it's one higher than the last
+    f->additional_data.last_frame_number = streaming.last_frame_number.fetch_add( 1 );
+    f->additional_data.frame_number = f->additional_data.last_frame_number + 1;
+
+    // the frame should already have empty metadata, so no need to do anything else
+}
+
+
 void dds_sensor_proxy::add_frame_metadata( frame * const f, nlohmann::json && dds_md, streaming_impl & streaming )
 {
-    if( dds_md.empty() )
-    {
-        // Without MD, we have no way of knowing the frame-number - we assume it's one higher than
-        // the last
-        f->additional_data.last_frame_number = streaming.last_frame_number.fetch_add( 1 );
-        f->additional_data.frame_number = f->additional_data.last_frame_number + 1;
-        // the frame should already have empty metadata, so no need to do anything else
-        return;
-    }
-
-    nlohmann::json const & md_header = dds_md[metadata_header_key];
-    nlohmann::json const & md = dds_md[metadata_key];
+    nlohmann::json const & md_header = rsutils::json::nested( dds_md, metadata_header_key );
+    nlohmann::json const & md = rsutils::json::nested( dds_md, metadata_key );
 
     // A frame number is "optional". If the server supplies it, we try to use it for the simple fact that,
     // otherwise, we have no way of detecting drops without some advanced heuristic tracking the FPS and
@@ -401,27 +401,27 @@ void dds_sensor_proxy::add_frame_metadata( frame * const f, nlohmann::json && dd
     f->additional_data.timestamp;
     rsutils::json::get_ex( md_header, timestamp_domain_key, &f->additional_data.timestamp_domain );
 
-    // Expected metadata for all depth images
-    rsutils::json::get_ex( md_header, depth_units_key, &f->additional_data.depth_units );
-
-    // Other metadata fields. Metadata fields that are present but unknown by librealsense will be ignored.
-    auto & metadata = reinterpret_cast< metadata_array & >( f->additional_data.metadata_blob );
-    for( size_t i = 0; i < static_cast< size_t >( RS2_FRAME_METADATA_COUNT ); ++i )
+    if( ! md.empty() )
     {
-        auto key = static_cast< rs2_frame_metadata_value >( i );
-        std::string const & keystr = librealsense::get_string( key );
-        try
+        // Other metadata fields. Metadata fields that are present but unknown by librealsense will be ignored.
+        auto & metadata = reinterpret_cast< metadata_array & >( f->additional_data.metadata_blob );
+        for( size_t i = 0; i < static_cast< size_t >( RS2_FRAME_METADATA_COUNT ); ++i )
         {
-            if( auto value = rsutils::json::nested( md, keystr ) )
+            auto key = static_cast< rs2_frame_metadata_value >( i );
+            std::string const & keystr = librealsense::get_string( key );
+            try
             {
-                if( value->is_number_integer() )
-                    metadata[key] = { true, rsutils::json::get< rs2_metadata_type >( md, keystr ) };
+                if( auto value = rsutils::json::nested( md, keystr ) )
+                {
+                    if( value->is_number_integer() )
+                        metadata[key] = { true, rsutils::json::get< rs2_metadata_type >( md, keystr ) };
+                }
             }
-        }
-        catch( nlohmann::json::exception const & )
-        {
-            // The metadata key doesn't exist or the value isn't the right type... we ignore it!
-            // (all metadata is not there when we create the frame, so no need to erase)
+            catch( nlohmann::json::exception const & )
+            {
+                // The metadata key doesn't exist or the value isn't the right type... we ignore it!
+                // (all metadata is not there when we create the frame, so no need to erase)
+            }
         }
     }
 }
@@ -447,7 +447,10 @@ void dds_sensor_proxy::start( rs2_frame_callback_sptr callback )
             {
                 if( _is_streaming ) // stop was not called
                 {
-                    add_frame_metadata( static_cast< frame * >( fh.get() ), std::move( md ), streaming );
+                    if( md.empty() )
+                        add_no_metadata( static_cast< frame * >( fh.get() ), streaming );
+                    else
+                        add_frame_metadata( static_cast< frame * >( fh.get() ), std::move( md ), streaming );
                     invoke_new_frame( static_cast< frame * >( fh.release() ), nullptr, nullptr );
                 }
             } );

--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -45,12 +45,14 @@ class dds_sensor_proxy : public software_sensor
     typedef realdds::dds_metadata_syncer syncer_type;
     static void frame_releaser( syncer_type::frame_type * f ) { static_cast< frame * >( f )->release(); }
 
+protected:
     struct streaming_impl
     {
         syncer_type syncer;
         std::atomic< unsigned long long > last_frame_number{ 0 };
     };
 
+private:
     std::map< sid_index, std::shared_ptr< realdds::dds_stream > > _streams;
     std::map< std::string, streaming_impl > _streaming_by_name;
 
@@ -77,7 +79,7 @@ public:
 
     const std::map< sid_index, std::shared_ptr< realdds::dds_stream > > & streams() const { return _streams; }
 
-private:
+protected:
     void register_basic_converters();
     stream_profiles init_stream_profiles() override;
 
@@ -95,7 +97,8 @@ private:
                              streaming_impl & );
     void handle_new_metadata( std::string const & stream_name, nlohmann::json && metadata );
 
-    void add_frame_metadata( frame * const, nlohmann::json && metadata, streaming_impl & );
+    virtual void add_no_metadata( frame *, streaming_impl & );
+    virtual void add_frame_metadata( frame * const, nlohmann::json && metadata, streaming_impl & );
 
     friend class dds_device_proxy;  // Currently calls handle_new_metadata
 };

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -129,7 +129,7 @@ stream_profiles formats_converter::get_all_possible_profiles( const stream_profi
                             target.resolution_transform( width, height );
                             cloned_vsp->set_dims( width, height );
                         }
-                        LOG_DEBUG( "         -> " << cloned_profile );
+                        LOG_DEBUG( "          -> " << cloned_profile );
 
                         // Cache pbf supported profiles for efficiency in find_pbf_matching_most_profiles
                         _pbf_supported_profiles[pbf.get()].push_back( cloned_profile );

--- a/src/software-device.cpp
+++ b/src/software-device.cpp
@@ -6,6 +6,7 @@
 #include "environment.h"
 #include "core/matcher-factory.h"
 #include "core/notification.h"
+#include "stream.h"
 
 
 namespace librealsense
@@ -67,13 +68,16 @@ namespace librealsense
 
     std::shared_ptr<matcher> software_device::create_matcher(const frame_holder& frame) const
     {
-        std::vector<stream_interface*> profiles;
+        using stream_uid = std::pair< rs2_stream, int >;
+        std::set< stream_uid > streams;
+        std::vector< stream_interface * > stream_interfaces;
 
-        for (auto&& s : _software_sensors)
-            for (auto&& p : s->get_stream_profiles())
-                profiles.push_back(p.get());
+        for( auto const & s : _software_sensors )
+            for( auto const & p : s->_sw_profiles )
+                if( streams.insert( { p->get_stream_type(), p->get_unique_id() } ).second )
+                    stream_interfaces.push_back( p.get() );
 
-        return matcher_factory::create(_matcher, profiles);
+        return matcher_factory::create( _matcher, stream_interfaces );
     }
 
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -193,7 +193,7 @@ namespace librealsense
                 return matcher;
             }
         }
-        LOG_DEBUG( "no matcher found for " << get_abbr_string( stream_type ) << '.' << stream_id
+        LOG_DEBUG( "no matcher found for " << get_abbr_string( stream_type ) << stream_id
                                            << "; creating matcher from device..." );
 
         auto sensor = frame.frame->get_sensor().get(); //TODO: Potential deadlock if get_sensor() gets a hold of the last reference of that sensor

--- a/third-party/realdds/doc/device.md
+++ b/third-party/realdds/doc/device.md
@@ -27,21 +27,55 @@ Currently, the topic root as used by `rs-dds-adapter` is built as:
 
 ## Settings
 
-On the client, device behavior with librealsense can be fine-tuned with certain JSON settings passed through the participant (and therefore from the librealsense context's `dds` settings):
+On the client, device behavior with librealsense can be fine-tuned with JSON settings passed through the participant (and therefore from the librealsense context's `dds` settings), inside a `device` object:
+
+```JSON
+{
+  "dds": {
+    "device": {
+      "control": { "reply-timeout-ms": 2000 },
+      "metadata": { "reliability": "reliable" }
+    }
+  }
+}
+```
+
+The above overrides the default reply timeout to 2 seconds and makes the metadata topic use reliable QoS rather than the default `best-effort`.
+
+#### Standard topic QoS settings
+
+`control`, `notification`, and `metadata` topics all can have their own objects to override default QoS and other settings. See the above for an example. They all share common settings:
+
+* `reliability` can be a string denoting the `kind`, or an object:
+    * `kind` is `best-effort` or `reliable`
+* `durability` can be a string denoting the `kind`, or an object:
+    * `kind` is `volatile`, `transient-local`, `transient`, or `persistent`
+* `history` can be a number denoting the `depth`, or an object:
+    * `kind` is `keep-last` or `keep-all`
+    * `depth` is the number of samples to manage with `keep-last`
+* `data-sharing` is a boolean: `true` to automatically enable if needed; `false` to turn off
+* `endpoint` is an object:
+    * `history-memory-policy` is `preallocated`, `preallocated-with-realloc`, `dynamic-reserve`, or `dynamic-reusable`
+
+Note that these settings are **overrides**. The default values may be different depending on the topic for which they're intended (for example, `metadata` uses `best-effort` by default while `control` and `notification` use `reliable`).
+
+#### Other Settings
 
 | Field                    | Default | Type    | Description        |
-|--------------------------|---------|---------|--------------------|
-| device-reply-timeout-ms  |    1000 | size_t  | How long to wait for a control reply to arrive, in millisec
-| disable-metadata         |   false | bool    | When true, the metadata topic will be disabled, even with metadata-enabled streams
+|--------------------------|--------:|---------|--------------------|
+| `control`/
+| &nbsp;&nbsp;&nbsp;&nbsp;`reply-timeout-ms` |    1000 | size_t  | How long to wait for a control reply to arrive, in milliseconds
 
-To control device-level options of the server's, controls need to be sent.
-The server should publish its device options as part of the initialization sequence, in the `device-options` message.
-If available, the [`query-option` and `set-option` controls](control.md#query-option--set-option) can be used (no `owner-name`) to retrieve or update the values. **Setting these options will not take effect until the device is reset.**
+#### Device Options
 
-The following settings may have options available for controlling:
+To use device-level options, the control-reply needs to be used.
+The server publishes device options as part of the initialization sequence, in the `device-options` message.
+If available, the [`query-option` and `set-option` controls](control.md#query-option--set-option) can be used (no `stream-name`) to retrieve or update the values. **Setting these options will not take effect until the device is reset.**
+
+The following device options may be available:
 
 | Setting        | Default | Type             | `option-name`   | Description
-|----------------|---------|------------------|-----------------|---------------
+|----------------|--------:|------------------|-----------------|---------------
 | Domain ID      |       0 | int 0-232        | `domain-id`     | The DDS domain number to use to segment communications on the network
 | IP address     |       ? | string "#.#.#.#" | `ip-address`    | The static IP that the server uses for itself (if DHCP is off)
 | DHCP enable    |       ? | bool             | `dhcp`          | If on, the `ip-address` is ignored and retrieved on startup from a DHCP server

--- a/third-party/realdds/doc/device.md
+++ b/third-party/realdds/doc/device.md
@@ -64,7 +64,7 @@ Note that these settings are **overrides**. The default values may be different 
 | Field                    | Default | Type    | Description        |
 |--------------------------|--------:|---------|--------------------|
 | `control`/
-| &nbsp;&nbsp;&nbsp;&nbsp;`reply-timeout-ms` |    1000 | size_t  | How long to wait for a control reply to arrive, in milliseconds
+| &nbsp;&nbsp;&nbsp;&nbsp;`reply-timeout-ms` |    2000 | size_t  | Reply timeout, in milliseconds
 
 #### Device Options
 

--- a/third-party/realdds/include/realdds/dds-serialization.h
+++ b/third-party/realdds/include/realdds/dds-serialization.h
@@ -1,0 +1,89 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <fastdds/dds/core/policy/QosPolicies.hpp>
+
+#include <nlohmann/json_fwd.hpp>
+#include <iosfwd>
+
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+std::ostream & operator<<( std::ostream &, ReliabilityQosPolicyKind );
+std::ostream & operator<<( std::ostream &, ReliabilityQosPolicy const & );
+std::ostream & operator<<( std::ostream &, DurabilityQosPolicyKind );
+std::ostream & operator<<( std::ostream &, DurabilityQosPolicy const & );
+std::ostream & operator<<( std::ostream &, HistoryQosPolicy const & );
+std::ostream & operator<<( std::ostream &, DataSharingQosPolicy const & );
+std::ostream & operator<<( std::ostream &, RTPSEndpointQos const & );
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+std::ostream & operator<<( std::ostream &, class WriterProxyData const & );
+std::ostream & operator<<( std::ostream &, class ReaderProxyData const & );
+}  // namespace rtps
+}  // namespace fastrtps
+}  // namespace eprosima
+
+
+namespace realdds {
+
+
+eprosima::fastdds::dds::ReliabilityQosPolicyKind reliability_kind_from_string( std::string const & );
+eprosima::fastdds::dds::DurabilityQosPolicyKind durability_kind_from_string( std::string const & );
+eprosima::fastdds::dds::HistoryQosPolicyKind history_kind_from_string( std::string const & );
+eprosima::fastrtps::rtps::MemoryManagementPolicy_t history_memory_policy_from_string( std::string const & );
+
+// Override QoS reliability from a JSON source.
+// The JSON can be a simple string indicating simple reliability kind:
+//      "reliability": "best-effort"  // <-- the JSON is the "best-effort" value
+// If an object, more detail is possible and it's possible to extend:
+//      "reliability": {
+//          "kind": "reliable"
+//          }
+//
+void override_reliability_qos_from_json( eprosima::fastdds::dds::ReliabilityQosPolicy & qos, nlohmann::json const & );
+
+// Override QoS durability from a JSON source.
+// The JSON can be a simple string indicating simple durability kind:
+//      "durability": "volatile"  // <-- the JSON is the "volatile" value
+// If an object, more detail is possible and it's possible to extend:
+//      "durability": {
+//          "kind": "persistent"
+//          }
+//
+void override_durability_qos_from_json( eprosima::fastdds::dds::DurabilityQosPolicy & qos, nlohmann::json const & );
+
+// Override QoS history from a JSON source.
+// The JSON can be a simple unsigned integer indicating simple history depth:
+//      "history": 10  // <-- the JSON is the 10 value
+// If an object, more detail is possible and it's possible to extend:
+//      "history": {
+//          "kind": "keep-last",
+//          "depth": 20
+//          }
+//
+void override_history_qos_from_json( eprosima::fastdds::dds::HistoryQosPolicy & qos, nlohmann::json const & );
+
+// Override QoS data-sharing from a JSON source.
+// The JSON can be a simple boolean indicating off or automatic mode:
+//      "data-sharing": true  // <-- the JSON is the true value
+//
+void override_data_sharing_qos_from_json( eprosima::fastdds::dds::DataSharingQosPolicy & qos, nlohmann::json const & );
+
+// Override QoS endpoint from a JSON source.
+// The JSON can is an object:
+//      "endpoint": {  // <-- the JSON is the true value
+//          "history-memory-policy": "preallocated-with-realloc"
+//          }
+//
+void override_endpoint_qos_from_json( eprosima::fastdds::dds::RTPSEndpointQos & qos, nlohmann::json const & );
+
+
+}  // namespace realdds

--- a/third-party/realdds/include/realdds/dds-topic-reader.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader.h
@@ -6,6 +6,7 @@
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 
+#include <nlohmann/json_fwd.hpp>
 #include <functional>
 #include <memory>
 
@@ -73,6 +74,9 @@ public:
                = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS,  // default
              eprosima::fastdds::dds::DurabilityQosPolicyKind durability
                = eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS );  // default is transient local
+
+        // Override default values with JSON contents
+        void override_from_json( nlohmann::json const & );
     };
 
     // The callbacks should be set before we actually create the underlying DDS objects, so the reader does not

--- a/third-party/realdds/include/realdds/dds-topic-writer.h
+++ b/third-party/realdds/include/realdds/dds-topic-writer.h
@@ -7,6 +7,7 @@
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include "dds-defines.h"
 
+#include <nlohmann/json_fwd.hpp>
 #include <memory>
 
 
@@ -71,6 +72,9 @@ public:
                = eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS,  // default
              eprosima::fastdds::dds::DurabilityQosPolicyKind durability
                = eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS );  // default is transient local
+    
+        // Override default values with JSON contents
+        void override_from_json( nlohmann::json const & );
     };
 
     // The callbacks should be set before we actually create the underlying DDS objects, so the writer does not

--- a/third-party/realdds/include/realdds/topics/flexible-msg.h
+++ b/third-party/realdds/include/realdds/topics/flexible-msg.h
@@ -75,10 +75,10 @@ public:
                            eprosima::fastdds::dds::SampleInfo * optional_info = nullptr );
 
     // WARNING: this moves the message content!
-    raw::flexible to_raw();
+    raw::flexible to_raw() &&;
     // WARNING: this moves the message content!
     // Returns some unique (to the writer) identifier for the sample that was sent, or 0 if unsuccessful
-    dds_sequence_number write_to( dds_topic_writer & );
+    dds_sequence_number write_to( dds_topic_writer & ) &&;
 
     flexible_msg() = default;
     flexible_msg( raw::flexible && );

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -482,7 +482,8 @@ PYBIND11_MODULE(NAME, m) {
         .def( "json_string",
               []( flexible_msg const & self )
               { return std::string( (char const *)self._data.data(), self._data.size() ); } )
-        .def( "write_to", &flexible_msg::write_to, py::call_guard< py::gil_scoped_release >() );
+        .def( "write_to",
+              []( flexible_msg & self, dds_topic_writer & writer ) { std::move( self ).write_to( writer ); } );
 
 
     using image_msg = realdds::topics::image_msg;

--- a/third-party/realdds/scripts/fps.py
+++ b/third-party/realdds/scripts/fps.py
@@ -40,7 +40,7 @@ dds.debug( args.debug )
 
 settings = {}
 if not args.with_metadata:
-    settings['disable-metadata'] = True
+    settings['device'] = { 'metadata' : False };
 
 participant = dds.participant()
 participant.init( args.domain, 'fps', settings )

--- a/third-party/realdds/src/dds-device-broadcaster.cpp
+++ b/third-party/realdds/src/dds-device-broadcaster.cpp
@@ -142,7 +142,7 @@ void dds_device_broadcaster::broadcast() const
     {
         topics::flexible_msg msg( _device_info.to_json() );
         LOG_DEBUG( "sending device-info message " << slice( msg.custom_data< char const >(), msg._data.size() ) );
-        msg.write_to( *_writer );
+        std::move( msg ).write_to( *_writer );
     }
     catch( std::exception const & e )
     {

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -423,7 +423,7 @@ float dds_device::impl::query_option_value( const std::shared_ptr< dds_option > 
 void dds_device::impl::write_control_message( topics::flexible_msg && msg, nlohmann::json * reply )
 {
     assert( _control_writer != nullptr );
-    auto this_sequence_number = msg.write_to( *_control_writer );
+    auto this_sequence_number = std::move( msg ).write_to( *_control_writer );
     if( reply )
     {
         std::unique_lock< std::mutex > lock( _replies_mutex );
@@ -437,7 +437,7 @@ void dds_device::impl::write_control_message( topics::flexible_msg && msg, nlohm
                                         return true;
                                     } ) )
         {
-            throw std::runtime_error( "timeout waiting for reply #" + std::to_string( this_sequence_number ) );
+            DDS_THROW( runtime_error, "timeout waiting for reply #" << this_sequence_number );
         }
         //LOG_DEBUG( "got reply: " << actual_reply );
         *reply = std::move( actual_reply );

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -139,7 +139,7 @@ dds_device::impl::impl( std::shared_ptr< dds_participant > const & participant,
     , _subscriber( std::make_shared< dds_subscriber >( participant ) )
     , _device_settings( device_settings( participant ) )
     , _reply_timeout_ms(
-          rsutils::json::nested( _device_settings, "control", "reply-timeout-ms" ).value< size_t >( 1000 ) )
+          rsutils::json::nested( _device_settings, "control", "reply-timeout-ms" ).value< size_t >( 2000 ) )
 {
     create_notifications_reader();
     create_control_writer();

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -46,6 +46,25 @@ static std::string const entries_key( "entries", 7 );
 static std::string const id_hwm( "hwm", 3 );
 
 
+namespace {
+
+
+nlohmann::json device_settings( std::shared_ptr< realdds::dds_participant > const & participant )
+{
+    nlohmann::json settings = rsutils::json::nested( participant->settings(), "device" );
+    if( settings.is_null() )
+        // Nothing there: default is empty object
+        return nlohmann::json::object();
+    if( ! settings.is_object() )
+        // Device settings, if they exist, must be an object!
+        DDS_THROW( runtime_error, "participant 'device' settings must be an object: " << settings );
+    return settings;
+}
+
+
+}
+
+
 namespace realdds {
 
 
@@ -78,9 +97,10 @@ void dds_device::impl::set_state( state_t new_state )
     {
         if( _metadata_reader )
         {
-            if( rsutils::json::get( _participant->settings(), "disable-metadata", false ) )
+            nlohmann::json md_settings = rsutils::json::nested( _device_settings, "metadata" );
+            if( ! md_settings.is_null() && ! md_settings.is_object() )  // not found is null
             {
-                LOG_DEBUG( "... metadata is available but 'disable-metadata' is set" );
+                LOG_DEBUG( "... metadata is available but device/metadata is disabled" );
                 _metadata_reader.reset();
             }
             else
@@ -88,6 +108,7 @@ void dds_device::impl::set_state( state_t new_state )
                 LOG_DEBUG( "... metadata is enabled" );
                 dds_topic_reader::qos rqos( eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS );
                 rqos.history().depth = 10; // Support receive metadata from multiple streams
+                rqos.override_from_json( md_settings );
                 _metadata_reader->run( rqos );
             }
         }
@@ -116,7 +137,9 @@ dds_device::impl::impl( std::shared_ptr< dds_participant > const & participant,
     : _info( info )
     , _participant( participant )
     , _subscriber( std::make_shared< dds_subscriber >( participant ) )
-    , _reply_timeout_ms( rsutils::json::get< size_t >( participant->settings(), "device-reply-timeout-ms", 1000 ) )
+    , _device_settings( device_settings( participant ) )
+    , _reply_timeout_ms(
+          rsutils::json::nested( _device_settings, "control", "reply-timeout-ms" ).value< size_t >( 1000 ) )
 {
     create_notifications_reader();
     create_control_writer();
@@ -438,6 +461,7 @@ void dds_device::impl::create_notifications_reader()
     //On discovery writer sends a burst of messages, if history is too small we might loose some of them
     //(even if reliable). Setting depth to cover known use-cases plus some spare
     rqos.history().depth = 24;
+    rqos.override_from_json( rsutils::json::nested( _device_settings, "notification" ) );
 
     _notifications_reader->on_data_available(
         [&]()
@@ -503,6 +527,7 @@ void dds_device::impl::create_control_writer()
     _control_writer = std::make_shared< dds_topic_writer >( topic );
     dds_topic_writer::qos wqos( eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS );
     wqos.history().depth = 10;  // default is 1
+    wqos.override_from_json( rsutils::json::nested( _device_settings, "control" ) );
     _control_writer->run( wqos );
 }
 

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -50,6 +50,7 @@ class dds_device::impl
 
 public:
     topics::device_info const _info;
+    nlohmann::json const _device_settings;
     dds_guid _server_guid;
     std::shared_ptr< dds_participant > const _participant;
     std::shared_ptr< dds_subscriber > _subscriber;

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -205,6 +205,8 @@ void dds_device_server::init( std::vector< std::shared_ptr< dds_stream_server > 
                 _metadata_writer = std::make_shared< dds_topic_writer >( topic, _publisher );
                 dds_topic_writer::qos wqos( eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS );
                 wqos.history().depth = 10;  // default is 1
+                wqos.override_from_json(
+                    rsutils::json::nested( _subscriber->get_participant()->settings(), "device", "metadata" ) );
                 _metadata_writer->run( wqos );
             }
         }
@@ -218,6 +220,7 @@ void dds_device_server::init( std::vector< std::shared_ptr< dds_stream_server > 
         _control_reader->on_data_available( [&]() { on_control_message_received(); } );
 
         dds_topic_reader::qos rqos( RELIABLE_RELIABILITY_QOS );
+        rqos.override_from_json( rsutils::json::nested( _subscriber->get_participant()->settings(), "device", "control" ) );
         _control_reader->run( rqos );
     }
     catch( std::exception const & )

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -258,7 +258,7 @@ void dds_device_server::publish_metadata( nlohmann::json && md )
     LOG_DEBUG(
         "publishing metadata: " << shorten_json_string( slice( msg.custom_data< char const >(), msg._data.size() ),
                                                         300 ) );
-    msg.write_to( *_metadata_writer );
+    std::move( msg ).write_to( *_metadata_writer );
 }
 
 

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -18,45 +18,50 @@
 #include <fastdds/dds/publisher/DataWriterListener.hpp>
 #include <fastdds/dds/publisher/qos/PublisherQos.hpp>
 
+#include <rsutils/json.h>
+
 
 using namespace eprosima::fastdds::dds;
 
 namespace realdds {
 
 
-dds_notification_server::dds_notification_server( std::shared_ptr< dds_publisher > const & publisher, const std::string & topic_name )
+dds_notification_server::dds_notification_server( std::shared_ptr< dds_publisher > const & publisher,
+                                                  const std::string & topic_name )
     : _publisher( publisher )
-    , _notifications_loop( [this]( dispatcher::cancellable_timer timer ) {
-        if( _active )
-        {
-            // We can send 2 types of notifications:
-            // * Initialize notifications that should be sent for every new reader (like sensors & profiles data)
-            // * Instant notifications that can be sent upon an event and is not required to be
-            //   resent to new readers
-            std::unique_lock< std::mutex > lock( _notification_send_mutex );
-            _send_notification_cv.wait( lock, [this]() {
-                return ! _active || _send_init_msgs || _new_instant_notification;
-            } );
+    , _notifications_loop(
+          [this]( dispatcher::cancellable_timer timer )
+          {
+              if( _active )
+              {
+                  // We can send 2 types of notifications:
+                  // * Initialize notifications that should be sent for every new reader (like sensors & profiles data)
+                  // * Instant notifications that can be sent upon an event and is not required to be
+                  //   resent to new readers
+                  std::unique_lock< std::mutex > lock( _notification_send_mutex );
+                  _send_notification_cv.wait( lock,
+                                              [this]()
+                                              { return ! _active || _send_init_msgs || _new_instant_notification; } );
 
-            if( _active && _send_init_msgs )
-            {
-                // Note: new discoveries can happen while we're sending them! (though they'll wait on the mutex)
-                _send_init_msgs = false;
-                send_discovery_notifications();
-            }
+                  if( _active && _send_init_msgs )
+                  {
+                      // Note: new discoveries can happen while we're sending them! (though they'll wait on the mutex)
+                      _send_init_msgs = false;
+                      send_discovery_notifications();
+                  }
 
-            if( _active && _new_instant_notification )
-            {
-                // Send all instant notifications
-                topics::raw::flexible notification;
-                while( _instant_notifications.try_dequeue( &notification ) )
-                {
-                    DDS_API_CALL( _writer->get()->write( &notification ) );
-                }
-                _new_instant_notification = false;
-            }
-        }
-    } )
+                  if( _active && _new_instant_notification )
+                  {
+                      // Send all instant notifications
+                      topics::raw::flexible notification;
+                      while( _instant_notifications.try_dequeue( &notification ) )
+                      {
+                          DDS_API_CALL( _writer->get()->write( &notification ) );
+                      }
+                      _new_instant_notification = false;
+                  }
+              }
+          } )
 {
     auto topic = topics::flexible_msg::create_topic( publisher->get_participant(), topic_name.c_str() );
     _writer = std::make_shared< dds_topic_writer >( topic, publisher );
@@ -80,12 +85,13 @@ dds_notification_server::dds_notification_server( std::shared_ptr< dds_publisher
         }
     } );
 
-    dds_topic_writer::qos wqos( RELIABLE_RELIABILITY_QOS ); //RELIABLE_RELIABILITY_QOS default but worth mentioning
+    dds_topic_writer::qos wqos( RELIABLE_RELIABILITY_QOS ); // the default, but worth mentioning
     // Writer can finish reader-writer handshake and start transmitting the discovery messages before the reader have
     // finished the handshake and can receivethe messages.
     // If history is too small writer will not be able to re-transmit needed samples.
     // Setting history to cover known use-cases plus some spare
     wqos.history().depth = 24;
+    wqos.override_from_json( rsutils::json::nested( publisher->get_participant()->settings(), "device", "notification" ) );
 
     _writer->run( wqos );
 }

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -131,7 +131,7 @@ void dds_notification_server::send_notification( topics::flexible_msg && notific
     if( ! is_running() )
         DDS_THROW( runtime_error, "cannot send notification while server isn't running" );
 
-    auto raw_notification = notification.to_raw();
+    auto raw_notification = std::move( notification ).to_raw();
 
     std::unique_lock< std::mutex > lock( _notification_send_mutex );
     if( ! _instant_notifications.enqueue( std::move( raw_notification ) ) )
@@ -146,7 +146,7 @@ void dds_notification_server::add_discovery_notification( topics::flexible_msg &
     if( is_running() )
         DDS_THROW( runtime_error, "cannot add discovery notification while server is running" );
 
-    _discovery_notifications.push_back( notification.to_raw() );
+    _discovery_notifications.push_back( std::move( notification ).to_raw() );
 }
 
 

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -5,6 +5,7 @@
 #include <realdds/dds-utilities.h>
 #include <realdds/dds-guid.h>
 #include <realdds/dds-time.h>
+#include <realdds/dds-serialization.h>
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -138,8 +139,8 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
         {
         case eprosima::fastrtps::rtps::WriterDiscoveryInfo::DISCOVERED_WRITER:
             /* Process the case when a new publisher was found in the domain */
-            LOG_DEBUG( _owner.name() << ": +writer (" << _owner.print( info.info.guid() ) << ") publishing '"
-                                     << info.info.topicName() << "' of type '" << info.info.typeName() << "'" );
+            LOG_DEBUG( _owner.name() << ": +writer (" << _owner.print( info.info.guid() ) << ") publishing "
+                                     << info.info );
             _owner.on_writer_added( info.info.guid(), info.info.topicName().c_str() );
             break;
 
@@ -158,8 +159,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
         switch( info.status )
         {
         case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER:
-            LOG_DEBUG( _owner.name() << ": +reader (" << _owner.print( info.info.guid() ) << ") of '"
-                                     << info.info.topicName() << "' of type '" << info.info.typeName() << "'" );
+            LOG_DEBUG( _owner.name() << ": +reader (" << _owner.print( info.info.guid() ) << ") of " << info.info );
             _owner.on_reader_added( info.info.guid(), info.info.topicName().c_str() );
             break;
 

--- a/third-party/realdds/src/dds-serialization.cpp
+++ b/third-party/realdds/src/dds-serialization.cpp
@@ -1,0 +1,245 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include <realdds/dds-serialization.h>
+#include <realdds/dds-utilities.h>
+
+#include <fastdds/rtps/writer/WriterDiscoveryInfo.h>
+#include <fastdds/rtps/reader/ReaderDiscoveryInfo.h>
+
+#include <rsutils/json.h>
+
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+
+
+std::ostream & operator<<( std::ostream & os, ReliabilityQosPolicyKind kind )
+{
+    switch( kind )
+    {
+    case eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS:
+        return os << "best-effort";
+    case eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS:
+        return os << "reliable";
+    }
+    return os << (int)kind;
+}
+
+
+std::ostream & operator<<( std::ostream & os, ReliabilityQosPolicy const & qos )
+{
+    return os << qos.kind;
+}
+
+
+std::ostream & operator<<( std::ostream & os, DurabilityQosPolicyKind kind )
+{
+    switch( kind )
+    {
+    case eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS:
+        return os << "volatile";
+    case eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS:
+        return os << "transient-local";
+    case eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS:
+        return os << "transient";
+    case eprosima::fastdds::dds::PERSISTENT_DURABILITY_QOS:
+        return os << "persistent";
+    }
+    return os << (int)kind;
+}
+
+
+std::ostream & operator<<( std::ostream & os, DurabilityQosPolicy const & qos )
+{
+    return os << qos.kind;
+}
+
+
+std::ostream & operator<<( std::ostream & os, HistoryQosPolicy const & qos )
+{
+    return os;
+}
+
+
+std::ostream & operator<<( std::ostream & os, DataSharingQosPolicy const & qos )
+{
+    return os;
+}
+
+
+std::ostream & operator<<( std::ostream & os, RTPSEndpointQos const & qos )
+{
+    return os;
+}
+
+
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+
+namespace eprosima {
+namespace fastrtps {
+namespace rtps {
+
+
+std::ostream & operator<<( std::ostream & os, WriterProxyData const & info )
+{
+    os << "'" << info.topicName() << "' [";
+    os << /*"type " <<*/ info.typeName();
+    os << /*" reliability"*/ " " << info.m_qos.m_reliability;
+    if( ! ( info.m_qos.m_durability == eprosima::fastdds::dds::DurabilityQosPolicy() ) )
+        os << /*" durability"*/ " " << info.m_qos.m_durability;
+    os << "]";
+    return os;
+}
+
+
+std::ostream & operator<<( std::ostream & os, ReaderProxyData const & info )
+{
+    os << "'" << info.topicName() << "' [";
+    os << /*"type " <<*/ info.typeName();
+    os << /*" reliability"*/ " " << info.m_qos.m_reliability;
+    if( !(info.m_qos.m_durability == eprosima::fastdds::dds::DurabilityQosPolicy()) )
+        os << /*" durability"*/ " " << info.m_qos.m_durability;
+    os << "]";
+    return os;
+}
+
+
+}  // namespace rtps
+}  // namespace fastrtps
+}  // namespace eprosima
+
+
+namespace realdds {
+
+
+eprosima::fastdds::dds::ReliabilityQosPolicyKind reliability_kind_from_string( std::string const & s )
+{
+    if( s == "best-effort" )
+        return eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS;
+    if( s == "reliable" )
+        return eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS;
+    DDS_THROW( runtime_error, "invalid reliability kind '" << s << "'" );
+}
+
+
+eprosima::fastdds::dds::DurabilityQosPolicyKind durability_kind_from_string( std::string const & s )
+{
+    if( s == "volatile" )
+        return eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS;
+    if( s == "transient-local" )
+        return eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+    if( s == "transient" )
+        return eprosima::fastdds::dds::TRANSIENT_DURABILITY_QOS;
+    if( s == "persistent" )
+        return eprosima::fastdds::dds::PERSISTENT_DURABILITY_QOS;
+    DDS_THROW( runtime_error, "invalid durability kind '" << s << "'" );
+}
+
+
+eprosima::fastdds::dds::HistoryQosPolicyKind history_kind_from_string( std::string const & s )
+{
+    if( s == "keep-last" )
+        return eprosima::fastdds::dds::KEEP_LAST_HISTORY_QOS;
+    if( s == "keep-all" )
+        return eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS;
+    DDS_THROW( runtime_error, "invalid history kind '" << s << "'" );
+}
+
+
+eprosima::fastrtps::rtps::MemoryManagementPolicy_t history_memory_policy_from_string( std::string const & s )
+{
+    if( s == "preallocated" )
+        return eprosima::fastrtps::rtps::PREALLOCATED_MEMORY_MODE;
+    if( s == "preallocated-with-realloc" )
+        return eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+    if( s == "dynamic-reserve" )
+        return eprosima::fastrtps::rtps::DYNAMIC_RESERVE_MEMORY_MODE;
+    if( s == "dynamic-reusable" )
+        return eprosima::fastrtps::rtps::DYNAMIC_REUSABLE_MEMORY_MODE;
+    DDS_THROW( runtime_error, "invalid history memory policy '" << s << "'" );
+}
+
+
+void override_reliability_qos_from_json( eprosima::fastdds::dds::ReliabilityQosPolicy & qos, nlohmann::json const & j )
+{
+    if( j.is_null() )
+        return;
+    if( j.is_string() )
+        qos.kind = reliability_kind_from_string( rsutils::json::string_ref( j ) );
+    else if( j.is_object() )
+    {
+        std::string kind_str;
+        if( rsutils::json::get_ex( j, "kind", &kind_str ) )
+            qos.kind = reliability_kind_from_string( kind_str );
+    }
+}
+
+
+void override_durability_qos_from_json( eprosima::fastdds::dds::DurabilityQosPolicy & qos, nlohmann::json const & j )
+{
+    if( j.is_null() )
+        return;
+    if( j.is_string() )
+        qos.kind = durability_kind_from_string( j.get_ref< const nlohmann::json::string_t & >() );
+    else if( j.is_object() )
+    {
+        std::string kind_str;
+        if( rsutils::json::get_ex( j, "kind", &kind_str ) )
+            qos.kind = durability_kind_from_string( kind_str );
+    }
+}
+
+
+void override_history_qos_from_json( eprosima::fastdds::dds::HistoryQosPolicy & qos, nlohmann::json const & j )
+{
+    if( j.is_null() )
+        return;
+    if( j.is_number_unsigned() )
+        qos.depth = rsutils::json::value< int32_t >( j );
+    else if( j.is_object() )
+    {
+        std::string kind_str;
+        if( rsutils::json::get_ex( j, "kind", &kind_str ) )
+            qos.kind = history_kind_from_string( kind_str );
+        rsutils::json::get_ex( j, "depth", &qos.depth );
+    }
+}
+
+
+void override_data_sharing_qos_from_json( eprosima::fastdds::dds::DataSharingQosPolicy & qos, nlohmann::json const & j )
+{
+    if( j.is_null() )
+        return;
+    if( j.is_boolean() )
+    {
+        if( rsutils::json::value< bool >( j ) )
+            qos.automatic();
+        else
+            qos.off();
+    }
+    else
+    {
+        DDS_THROW( runtime_error, "data-sharing must be a boolean (off/automatic)" );
+    }
+}
+
+
+void override_endpoint_qos_from_json( eprosima::fastdds::dds::RTPSEndpointQos & qos, nlohmann::json const & j )
+{
+    if( j.is_null() )
+        return;
+    if( j.is_object() )
+    {
+        std::string policy_str;
+        if( rsutils::json::get_ex( j, "history-memory-policy", &policy_str ) )
+            qos.history_memory_policy = history_memory_policy_from_string( policy_str );
+    }
+}
+
+
+}  // namespace realdds

--- a/third-party/realdds/src/dds-topic-reader.cpp
+++ b/third-party/realdds/src/dds-topic-reader.cpp
@@ -5,6 +5,7 @@
 #include <realdds/dds-topic.h>
 #include <realdds/dds-participant.h>
 #include <realdds/dds-subscriber.h>
+#include <realdds/dds-serialization.h>
 #include <realdds/dds-utilities.h>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
@@ -12,6 +13,8 @@
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
+
+#include <rsutils/json.h>
 
 
 namespace realdds {
@@ -79,8 +82,23 @@ dds_topic_reader::qos::qos( eprosima::fastdds::dds::ReliabilityQosPolicyKind rel
 
     // Does not allocate for every sample but still gives flexibility. See:
     //     https://github.com/eProsima/Fast-DDS/discussions/2707
-    // (default is PREALLOCATED_MEMORY_MODE)
+    // (default is PREALLOCATED_WITH_REALLOC_MEMORY_MODE)
     endpoint().history_memory_policy = eprosima::fastrtps::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+}
+
+
+void dds_topic_reader::qos::override_from_json( nlohmann::json const & qos_settings )
+{
+    // Default values should be set before we're called:
+    // All we do here is override those - if specified!
+    if( qos_settings.is_null() )
+        return;
+
+    override_reliability_qos_from_json( reliability(), rsutils::json::nested( qos_settings, "reliability" ) );
+    override_durability_qos_from_json( durability(), rsutils::json::nested( qos_settings, "durability" ) );
+    override_history_qos_from_json( history(), rsutils::json::nested( qos_settings, "history" ) );
+    override_data_sharing_qos_from_json( data_sharing(), rsutils::json::nested( qos_settings, "data-sharing" ) );
+    override_endpoint_qos_from_json( endpoint(), rsutils::json::nested( qos_settings, "endpoint" ) );
 }
 
 

--- a/third-party/realdds/src/dds-topic-writer.cpp
+++ b/third-party/realdds/src/dds-topic-writer.cpp
@@ -5,6 +5,7 @@
 #include <realdds/dds-topic.h>
 #include <realdds/dds-participant.h>
 #include <realdds/dds-publisher.h>
+#include <realdds/dds-serialization.h>
 #include <realdds/dds-utilities.h>
 #include <realdds/dds-guid.h>
 
@@ -12,6 +13,8 @@
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
+
+#include <rsutils/json.h>
 
 
 namespace realdds {
@@ -79,6 +82,21 @@ dds_topic_writer::qos::qos( eprosima::fastdds::dds::ReliabilityQosPolicyKind rel
     // See https://github.com/eProsima/Fast-DDS/issues/2641
     //
     data_sharing().off();
+}
+
+
+void dds_topic_writer::qos::override_from_json( nlohmann::json const & qos_settings )
+{
+    // Default values should be set before we're called:
+    // All we do here is override those - if specified!
+    if( qos_settings.is_null() )
+        return;
+
+    override_reliability_qos_from_json( reliability(), rsutils::json::nested( qos_settings, "reliability" ) );
+    override_durability_qos_from_json( durability(), rsutils::json::nested( qos_settings, "durability" ) );
+    override_history_qos_from_json( history(), rsutils::json::nested( qos_settings, "history" ) );
+    override_data_sharing_qos_from_json( data_sharing(), rsutils::json::nested( qos_settings, "data-sharing" ) );
+    override_endpoint_qos_from_json( endpoint(), rsutils::json::nested( qos_settings, "endpoint" ) );
 }
 
 

--- a/third-party/realdds/src/topics/flexible-msg.cpp
+++ b/third-party/realdds/src/topics/flexible-msg.cpp
@@ -117,7 +117,7 @@ json flexible_msg::json_data() const
 }
 
 
-raw::flexible flexible_msg::to_raw()
+raw::flexible flexible_msg::to_raw() &&
 {
     raw::flexible raw_msg;
     raw_msg.data_format( (raw::flexible_data_format) _data_format );
@@ -130,9 +130,9 @@ raw::flexible flexible_msg::to_raw()
 }
 
 
-dds_sequence_number flexible_msg::write_to( dds_topic_writer & writer )
+dds_sequence_number flexible_msg::write_to( dds_topic_writer & writer ) &&
 {
-    auto raw_msg = to_raw();
+    auto raw_msg = std::move( *this ).to_raw();
 
     eprosima::fastrtps::rtps::WriteParams params;
     bool success = DDS_API_CALL( writer.get()->write( &raw_msg, params ) );

--- a/third-party/realdds/src/topics/flexible-writer.cpp
+++ b/third-party/realdds/src/topics/flexible-writer.cpp
@@ -51,7 +51,7 @@ void flexible_writer::write( nlohmann::json && json )
     std::string json_string = json.dump();
     flexible_msg msg( std::move( json ) );
     auto write_time = now();
-    msg.write_to( *_writer );
+    std::move( msg ).write_to( *_writer );
     LOG_DEBUG( name() << ".write JSON " << json_string << " @" << timestr( write_time, timestr::no_suffix )
                       << timestr( now(), write_time ) );
 }

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -11,6 +11,9 @@ namespace rsutils {
 namespace json {
 
 
+extern nlohmann::json const null_json;
+
+
 // Returns true if the json has a certain key.
 // Does not check the value at all, so it could be any type or null.
 inline bool has( nlohmann::json const & j, std::string const & key )
@@ -30,6 +33,27 @@ inline bool has_value( nlohmann::json const & j, std::string const & key )
     if( it == j.end() || it->is_null() )
         return false;
     return true;
+}
+
+
+// Get the JSON as a value (copy involved); it must exist
+template < class T >
+T value( nlohmann::json const & j )
+{
+    return j.get< T >();
+}
+// Get the JSON as a value, or a default if not there (copy involved)
+template < class T >
+T value( nlohmann::json const & j, T const & default_value )
+{
+    if( j.is_null() )
+        return default_value;
+    return j.get< T >();
+}
+// Get a JSON string by reference (zero copy); it must be a string or it'll throw
+inline std::string const & string_ref( nlohmann::json const & j )
+{
+    return j.get_ref< const nlohmann::json::string_t & >();
 }
 
 
@@ -55,14 +79,12 @@ bool get_ex( nlohmann::json const & j, std::string const & key, T * pv )
 
 
 // If there, returns the value at the given key; otherwise returns a default value.
-// Turns json exceptions into runtime errors with additional info.
 template < class T >
 T get( nlohmann::json const & j, std::string const & key, T const & default_value )
 {
-    T v;
-    if( get_ex< T >( j, key, &v ) )
-        return v;
-    return default_value;
+    if( ! j.is_object() )
+        return default_value;
+    return j.value( key, default_value );
 }
 
 
@@ -99,6 +121,56 @@ T get( nlohmann::json const & j, nlohmann::json::const_iterator const & it )
     // Does not check for existence: will throw, too!
     return it->get< T >();
 }
+
+
+template< typename... Rest >
+nlohmann::json const * _nested( nlohmann::json const & j )
+{
+    return &j;
+}
+template< typename... Rest >
+nlohmann::json const * _nested( nlohmann::json const & j, std::string const & inner, Rest... rest )
+{
+    auto it = j.find( inner );
+    if( it == j.end() )
+        return nullptr;
+    return _nested( *it, std::forward< Rest >( rest )... );
+}
+
+
+// Allow easy read-only lookup of nested json hierarchies:
+//      j["one"]["two"]["three"]            // undefined; will throw/assert if a hierarchy isn't there
+// But:
+//      nested( j, "one", "two", "three" )  // will not throw; does not copy!
+// The result is either a null JSON object or a valid one. The boolean operator can be used as an easy check:
+//      if( auto inside = nested( j, "one", "two" ) )
+//          { ... }
+//
+class nested
+{
+    nlohmann::json const * _pj;
+
+public:
+    template< typename... Rest >
+    nested( nlohmann::json const & j, Rest... rest )
+        : _pj( _nested( j, std::forward< Rest >( rest )... ) )
+    {}
+
+    nlohmann::json const * operator->() const { return _pj; }
+
+    bool exists() const { return _pj; }
+    operator bool() const { return exists(); }
+
+    nlohmann::json const & get() const { return _pj ? *_pj : null_json; }
+    operator nlohmann::json const & () const { return get(); }
+
+    // Get the JSON as a value
+    template< class T > T value() { return json::value< T >( get() ); }
+    // Get the JSON as a value, or a default if not there
+    template < class T > T value( T const & default_value ) { return json::value< T >( get(), default_value ); }
+    // Get a JSON string by reference (zero copy); it must be a string or it'll throw
+    inline std::string const & string_ref() const { return json::string_ref( get() ); }
+};
 
 
 }  // namespace json

--- a/third-party/rsutils/src/json.cpp
+++ b/third-party/rsutils/src/json.cpp
@@ -1,0 +1,14 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include <rsutils/json.h>
+
+namespace rsutils {
+namespace json {
+
+
+nlohmann::json const null_json = {};
+
+
+}  // namespace json
+}  // namespace rsutils


### PR DESCRIPTION
* add `nested` functionality in `rsutils::json`
* improve reliability debug output for writers/readers
* fix software-device matcher creation:
    * the syncer showed: `(TS: C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 C0 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR4 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 IR6 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 D2 M8 M8)`
    * it now takes only unique (stream-uid) values, so now `(TS: C0 D2 IR4 IR6)`
    * device-proxy now uses the `DLR_C` matcher, which is also overridable in the settings
* increase default reply timeout to 2 seconds
    * we were almost consistently running into the timeout right after stopping the sensor, even on the same computer
* fix depth-unit
    * now set even when no MD
    * localized in depth-sensor-proxy
    * has a default value of `0.001`, without which depth shows up as black

Tracked on [LRS-956]