### PR TITLE
try to fix global timestamp mapping issue when HW timestamp is rollback to 0

### DIFF
--- a/src/global_timestamp_reader.cpp
+++ b/src/global_timestamp_reader.cpp
@@ -145,7 +145,7 @@ namespace librealsense
             sample._x -= base_x;
         }
         _prev_time -= base_x;
-        _base_sample._y += a * base_x;
+        _base_sample._x -= base_x;
         return true;
     }
 


### PR DESCRIPTION
HW timestamp is 32bit.
when the HW timestamp is rollbacked to 0 from 2^32, the global timestamp may drift a little in about 1 second.

the value of _base_sample._x is copied from the HW timestamp.
the value of _base_sample._y is host timestamp.
when the HW timestamp is rollback, _x should be changed.


