### PR TITLE
fix json install for debians

### DIFF
--- a/CMake/external_json.cmake
+++ b/CMake/external_json.cmake
@@ -37,10 +37,8 @@ function(get_nlohmann_json)
     add_subdirectory( "${CMAKE_BINARY_DIR}/third-party/json"
                       "${CMAKE_BINARY_DIR}/third-party/json/build" )
 
-    install( TARGETS nlohmann_json
-        EXPORT realsense2Targets
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        )
+    # We cannot directly interface with nlohmann_json (doesn't work on bionic)
+    #install( TARGETS nlohmann_json EXPORT realsense2Targets )
 
     message( STATUS #CHECK_PASS
         "Fetching nlohmann/json - Done" )

--- a/third-party/rsutils/CMakeLists.txt
+++ b/third-party/rsutils/CMakeLists.txt
@@ -4,12 +4,14 @@ cmake_minimum_required(VERSION 3.8.0)  # source_group(TREE)
 project( rsutils )
 
 add_library( ${PROJECT_NAME} STATIC "" )
-target_link_libraries( ${PROJECT_NAME} PUBLIC nlohmann_json )
+# We cannot directly interface with nlohmann_json (doesn't work on bionic)
+#target_link_libraries( ${PROJECT_NAME} PUBLIC nlohmann_json )
 set_target_properties( ${PROJECT_NAME} PROPERTIES FOLDER Library )
 
 target_include_directories( ${PROJECT_NAME}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/third-party/json/include>
 )
 
 # Headers -----------------------------------------------------------------------------------


### PR DESCRIPTION
Fix #12398 which caused a problem on bionic debian creation. It works on focal and jammy.
For now, no direct linking with nlohmann_json -- I went back to just directly pointing to the include dir.

Tracked on [LRS-958]