### PR TITLE
JSON-based device-info & fix for no 'dds' settings

### DIFF
--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -49,6 +49,48 @@ namespace rs2
             return results;
         }
 
+        /**
+         * \return   the type of device: USB/GMSL/DDS, etc.
+         */
+        std::string get_type() const
+        {
+            if( supports( RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR ) )
+                return "USB";
+            if( supports( RS2_CAMERA_INFO_PRODUCT_ID ) )
+            {
+                std::string pid = get_info( RS2_CAMERA_INFO_PRODUCT_ID );
+                if( pid == "ABCD" ) // Specific for D457
+                    return "GMSL";
+                return pid;  // for DDS devices, this will be "DDS"
+            }
+            return {};
+        }
+
+        /**
+         * \return   the one-line description: "[<type>] <name> s/n <#>"
+         */
+        std::string get_description() const
+        {
+            std::ostringstream os;
+            auto type = get_type();
+            if( supports( RS2_CAMERA_INFO_NAME ) )
+            {
+                if( ! type.empty() )
+                    os << "[" << type << "] ";
+                os << get_info( RS2_CAMERA_INFO_NAME );
+            }
+            else
+            {
+                if( ! type.empty() )
+                    os << type << " device";
+                else
+                    os << "unknown device";
+            }
+            if( supports( RS2_CAMERA_INFO_SERIAL_NUMBER ) )
+                os << " s/n " << get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
+            return os.str();
+        }
+
         template<class T>
         T first() const
         {

--- a/src/dds/rs-dds-device-info.cpp
+++ b/src/dds/rs-dds-device-info.cpp
@@ -27,22 +27,14 @@ std::string dds_device_info::get_address() const
 
     return rsutils::string::from() << "dds." << domain_id << "://"
                                    << _dev->participant()->print( _dev->server_guid() ) << "@"
-                                   << _dev->device_info().topic_root;
+                                   << _dev->device_info().topic_root();
 }
 
 
 void dds_device_info::to_stream( std::ostream & os ) const
 {
     os << "DDS device (" << _dev->participant()->print( _dev->guid() ) << " on domain "
-       << _dev->participant()->get()->get_domain_id() << "):";
-    os << "\n\tName: " << _dev->device_info().name;
-    if( ! _dev->device_info().serial.empty() )
-        os << "\n\tSerial: " << _dev->device_info().serial;
-    if( ! _dev->device_info().product_line.empty() )
-        os << "\n\tProduct line: " << _dev->device_info().product_line;
-    os << "\n\tTopic root: " << _dev->device_info().topic_root;
-    if( _dev->device_info().locked )
-        os << "\n\tLOCKED";
+       << _dev->participant()->get()->get_domain_id() << "):" << _dev->device_info().to_json().dump( 4 );
 }
 
 

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -436,7 +436,7 @@ void dds_sensor_proxy::start( rs2_frame_callback_sptr callback )
         }
         auto const & dds_stream = streamit->second;
         // Opening it will start streaming on the server side automatically
