### PR TITLE
derive context settings from configuration file

### DIFF
--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -3,6 +3,7 @@
 
 #include "rs-config.h"
 
+#include <librealsense2/rs.h>
 #include <rsutils/os/special-folder.h>
 #include <rsutils/json.h>
 #include <fstream>
@@ -79,7 +80,7 @@ void config_file::save(const char* filename)
 config_file& config_file::instance()
 {
     static config_file inst( rsutils::os::get_special_folder( rsutils::os::special_folder::app_data )
-                             + "realsense-config.json" );
+                             + RS2_CONFIG_FILENAME );
     return inst;
 }
 

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -1,7 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
-
 #pragma once
+
+#include <nlohmann/json.hpp>
 
 #include <map>
 #include <string>
@@ -40,7 +41,7 @@ namespace rs2
     {
     public:
         config_file();
-        config_file(std::string filename);
+        config_file( std::string const & filename );
 
         void set_default(const char* key, const char* calculate);
 
@@ -91,8 +92,8 @@ namespace rs2
 
         void save();
 
-        std::map<std::string, std::string> _values;
         std::map<std::string, std::string> _defaults;
         std::string _filename;
+        nlohmann::json _j;
     };
 }

--- a/include/librealsense2/h/rs_context.h
+++ b/include/librealsense2/h/rs_context.h
@@ -16,6 +16,7 @@ extern "C" {
 
 /**
 * \brief Creates RealSense context that is required for the rest of the API.
+* Context settings are taken from the library configuration file's 'context' key.
 * \param[in] api_version Users are expected to pass their version of \c RS2_API_VERSION to make sure they are running the correct librealsense version.
 * \param[out] error  If non-null, receives any error that occurs during this call, otherwise, errors are ignored.
 * \return            Context object
@@ -27,6 +28,10 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error);
 * \param[in] api_version Users are expected to pass their version of \c RS2_API_VERSION to make sure they are running the correct librealsense version.
 * \param[in] json_settings Pointer to a string containing a JSON configuration to use, or null if none
 *     Possible <setting>:<default-value> :
+*         inherit: true                - (bool) whether to inherit and override library configuration file values:
+*             the 'context' key in the file is taken as-is
+*             '<executable-name>/context' is merged, if it exists
+*             then the context-settings are merged
 *         dds: {}                      - (requires BUILD_WITH_DDS) false disables DDS; otherwise the DDS settings:
 *             domain: 0                - (int) the number of the DDS domain [0-232]
 *             participant: <exe name>  - (string) the name of the participant

--- a/include/librealsense2/rs.h
+++ b/include/librealsense2/rs.h
@@ -45,6 +45,20 @@ extern "C" {
 #define RS2_API_FULL_VERSION_STR (VAR_ARG_STRING(RS2_API_MAJOR_VERSION.RS2_API_MINOR_VERSION.RS2_API_PATCH_VERSION.RS2_API_BUILD_VERSION))
 
 /**
+ * The library keeps persistent global settings in a per-user configuration file. These settings can relate to tool
+ * behavior (e.g., realsense-viewer) or library functionality (context creation, etc.) where settings are accepted
+ * (e.g., rs2_create_context_ex).
+ * 
+ * The filename is appended to the user's AppData folder on Windows (<AppData>/<filename>) and home directory as a
+ * hidden file on Linux (~/.<filename>).
+ * 
+ * The content is a JSON file and by default contains an empty object so default values are used. JSON ordering may
+ * shift when written to by the various tools but the contents should stay the same. Any values that do not match the
+ * expected type may be ignored.
+ */
+#define RS2_CONFIG_FILENAME "realsense-config.json"
+
+/**
 * get the size of rs2_raw_data_buffer
 * \param[in] buffer  pointer to rs2_raw_data_buffer returned by rs2_send_and_receive_raw_data
 * \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -83,10 +83,8 @@ static std::mutex domain_context_by_id_mutex;
 rsdds_device_factory::rsdds_device_factory( context & ctx, callback && cb )
     : super( ctx )
 {
-    nlohmann::json dds_settings = rsutils::json::get< nlohmann::json >( _context.get_settings(),
-                                                                        std::string( "dds", 3 ),
-                                                                        nlohmann::json::object() );
-    if( dds_settings.is_object() )
+    nlohmann::json const & dds_settings = rsutils::json::nested( _context.get_settings(), std::string( "dds", 3 ) );
+    if( dds_settings.is_object() && rsutils::json::get( dds_settings, std::string( "enabled", 7 ), true ) )
     {
         auto domain_id = rsutils::json::get< realdds::dds_domain_id >( dds_settings, std::string( "domain", 6 ), 0 );
         std::string participant_name = rsutils::json::get< std::string >( dds_settings,

--- a/third-party/realdds/doc/discovery.md
+++ b/third-party/realdds/doc/discovery.md
@@ -123,9 +123,10 @@ The `context` has been augmented to be able to see DDS devices. This is on by de
 
 When a context is created, a JSON representation may be passed to it, e.g.: `{"dds": { "domain": 123, "participant": "librs" }}`. This allows various customizations:
 
-| Field                | Description                            |
-|----------------------|----------------------------------------|
-| dds                  | Set to `false` to turn off DDS in this context; otherwise a JSON object
+| Field                | Default | Description                  |
+|----------------------|--------:|------------------------------|
+| dds                  | `{}`      | Set to `false` to turn off DDS in this context
+| dds/`enabled`          | `true`    | If `false`, DDS is disabled
 
 The `dds` is there by default (i.e., not `false`). The value may contain the following settings dealing with discovery:
 

--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -59,8 +59,11 @@ public:
     dds_participant( const dds_participant & ) = delete;
     ~dds_participant();
 
-    // Creates the underlying DDS participant and sets the QoS
-    // If need to use callbacks set them before calling init, they may be called before init returns.
+    // Creates the underlying DDS participant and sets the QoS.
+    // If callbacks are needed, set them before calling init. Note they may be called before init returns!
+    // 
+    // The domain ID may be -1: in this case the settings "domain" is queried and a default of 0 is used
+    //
     void init( dds_domain_id, std::string const & participant_name, nlohmann::json const & settings );
 
     bool is_valid() const { return ( nullptr != _participant ); }

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -15,6 +15,7 @@
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 
 #include <rsutils/string/slice.h>
+#include <rsutils/json.h>
 
 #include <map>
 #include <mutex>
@@ -192,6 +193,13 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
         DDS_THROW( runtime_error,
                    "participant is already initialized; cannot init '" + participant_name + "' on domain id "
                        + std::to_string( domain_id ) );
+    }
+
+    if( domain_id == -1 )
+    {
+        // Get it from settings and default to 0
+        if( ! rsutils::json::get_ex( settings, "domain", &domain_id ) )
+            domain_id = 0;
     }
 
     _domain_listener = std::make_shared< listener_impl >( *this );

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -1,6 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include <nlohmann/json.hpp>
@@ -171,6 +170,69 @@ public:
     // Get a JSON string by reference (zero copy); it must be a string or it'll throw
     inline std::string const & string_ref() const { return json::string_ref( get() ); }
 };
+
+
+// Recursively patches existing 'j' with contents of 'patches', which must be a JSON object.
+// A 'null' value inside erases previous contents. Any other value overrides.
+// See: https://json.nlohmann.me/api/basic_json/merge_patch/
+// Example below, for load_app_settings.
+// Use 'what' to denote what it is we're patching in, if a failure happens. The std::runtime_error will populate with
+// it.
+//
+void patch( nlohmann::json & j, nlohmann::json const & patches, std::string const & what = {} );
+
+
+// Loads configuration settings from 'global' content.
+// E.g., a configuration file may contain:
+//     {
+//         "context": {
+//             "dds": {
+//                 "enabled": false,
+//                 "domain" : 5
+//             }
+//         },
+//         ...
+//     }
+// This function will load a specific key 'context' inside and return it. The result will be a disabling of dds:
+// Besides this "global" key, application-specific settings can override the global settings, e.g.:
+//     {
+//         "context": {
+//             "dds": {
+//                 "enabled": false,
+//                 "domain" : 5
+//             }
+//         },
+//         "realsense-viewer": {
+//             "context": {
+//                 "dds": { "enabled": null }
+//             }
+//         },
+//         ...
+//     }
+// If the current application is 'realsense-viewer', then the global 'context' settings will be patched with the
+// application-specific 'context' and returned:
+//     {
+//         "dds": {
+//             "domain" : 5
+//         }
+//     }
+// See rules for patching in patch().
+// The 'application' is usually any single-word executable name (without extension).
+// The 'subkey' is mandatory.
+// The 'error_context' is used for error reporting, to show what failed. Like application, it should be a single word
+// that can be used to denote hierarchy within the global json.
+//
+nlohmann::json load_app_settings( nlohmann::json const & global,
+                                  std::string const & application,
+                                  std::string const & subkey,
+                                  std::string const & error_context );
+
+
+// Same as above, but automatically takes the application name from the executable-name.
+//
+nlohmann::json load_settings( nlohmann::json const & global,
+                              std::string const & subkey,
+                              std::string const & error_context );
 
 
 }  // namespace json

--- a/third-party/rsutils/src/json.cpp
+++ b/third-party/rsutils/src/json.cpp
@@ -2,12 +2,58 @@
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
 #include <rsutils/json.h>
+#include <rsutils/os/executable-name.h>
 
 namespace rsutils {
 namespace json {
 
 
 nlohmann::json const null_json = {};
+
+
+void patch( nlohmann::json & j, nlohmann::json const & patches, std::string const & what )
+{
+    if( ! patches.is_object() )
+    {
+        std::string context = what.empty() ? std::string( "patch", 5 ) : what;
+        throw std::runtime_error( context + ": expecting an object; got " + patches.dump() );
+    }
+
+    try
+    {
+        j.merge_patch( patches );
+    }
+    catch( std::exception const & e )
+    {
+        std::string context = what.empty() ? std::string( "patch", 5 ) : what;
+        throw std::runtime_error( "failed to merge " + context + ": " + e.what() );
+    }
+}
+
+
+nlohmann::json load_app_settings( nlohmann::json const & global,
+                                  std::string const & application,
+                                  std::string const & subkey,
+                                  std::string const & error_context )
+{
+    // Take the global subkey settings out of the configuration
+    nlohmann::json settings;
+    if( auto global_subkey = rsutils::json::nested( global, subkey ) )
+        patch( settings, global_subkey, "global " + error_context + '/' + subkey );
+
+    // Patch any application-specific subkey settings
+    if( auto application_subkey = rsutils::json::nested( global, application, subkey ) )
+        patch( settings, application_subkey, error_context + '/' + application + '/' + subkey );
+
+    return settings;
+}
+
+
+nlohmann::json
+load_settings( nlohmann::json const & global, std::string const & subkey, std::string const & error_context )
+{
+    return load_app_settings( global, rsutils::os::executable_name(), subkey, error_context );
+}
 
 
 }  // namespace json

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -358,8 +358,11 @@ int main(int argc, char** argv) try
     json settings;
 #ifdef BUILD_WITH_DDS
     json dds;
-    dds["domain"] = domain_arg.getValue();
-    settings["dds"] = std::move( dds ); 
+    if( domain_arg.isSet() )
+        dds["domain"] = domain_arg.getValue();
+    if( only_sw_arg.isSet() )
+        dds["enabled"];  // null: remove global dds:false or dds/enabled:false, if any
+    settings["dds"] = std::move( dds );
 #endif
     settings["format-conversion"] = format_arg.getValue();
     context ctx( settings.dump() );

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -332,9 +332,14 @@ int main(int argc, const char** argv) try
 
     std::shared_ptr<device_models_list> device_models = std::make_shared<device_models_list>();
 
-    nlohmann::json settings;
+    nlohmann::json settings = nlohmann::json::object();
     if( only_sw_arg.getValue() )
+    {
+#if defined( BUILD_WITH_DDS )
+        settings["dds"]["enabled"];  // null: remove global dds:false or dds/enabled:false, if any
+#endif
         settings["device-mask"] = RS2_PRODUCT_LINE_SW_ONLY | RS2_PRODUCT_LINE_ANY;
+    }
 
     context ctx( settings.dump() );
     ux_window window("Intel RealSense Viewer", ctx);

--- a/tools/terminal/rs-terminal.cpp
+++ b/tools/terminal/rs-terminal.cpp
@@ -200,7 +200,10 @@ int main(int argc, char** argv)
     nlohmann::json settings;
 #ifdef BUILD_WITH_DDS
     nlohmann::json dds;
-    dds["domain"] = domain_arg.getValue();
+    if( domain_arg.isSet() )
+        dds["domain"] = domain_arg.getValue();
+    if( only_sw_arg.isSet() )
+        dds["enabled"];  // null: remove global dds:false or dds/enabled:false, if any
     settings["dds"] = std::move( dds );
 #endif
     if( only_sw_arg.getValue() )


### PR DESCRIPTION
Continuation (2/3) of previous PR for persistent DDS settings.

* Move the filename for our config file (the one the Viewer uses) into rs.h as `RS2_CONFIG_FILENAME`
* The configuration file (JSON) implementation in `common/rs-config` now can read non-string JSON values
* Contexts now take their settings from:
    * The global configuration file `context` key, merged with:
    * Application-specific context key, merged with:
    * Context-specific settings as handed to the context
* Context settings can disable the above with `"inherit":false`

E.g.:
```JSON
{
  "context": {
    "dds": {
      "enabled": false,
      "domain": 5
    }
  },
  "realsense-viewer": {
    "context": {
      "dds": {
        "enabled": true,
        "device": {
          "metadata": { "reliability": "best-effort" }
        }
      }
    }
  },
  ...
}
```
* would disable DDS by default, except in the viewer
* would default to domain 5 when enabled

Tracked on [LRS-963]