### PR TITLE
fix auto return value error grrrrr

### DIFF
--- a/tools/dds/dds-sniffer/rs-dds-sniffer.cpp
+++ b/tools/dds/dds-sniffer/rs-dds-sniffer.cpp
@@ -49,7 +49,7 @@ constexpr uint8_t GUID_PROCESS_LOCATION = 4;
 
 static eprosima::fastrtps::rtps::GuidPrefix_t std_prefix;
 
-static inline auto print_guid( realdds::dds_guid const & guid )
+static inline realdds::print_guid print_guid( realdds::dds_guid const & guid )
 {
     return realdds::print_guid( guid, std_prefix );
 }

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -752,7 +752,7 @@ if __name__ == '__main__':
     import os, sys, getopt
     try:
         opts,args = getopt.getopt( sys.argv[1:], '',
-            longopts = [ 'help', 'recycle', 'all', 'list', 'port=', 'ports' ])
+            longopts = [ 'help', 'recycle', 'all', 'none', 'list', 'port=', 'ports' ])
     except getopt.GetoptError as err:
         print( '-F-', err )   # something like "option -a not recognized"
         usage()
@@ -786,13 +786,17 @@ if __name__ == '__main__':
                 ports = [int(port) for port in str_ports if port.isnumeric() and int(port) in all_ports]
                 if len(ports) != len(str_ports):
                     log.f( 'Invalid ports', str_ports )
-                acroname.enable_ports( ports, disable_other_ports = True, sleep_on_change = MAX_ENUMERATION_TIME )
+                acroname.enable_ports( ports, disable_other_ports=False, sleep_on_change=MAX_ENUMERATION_TIME )
             elif opt in ('--ports'):
                 printer = get_phys_port
             elif opt in ('--all'):
                 if not acroname:
                     log.f( 'No acroname available' )
                 acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
+            elif opt in ('--none'):
+                if not acroname:
+                    log.f( 'No acroname available' )
+                acroname.disable_ports()
             elif opt in ('--recycle'):
                 action = 'recycle'
             else:

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -204,7 +204,7 @@ def map_unknown_ports():
         log.debug_unindent()
 
 
-def query( monitor_changes = True, hub_reset = False ):
+def query( monitor_changes=True, hub_reset=False ):
     """
     Start a new LRS context, and collect all devices
     :param monitor_changes: If True, devices will update dynamically as they are removed/added
@@ -219,8 +219,9 @@ def query( monitor_changes = True, hub_reset = False ):
         if not acroname.hub:
             acroname.connect( hub_reset )  # MAY THROW!
 
-            acroname.disable_ports( sleep_on_change = 5 )
-            acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
+            if monitor_changes:
+                acroname.disable_ports( sleep_on_change = 5 )
+                acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
 
             if platform.system() == 'Linux':
                 global _acroname_hubs
@@ -797,7 +798,7 @@ if __name__ == '__main__':
             else:
                 usage()
         if action == 'list':
-            query()
+            query( monitor_changes=False )
             for sn in all():
                 device = get( sn )
                 print( '{port} {name:30} {sn:20} {handle}'.format(

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -204,10 +204,13 @@ def map_unknown_ports():
         log.debug_unindent()
 
 
-def query( monitor_changes=True, hub_reset=False ):
+def query( monitor_changes=True, hub_reset=False, recycle_ports=True ):
     """
     Start a new LRS context, and collect all devices
     :param monitor_changes: If True, devices will update dynamically as they are removed/added
+    :param recycle_ports: True to recycle all ports before querying devices; False to leave as-is
+    :param hub_reset: Whether we want to reset the Acroname hub - this might be an better way to
+        recycle the ports in certain cases that leave the ports in a bad state
     """
     global rs
     if not rs:
@@ -219,7 +222,7 @@ def query( monitor_changes=True, hub_reset=False ):
         if not acroname.hub:
             acroname.connect( hub_reset )  # MAY THROW!
 
-            if monitor_changes:
+            if recycle_ports:
                 acroname.disable_ports( sleep_on_change = 5 )
                 acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
 
@@ -805,7 +808,7 @@ if __name__ == '__main__':
             else:
                 usage()
         if action == 'list':
-            query( monitor_changes=False )
+            query( monitor_changes=False, recycle_ports=False )
             for sn in all():
                 device = get( sn )
                 print( '{port} {name:30} {sn:20} {handle}'.format(

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -786,17 +786,20 @@ if __name__ == '__main__':
                 ports = [int(port) for port in str_ports if port.isnumeric() and int(port) in all_ports]
                 if len(ports) != len(str_ports):
                     log.f( 'Invalid ports', str_ports )
-                acroname.enable_ports( ports, disable_other_ports=False, sleep_on_change=MAX_ENUMERATION_TIME )
+                acroname.enable_ports( ports, disable_other_ports=False )
+                action = 'none'
             elif opt in ('--ports'):
                 printer = get_phys_port
             elif opt in ('--all'):
                 if not acroname:
                     log.f( 'No acroname available' )
-                acroname.enable_ports( sleep_on_change = MAX_ENUMERATION_TIME )
+                acroname.enable_ports()
+                action = 'none'
             elif opt in ('--none'):
                 if not acroname:
                     log.f( 'No acroname available' )
                 acroname.disable_ports()
+                action = 'none'
             elif opt in ('--recycle'):
                 action = 'recycle'
             else:


### PR DESCRIPTION
PR #12467 introduced `auto` function return value that wasn't liked:
```
rs-dds-sniffer.cpp:52:15: error: 'print_guid' function uses 'auto' type specifier without trailing return type
```
Only on jammy debian creation...

Added some small changes in manual usage of `devices.py` script, to avoid annoying wait times and compound behavior.