### PR TITLE
Fix: Should not set HDR when it is already enabled

### DIFF
--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -200,10 +200,6 @@ namespace librealsense
 
                 synthetic_sensor::open(requests);
 
-                // needed in order to restore the HDR sub-preset when streaming is turned off and on
-                if (_hdr_cfg && _hdr_cfg->is_enabled())
-                    get_option(RS2_OPTION_HDR_ENABLED).set(1.f);
-
                 // Activate Thermal Compensation tracking
                 if (supports_option(RS2_OPTION_THERMAL_COMPENSATION))
                     _owner->_thermal_monitor->update(true);

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -163,10 +163,6 @@ namespace librealsense
                 set_frame_metadata_modifier([&](frame_additional_data& data) {data.depth_units = _depth_units.load(); });
 
                 synthetic_sensor::open(requests);
-
-                // needed in order to restore the HDR sub-preset when streaming is turned off and on
-                if (_hdr_cfg && _hdr_cfg->is_enabled())
-                    get_option(RS2_OPTION_HDR_ENABLED).set(1.f);
                 }); //group_multiple_fw_calls
         }
 

--- a/src/ds/ds-options.cpp
+++ b/src/ds/ds-options.cpp
@@ -629,8 +629,9 @@ namespace librealsense
         else
         {
             if (_hdr_cfg->is_enabled())
-                LOG_WARNING("The control - " << _uvc_option->get_description()
-                     << " - is locked while HDR mode is active.\n"); 
+                throw wrong_api_call_sequence_exception(
+                    rsutils::string::from() << "The control - " << _uvc_option->get_description()
+                                    << " - is locked while HDR mode is active.");
             else
                 _uvc_option->set(value);
         }

--- a/src/hdr-config.h
+++ b/src/hdr-config.h
@@ -79,7 +79,6 @@ namespace librealsense
         int _current_hdr_sequence_index;
         mutable bool _is_enabled;
         bool _is_config_in_process;
-        bool _has_config_changed;
         bool _auto_exposure_to_be_restored;
         bool _emitter_on_off_to_be_restored;
         hw_monitor& _hwm;


### PR DESCRIPTION
Tracked on LRS-962

From FW version 5.14.x.x, the FW doesn't support updating the HDR presets when HDR is already enabled.