### PR TITLE
abstract post-processing filter factory via context

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,8 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/sensor.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/hid-sensor.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/uvc-sensor.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/rscore-pp-block-factory.h"
+        "${CMAKE_CURRENT_LIST_DIR}/rscore-pp-block-factory.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/software-device.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/software-device-info.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/software-sensor.cpp"

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -8,6 +8,7 @@
 #ifdef BUILD_WITH_DDS
 #include "dds/rsdds-device-factory.h"
 #endif
+#include "rscore-pp-block-factory.h"
 
 #include <librealsense2/hpp/rs_types.hpp>  // rs2_devices_changed_callback
 #include <librealsense2/rs.h>              // RS2_API_FULL_VERSION_STR
@@ -176,5 +177,11 @@ namespace librealsense {
         }
     }
 
+
+    std::shared_ptr< processing_block_interface > context::create_pp_block( std::string const & name,
+                                                                            nlohmann::json const & settings )
+    {
+        return rscore_pp_block_factory().create_pp_block( name, settings );
+    }
 
 }  // namespace librealsense

--- a/src/context.h
+++ b/src/context.h
@@ -13,6 +13,7 @@ namespace librealsense
 {
     class device_factory;
     class device_info;
+    class processing_block_interface;
 
 
     class context : public std::enable_shared_from_this<context>
@@ -57,6 +58,11 @@ namespace librealsense
         void remove_device( std::shared_ptr< device_info > const & );
 
         const nlohmann::json & get_settings() const { return _settings; }
+
+        // Create processing blocks given a name and settings.
+        //
+        std::shared_ptr< processing_block_interface > create_pp_block( std::string const & name,
+                                                                       nlohmann::json const & settings );
 
     private:
         void invoke_devices_changed_callbacks( std::vector< std::shared_ptr< device_info > > const & devices_removed,

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/info.h"
         "${CMAKE_CURRENT_LIST_DIR}/extension.h"
         "${CMAKE_CURRENT_LIST_DIR}/pose-frame.h"
+        "${CMAKE_CURRENT_LIST_DIR}/pp-block-factory.h"
         "${CMAKE_CURRENT_LIST_DIR}/processing.h"
         "${CMAKE_CURRENT_LIST_DIR}/processing-block-interface.h"
         "${CMAKE_CURRENT_LIST_DIR}/recommended-processing-blocks-interface.h"

--- a/src/core/pp-block-factory.h
+++ b/src/core/pp-block-factory.h
@@ -1,0 +1,38 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+
+
+namespace librealsense {
+
+
+class processing_block_interface;
+
+
+// Instantiator of post-processing filters, AKA processing blocks, based on name and settings.
+// These are the ones you see in the Viewer, and are also returned by
+// sensor_interface::get_recommended_processing_blocks(). Their names are serialized to rosbags when recording and
+// reinstantiated on playback.
+//
+// Do not use directly: the context manages these!
+//
+class pp_block_factory
+{
+public:
+    virtual ~pp_block_factory() = default;
+
+    // Creates a post-processing block. If the name is unrecognized, a null pointer is returned. Otherwise, if the
+    // settings are wrong or some other error condition is encountered, an exception is raised.
+    // 
+    // The name is case-insensitive.
+    //
+    virtual std::shared_ptr< processing_block_interface > create_pp_block( std::string const & name,
+                                                                           nlohmann::json const & settings )
+        = 0;
+};
+
+
+}  // namespace librealsense

--- a/src/media/ros/ros_reader.h
+++ b/src/media/ros/ros_reader.h
@@ -115,7 +115,11 @@ namespace librealsense
         static std::pair<rs2_option, std::shared_ptr<librealsense::option>> create_property(const rosbag::MessageInstance& property_message_instance);
         /*Starting version 3*/
         static std::pair<rs2_option, std::shared_ptr<librealsense::option>> create_option(const rosbag::Bag& file, const rosbag::MessageInstance& value_message_instance);
-        static std::shared_ptr<processing_block_interface> create_processing_block(const rosbag::MessageInstance& value_message_instance, bool& depth_to_disparity, std::shared_ptr<options_interface> options);
+
+        std::shared_ptr< processing_block_interface >
+        create_processing_block( const rosbag::MessageInstance & value_message_instance,
+                                 bool & depth_to_disparity,
+                                 std::shared_ptr< options_interface > options );
 
         static notification create_notification(const rosbag::Bag& file, const rosbag::MessageInstance& message_instance);
         static std::shared_ptr<options_container> read_sensor_options(const rosbag::Bag& file, device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, uint32_t file_version);

--- a/src/media/ros/ros_writer.cpp
+++ b/src/media/ros/ros_writer.cpp
@@ -492,11 +492,17 @@ namespace librealsense
         }
     }
 
