### PR TITLE
Color Y formats

### DIFF
--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -138,12 +138,12 @@ void dds_sensor_proxy::register_basic_converters()
     _formats_converter.register_converters(
         processing_block_factory::create_pbf_vector< uyvy_converter >(
             RS2_FORMAT_UYVY,
-            { RS2_FORMAT_UYVY, RS2_FORMAT_YUYV, RS2_FORMAT_RGB8, RS2_FORMAT_RGBA8, RS2_FORMAT_BGR8, RS2_FORMAT_BGRA8 },
+            { RS2_FORMAT_UYVY, RS2_FORMAT_YUYV, RS2_FORMAT_RGB8, RS2_FORMAT_Y8, RS2_FORMAT_RGBA8, RS2_FORMAT_BGR8, RS2_FORMAT_BGRA8 },
             RS2_STREAM_COLOR ) );
     _formats_converter.register_converters(
         processing_block_factory::create_pbf_vector< yuy2_converter >(
             RS2_FORMAT_YUYV,
-            { RS2_FORMAT_YUYV, RS2_FORMAT_RGB8, RS2_FORMAT_RGBA8, RS2_FORMAT_BGR8, RS2_FORMAT_BGRA8 },
+            { RS2_FORMAT_YUYV, RS2_FORMAT_RGB8, RS2_FORMAT_Y8, RS2_FORMAT_RGBA8, RS2_FORMAT_BGR8, RS2_FORMAT_BGRA8 },
             RS2_STREAM_COLOR ) );
 
     // Depth

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -186,7 +186,6 @@ std::vector<rs2_format> device::map_supported_color_formats(rs2_format source_fo
     {
     case RS2_FORMAT_YUYV:
         target_formats.push_back(RS2_FORMAT_YUYV);
-        target_formats.push_back(RS2_FORMAT_Y16);
         target_formats.push_back(RS2_FORMAT_Y8);
         break;
     case RS2_FORMAT_UYVY:

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -92,7 +92,7 @@ namespace librealsense
 
         register_options();
         register_metadata();
-        register_processing_blocks();
+        register_color_processing_blocks();
     }
 
     void d500_color::register_options()
@@ -121,15 +121,6 @@ namespace librealsense
             [](rs2_metadata_type param) { return (param != 1); })); // OFF value via UVC is 1 (ON is 8)
 
         _ds_color_common->register_metadata();
-    }
-
-    void d500_color::register_processing_blocks()
-    {
-        auto& color_ep = get_color_sensor();
-
-        color_ep.register_processing_block(processing_block_factory::create_id_pbf(RS2_FORMAT_RAW16, RS2_STREAM_COLOR));
-
-        color_ep.register_processing_block(processing_block_factory::create_pbf_vector<m420_converter>(RS2_FORMAT_M420, map_supported_color_formats(RS2_FORMAT_M420), RS2_STREAM_COLOR));
     }
 
     rs2_intrinsics d500_color_sensor::get_intrinsics(const stream_profile& profile) const

--- a/src/ds/d500/d500-color.h
+++ b/src/ds/d500/d500-color.h
@@ -35,10 +35,11 @@ namespace librealsense
         std::shared_ptr<stream_interface> _color_stream;
         std::shared_ptr<ds_color_common> _ds_color_common;
 
+        virtual void register_color_processing_blocks() = 0;
+
     private:
         void register_options();
         void register_metadata();
-        void register_processing_blocks();
 
         void register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index);
 

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -48,7 +48,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             test.check( rs.color_sensor( sensor ))
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'RGB Camera' )
-            test.check_equal( len(sensor.get_stream_profiles()), 160 ) # As measured running rs-sensor-control example
+            test.check_equal( len(sensor.get_stream_profiles()), 192 ) # As measured running rs-sensor-control example
         sensor = dev.first_motion_sensor()
         if test.check( sensor ):
             test.check( rs.motion_sensor( sensor ))
@@ -72,7 +72,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         if test.check( sensor ):
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'Stereo Module' )
-            test.check_equal( len(sensor.get_stream_profiles()), 230 ) # As measured running rs-sensor-control example
+            test.check_equal( len(sensor.get_stream_profiles()), 258 ) # As measured running rs-sensor-control example
     remote.run( 'close_server( instance )' )
     dev = None
     #
@@ -95,7 +95,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         if test.check( sensor ):
             test.check( sensors[sensor.name] )
             test.check_equal( sensor.name, 'RGB Camera' )
