### PR TITLE
End recording and start streaming again - bug fix 

### DIFF
--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -42,7 +42,11 @@ std::vector<std::shared_ptr<librealsense::record_sensor>> librealsense::record_d
         recording_sensor->on_notification(
             [this, sensor_index]( const notification & n )
             { write_notification( sensor_index, n ); } );
-        auto on_error = [&recording_sensor](const std::string& s) {recording_sensor->stop_with_error(s); };
+        auto on_error = [weak = std::weak_ptr< librealsense::record_sensor >( recording_sensor )](const std::string& s) {
+            auto strong_recording_sensor = weak.lock();
+            if(strong_recording_sensor)
+                strong_recording_sensor->stop_with_error(s);
+        };
         recording_sensor->on_frame( [this, sensor_index, on_error]( frame_holder f )
                                     { write_data( sensor_index, std::move( f ), on_error ); } );
         recording_sensor->on_extension_change(

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -40,13 +40,13 @@ std::vector<std::shared_ptr<librealsense::record_sensor>> librealsense::record_d
         auto& live_sensor = device->get_sensor(sensor_index);
         auto recording_sensor = std::make_shared<librealsense::record_sensor>(*this, live_sensor);
         recording_sensor->on_notification(
-            [this, recording_sensor, sensor_index]( const notification & n )
+            [this, sensor_index]( const notification & n )
             { write_notification( sensor_index, n ); } );
-        auto on_error = [recording_sensor](const std::string& s) {recording_sensor->stop_with_error(s); };
-        recording_sensor->on_frame( [this, recording_sensor, sensor_index, on_error]( frame_holder f )
+        auto on_error = [&recording_sensor](const std::string& s) {recording_sensor->stop_with_error(s); };
+        recording_sensor->on_frame( [this, sensor_index, on_error]( frame_holder f )
                                     { write_data( sensor_index, std::move( f ), on_error ); } );
         recording_sensor->on_extension_change(
-            [this, recording_sensor, sensor_index, on_error]( rs2_extension ext,
+            [this, sensor_index, on_error]( rs2_extension ext,
                                                               std::shared_ptr< extension_snapshot > snapshot )
             { write_sensor_extension_snapshot( sensor_index, ext, snapshot, on_error ); } );
         recording_sensor->init(); //Calling init AFTER register to the above events

--- a/src/media/record/record_device.cpp
+++ b/src/media/record/record_device.cpp
@@ -44,7 +44,7 @@ std::vector<std::shared_ptr<librealsense::record_sensor>> librealsense::record_d
             { write_notification( sensor_index, n ); } );
         auto on_error = [weak = std::weak_ptr< librealsense::record_sensor >( recording_sensor )](const std::string& s) {
             auto strong_recording_sensor = weak.lock();
-            if(strong_recording_sensor)
+            if( strong_recording_sensor )
                 strong_recording_sensor->stop_with_error(s);
         };
         recording_sensor->on_frame( [this, sensor_index, on_error]( frame_holder f )


### PR DESCRIPTION
- After recording is finished record_device destructor is called. The vector of shared_ptr that points to each record_sensor is cleared but record_sensor isn't destructed. 
It is caused because the lambda function in record_device::create_record_sensors calls recording_sensor (shared_ptr<librealsense::record_sensor>) without using weak_ptr.

- removed paramaters that are not used inside the function.