-    rs2_extension ros_writer::get_processing_block_extension(const std::shared_ptr<processing_block_interface> block)
+    static std::string get_processing_block_extension_name( const std::shared_ptr< processing_block_interface > block )
     {
-#define RETURN_IF_EXTENSION(E, T)\
-    if (Is<ExtensionToType<T>::type>(E))\
-    return T;\
+        // We want to write the block name (as opposed to the extension name):
+        // The block can behave differently and have a different name based on how it was created (e.g., the disparity
+        // filter). This makes new rosbag files incompatible with older librealsense versions.
+        if( block->supports_info( RS2_CAMERA_INFO_NAME ) )
+            return block->get_info( RS2_CAMERA_INFO_NAME );
+
+#define RETURN_IF_EXTENSION( B, E )                                                                                    \
+    if( Is< ExtensionToType< E >::type >( B ) )                                                                        \
+        return rs2_extension_type_to_string( E )
  
         RETURN_IF_EXTENSION(block, RS2_EXTENSION_DECIMATION_FILTER);
         RETURN_IF_EXTENSION(block, RS2_EXTENSION_THRESHOLD_FILTER);
@@ -509,33 +515,29 @@ namespace librealsense
 
 #undef RETURN_IF_EXTENSION
 
-        throw invalid_value_exception( rsutils::string::from()
-                                       << "processing block " << block->get_info( RS2_CAMERA_INFO_NAME )
-                                       << "has no map to extension" );
+        return {};
     }
 
     void ros_writer::write_sensor_processing_blocks(device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, std::shared_ptr<recommended_proccesing_blocks_interface> proccesing_blocks)
     {
-        rs2_extension ext = RS2_EXTENSION_UNKNOWN;
         for (auto block : proccesing_blocks->get_recommended_processing_blocks())
         {
+            std::string name = get_processing_block_extension_name( block );
+            if( name.empty() )
+            {
+                LOG_WARNING( "Failed to get recommended processing block name for sensor " << sensor_id.sensor_index );
+                continue;
+            }
             try
             {
-                try
-                {
-                    ext = get_processing_block_extension(block);
-                }
-                catch (std::exception& e)
-                {
-                    LOG_WARNING("Failed to write proccesing block " << " for sensor " << sensor_id.sensor_index << ". Exception: " << e.what());
-                }
                 std_msgs::String processing_block_msg;
-                processing_block_msg.data = rs2_extension_type_to_string(ext);
-                write_message(ros_topic::post_processing_blocks_topic(sensor_id), timestamp, processing_block_msg);
+                processing_block_msg.data = name;
+                write_message( ros_topic::post_processing_blocks_topic( sensor_id ), timestamp, processing_block_msg );
             }
-            catch (std::exception& e)
+            catch( std::exception & e )
             {
-                LOG_WARNING("Failed to get or write recommended proccesing blocks " << " for sensor " << sensor_id.sensor_index << ". Exception: " << e.what());
+                LOG_WARNING( "Failed to write processing block '" << name << "' for sensor " << sensor_id.sensor_index
+                                                                  << ": " << e.what() );
             }
         }
     }

--- a/src/media/ros/ros_writer.h
+++ b/src/media/ros/ros_writer.h
@@ -60,8 +60,6 @@ namespace librealsense
         void write_vendor_info(const std::string& topic, nanoseconds timestamp, std::shared_ptr<info_interface> info_snapshot);
         void write_sensor_option(device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, rs2_option type, const librealsense::option& option);
         void write_sensor_options(device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, std::shared_ptr<options_interface> options);
-
-        rs2_extension get_processing_block_extension(const std::shared_ptr<processing_block_interface> block);
         void write_sensor_processing_blocks(device_serializer::sensor_identifier sensor_id, const nanoseconds& timestamp, std::shared_ptr<recommended_proccesing_blocks_interface> proccesing_blocks);
 
         template <typename T>

--- a/src/rscore-pp-block-factory.cpp
+++ b/src/rscore-pp-block-factory.cpp
@@ -1,0 +1,53 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+
+#include "rscore-pp-block-factory.h"
+
+#include "proc/decimation-filter.h"
+#include "proc/disparity-transform.h"
+#include "proc/hdr-merge.h"
+#include "proc/hole-filling-filter.h"
+#include "proc/sequence-id-filter.h"
+#include "proc/spatial-filter.h"
+#include "proc/temporal-filter.h"
+#include "proc/threshold.h"
+
+#include <rsutils/string/nocase.h>
+#include <rsutils/json.h>
+
+
+namespace librealsense {
+
+
+std::shared_ptr< processing_block_interface >
+rscore_pp_block_factory::create_pp_block( std::string const & name, nlohmann::json const & settings )
+{
+    // These filters do not accept settings (nor are settings recorded in ros_writer)
+    (void *)&settings;
+
+    if( rsutils::string::nocase_equal( name, "Decimation Filter" ) )
+        return std::make_shared< decimation_filter >();
+    if( rsutils::string::nocase_equal( name, "HDR Merge" ) )  // and Hdr Merge
+        return std::make_shared< hdr_merge >();
+    if( rsutils::string::nocase_equal( name, "Filter By Sequence id" )    // name
+        || rsutils::string::nocase_equal( name, "Sequence Id Filter" ) )  // extension
+        return std::make_shared< sequence_id_filter >();
+    if( rsutils::string::nocase_equal( name, "Threshold Filter" ) )
+        return std::make_shared< threshold >();
+    if( rsutils::string::nocase_equal( name, "Depth to Disparity" )     // name
+        || rsutils::string::nocase_equal( name, "Disparity Filter" ) )  // extension
+        return std::make_shared< disparity_transform >( true );
+    if( rsutils::string::nocase_equal( name, "Disparity to Depth" ) )
+        return std::make_shared< disparity_transform >( false );
+    if( rsutils::string::nocase_equal( name, "Spatial Filter" ) )
+        return std::make_shared< spatial_filter >();
+    if( rsutils::string::nocase_equal( name, "Temporal Filter" ) )
+        return std::make_shared< temporal_filter >();
+    if( rsutils::string::nocase_equal( name, "Hole Filling Filter" ) )
+        return std::make_shared< hole_filling_filter >();
+
+    return {};
+}
+
+
+}  // namespace librealsense

