### PR TITLE
Don't get GVD a second time to check if camera is locked

### DIFF
--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -657,7 +657,7 @@ namespace librealsense
 
             if (_fw_version >= firmware_version("5.6.3.0"))
             {
-                _is_locked = _ds_device_common->is_locked(GVD, is_camera_locked_offset);
+                _is_locked = _ds_device_common->is_locked( gvd_buff.data(), is_camera_locked_offset );
             }
 
             if (_fw_version >= firmware_version("5.5.8.0"))

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -491,7 +491,7 @@ namespace librealsense
                 
             pid_hex_str = rsutils::string::from() << std::uppercase << rsutils::string::hexdump( _pid );
 
-            _is_locked = _ds_device_common->is_locked(GVD, is_camera_locked_offset);
+            _is_locked = _ds_device_common->is_locked( gvd_buff.data(), is_camera_locked_offset );
 
             depth_sensor.register_option(RS2_OPTION_OUTPUT_TRIGGER_ENABLED,
                 std::make_shared<uvc_xu_option<uint8_t>>(raw_depth_sensor, depth_xu, DS5_EXT_TRIGGER,

--- a/src/ds/ds-device-common.cpp
+++ b/src/ds/ds-device-common.cpp
@@ -115,12 +115,6 @@ namespace librealsense
         throw std::runtime_error("device not referenced in the product line");
     }
 
-    bool ds_device_common::is_locked(uint8_t gvd_cmd, uint32_t offset)
-    {
-        _is_locked = _hw_monitor->is_camera_locked(gvd_cmd, offset);
-        return _is_locked;
-    }
-
     bool ds_device_common::is_locked( const uint8_t * gvd_buff, uint32_t offset )
     {
         std::memcpy( &_is_locked, gvd_buff + offset, 1 );

--- a/src/ds/ds-device-common.cpp
+++ b/src/ds/ds-device-common.cpp
@@ -121,6 +121,12 @@ namespace librealsense
         return _is_locked;
     }
 
+    bool ds_device_common::is_locked( const uint8_t * gvd_buff, uint32_t offset )
+    {
+        std::memcpy( &_is_locked, gvd_buff + offset, 1 );
+        return _is_locked;
+    }
+
     void ds_device_common::get_fw_details( const std::vector<uint8_t> &gvd_buff, std::string& optic_serial, std::string& asic_serial, std::string& fwv ) const
     {
         optic_serial = _hw_monitor->get_module_serial_string(gvd_buff, module_serial_offset);

--- a/src/ds/ds-device-common.h
+++ b/src/ds/ds-device-common.h
@@ -38,7 +38,6 @@ namespace librealsense
         void update_flash(const std::vector<uint8_t>& image, rs2_update_progress_callback_sptr callback, int update_mode);
 
         bool is_camera_in_advanced_mode() const;
-        bool is_locked(uint8_t gvd_cmd, uint32_t offset);
         bool is_locked( const uint8_t * gvd_buff, uint32_t offset );
         void get_fw_details( const std::vector<uint8_t> &gvd_buff, std::string& optic_serial, std::string& asic_serial, std::string& fwv ) const;
 

--- a/src/ds/ds-device-common.h
+++ b/src/ds/ds-device-common.h
@@ -30,7 +30,7 @@ namespace librealsense
         ds_device_common(device* ds_device, std::shared_ptr<hw_monitor> hwm) :
             _owner(ds_device),
             _hw_monitor(hwm),
-            _is_locked(false)
+            _is_locked(true)
         {}
 
         void enter_update_state() const;
@@ -39,6 +39,7 @@ namespace librealsense
 
         bool is_camera_in_advanced_mode() const;
         bool is_locked(uint8_t gvd_cmd, uint32_t offset);
+        bool is_locked( const uint8_t * gvd_buff, uint32_t offset );
         void get_fw_details( const std::vector<uint8_t> &gvd_buff, std::string& optic_serial, std::string& asic_serial, std::string& fwv ) const;
 
     private:

--- a/src/hw-monitor.cpp
+++ b/src/hw-monitor.cpp
@@ -241,13 +241,4 @@ namespace librealsense
         auto minSize = std::min(sz, data.size());
         std::memcpy( gvd, data.data(), minSize );
     }
-
-    bool hw_monitor::is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const
-    {
-        std::vector<unsigned char> gvd(HW_MONITOR_BUFFER_SIZE);
-        get_gvd(gvd.size(), gvd.data(), gvd_cmd);
-        bool value;
-        std::memcpy( &value, gvd.data() + offset, 1 );
-        return value;
-    }
 }

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -401,7 +401,6 @@ namespace librealsense
         }
 
         static std::string get_module_serial_string(const std::vector<uint8_t>& buff, size_t index, size_t length = 6);
-        bool is_camera_locked(uint8_t gvd_cmd, uint32_t offset) const;
 
         template <typename T>
         T get_gvd_field(const std::vector<uint8_t>& data, size_t index)


### PR DESCRIPTION
To make minimum changes I added an overload to `ds_device_common::is_locked` that gets the previously queried buffer, avoiding the need to get the GVD buffer again.