### PR TITLE
Fix visual preset depth settings

### DIFF
--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -208,8 +208,8 @@ namespace librealsense
         preset get_all() const;
         void set_all( const preset & p );
         void set_all_depth( const preset & p );
-        void set_all_color( const preset & p );
-        bool should_set_color_preset() const;
+        void set_all_rgb( const preset & p );
+        bool should_set_rgb_preset() const;
 
         std::vector<uint8_t> send_receive(const std::vector<uint8_t>& input) const;
 

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -758,8 +758,8 @@ namespace librealsense
     void ds_advanced_mode_base::set_all( const preset & p )
     {
         set_all_depth( p );
-        if( should_set_color_preset() )
-            set_all_color( p );
+        if( should_set_rgb_preset() )
+            set_all_rgb( p );
     }
 
     void ds_advanced_mode_base::set_all_depth(const preset& p)
@@ -789,15 +789,16 @@ namespace librealsense
             set_depth_gain(p.depth_gain);
             set_depth_exposure(p.depth_exposure);
         }
-    }
 
-    void ds_advanced_mode_base::set_all_color( const preset & p )
-    {
+        // Depth sensor related even though they have color in the name. Probably color from left IR imager.
         set( p.color_control, advanced_mode_traits< STColorControl >::group );
         set( p.rctc         , advanced_mode_traits< STRauColorThresholdsControl >::group );
         set( p.sctc         , advanced_mode_traits< STSloColorThresholdsControl >::group );
         set( p.spc          , advanced_mode_traits< STSloPenaltyControl >::group );
+    }
 
+    void ds_advanced_mode_base::set_all_rgb( const preset & p )
+    {
         set_color_auto_exposure(p.color_auto_exposure);
         if (p.color_auto_exposure.was_set && p.color_auto_exposure.auto_exposure == 0)
         {
@@ -821,7 +822,7 @@ namespace librealsense
         //set_color_power_line_frequency(p.color_power_line_frequency);
     }
 
-    bool ds_advanced_mode_base::should_set_color_preset() const
+    bool ds_advanced_mode_base::should_set_rgb_preset() const
     {
         auto product_line = _depth_sensor.get_device().get_info( rs2_camera_info::RS2_CAMERA_INFO_PRODUCT_LINE );
 


### PR DESCRIPTION
Colored IR settings were set along with RGB settings, moved to be with depth module settings.
Tracked on [RSDEV-1176]