### PR TITLE
context construction using make()

### DIFF
--- a/src/backend-device-factory.h
+++ b/src/backend-device-factory.h
@@ -37,7 +37,7 @@ class backend_device_factory : public device_factory
     rsutils::subscription const _dtor;  // raii generic code, used to automatically unsubscribe our callback
 
 public:
-    backend_device_factory( context &, callback && );
+    backend_device_factory( std::shared_ptr< context > const &, callback && );
     ~backend_device_factory();
 
     // Query any subset of available devices and return them as device-info objects

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -67,16 +67,23 @@ namespace librealsense {
             version_logged = true;
             LOG_DEBUG( "Librealsense VERSION: " << RS2_API_FULL_VERSION_STR );
         }
+    }
+
+
+    void context::create_factories()
+    {
+        // This can only get called once the constructor is done:
+        auto sptr = shared_from_this();
 
         _factories.push_back( std::make_shared< backend_device_factory >(
-            *this,
+            sptr,
             [this]( std::vector< std::shared_ptr< device_info > > const & removed,
                     std::vector< std::shared_ptr< device_info > > const & added )
             { invoke_devices_changed_callbacks( removed, added ); } ) );
 
 #ifdef BUILD_WITH_DDS
         _factories.push_back( std::make_shared< rsdds_device_factory >(
-            *this,
+            sptr,
             [this]( std::vector< std::shared_ptr< device_info > > const & removed,
                     std::vector< std::shared_ptr< device_info > > const & added )
             { invoke_devices_changed_callbacks( removed, added ); } ) );
@@ -84,9 +91,17 @@ namespace librealsense {
     }
 
 
-    context::context( char const * json_settings )
-        : context( json_settings ? json::parse( json_settings ) : json::object() )
+    /*static*/ std::shared_ptr< context > context::make( json const & settings )
     {
+        std::shared_ptr< context > ctx( new context( settings ) );
+        ctx->create_factories();
+        return ctx;
+    }
+
+
+    /*static*/ std::shared_ptr< context > context::make( char const * json_settings )
+    {
+        return make( json_settings ? json::parse( json_settings ) : json::object() );
     }
 
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -70,11 +70,8 @@ namespace librealsense {
     }
 
 
-    void context::create_factories()
+    void context::create_factories( std::shared_ptr< context > const & sptr )
     {
-        // This can only get called once the constructor is done:
-        auto sptr = shared_from_this();
-
         _factories.push_back( std::make_shared< backend_device_factory >(
             sptr,
             [this]( std::vector< std::shared_ptr< device_info > > const & removed,
@@ -93,9 +90,9 @@ namespace librealsense {
 
     /*static*/ std::shared_ptr< context > context::make( json const & settings )
     {
-        std::shared_ptr< context > ctx( new context( settings ) );
-        ctx->create_factories();
-        return ctx;
+        std::shared_ptr< context > sptr( new context( settings ) );
+        sptr->create_factories( sptr );
+        return sptr;
     }
 
 

--- a/src/context.h
+++ b/src/context.h
@@ -16,11 +16,11 @@ namespace librealsense
     class processing_block_interface;
 
 
-    class context : public std::enable_shared_from_this<context>
+    class context
     {
         context( nlohmann::json const & );  // private! use make()
 
-        void create_factories();
+        void create_factories( std::shared_ptr< context > const & sptr );
 
     public:
         static std::shared_ptr< context > make( nlohmann::json const & );

--- a/src/context.h
+++ b/src/context.h
@@ -18,9 +18,13 @@ namespace librealsense
 
     class context : public std::enable_shared_from_this<context>
     {
+        context( nlohmann::json const & );  // private! use make()
+
+        void create_factories();
+
     public:
-        explicit context( nlohmann::json const & );
-        explicit context( char const * json_settings );
+        static std::shared_ptr< context > make( nlohmann::json const & );
+        static std::shared_ptr< context > make( char const * json_settings );
 
         ~context();
 

--- a/src/dds/rsdds-device-factory.h
+++ b/src/dds/rsdds-device-factory.h
@@ -34,7 +34,7 @@ class rsdds_device_factory : public device_factory
     rsutils::subscription _subscription;
 
 public:
-    rsdds_device_factory( context &, callback && );
+    rsdds_device_factory( std::shared_ptr< context > const &, callback && );
     ~rsdds_device_factory();
 
     // Query any subset of available devices and return them as device-info objects

--- a/src/device_hub.cpp
+++ b/src/device_hub.cpp
@@ -11,25 +11,41 @@ namespace librealsense
 {
     typedef rs2::devices_changed_callback<std::function<void(rs2::event_information& info)>> hub_devices_changed_callback;
 
-    device_hub::device_hub(std::shared_ptr<librealsense::context> ctx, int mask)
+    device_hub::device_hub( std::shared_ptr< librealsense::context > ctx, int mask )
         : _ctx( ctx )
         , _mask( mask )
     {
-        _device_list = _ctx->query_devices(mask);
+    }
+
+    void device_hub::init( std::shared_ptr< device_hub > const & sptr )
+    {
+        _device_list = _ctx->query_devices( _mask );
 
         _device_change_subscription = _ctx->on_device_changes(
-            [&, mask]( std::vector< std::shared_ptr< device_info > > const & /*removed*/,
-                       std::vector< std::shared_ptr< device_info > > const & /*added*/ )
+            [&, liveliness = std::weak_ptr< device_hub >( sptr )](
+                std::vector< std::shared_ptr< device_info > > const & /*removed*/,
+                std::vector< std::shared_ptr< device_info > > const & /*added*/ )
             {
-                std::unique_lock< std::mutex > lock( _mutex );
+                if( auto keepalive = liveliness.lock() )
+                {
+                    std::unique_lock< std::mutex > lock( _mutex );
 
-                _device_list = _ctx->query_devices( mask );
+                    _device_list = _ctx->query_devices( _mask );
 
-                // Current device will point to the first available device
-                _camera_index = 0;
-                if( _device_list.size() > 0 )
-                    _cv.notify_all();
+                    // Current device will point to the first available device
+                    _camera_index = 0;
+                    if( _device_list.size() > 0 )
+                        _cv.notify_all();
+                }
             } );
+    }
+
+    /*static*/ std::shared_ptr< device_hub > device_hub::make( std::shared_ptr< librealsense::context > const & ctx,
+                                                               int mask )
+    {
+        std::shared_ptr< device_hub > sptr( new device_hub( ctx, mask ) );
+        sptr->init( sptr );
+        return sptr;
     }
 
     device_hub::~device_hub()

--- a/src/device_hub.h
+++ b/src/device_hub.h
@@ -21,8 +21,12 @@ namespace librealsense
     */
     class device_hub
     {
+        device_hub( std::shared_ptr< context > ctx, int device_mask );  // private; use make()!
+        void init( std::shared_ptr< device_hub > const & );
+
     public:
-        explicit device_hub(std::shared_ptr<librealsense::context> ctx, int mask = RS2_PRODUCT_LINE_ANY);
+        static std::shared_ptr< device_hub > make( std::shared_ptr< context > const &,
+                                                   int device_mask = RS2_PRODUCT_LINE_ANY );
 
         ~device_hub();
 

--- a/src/pipeline/pipeline.cpp
+++ b/src/pipeline/pipeline.cpp
@@ -20,7 +20,7 @@ namespace librealsense
         pipeline::pipeline(std::shared_ptr<librealsense::context> ctx) :
             _ctx(ctx),
             _dispatcher(10),
-            _hub(ctx, RS2_PRODUCT_LINE_ANY_INTEL),
+            _hub( device_hub::make( ctx, RS2_PRODUCT_LINE_ANY_INTEL )),
             _synced_streams({ RS2_STREAM_COLOR, RS2_STREAM_DEPTH, RS2_STREAM_INFRARED, RS2_STREAM_FISHEYE })
         {}
 
@@ -165,7 +165,7 @@ namespace librealsense
         std::shared_ptr<device_interface> pipeline::wait_for_device(const std::chrono::milliseconds& timeout, const std::string& serial)
         {
             // pipeline's device selection shall be deterministic
-            return _hub.wait_for_device(timeout, false, serial);
+            return _hub->wait_for_device(timeout, false, serial);
         }
 
         std::shared_ptr<librealsense::context> pipeline::get_context() const
@@ -239,7 +239,7 @@ namespace librealsense
             }
 
             //hub returns true even if device already reconnected
-            if (!_hub.is_connected(*_active_profile->get_device()))
+            if (!_hub->is_connected(*_active_profile->get_device()))
             {
                 try
                 {
@@ -300,7 +300,7 @@ namespace librealsense
             }
 
             //hub returns true even if device already reconnected
-            if (!_hub.is_connected(*_active_profile->get_device()))
+            if (!_hub->is_connected(*_active_profile->get_device()))
             {
                 try
                 {

--- a/src/pipeline/pipeline.h
+++ b/src/pipeline/pipeline.h
@@ -46,7 +46,7 @@ namespace librealsense
 
             mutable std::mutex _mtx;
             std::shared_ptr<profile> _active_profile;
-            device_hub _hub;
+            std::shared_ptr< device_hub > _hub;
             std::shared_ptr<config> _prev_conf;
 
         private:

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -209,7 +209,7 @@ NOEXCEPT_RETURN(, context)
 
 rs2_device_hub* rs2_create_device_hub(const rs2_context* context, rs2_error** error) BEGIN_API_CALL
 {
-    return new rs2_device_hub{ std::make_shared<librealsense::device_hub>(context->ctx) };
+    return new rs2_device_hub{ device_hub::make( context->ctx ) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, context)
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -188,7 +188,7 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error) BEGIN_API_CA
     verify_version_compatibility(api_version);
 
     nlohmann::json settings;
-    return new rs2_context{ std::make_shared< librealsense::context >( settings ) };
+    return new rs2_context{ context::make( settings ) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version)
 
@@ -196,8 +196,7 @@ rs2_context* rs2_create_context_ex(int api_version, const char * json_settings, 
 {
     verify_version_compatibility(api_version);
 
-    return new rs2_context{
-        std::make_shared< librealsense::context >( json_settings ) };
+    return new rs2_context{ context::make( json_settings ) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version, json_settings)
 
@@ -2652,7 +2651,7 @@ NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(0)
 rs2_device* rs2_create_software_device(rs2_error** error) BEGIN_API_CALL
 {
     // We're not given a context...
-    auto ctx = std::make_shared< context >( nlohmann::json::object( { { "dds", false } } ) );
+    auto ctx = context::make( nlohmann::json::object( { { "dds", false } } ) );
     auto dev_info = std::make_shared< software_device_info >( ctx );
     auto dev = std::make_shared< software_device >( dev_info );
     dev_info->set_device( dev );

--- a/src/rscore/device-factory.h
+++ b/src/rscore/device-factory.h
@@ -25,10 +25,10 @@ class context;
 
 class device_factory
 {
-protected:
-    context & _context;
+    std::weak_ptr< context > _context;
 
-    device_factory( context & ctx )
+protected:
+    device_factory( std::shared_ptr< context > const & ctx )
         : _context( ctx )
     {
     }
@@ -40,6 +40,8 @@ public:
                                           std::vector< std::shared_ptr< device_info > > const & devices_added ) >;
 
     virtual ~device_factory() = default;
+
+    std::shared_ptr< context > get_context() const { return _context.lock(); }
 
     // Query any subset of available devices and return them as device-info objects from which actual devices can be
     // created as needed.

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -2,6 +2,7 @@
 # Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
+#test:retries:gha 2
 
 from rspy import log, test
 import pyrealsense2 as rs


### PR DESCRIPTION
Following crash report from customer performing repeated dis/connects with device, while using callback that actually instantiates a pipeline inside (!! not recommended !!).

This makes the code more robust by switching to shared-ptr for contexts inside the factories.
Did the same for `device_hub`, based on another report of crashes there, too...

Tracked on [LRS-981]