### PR TITLE
Fix get future timestamp from hardware clock domain.

### DIFF
--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -216,7 +216,7 @@ namespace librealsense
                 _coefs.add_const_y_coefs(command_delay - _min_command_delay);
                 _min_command_delay = command_delay;
             }
-            double system_time(system_time_finish - _min_command_delay);
+            double system_time(system_time_start + _min_command_delay);
             if (_is_ready)
             {
                 _coefs.update_samples_base(sample_hw_time);


### PR DESCRIPTION
Frame timestamp from hardware clock domain is incorrect. Sometimes the timestamp is a future time compared to
the time of getting it. This is because the samples for calculating the linear regression coefficients are not precision.
The system time of a sample is incorrect because the delay between hardware time and system time happens during
sending back the hardware time result, not prior to retrieving the hardware time.