-            test.check_equal( len(sensor.get_stream_profiles()), 155 ) # As measured running rs-sensor-control example
+            test.check_equal( len(sensor.get_stream_profiles()), 186 ) # As measured running rs-sensor-control example
         sensor = dev.first_motion_sensor()
         if test.check( sensor ):
             test.check( sensors[sensor.name] )

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -48,12 +48,13 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             sensor = sensors.get('YUYV-sensor')
             profiles = sensor.get_stream_profiles()
 
-            test.check_equal( len( profiles ), 5 ) # YUYV -> YUYV/RGB8/RGBA8/BGR8/BGRA8
+            test.check_equal( len( profiles ), 6 ) # YUYV -> YUYV/RGB8/RGBA8/BGR8/BGRA8/Y8
             test.check_equal( profiles[0].format(), rs.format.rgb8 )
-            test.check_equal( profiles[1].format(), rs.format.bgra8 )
-            test.check_equal( profiles[2].format(), rs.format.rgba8 )
-            test.check_equal( profiles[3].format(), rs.format.bgr8 )
-            test.check_equal( profiles[4].format(), rs.format.yuyv )
+            test.check_equal( profiles[1].format(), rs.format.y8 )
+            test.check_equal( profiles[2].format(), rs.format.bgra8 )
+            test.check_equal( profiles[3].format(), rs.format.rgba8 )
+            test.check_equal( profiles[4].format(), rs.format.bgr8 )
+            test.check_equal( profiles[5].format(), rs.format.yuyv )
     #
     #############################################################################################
     #
@@ -62,13 +63,14 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             sensor = sensors.get('UYVY-sensor')
             profiles = sensor.get_stream_profiles()
 
-            test.check_equal( len( profiles ), 6 ) # UYVY -> UYVY/YUYV/RGB8/RGBA8/BGR8/BGRA8
+            test.check_equal( len( profiles ), 7 ) # UYVY -> UYVY/YUYV/RGB8/RGBA8/BGR8/BGRA8/Y8
             test.check_equal( profiles[0].format(), rs.format.rgb8 )
             test.check_equal( profiles[1].format(), rs.format.uyvy )
-            test.check_equal( profiles[2].format(), rs.format.bgra8 )
-            test.check_equal( profiles[3].format(), rs.format.rgba8 )
-            test.check_equal( profiles[4].format(), rs.format.bgr8 )
-            test.check_equal( profiles[5].format(), rs.format.yuyv )
+            test.check_equal( profiles[2].format(), rs.format.y8 )
+            test.check_equal( profiles[3].format(), rs.format.bgra8 )
+            test.check_equal( profiles[4].format(), rs.format.rgba8 )
+            test.check_equal( profiles[5].format(), rs.format.bgr8 )
+            test.check_equal( profiles[6].format(), rs.format.yuyv )
     #
     #############################################################################################
     #
@@ -115,18 +117,20 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
             #     RGBA8 @ 30/15/5 Hz
             #     BGR8 @ 30/15/5 Hz
             #     YUYV @ 30/15/5 Hz
-            test.check_equal( len( profiles ), 15 )
+            test.check_equal( len( profiles ), 18 )
             for i,f in zip( range(3), (30,15,5) ):
                 test.check_equal( profiles[0 + i].format(), rs.format.rgb8 )
                 test.check_equal( profiles[0 + i].fps(), f )
-                test.check_equal( profiles[3 + i].format(), rs.format.bgra8 )
+                test.check_equal( profiles[3 + i].format(), rs.format.y8 )
                 test.check_equal( profiles[3 + i].fps(), f )
-                test.check_equal( profiles[6 + i].format(), rs.format.rgba8 )
+                test.check_equal( profiles[6 + i].format(), rs.format.bgra8 )
                 test.check_equal( profiles[6 + i].fps(), f )
-                test.check_equal( profiles[9 + i].format(), rs.format.bgr8 )
+                test.check_equal( profiles[9 + i].format(), rs.format.rgba8 )
                 test.check_equal( profiles[9 + i].fps(), f )
-                test.check_equal( profiles[12 + i].format(), rs.format.yuyv )
+                test.check_equal( profiles[12 + i].format(), rs.format.bgr8 )
                 test.check_equal( profiles[12 + i].fps(), f )
+                test.check_equal( profiles[15 + i].format(), rs.format.yuyv )
+                test.check_equal( profiles[15 + i].fps(), f )
     #
     #############################################################################################
     #


### PR DESCRIPTION
* remove Y16 from color formats; tracked on [RSDSO-19329]
* `d500_color` processing-blocks now in `register_color_processing_blocks()`
* 5e using YUYV instead of M420
* add Y8 to dds supported color formats; tracked on [LRS-870]
* fix YUYV -> Y8 SSE conversion (wasn't showing right)
