### PR TITLE
Add volatile flag to options

### DIFF
--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -38,6 +38,7 @@ namespace rs2
             {
                 option.range = options->get_option_range(opt);
                 option.read_only = options->is_option_read_only(opt);
+                option._volatile = options->is_option_volatile( opt );
                 option.value = options->get_option(opt);
             }
             catch (const error& e)
@@ -633,7 +634,7 @@ bool option_model::draw_option(bool update_read_only_options,
         if (supported && is_streaming)
         {
             update_read_only_status(error_message);
-            if (read_only)
+            if( read_only || _volatile )
             {
                 update_all_fields(error_message, model);
             }

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -32,6 +32,7 @@ namespace rs2
         bool* invalidate_flag = nullptr;
         bool supported = false;
         bool read_only = false;
+        bool _volatile = false;
         float value = 0.0f;
         std::string label = "";
         std::string id = "";

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -247,6 +247,15 @@ extern "C" {
     int rs2_is_option_read_only(const rs2_options* options, rs2_option option, rs2_error** error);
 
     /**
+     * check if an option is volatile, that is, value set by us can change without us setting it again
+     * \param[in] options  the options container
+     * \param[in] option   option id to be checked
+     * \param[out] error   if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+     * \return true if option is volatile
+     */
+    int rs2_is_option_volatile( const rs2_options * options, rs2_option option, rs2_error ** error );
+
+    /**
     * read option value from the sensor
     * \param[in] options  the options container
     * \param[in] option   option id to be queried

--- a/include/librealsense2/hpp/rs_options.hpp
+++ b/include/librealsense2/hpp/rs_options.hpp
@@ -116,6 +116,19 @@ namespace rs2
             return res > 0;
         }
 
+        /**
+         * check if particular option is volatile
+         * \param[in] option     option id to be checked
+         * \return true if option is read-only
+         */
+        bool is_option_volatile( rs2_option option ) const
+        {
+            rs2_error * e = nullptr;
+            auto res = rs2_is_option_volatile( _options, option, &e );
+            error::handle( e );
+            return res > 0;
+        }
+
         std::vector<rs2_option> get_supported_options()
         {
             std::vector<rs2_option> res;

--- a/src/core/option-interface.h
+++ b/src/core/option-interface.h
@@ -26,6 +26,7 @@ public:
     virtual option_range get_range() const = 0;
     virtual bool is_enabled() const = 0;
     virtual bool is_read_only() const { return false; }
+    virtual bool is_volatile() const { return false; }
     virtual const char * get_description() const = 0;
     virtual const char * get_value_description( float ) const { return nullptr; }
     

--- a/src/platform/uvc-option.h
+++ b/src/platform/uvc-option.h
@@ -103,17 +103,20 @@ public:
     }
 
     bool is_enabled() const override { return true; }
+    bool is_volatile() const override { return _is_volatile; }
 
     uvc_xu_option( uvc_sensor & ep,
                    platform::extension_unit xu,
                    uint8_t id,
                    std::string description,
-                   bool allow_set_while_streaming = true )
+                   bool allow_set_while_streaming = true,
+                   bool is_volatile = false )
         : _ep( ep )
         , _xu( xu )
         , _id( id )
         , _desciption( std::move( description ) )
         , _allow_set_while_streaming( allow_set_while_streaming )
+        , _is_volatile( is_volatile )
     {
     }
 
@@ -122,13 +125,15 @@ public:
                    uint8_t id,
                    std::string description,
                    const std::map< float, std::string > & description_per_value,
-                   bool allow_set_while_streaming = true )
+                   bool allow_set_while_streaming = true,
+                   bool is_volatile = false )
         : _ep( ep )
         , _xu( xu )
         , _id( id )
         , _desciption( std::move( description ) )
         , _description_per_value( description_per_value )
         , _allow_set_while_streaming( allow_set_while_streaming )
+        , _is_volatile( is_volatile )
     {
     }
 
@@ -153,6 +158,7 @@ protected:
     };
     const std::map< float, std::string > _description_per_value;
     bool _allow_set_while_streaming;
+    bool _is_volatile = false;
 };
 
 

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -93,6 +93,7 @@ EXPORTS
     rs2_get_option_name
     rs2_get_option_value_description
     rs2_is_option_read_only
+    rs2_is_option_volatile
     rs2_get_options_list
     rs2_get_option_from_list
     rs2_get_options_list_size

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -654,6 +654,13 @@ int rs2_is_option_read_only(const rs2_options* options, rs2_option option, rs2_e
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0, options, option)
 
+int rs2_is_option_volatile( const rs2_options * options, rs2_option option, rs2_error ** error ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( options );
+    return options->options->get_option( option ).is_volatile();
+}
+HANDLE_EXCEPTIONS_AND_RETURN( 0, options, option )
+
 float rs2_get_option(const rs2_options* options, rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);

--- a/wrappers/python/pyrs_options.cpp
+++ b/wrappers/python/pyrs_options.cpp
@@ -9,6 +9,7 @@ void init_options(py::module &m) {
     py::class_<rs2::options> options(m, "options", "Base class for options interface. Should be used via sensor or processing_block."); // No docstring in C++
     options.def("is_option_read_only", &rs2::options::is_option_read_only, "Check if particular option "
                 "is read only.", "option"_a)
+        .def("is_option_volatile", &rs2::options::is_option_volatile, "Check if particular option is volatile.", "option"_a)
         .def("get_option", &rs2::options::get_option, "Read option value from the device.", "option"_a, py::call_guard<py::gil_scoped_release>())
         .def("get_option_range", &rs2::options::get_option_range, "Retrieve the available range of values "
              "of a supported option", "option"_a, py::call_guard<py::gil_scoped_release>())


### PR DESCRIPTION
Some options that are not read only might change without us setting them.
We want the viewer to query them periodically to reflect their current value, like it does with read only options.
