### PR TITLE
Enable frame-source create/delete from RS APIs

### DIFF
--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -272,6 +272,22 @@ const rs2_stream_profile* rs2_get_frame_stream_profile(const rs2_frame* frame, r
 int rs2_is_frame_extendable_to(const rs2_frame* frame, rs2_extension extension_type, rs2_error ** error);
 
 /**
+ * Create a source that can be used to allocate frames. Usually this is provided inside processing blocks, but there may
+ * be situations where one would need to creat frames on the fly.
+ * 
+ * \param[in]  context                 The context for the source, and frames
+ * \param[in]  max_publish_list_size   The maximum size of built-in archive; librealsense defaults to 16
+ * \return The new source; use rs2_delete_frame_source when done with it
+ */
+rs2_source * rs2_create_frame_source( rs2_context * context, unsigned max_publish_list_size, rs2_error ** error );
+
+/**
+ * Delete a source created with rs2_create_frame_source.
+ * \param[in]  source                  The source created with rs2_create_frame_source
+ */
+void rs2_delete_frame_source( rs2_source * source );
+
+/**
 * Allocate new video frame using a frame-source provided form a processing block
 * \param[in] source      Frame pool to allocate the frame from
 * \param[in] new_stream  New stream profile to assign to newly created frame

--- a/src/core/processing.h
+++ b/src/core/processing.h
@@ -16,9 +16,11 @@ namespace librealsense
     class synthetic_source_interface;
 }
 
+struct rs2_frame_source;
 struct rs2_source
 {
     librealsense::synthetic_source_interface* source;
+    std::shared_ptr< rs2_frame_source > frame_source;
 };
 
 namespace librealsense

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -407,17 +407,23 @@ namespace librealsense
             height = vf->get_height();
         }
 
-        auto of = dynamic_cast<frame*>(original);
-        frame_additional_data data = of->additional_data;
+        auto of = dynamic_cast<frame *>(original);
+        frame_additional_data data;
+        if( of )
+            data = of->additional_data;
+        else
+            data.system_time = time_service::get_time();
         auto res = _actual_source.alloc_frame( frame_type, stride * height, std::move( data ), true );
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = dynamic_cast<video_frame*>(res);
-        vf->metadata_parsers = of->metadata_parsers;
+        if( of )
+            vf->metadata_parsers = of->metadata_parsers;
         vf->assign(width, height, stride, bpp);
-        vf->set_sensor(original->get_sensor());
+        if( original )
+            vf->set_sensor(original->get_sensor());
         res->set_stream(stream);
 
-        if (frame_type == RS2_EXTENSION_DEPTH_FRAME)
+        if( original && frame_type == RS2_EXTENSION_DEPTH_FRAME )
         {
             original->acquire();
             (dynamic_cast<depth_frame*>(res))->set_original(original);

--- a/src/proc/synthetic-stream.h
+++ b/src/proc/synthetic-stream.h
@@ -50,13 +50,13 @@ namespace librealsense
     {
     public:
         processing_block(const char* name);
+        virtual ~processing_block() { _source.flush(); }
 
         void set_processing_callback( rs2_frame_processor_callback_sptr callback) override;
         void set_output_callback( rs2_frame_callback_sptr callback) override;
         void invoke(frame_holder frames) override;
         synthetic_source_interface& get_source() override { return _source_wrapper; }
 
-        virtual ~processing_block() { _source.flush(); }
     protected:
         frame_source _source;
         std::mutex _mutex;
@@ -68,7 +68,6 @@ namespace librealsense
     {
     public:
         generic_processing_block(const char* name);
-        virtual ~generic_processing_block() { _source.flush(); }
 
     protected:
         virtual rs2::frame prepare_output(const rs2::frame_source& source, rs2::frame input, std::vector<rs2::frame> results);
@@ -131,7 +130,6 @@ namespace librealsense
     {
     public:
         stream_filter_processing_block(const char* name);
-        virtual ~stream_filter_processing_block() { _source.flush(); }
 
     protected:
         stream_filter _stream_filter;
@@ -199,8 +197,6 @@ namespace librealsense
     public:
         depth_processing_block(const char* name) : stream_filter_processing_block(name) {}
 
-        virtual ~depth_processing_block() { _source.flush(); }
-
     protected:
         bool should_process(const rs2::frame& frame) override;
     };
@@ -246,7 +242,6 @@ namespace librealsense
 
         composite_processing_block();
         composite_processing_block(const char* name);
-        virtual ~composite_processing_block() { _source.flush(); };
 
         processing_block& get(rs2_option option);
         void add(std::shared_ptr<processing_block> block);

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -184,6 +184,8 @@ EXPORTS
     rs2_clone_stream_profile
     rs2_clone_video_stream_profile
 
+    rs2_create_frame_source
+    rs2_delete_frame_source
     rs2_allocate_synthetic_video_frame
     rs2_allocate_synthetic_motion_frame
     rs2_allocate_points

--- a/wrappers/python/pyrs_context.cpp
+++ b/wrappers/python/pyrs_context.cpp
@@ -36,8 +36,12 @@ void init_context(py::module &m) {
         .def("load_device", &rs2::context::load_device, "Creates a devices from a RealSense file.\n"
              "On successful load, the device will be appended to the context and a devices_changed event triggered.",
              "filename"_a)
-        .def("unload_device", &rs2::context::unload_device, "filename"_a) // No docstring in C++
-        .def("unload_tracking_module", &rs2::context::unload_tracking_module); // No docstring in C++
+        .def("unload_device", &rs2::context::unload_device, "filename"_a)
+        .def("unload_tracking_module", &rs2::context::unload_tracking_module)
+        .def( "create_frame_source",
+              []( rs2::context & self, unsigned size )
+                  { return rs2::frame_source( self.operator std::shared_ptr< rs2_context >(), size ); },
+              py::arg( "max_publish_list_size" ) = 16 );
 
     // rs2::device_hub
     /** end rs_context.hpp **/


### PR DESCRIPTION
We currently need to create complicated processing blocks just to be able to create composite frames for passing to a real processing blocks such as `align`. We're running into this in our unit-test creation.

We can add an API and use the sensor's source, like `sensor.get_source()`.
We can add an API to specifically create a composite frame (somewhere).
Or we can add the missing frame-source construction and deletion: the source interface was already exposed, just not a way to create one manually.

All of them add APIs. I chose the latter.

* add `rs2_create_frame_source`, taking a context
* add `rs2_delete_frame_source`
* add corresponding `rs2::frame_source` functionality
* add pyrealsense2 `context.create_frame_source()`
* enable null frame passing to `rs2_allocate_synthetic_video_frame`, for testing; decided to keep it as it doesn't hurt the logic


