### PR TITLE
Acroname reset on libCI start

### DIFF
--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -217,7 +217,7 @@ def query( monitor_changes = True ):
     # on the acroname, if any:
     if acroname:
         if not acroname.hub:
-            acroname.connect()  # MAY THROW!
+            acroname.connect( reset = True )  # MAY THROW!
 
             acroname.disable_ports( sleep_on_change = 5 )
             acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )


### PR DESCRIPTION
* Reset Acroname HUB at LibCI start to avoid regressions from previous builds
* Currently we don't see many of those cases but this could be a good enhancement to keep libCI stable

This takes ~4 seconds on Linux / Windows according to the logs


Tracked on [LRS-933]