### PR TITLE
FIX: Add iostream explicit dependency for building with older gcc (7.5.0)

### DIFF
--- a/src/terminal-parser.cpp
+++ b/src/terminal-parser.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
 #include "terminal-parser.h"
+#include <iostream>
 #include <rsutils/string/from.h>
 
 


### PR DESCRIPTION
<!--
    Pull requests should go to the development branch:
    https://github.com/IntelRealSense/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/IntelRealSense/librealsense/blob/master/CONTRIBUTING.md
-->

librealsense doesn't build on older gcc compilers due to the implicitly solved dependency of iostream in terminal-parser.cpp. Adding the include to iostream solves this issue.

Tried successfully on gcc 7.5.0