--- a/src/rscore-pp-block-factory.h
+++ b/src/rscore-pp-block-factory.h
@@ -1,0 +1,19 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include "core/pp-block-factory.h"
+
+
+namespace librealsense {
+
+
+class rscore_pp_block_factory : public pp_block_factory
+{
+public:
+    std::shared_ptr< processing_block_interface > create_pp_block( std::string const & name,
+                                                                   nlohmann::json const & settings ) override;
+};
+
+
+}  // namespace librealsense

--- a/third-party/rsutils/include/rsutils/string/nocase.h
+++ b/third-party/rsutils/include/rsutils/string/nocase.h
@@ -1,0 +1,71 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <string.h>  // strcasecmp in linux
+
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#endif
+
+
+namespace rsutils {
+namespace string {
+
+
+// Use in containers:
+//      std::map< KEY, VALUE, nocase_less_t >
+//
+struct nocase_less_t
+{
+    // case-independent (ci) compare_less binary function
+    bool operator()( std::string const & l, std::string const & r ) const
+    {
+        // If internationalization or embedded NULLs aren't an issue, this should be faster than the STL
+        return strcasecmp( l.c_str(), r.c_str() ) < 0;
+        //return std::lexicographical_compare( s1.begin(), s1.end(),
+        //                                     s2.begin(), s2.end(),
+        //                                     nocase_compare() );  // comparison
+    }
+};
+
+
+inline int nocase_compare( std::string const & l, std::string const & r )
+{
+    return strcasecmp( l.c_str(), r.c_str() );
+}
+inline int nocase_compare( std::string const & l, char const * r )
+{
+    return strcasecmp( l.c_str(), r );
+}
+inline int nocase_compare( char const * l, std::string const & r )
+{
+    return strcasecmp( l, r.c_str() );
+}
+inline int nocase_compare( char const * l, char const * r )
+{
+    return strcasecmp( l, r );
+}
+
+
+inline int nocase_equal( std::string const & l, std::string const & r )
+{
+    return l.length() == r.length() && 0 == strcasecmp( l.c_str(), r.c_str() );
+}
+inline int nocase_equal( std::string const & l, char const * r )
+{
+    return 0 == strcasecmp( l.c_str(), r );
+}
+inline int nocase_equal( char const * l, std::string const & r )
+{
+    return 0 == strcasecmp( l, r.c_str() );
+}
+inline int nocase_equal( char const * l, char const * r )
+{
+    return 0 == strcasecmp( l, r );
+}
+
+
+}  // namespace string
+}  // namespace rsutils


### PR DESCRIPTION
Today, if you want to return "recommended processing blocks" (AKA recommended filters in the API), then you need to return the actual instantiation of the blocks.
This means that everyone needs to know how to instantiate them: the rosbag reader; the DDS device; etc.
The problem is that, if we add new filters (or remove old ones), the code needs to be updated everywhere.
The problem is that there's no abstraction of a factory that can instantiate a filter by name, that would allow a piece of code to know about the factory rather than the block implementations.

This adds such a factory, with the goal of separating the DDS/ROS/whatever code from post-processing (which may not even exist!).

* the factory interface is called `pp_block_factory`
    * `pp` == post-processing, to denote these are used for post-processing
    * kept the `block` designation because it returns `processing_block_interface`
    * there is already an internal `processing_block_factory` that's used for more-internal non-filter stuff, so I couldn't call it what it should be called
* the factory is implemented by `rscore_pp_block_factory` which the `context` knows about
* added `context::create_pp_block()` - the context will know what factories exist and how to use them; nobody else should
* `create_pp_block()` accepts JSON settings that can be used to serialize settings; these aren't used right now
    * rosbag files do not record any PP settings
    * DDS doesn't communicate those but that should be easy to communicate
    * persistent context settings are pending PR and could be used easily, too

Tracked on [LRS-967]