-        dds_stream->open( "rt/" + _dev->device_info().topic_root + '_' + dds_stream->name(), _dev->subscriber() );
+        dds_stream->open( "rt/" + _dev->device_info().topic_root() + '_' + dds_stream->name(), _dev->subscriber() );
         auto & streaming = _streaming_by_name[dds_stream->name()];
         streaming.syncer.on_frame_release( frame_releaser );
         streaming.syncer.on_frame_ready(

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -84,7 +84,8 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
     : super( ctx )
 {
     rsutils::json::nested dds_settings( ctx->get_settings(), std::string( "dds", 3 ) );
-    if( dds_settings.is_object() && dds_settings.find( std::string( "enabled", 7 ) ).default_value( true ) )
+    if( ! dds_settings.exists()
+        || dds_settings->is_object() && dds_settings.find( std::string( "enabled", 7 ) ).default_value( true ) )
     {
         auto domain_id = dds_settings.find( std::string( "domain", 6 ) ).default_value< realdds::dds_domain_id >( 0 );
         auto participant_name_j = dds_settings.find( std::string( "participant", 11 ) );

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -145,15 +145,23 @@ std::vector< std::shared_ptr< device_info > > rsdds_device_factory::query_device
                     LOG_DEBUG( "device '" << dev->device_info().debug_name() << "' is not ready" );
                     return true;
                 }
-                if( dev->device_info().product_line == "D400" )
+                std::string product_line;
+                if( rsutils::json::get_ex( dev->device_info().to_json(), "product-line", &product_line ) )
                 {
-                    if( ! ( mask & RS2_PRODUCT_LINE_D400 ) )
+                    if( product_line == "D400" )
+                    {
+                        if( ! ( mask & RS2_PRODUCT_LINE_D400 ) )
+                            return true;
+                    }
+                    else if( product_line == "D500" )
+                    {
+                        if( ! ( mask & RS2_PRODUCT_LINE_D500 ) )
+                            return true;
+                    }
+                    else if( ! ( mask & RS2_PRODUCT_LINE_NON_INTEL ) )
+                    {
                         return true;
-                }
-                else if( dev->device_info().product_line == "D500" )
-                {
-                    if( ! ( mask & RS2_PRODUCT_LINE_D500 ) )
-                        return true;
+                    }
                 }
                 else if( ! ( mask & RS2_PRODUCT_LINE_NON_INTEL ) )
                 {

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -75,7 +75,7 @@ public:
     rsutils::subscription on_metadata_available( on_metadata_available_callback && );
 
     typedef std::function< void(
-        dds_time const & timestamp, char type, std::string const & text, nlohmann::json const & data ) >
+        dds_nsec timestamp, char type, std::string const & text, nlohmann::json const & data ) >
         on_device_log_callback;
     rsutils::subscription on_device_log( on_device_log_callback && cb );
 

--- a/third-party/realdds/include/realdds/topics/device-info-msg.h
+++ b/third-party/realdds/include/realdds/topics/device-info-msg.h
@@ -1,9 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include <nlohmann/json.hpp>
 
 #include <rsutils/string/slice.h>
 
@@ -12,14 +11,23 @@ namespace topics {
 
 class device_info
 {
-public:
-    std::string name;
-    std::string serial;
-    std::string product_line;
-    std::string topic_root;
-    bool locked = true;
+    nlohmann::json _json;
 
-    nlohmann::json to_json() const;
+public:
+    //std::string serial;
+    //std::string product_line;
+    //bool locked = true;
+
+    std::string const & name() const;
+    void set_name( std::string && );
+
+    std::string const & topic_root() const;
+    void set_topic_root( std::string && );
+
+    std::string const & serial_number() const;
+    void set_serial_number( std::string && );
+
+    nlohmann::json const & to_json() const;
     static device_info from_json( nlohmann::json const & j );
 
     // Substring of information already stored in the device-info that can be used to print the device 'name'.

--- a/third-party/realdds/include/realdds/topics/device-info-msg.h
+++ b/third-party/realdds/include/realdds/topics/device-info-msg.h
@@ -19,16 +19,16 @@ public:
     //bool locked = true;
 
     std::string const & name() const;
-    void set_name( std::string && );
+    void set_name( std::string const & );
 
     std::string const & topic_root() const;
-    void set_topic_root( std::string && );
+    void set_topic_root( std::string const & );
 
     std::string const & serial_number() const;
-    void set_serial_number( std::string && );
+    void set_serial_number( std::string const & );
 
     nlohmann::json const & to_json() const;
-    static device_info from_json( nlohmann::json const & j );
+    static device_info from_json( nlohmann::json const & );
 
     // Substring of information already stored in the device-info that can be used to print the device 'name'.
     // (mostly for use with debug messages)

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -898,10 +898,10 @@ PYBIND11_MODULE(NAME, m) {
                       { FN_FWD_CALL( dds_device, "on_metadata_available", callback( self, json_to_py( *pj ) ); ) } ) );
               } )
         .def( "on_device_log",
-              []( dds_device & self, std::function< void( dds_device &, dds_time const &, char, std::string const &, py::object && ) > callback )
+              []( dds_device & self, std::function< void( dds_device &, dds_nsec, char, std::string const &, py::object && ) > callback )
               {
                   return std::make_shared< subscription >( self.on_device_log(
-                      [&self, callback]( dds_time const & timestamp, char type, std::string const & text, nlohmann::json const & data )
+                      [&self, callback]( dds_nsec timestamp, char type, std::string const & text, nlohmann::json const & data )
                       { FN_FWD_CALL( dds_device, "on_device_log", callback( self, timestamp, type, text, json_to_py( data ) ); ) } ) );
               } )
         .def( "on_notification",

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -375,27 +375,16 @@ PYBIND11_MODULE(NAME, m) {
     py::class_< device_info >( message, "device_info" )
         .def( py::init<>() )
         .def_static( "create_topic", static_cast< flexible_msg_create_topic * >( &flexible_msg::create_topic ) )
-        .def_readwrite( "name", &device_info::name )
-        .def_readwrite( "serial", &device_info::serial )
-        .def_readwrite( "product_line", &device_info::product_line )
-        .def_readwrite( "locked", &device_info::locked )
-        .def_readwrite( "topic_root", &device_info::topic_root )
+        .def_property( "name", &device_info::name, &device_info::set_name )
+        .def_property( "topic_root", &device_info::topic_root, &device_info::set_topic_root )
+        .def_property( "serial", &device_info::serial_number, &device_info::set_serial_number )
         .def_static( "from_json", &device_info::from_json )
         .def( "to_json", &device_info::to_json )
         .def( "__repr__",
               []( device_info const & self ) {
                   std::ostringstream os;
                   os << "<" SNAME ".device_info";
-                    if( ! self.name.empty() )
-                        os << " \"" << self.name << "\"";
-                    if( ! self.serial.empty() )
-                        os << " s/n \"" << self.serial << "\"";
-                    if( ! self.topic_root.empty() )
-                        os << " @ \"" << self.topic_root << "\"";
-                    if( ! self.product_line.empty() )
-                        os << " product-line \"" << self.product_line << "\"";
-                    if( self.locked )
-                        os << " locked";
+                  os << " " << self.to_json();
                   os << ">";
                   return os.str();
               } );
@@ -953,8 +942,8 @@ PYBIND11_MODULE(NAME, m) {
             std::ostringstream os;
             os << "<" SNAME ".device";
             os << " " << self.participant()->print( self.guid() );
-            if( ! self.device_info().name.empty() )
-                os << " \"" << self.device_info().name << "\"";
+            if( ! self.device_info().name().empty() )
+                os << " \"" << self.device_info().name() << "\"";
             os << " @ " << self.device_info().debug_name();
             os << ">";
             return os.str();

--- a/third-party/realdds/scripts/devices.py
+++ b/third-party/realdds/scripts/devices.py
@@ -35,6 +35,8 @@ import time
 
 dds.debug( args.debug )
 
+settings = {}
+
 participant = dds.participant()
 participant.init( dds.load_rs_settings( settings ), args.domain )
 

--- a/third-party/realdds/scripts/fps.py
+++ b/third-party/realdds/scripts/fps.py
@@ -53,7 +53,7 @@ info.topic_root = args.device
 
 # Create the device and initialize
 # The server must be up and running, or the init will time out!
-device = dds.device( participant, participant.create_guid(), info )
+device = dds.device( participant, info )
 try:
     i( 'Looking for device at', info.topic_root, '...' )
     device.wait_until_ready()  # If unavailable before timeout, this throws

--- a/third-party/realdds/src/dds-device-broadcaster.cpp
+++ b/third-party/realdds/src/dds-device-broadcaster.cpp
@@ -146,7 +146,7 @@ void dds_device_broadcaster::broadcast() const
     }
     catch( std::exception const & e )
     {
-        LOG_ERROR( "Error sending device-info message for S/N " << _device_info.serial << ": " << e.what() );
+        LOG_ERROR( "Error sending device-info message for S/N " << _device_info.serial_number() << ": " << e.what() );
     }
 }
 

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -253,8 +253,8 @@ void dds_device::impl::on_option_value( nlohmann::json const & j, eprosima::fast
 
     // Find the relevant (stream) options to update
     dds_options const * options = &_options;
-    std::string stream_name;  // default = empty = device option
-    if( rsutils::json::get_ex( control, stream_name_key, &stream_name ) && ! stream_name.empty() )
+    std::string const & stream_name = control.find( stream_name_key ).string_ref_or_empty();  // default = empty = device option
+    if( ! stream_name.empty() )
     {
         auto stream_it = _streams.find( stream_name );
         if( stream_it == _streams.end() )
@@ -291,7 +291,7 @@ void dds_device::impl::on_option_value( nlohmann::json const & j, eprosima::fast
         return;
     }
 
-    rsutils::json::nested option_name_j( control, option_name_key );
+    auto option_name_j = control.find( option_name_key );
     if( ! option_name_j.exists() )
         throw std::runtime_error( "missing option-name" );
 

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -475,7 +475,7 @@ void dds_device::impl::create_notifications_reader()
     if( _notifications_reader )
         return;
 
-    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + topics::NOTIFICATION_TOPIC_NAME );
+    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root() + topics::NOTIFICATION_TOPIC_NAME );
 
     // We have some complicated topic structures. In particular, the metadata topic is created on demand while handling
     // other notifications, which doesn't work well (deadlock) if the notification is not called from another thread. So
@@ -518,7 +518,7 @@ void dds_device::impl::create_metadata_reader()
     if( _metadata_reader ) // We can be called multiple times, once per stream
         return;
 
-    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + topics::METADATA_TOPIC_NAME );
+    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root() + topics::METADATA_TOPIC_NAME );
     _metadata_reader = std::make_shared< dds_topic_reader_thread >( topic, _subscriber );
     _metadata_reader->on_data_available(
         [this]()
@@ -549,7 +549,7 @@ void dds_device::impl::create_control_writer()
     if( _control_writer )
         return;
 
-    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root + topics::CONTROL_TOPIC_NAME );
+    auto topic = topics::flexible_msg::create_topic( _participant, _info.topic_root() + topics::CONTROL_TOPIC_NAME );
     _control_writer = std::make_shared< dds_topic_writer >( topic );
     dds_topic_writer::qos wqos( eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS );
     wqos.history().depth = 10;  // default is 1

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -137,7 +137,7 @@ dds_device::impl::impl( std::shared_ptr< dds_participant > const & participant,
     , _subscriber( std::make_shared< dds_subscriber >( participant ) )
     , _device_settings( device_settings( participant ) )
     , _reply_timeout_ms(
-          rsutils::json::nested( _device_settings, "control", "reply-timeout-ms" ).value< size_t >( 2000 ) )
+          rsutils::json::nested( _device_settings, "control", "reply-timeout-ms" ).default_value< size_t >( 2000 ) )
 {
     create_notifications_reader();
     create_control_writer();

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -356,7 +356,7 @@ void dds_device::impl::on_log( nlohmann::json const & j, eprosima::fastdds::dds:
                 throw std::runtime_error( "not an array" );
             if( entry.size() < 3 || entry.size() > 4 )
                 throw std::runtime_error( "bad array length" );
-            auto timestamp = time_from( rsutils::json::get< dds_nsec >( entry, 0 ) );
+            auto timestamp = rsutils::json::get< dds_nsec >( entry, 0 );
             auto const & stype = rsutils::json::string_ref( entry[1] );
             if( stype.length() != 1 || ! strchr( "EWID", stype[0] ) )
                 throw std::runtime_error( "type not one of 'EWID'" );
@@ -365,7 +365,7 @@ void dds_device::impl::on_log( nlohmann::json const & j, eprosima::fastdds::dds:
             nlohmann::json const & data = entry.size() > 3 ? entry[3] : rsutils::json::null_json;
 
             if( ! _on_device_log.raise( timestamp, type, text, data ) )
-                LOG_DEBUG( "[" << debug_name() << "][" << timestr( timestamp ) << "][" << type << "] " << text
+                LOG_DEBUG( "[" << debug_name() << "][" << timestamp << "][" << type << "] " << text
                                << " [" << data << "]" );
         }
         catch( std::exception const & e )

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -94,7 +94,7 @@ public:
         return _on_metadata_available.subscribe( std::move( cb ) );
     }
 
-    using on_device_log_signal = rsutils::signal< dds_time const &,          // timestamp
+    using on_device_log_signal = rsutils::signal< dds_nsec,                  // timestamp
                                                   char,                      // type
                                                   std::string const &,       // text
                                                   nlohmann::json const & >;  // data

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -238,7 +238,7 @@ void dds_device_server::broadcast( topics::device_info const & device_info )
 {
     if( _broadcaster )
         DDS_THROW( runtime_error, "device server was already broadcast" );
-    if( device_info.topic_root != _topic_root )
+    if( device_info.topic_root() != _topic_root )
         DDS_THROW( runtime_error, "topic roots do not match" );
     _broadcaster = std::make_shared< dds_device_broadcaster >( _publisher, device_info );
 }

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -15,7 +15,7 @@ namespace realdds {
 dds_device::dds_device( std::shared_ptr< dds_participant > const & participant, topics::device_info const & info )
     : _impl( std::make_shared< dds_device::impl >( participant, info ) )
 {
-    LOG_DEBUG( "+device '" << _impl->debug_name() << "' on " << info.topic_root );
+    LOG_DEBUG( "+device '" << _impl->debug_name() << "' on " << info.topic_root() );
 }
 
 

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -242,9 +242,12 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
                    "failed creating participant " + participant_name + " on domain id " + std::to_string( domain_id ) );
     }
 
-    if( ! settings.is_object() )
-        DDS_THROW( runtime_error, "provided settings are invalid" );
-    _settings = settings;
+    if( settings.is_object() )
+        _settings = settings;
+    else if( settings.is_null() )
+        _settings = nlohmann::json::object();
+    else
+        DDS_THROW( runtime_error, "provided settings are invalid: " << settings );
 
     LOG_DEBUG( "participant '" << participant_name << "' (" << realdds::print_guid( guid() ) << ") is up on domain "
                                << domain_id << " with settings: " << _settings.dump( 4 ) );

--- a/third-party/realdds/src/topics/device-info-msg.cpp
+++ b/third-party/realdds/src/topics/device-info-msg.cpp
@@ -43,9 +43,9 @@ std::string const & device_info::name() const
     return rsutils::json::nested( _json, name_key ).string_ref_or_empty();
 }
 
