### PR TITLE
Test point-cloud-from-recordng

### DIFF
--- a/unit-tests/live/CMakeLists.txt
+++ b/unit-tests/live/CMakeLists.txt
@@ -14,4 +14,5 @@ dl_file( ${PP_Rosbag_Recordings_URL} recordings [aligned_2c]_all_combinations_de
 # for post-processing/post-processing-from-bag.py
 dl_file( ${PP_Rosbag_Recordings_URL} recordings [aligned_2d]_all_combinations_depth_color.bag OFF )
 
-
+# for post-processing/post-processing-from-bag.py
+dl_file( ${PP_Rosbag_Recordings_URL} recordings [pointcloud]_all_combinations_depth_color.bag OFF )

--- a/unit-tests/post-processing/test-post-processing-from-bag.py
+++ b/unit-tests/post-processing/test-post-processing-from-bag.py
@@ -116,4 +116,10 @@ with test.closure("Test align color to depth from recording"):
 
     compare_processed_frames_vs_recorded_frames("[aligned_2d]_all_combinations_depth_color.bag")
 ################################################################################################
+with test.closure("Test point cloud from recording"):
+    pc = rs.pointcloud()
+    process_frame_callback = lambda fs: pc.calculate(fs.get_depth_frame())
+
+    compare_processed_frames_vs_recorded_frames("[pointcloud]_all_combinations_depth_color.bag")
+################################################################################################
 test.print_results_and_exit()

--- a/unit-tests/unit-tests-post-processing-from-bag.cpp
+++ b/unit-tests/unit-tests-post-processing-from-bag.cpp
@@ -541,19 +541,19 @@ TEST_CASE("Record point cloud software-device all resolutions", "[record-bag][po
     record_frames_all_res(record_block, "[pointcloud]_all_combinations_depth_color.bag");
 }
 
-TEST_CASE("Test align color to depth from recording", "[software-device][align]")
+TEST_CASE("Test align color to depth from recording", "[software-device-disabled][align]")
 {
     auto record_block = align_record_block(RS2_STREAM_DEPTH, RS2_STREAM_COLOR);
     compare_processed_frames_vs_recorded_frames(record_block, "[aligned_2d]_all_combinations_depth_color.bag");
 }
 
-TEST_CASE("Test align depth to color from recording", "[software-device][align]")
+TEST_CASE("Test align depth to color from recording", "[software-device-disabled][align]")
 {
     auto record_block = align_record_block(RS2_STREAM_COLOR, RS2_STREAM_DEPTH);
     compare_processed_frames_vs_recorded_frames(record_block, "[aligned_2c]_all_combinations_depth_color.bag");
 }
 
-TEST_CASE("Test point cloud from recording", "[software-device][point-cloud]")
+TEST_CASE("Test point cloud from recording", "[software-device-disabled][point-cloud]")
 {
     auto record_block = pointcloud_record_block();
     compare_processed_frames_vs_recorded_frames(record_block, "[pointcloud]_all_combinations_depth_color.bag");


### PR DESCRIPTION
Porting the last test for post-processing-from-bag.py
Disabling the ported tests from running in legacy live tests.
Adding the needed bag file to CMake.

Tracked on [LRS-683](https://jira.devtools.intel.com/browse/LRS-683)
