### PR TITLE
move to non-virtual d500_color::register_color_processing_blocks()

### DIFF
--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -32,10 +32,12 @@ namespace librealsense
         {rs_fourcc('M','4','2','0'), RS2_STREAM_COLOR}
     };
 
-    d500_color::d500_color( std::shared_ptr< const d500_info > const & dev_info )
-        : d500_device(dev_info), device(dev_info),
-          _color_stream(new stream(RS2_STREAM_COLOR)),
-          _separate_color(true)
+    d500_color::d500_color( std::shared_ptr< const d500_info > const & dev_info, rs2_format native_format )
+        : d500_device( dev_info )
+        , device( dev_info )
+        , _color_stream( new stream( RS2_STREAM_COLOR ) )
+        , _separate_color( true )
+        , _native_format( native_format )
     {
         create_color_device( dev_info->get_context(), dev_info->get_group() );
         init();
@@ -93,6 +95,32 @@ namespace librealsense
         register_options();
         register_metadata();
         register_color_processing_blocks();
+    }
+
+    void d500_color::register_color_processing_blocks()
+    {
+        auto & color_ep = get_color_sensor();
+
+        switch( _native_format )
+        {
+        case RS2_FORMAT_YUYV:
+            color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
+                RS2_FORMAT_YUYV,
+                map_supported_color_formats( RS2_FORMAT_YUYV ),
+                RS2_STREAM_COLOR ) );
+            break;
+        case RS2_FORMAT_M420:
+            color_ep.register_processing_block( processing_block_factory::create_pbf_vector< m420_converter >(
+                RS2_FORMAT_M420,
+                map_supported_color_formats( RS2_FORMAT_M420 ),
+                RS2_STREAM_COLOR ) );
+            break;
+        default:
+            throw invalid_value_exception( "invalid native color format "
+                                           + std::string( get_string( _native_format ) ) );
+        }
+        color_ep.register_processing_block(  // Color Raw (Bayer 10-bit embedded in 16-bit) for calibration
+            processing_block_factory::create_id_pbf( RS2_FORMAT_RAW16, RS2_STREAM_COLOR ) );
     }
 
     void d500_color::register_options()

--- a/src/ds/d500/d500-color.h
+++ b/src/ds/d500/d500-color.h
@@ -18,7 +18,7 @@ namespace librealsense
     class d500_color : public virtual d500_device
     {
     public:
-        d500_color( std::shared_ptr< const d500_info > const & );
+        d500_color( std::shared_ptr< const d500_info > const &, rs2_format native_format );
 
         synthetic_sensor& get_color_sensor()
         {
@@ -34,12 +34,12 @@ namespace librealsense
     protected:
         std::shared_ptr<stream_interface> _color_stream;
         std::shared_ptr<ds_color_common> _ds_color_common;
-
-        virtual void register_color_processing_blocks() = 0;
+        rs2_format const _native_format;
 
     private:
         void register_options();
         void register_metadata();
+        void register_color_processing_blocks();
 
         void register_stream_to_extrinsic_group(const stream_interface& stream, uint32_t group_index);
 

--- a/src/ds/d500/d500-factory.cpp
+++ b/src/ds/d500/d500-factory.cpp
@@ -49,7 +49,7 @@ public:
         , backend_device( dev_info )
         , d500_device( dev_info )
         , d500_active( dev_info )
-        , d500_color( dev_info )
+        , d500_color( dev_info, RS2_FORMAT_YUYV )
         , d500_motion( dev_info )
         , ds_advanced_mode_base( d500_device::_hw_monitor, get_depth_sensor() )
         , firmware_logger_device(
@@ -64,19 +64,6 @@ public:
                                                        _ds_motion_common->get_gyro_stream().get() };
         streams.insert( streams.end(), mm_streams.begin(), mm_streams.end() );
         return matcher_factory::create( RS2_MATCHER_DEFAULT, streams );
-    }
-
-
-    void register_color_processing_blocks() override
-    {
-        auto & color_ep = get_color_sensor();
-
-        color_ep.register_processing_block( processing_block_factory::create_pbf_vector< yuy2_converter >(
-            RS2_FORMAT_YUYV,
-            map_supported_color_formats( RS2_FORMAT_YUYV ),
-            RS2_STREAM_COLOR ) );
-        color_ep.register_processing_block(  // Color Raw (Bayer 10-bit embedded in 16-bit) for calibration
-            processing_block_factory::create_id_pbf( RS2_FORMAT_RAW16, RS2_STREAM_COLOR ) );
     }
 
 


### PR DESCRIPTION
Fixes PR #12399 problem with virtual function being called from constructor.