-void device_info::set_name( std::string && v )
+void device_info::set_name( std::string const & v )
 {
-    _json[name_key] = std::move( v );
+    _json[name_key] = v;
 }
 
 
@@ -54,9 +54,9 @@ std::string const & device_info::topic_root() const
     return rsutils::json::nested( _json, topic_root_key ).string_ref_or_empty();
 }
 
-void device_info::set_topic_root( std::string && v )
+void device_info::set_topic_root( std::string const & v )
 {
-    _json[topic_root_key] = std::move( v );
+    _json[topic_root_key] = v;
 }
 
 
@@ -65,9 +65,9 @@ std::string const & device_info::serial_number() const
     return rsutils::json::nested( _json, serial_number_key ).string_ref_or_empty();
 }
 
-void device_info::set_serial_number( std::string && v )
+void device_info::set_serial_number( std::string const & v )
 {
-    _json[serial_number_key] = std::move( v );
+    _json[serial_number_key] = v;
 }
 
 

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -11,6 +11,8 @@ namespace json {
 
 
 extern nlohmann::json const null_json;
+extern nlohmann::json const empty_json_string;
+extern nlohmann::json const empty_json_object;
 
 
 // Returns true if the json has a certain key.
@@ -168,11 +170,15 @@ public:
     bool is_string() const { return exists() && _pj->is_string(); }
 
     // Get the JSON as a value
-    template< class T > T value() { return json::value< T >( get() ); }
+    template< class T > T value() const { return json::value< T >( get() ); }
     // Get the JSON as a value, or a default if not there
-    template < class T > T value( T const & default_value ) { return json::value< T >( get(), default_value ); }
+    template < class T > T default_value( T const & default_value ) const { return json::value< T >( get(), default_value ); }
+    // Get the object, with a default being an empty one
+    nlohmann::json const & default_object() const { return is_object() ? *_pj : empty_json_object; }
     // Get a JSON string by reference (zero copy); it must be a string or it'll throw
     inline std::string const & string_ref() const { return json::string_ref( get() ); }
+    // Get a JSON string by reference (zero copy); does not throw
+    inline std::string const & string_ref_or_empty() const { return json::string_ref( exists() ? *_pj : empty_json_string ); }
 };
 
 

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -152,6 +152,8 @@ class nested
     nlohmann::json const * _pj;
 
 public:
