### PR TITLE
Fixed inconsistent hardware clock timestamp.

### DIFF
--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -145,6 +145,7 @@ namespace librealsense
             sample._x -= base_x;
         }
         _prev_time -= base_x;
+        _last_request_time -= base_x;
         _base_sample._y += a * base_x;
         return true;
     }
@@ -216,7 +217,7 @@ namespace librealsense
                 _coefs.add_const_y_coefs(command_delay - _min_command_delay);
                 _min_command_delay = command_delay;
             }
-            double system_time(system_time_finish - _min_command_delay);
+            double system_time(system_time_start + _min_command_delay);
             if (_is_ready)
             {
                 _coefs.update_samples_base(sample_hw_time);


### PR DESCRIPTION
Camera Model: D455
SDK Version: 2.54.2
Firmware Version: 5.15.1

Apply the attached patch to watch measurements of mean, minimum, maximum and
standard deviation of the interval between the hardware clock timestamp and
current time for every 2000 frames.
[measure.patch](https://github.com/IntelRealSense/librealsense/files/13408993/measure.patch)

By the result, the hardware clock timestamp is inconsistent, and it may even
be a future time when the hardware clock (2^32) restarts from zero (on update_samples_base()).
[error.log](https://github.com/IntelRealSense/librealsense/files/13409179/error.log)

```
 20/11 10:53:16,748 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=26.544191 min=21.134033 max=29.761719 stdev=1.751351
 20/11 10:54:23,444 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=25.889587 min=21.957764 max=30.401611 stdev=2.073406
 20/11 10:55:30,140 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=26.397918 min=22.964844 max=28.806885 stdev=1.125099
 20/11 10:56:36,836 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=25.553728 min=19.912354 max=30.630371 stdev=2.161987
 20/11 10:57:28,925 INFO [140162835150592] (global_timestamp_reader.cpp:139) update_samples_base(4294967.296000)
 20/11 10:57:29,025 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,059 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,092 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,125 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,159 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,192 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,225 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,259 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,292 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,326 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,359 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,392 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,426 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,459 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,492 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,526 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,559 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,592 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,626 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,659 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,692 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,726 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,759 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,792 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,826 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,859 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,892 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,926 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,959 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:29,992 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,026 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,059 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,092 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,126 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,159 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,193 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,226 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,259 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,293 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,326 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,359 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,393 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:30,426 ERROR [140162835150592] (global_timestamp_reader.cpp:298) Future Timestamp!
 20/11 10:57:43,532 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=22.965311 min=-207.109131 max=28.433105 stdev=20.851958
 20/11 10:58:50,228 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=25.265000 min=21.204590 max=29.512451 stdev=1.783758
 20/11 10:59:56,924 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=25.783524 min=20.166992 max=30.530518 stdev=2.243548
 20/11 11:01:03,653 INFO [140162835150592] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=26.359362 min=22.466309 max=30.238037 stdev=1.734098
``` 

``` 
double system_time(system_time_finish - _min_command_delay);
``` 
About this line of current code, the author thinks the hardware clock timer is retrieved and 
is immediately sent back. That means the most duration (delay) of getting a hw clock
is spent before retrieving. Having this design is due to varying delay. I assume
the varying delay is caused by firmware design.

I tried the code that refers the delay happening after retrieving the hw clock.
This means the firmware receives the request and immediately processes it.
``` 
double system_time(system_time_start + _min_command_delay);
``` 

From the result, we have a consistent hardware clock timestamp.
[fixed.log](https://github.com/IntelRealSense/librealsense/files/13410858/fixed.log)
``` 
 20/11 13:15:37,356 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.298203 min=28.126953 max=28.494873 stdev=0.063428
 20/11 13:16:44,052 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.250524 min=28.116455 max=28.454590 stdev=0.047277
 20/11 13:17:50,748 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.262912 min=28.094727 max=28.534424 stdev=0.070366
 20/11 13:18:57,445 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.264807 min=28.108887 max=28.530273 stdev=0.072174
 20/11 13:20:04,141 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.273861 min=28.120117 max=28.477783 stdev=0.053090
 20/11 13:20:38,256 INFO [139883601434368] (global_timestamp_reader.cpp:139) update_samples_base(4294967.296000)
 20/11 13:21:10,837 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.348879 min=28.144043 max=33.188965 stdev=0.461801
 20/11 13:22:17,533 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.267152 min=28.090820 max=28.541504 stdev=0.065626
 20/11 13:23:24,229 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.267967 min=28.081299 max=28.506592 stdev=0.078478
 20/11 13:24:30,925 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.262112 min=28.088135 max=28.674072 stdev=0.080410
 20/11 13:25:37,621 INFO [139883601434368] (global_timestamp_reader.cpp:321) HW Timestamp Interval (ms): mean=28.261170 min=28.087646 max=28.437500 stdev=0.058966
``` 

``` 
_last_request_time -= base_x;
``` 
This line of commit is because _last_request_time is also connected with the hw clock.
It should be modified like _prev_time.
The future timestamp could also be fixed.

Thanks.
