### PR TITLE
make sure depth frame is used in hdr check to avoid merged frame from…

### DIFF
--- a/src/proc/hdr-merge.cpp
+++ b/src/proc/hdr-merge.cpp
@@ -89,7 +89,7 @@ namespace librealsense
         }
 
         // discard merged frame if not relevant
-        discard_depth_merged_frame_if_needed(f);
+        discard_depth_merged_frame_if_needed(depth_frame);
 
         // 3. check if size of this vector is at least 2 (if not - return latest merge frame)
         if (_framesets.size() >= 2)


### PR DESCRIPTION
fix hdr merged frame from being discarded and cause flashy issue

changes:
make sure depth frame is used in hdr check discard_depth_merged_frame_if_needed

Tracked on: LRS-965