+    nested() : _pj( nullptr ) {}
+
     template< typename... Rest >
     nested( nlohmann::json const & j, Rest... rest )
         : _pj( _nested( j, std::forward< Rest >( rest )... ) )
@@ -168,6 +170,14 @@ public:
     bool is_array() const { return exists() && _pj->is_array(); }
     bool is_object() const { return exists() && _pj->is_object(); }
     bool is_string() const { return exists() && _pj->is_string(); }
+
+    // Dig deeper
+    template< typename... Rest >
+    inline nested find( Rest... rest ) const
+    {
+        return _pj ? nested( *_pj, std::forward< Rest >( rest )... ) : nested();
+    }
+    inline nested operator[]( std::string const & key ) const { return find( key ); }
 
     // Get the JSON as a value
     template< class T > T value() const { return json::value< T >( get() ); }

--- a/third-party/rsutils/src/json.cpp
+++ b/third-party/rsutils/src/json.cpp
@@ -9,6 +9,8 @@ namespace json {
 
 
 nlohmann::json const null_json = {};
+nlohmann::json const empty_json_string = nlohmann::json::value_type( nlohmann::json::value_t::string );
+nlohmann::json const empty_json_object = nlohmann::json::object();
 
 
 void patch( nlohmann::json & j, nlohmann::json const & patches, std::string const & what )

--- a/tools/dds/dds-adapter/lrs-device-watcher.cpp
+++ b/tools/dds/dds-adapter/lrs-device-watcher.cpp
@@ -45,22 +45,27 @@ void lrs_device_watcher::run( std::function< void( rs2::device ) > add_device_cb
                     try
                     {
                         remove_device_cb( device_to_remove );
-                        std::cout << "Device '" << device_to_remove.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ) << "' - removed" << std::endl;
-                        auto it = std::find_if( strong_rs_device_list->begin(), strong_rs_device_list->end(),
-                            [&]( const rs2::device & dev ) {
-                                return strcmp( dev.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ), device_to_remove.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ) ) == 0;
-                        } );
+                        std::cout << device_to_remove.get_description() << " - removed" << std::endl;
+                        auto it = std::find_if(
+                            strong_rs_device_list->begin(),
+                            strong_rs_device_list->end(),
+                            [&]( const rs2::device & dev )
+                            {
+                                return strcmp( dev.get_info( RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID ),
+                                               device_to_remove.get_info( RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID ) )
+                                    == 0;
+                            } );
                         strong_rs_device_list->erase( it );
                     }
                     catch( std::exception e )
                     {
-                        std::cout << "Exception durin remove_device_cb: " << e.what() << std::endl;
+                        std::cout << "Exception during remove_device_cb: " << e.what() << std::endl;
                     }
                 }
  
                 for( auto && rs_device : info.get_new_devices() )
                 {
-                    std::cout << "Device '" << rs_device.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER ) << "' - detected" << std::endl;
+                    std::cout << rs_device.get_description() << " - detected" << std::endl;
                     add_device_cb( rs_device );
                     strong_rs_device_list->push_back(rs_device);
                 }
@@ -73,7 +78,7 @@ void lrs_device_watcher::notify_connected_devices_on_wake_up( std::function< voi
     auto connected_dev_list = _ctx.query_devices();
     for( auto connected_dev : connected_dev_list )
     {
-        std::cout << "Device '" << connected_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER) << "' - detected" << std::endl;
+        std::cout << connected_dev.get_description() << " - detected" << std::endl;
         add_device_cb( connected_dev );
         _rs_device_list->push_back(connected_dev);
     }

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -418,11 +418,6 @@ int main(int argc, char** argv) try
 
     if (short_view || compact_view)
     {
-        cout << left << setw(30) << "Device Name"
-            << setw(20) << "Serial Number"
-            << setw(20) << "Firmware Version"
-            << endl;
-
         auto dev_info = []( rs2::device dev, rs2_camera_info info )
         {
             if( dev.supports( info ) )
@@ -430,13 +425,30 @@ int main(int argc, char** argv) try
             return "N/A";
         };
 
+        size_t w_name = 28;
+        size_t w_sn = 18;
+        for( auto i = 0u; i < devices.size(); ++i )
+        {
+            auto dev = devices[i];
+
+            w_name = std::max( strlen( dev_info( dev, RS2_CAMERA_INFO_NAME ) ), w_name );
+            w_sn = std::max( strlen( dev_info( dev, RS2_CAMERA_INFO_SERIAL_NUMBER ) ), w_sn );
+        }
+        w_name += 2;
+        w_sn += 2;
+
+        cout << left << setw(w_name) << "Device Name"
+             << setw(w_sn) << "Serial Number"
+             << "Firmware Version"
+             << endl;
+
         for (auto i = 0u; i < devices.size(); ++i)
         {
             auto dev = devices[i];
 
-            cout << left << setw(30) << dev_info(dev,RS2_CAMERA_INFO_NAME)
-                << setw(20) << dev_info(dev,RS2_CAMERA_INFO_SERIAL_NUMBER)
-                << setw(20) << dev_info(dev,RS2_CAMERA_INFO_FIRMWARE_VERSION)
+            cout << left << setw(w_name) << dev_info(dev,RS2_CAMERA_INFO_NAME)
+                << setw(w_sn) << dev_info(dev,RS2_CAMERA_INFO_SERIAL_NUMBER)
+                << dev_info(dev,RS2_CAMERA_INFO_FIRMWARE_VERSION)
                 << endl;
         }
 

--- a/unit-tests/dds/d405.py
+++ b/unit-tests/dds/d405.py
@@ -5,11 +5,12 @@ import pyrealdds as dds
 from rspy import log, test
 
 
-device_info = dds.message.device_info()
-device_info.name = "Intel RealSense D405"
-device_info.serial = "123622270732"
-device_info.product_line = "D400"
-device_info.topic_root = "realdds/D405/" + device_info.serial
+device_info = dds.message.device_info.from_json( {
+    "name": "Intel RealSense D405",
+    "serial": "123622270732",
+    "product-line": "D400",
+    "topic-root": "realdds/D405/123622270732"
+} )
 
 
 def build( participant ):

--- a/unit-tests/dds/d435i.py
+++ b/unit-tests/dds/d435i.py
@@ -5,11 +5,12 @@ import pyrealdds as dds
 from rspy import log, test
 
 
-device_info = dds.message.device_info()
-device_info.name = "Intel RealSense D435I"
-device_info.serial = "036522070660"
-device_info.product_line = "D400"
-device_info.topic_root = "realsense/D435I_" + device_info.serial
+device_info = dds.message.device_info.from_json({
+    "name": "Intel RealSense D435I",
+    "serial": "036522070660",
+    "product-line": "D400",
+    "topic-root": "realsense/D435I_036522070660"
+})
 
 
 def build( participant ):

--- a/unit-tests/dds/d455.py
+++ b/unit-tests/dds/d455.py
@@ -5,11 +5,12 @@ import pyrealdds as dds
 from rspy import log, test
 
 
-device_info = dds.message.device_info()
-device_info.name = "Intel RealSense D455"
-device_info.serial = "114222251267"
-device_info.product_line = "D400"
-device_info.topic_root = "realdds/D455/" + device_info.serial
+device_info = dds.message.device_info.from_json( {
+    "name": "Intel RealSense D455",
+    "serial": "114222251267",
+    "product-line": "D400",
+    "topic-root": "realdds/D455/114222251267"
+} )
 
 
 def build( participant ):
@@ -233,7 +234,7 @@ def stereo_module_options():
     options.append( option )
     option = dds.option( "Stereo Baseline", dds.option_range( 94.9609, 94.9609, 0, 94.9609 ), "Distance in mm between the stereo imagers" )
     options.append( option )
-    option = dds.option( "Inter Cam Sync Mode", dds.option_range( 0, 260, 1, 0 ), 
+    option = dds.option( "Inter Cam Sync Mode", dds.option_range( 0, 260, 1, 0 ),
         "Inter-camera synchronization mode: 0:Default, 1:Master, 2:Slave, 3:Full Salve, 4-258:Genlock with burst count of 1-255 frames for each trigger, 259 and 260 for two frames per trigger with laser ON-OFF and OFF-ON." )
     options.append( option )
     option = dds.option( "Emitter On Off", dds.option_range( 0, 1, 1, 0 ), "Alternating emitter pattern, toggled on/off on per-frame basis" )
@@ -254,11 +255,11 @@ def stereo_module_options():
     options.append( option )
     option = dds.option( "Sequence Id", dds.option_range( 0, 2, 1, 0 ), "HDR Option" )
     options.append( option )
-    option = dds.option( "Auto Exposure Limit", dds.option_range( 1, 200000, 1, 33000 ), 
+    option = dds.option( "Auto Exposure Limit", dds.option_range( 1, 200000, 1, 33000 ),
         "Exposure limit is in microseconds. If the requested exposure limit is greater than frame time, it will be set to frame time at runtime. Setting will not take effect until next streaming session." )
     option.set_value( 200000 )
     options.append( option )
-    option = dds.option( "Auto Gain Limit", dds.option_range( 16, 248, 1, 16 ), 
+    option = dds.option( "Auto Gain Limit", dds.option_range( 16, 248, 1, 16 ),
         "Gain limits ranges from 16 to 248. If the requested gain limit is less than 16, it will be set to 16. If the requested gain limit is greater than 248, it will be set to 248. Setting will not take effect until next streaming session." )
     option.set_value( 248 )
     options.append( option )

--- a/unit-tests/dds/formats-conversion-server.py
+++ b/unit-tests/dds/formats-conversion-server.py
@@ -11,11 +11,10 @@ dds.debug( log.is_debug_on(), log.nested )
 participant = dds.participant()
 participant.init( 123, "formats-conversion-server" )
 
-device_info = dds.message.device_info()
-device_info.name = "formats-conversion-device"
-device_info.serial = "123"
-device_info.product_line = "D400"
-device_info.topic_root = "root_" + device_info.serial
+device_info = dds.message.device_info.from_json({
+    "name": "formats-conversion-device",
+    "topic-root": "root_123"
+})
 
 # Used to created a device_server per test case, but it currently creates problems when creating a second device while
 # the first did not yet close. Changing to one device_server with different sensor per test case.

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -13,7 +13,7 @@ if log.is_debug_on():
 log.nested = 'C  '
 
 context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'test-formats-conversion' }} )
-only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
+only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any)
 
 import os.path
 cwd = os.path.dirname(os.path.realpath(__file__))

--- a/unit-tests/dds/watcher-server.py
+++ b/unit-tests/dds/watcher-server.py
@@ -19,11 +19,10 @@ broadcasters = []
 
 def broadcast( props ):
     global broadcasters, publisher
-    di = dds.message.device_info()
-    di.serial = props.get( 'serial', str(len(broadcasters)) )
-    di.name = props.get( 'name', f'device{di.serial}' )
-    di.product_line = props.get( 'product_line', '' )
-    di.topic_root = props.get( 'topic_root', f'path/to/{di.name}' )
+    serial = props.setdefault( 'serial', str(len(broadcasters)) )
+    props.setdefault( 'name', f'device{serial}' )
+    props.setdefault( 'topic-root', f'device{serial}' )
+    di = dds.message.device_info.from_json( props )
     broadcasters.append( dds.device_broadcaster( publisher, di ) )
 
 


### PR DESCRIPTION
With DFU, we need to communicate more fields, and maybe even custom fields.
The device-info is now just a JSON proxy.

There was a bug introduced recently with `"dds": false` in the settings. This includes a fix.

Other minor stuff - go by commit.

Tracked on [LRS-989]