### PR TITLE
rsutils::json cleanup & usage

### DIFF
--- a/CMake/json-download.cmake.in
+++ b/CMake/json-download.cmake.in
@@ -6,7 +6,7 @@ ExternalProject_Add(
     nlohmann_json
     PREFIX .
     GIT_REPOSITORY "https://github.com/nlohmann/json.git"
-    #GIT_TAG        v3.11.2
+    GIT_TAG        v3.11.3
     GIT_CONFIG     advice.detachedHead=false  # otherwise we'll get "You are in 'detached HEAD' state..."
     SOURCE_DIR     "${CMAKE_BINARY_DIR}/third-party/json"
     GIT_SHALLOW    1        # No history needed (requires cmake 3.6)

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -22,7 +22,7 @@
 #include "device-model.h"
 
 using namespace rs400;
-using namespace nlohmann;
+using rsutils::json;
 using namespace rs2::sw_update;
 
 namespace rs2

--- a/common/device-model.h
+++ b/common/device-model.h
@@ -1,12 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include <set>
 #include "notifications.h"
 #include "realsense-ui-advanced-mode.h"
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 #include "sw-update/dev-updates-profile.h"
 #include <rsutils/time/periodic-timer.h>
 #include "updates-model.h"
@@ -426,7 +425,7 @@ namespace rs2
             const std::string& error_message);
 
         void load_viewer_configurations(const std::string& json_str);
-        void save_viewer_configurations(std::ofstream& outfile, nlohmann::json& j);
+        void save_viewer_configurations(std::ofstream& outfile, rsutils::json& j);
         void handle_online_sw_update(
             std::shared_ptr< notifications_model > nm,
             std::shared_ptr< sw_update::dev_updates_profile::update_profile > update_profile,

--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -8,7 +8,7 @@
 #include <rsutils/json.h>
 #include <fstream>
 
-using json = nlohmann::json;
+using json = rsutils::json;
 
 using namespace rs2;
 
@@ -31,7 +31,7 @@ void config_file::remove(const char* key)
 
 void config_file::reset()
 {
-    _j = nlohmann::json::object();
+    _j = json::object();
     save();
 }
 
@@ -40,7 +40,7 @@ std::string config_file::get(const char* key, const char* def) const
     auto it = _j.find(key);
     if (it != _j.end() && it->is_string())
     {
-        return rsutils::json::string_ref( *it );
+        return it->string_ref();
     }
     return get_default(key, def);
 }
@@ -105,7 +105,7 @@ void config_file::save()
 }
 
 config_file::config_file()
-    : _j( nlohmann::json::object() )
+    : _j( rsutils::json::object() )
 {
 }
 

--- a/common/rs-config.h
+++ b/common/rs-config.h
@@ -2,7 +2,7 @@
 // Copyright(c) 2017 Intel Corporation. All Rights Reserved.
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 
 #include <map>
 #include <string>
@@ -94,6 +94,6 @@ namespace rs2
 
         std::map<std::string, std::string> _defaults;
         std::string _filename;
-        nlohmann::json _j;
+        rsutils::json _j;
     };
 }

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -18,7 +18,6 @@
 #include <unordered_map>
 #include <fstream>
 
-#include <nlohmann/json.hpp>
 #include "objects-in-frame.h"
 #include "processing-block-model.h"
 

--- a/common/sw-update/versions-db-manager.cpp
+++ b/common/sw-update/versions-db-manager.cpp
@@ -2,7 +2,7 @@
 // Copyright(c) 2020 Intel Corporation. All Rights Reserved.
 
 #include "versions-db-manager.h"
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 #include <rsutils/os/os.h>
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <fstream>
@@ -16,7 +16,7 @@ namespace rs2
 
     namespace sw_update
     {
-        using json = nlohmann::json;
+        using json = rsutils::json;
         using namespace http;
 
         query_status_type versions_db_manager::query_versions(const std::string &device_name, component_part_type component, const update_policy_type policy, version& out_version)

--- a/src/context.h
+++ b/src/context.h
@@ -1,10 +1,9 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include <rsutils/signal.h>
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 #include <vector>
 #include <map>
 
@@ -18,12 +17,12 @@ namespace librealsense
 
     class context
     {
-        context( nlohmann::json const & );  // private! use make()
+        context( rsutils::json const & );  // private! use make()
 
         void create_factories( std::shared_ptr< context > const & sptr );
 
     public:
-        static std::shared_ptr< context > make( nlohmann::json const & );
+        static std::shared_ptr< context > make( rsutils::json const & );
         static std::shared_ptr< context > make( char const * json_settings );
 
         ~context();
@@ -61,12 +60,12 @@ namespace librealsense
         void add_device( std::shared_ptr< device_info > const & );
         void remove_device( std::shared_ptr< device_info > const & );
 
-        const nlohmann::json & get_settings() const { return _settings; }
+        const rsutils::json & get_settings() const { return _settings; }
 
         // Create processing blocks given a name and settings.
         //
         std::shared_ptr< processing_block_interface > create_pp_block( std::string const & name,
-                                                                       nlohmann::json const & settings );
+                                                                       rsutils::json const & settings );
 
     private:
         void invoke_devices_changed_callbacks( std::vector< std::shared_ptr< device_info > > const & devices_removed,
@@ -78,7 +77,7 @@ namespace librealsense
                          std::vector< std::shared_ptr< device_info > > const & /*added*/ >
             _devices_changed;
 
-        nlohmann::json _settings; // Save operation settings
+        rsutils::json _settings; // Save operation settings
         unsigned const _device_mask;
 
         std::vector< std::shared_ptr< device_factory > > _factories;

--- a/src/core/pp-block-factory.h
+++ b/src/core/pp-block-factory.h
@@ -2,7 +2,7 @@
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 #include <string>
 
 
@@ -30,7 +30,7 @@ public:
     // The name is case-insensitive.
     //
     virtual std::shared_ptr< processing_block_interface > create_pp_block( std::string const & name,
-                                                                           nlohmann::json const & settings )
+                                                                           rsutils::json const & settings )
         = 0;
 };
 

--- a/src/dds/rs-dds-depth-sensor-proxy.cpp
+++ b/src/dds/rs-dds-depth-sensor-proxy.cpp
@@ -38,15 +38,15 @@ void dds_depth_sensor_proxy::add_no_metadata( frame * const f, streaming_impl & 
 }
 
 
-void dds_depth_sensor_proxy::add_frame_metadata( frame * const f, nlohmann::json const & dds_md, streaming_impl & streaming )
+void dds_depth_sensor_proxy::add_frame_metadata( frame * const f, rsutils::json const & dds_md, streaming_impl & streaming )
 {
-    if( auto du = rsutils::json::nested( dds_md, metadata_header_key, depth_units_key ) )
+    if( auto du = dds_md.nested( metadata_header_key, depth_units_key ) )
     {
         try
         {
-            f->additional_data.depth_units = rsutils::json::value< float >( du );
+            f->additional_data.depth_units = du.get< float >();
         }
-        catch( nlohmann::json::exception const & )
+        catch( rsutils::json::exception const & )
         {
             f->additional_data.depth_units = get_depth_scale();
         }

--- a/src/dds/rs-dds-depth-sensor-proxy.h
+++ b/src/dds/rs-dds-depth-sensor-proxy.h
@@ -1,6 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include "rs-dds-sensor-proxy.h"
@@ -29,7 +28,7 @@ public:
 
 protected:
     void add_no_metadata( frame *, streaming_impl & ) override;
-    void add_frame_metadata( frame *, nlohmann::json const & md, streaming_impl & ) override;
+    void add_frame_metadata( frame *, rsutils::json const & md, streaming_impl & ) override;
 };
 
 

--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -10,7 +10,7 @@
 
 #include <realdds/dds-metadata-syncer.h>
 
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 #include <memory>
 #include <map>
 
@@ -96,10 +96,10 @@ protected:
                              const std::shared_ptr< stream_profile_interface > &,
                              streaming_impl & );
     void handle_new_metadata( std::string const & stream_name,
-                              std::shared_ptr< const nlohmann::json > const & metadata );
+                              std::shared_ptr< const rsutils::json > const & metadata );
 
     virtual void add_no_metadata( frame *, streaming_impl & );
-    virtual void add_frame_metadata( frame *, nlohmann::json const & metadata, streaming_impl & );
+    virtual void add_frame_metadata( frame *, rsutils::json const & metadata, streaming_impl & );
 
     friend class dds_device_proxy;  // Currently calls handle_new_metadata
 };

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -83,12 +83,12 @@ static std::mutex domain_context_by_id_mutex;
 rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & ctx, callback && cb )
     : super( ctx )
 {
-    rsutils::json::nested dds_settings( ctx->get_settings(), std::string( "dds", 3 ) );
+    auto dds_settings = ctx->get_settings().nested( std::string( "dds", 3 ) );
     if( ! dds_settings.exists()
-        || dds_settings->is_object() && dds_settings.find( std::string( "enabled", 7 ) ).default_value( true ) )
+        || dds_settings.is_object() && dds_settings.nested( std::string( "enabled", 7 ) ).default_value( true ) )
     {
-        auto domain_id = dds_settings.find( std::string( "domain", 6 ) ).default_value< realdds::dds_domain_id >( 0 );
-        auto participant_name_j = dds_settings.find( std::string( "participant", 11 ) );
+        auto domain_id = dds_settings.nested( std::string( "domain", 6 ) ).default_value< realdds::dds_domain_id >( 0 );
+        auto participant_name_j = dds_settings.nested( std::string( "participant", 11 ) );
         auto participant_name = participant_name_j.default_value( rsutils::os::executable_name() );
 
         std::lock_guard< std::mutex > lock( domain_context_by_id_mutex );
@@ -145,7 +145,7 @@ std::vector< std::shared_ptr< device_info > > rsdds_device_factory::query_device
                     return true;
                 }
                 std::string product_line;
-                if( rsutils::json::get_ex( dev->device_info().to_json(), "product-line", &product_line ) )
+                if( dev->device_info().to_json().nested( "product-line" ).get_ex( product_line ) )
                 {
                     if( product_line == "D400" )
                     {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -204,7 +204,7 @@ format_conversion device::get_format_conversion() const
         return format_conversion::full;
     std::string const format_conversion( "format-conversion", 17 );
     std::string const full( "full", 4 );
-    auto const value = rsutils::json::get( context->get_settings(), format_conversion, full );
+    auto const value = context->get_settings().nested( format_conversion ).default_value( full );
     if( value == full )
         return format_conversion::full;
     if( value == "basic" )

--- a/src/ds/advanced_mode/json_loader.hpp
+++ b/src/ds/advanced_mode/json_loader.hpp
@@ -12,7 +12,7 @@
 #include <string>
 #include <iomanip>
 
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 #include <librealsense2/h/rs_advanced_mode_command.h>
 #include "types.h"
 #include "presets.h"
@@ -23,7 +23,7 @@
 
 namespace librealsense
 {
-    using json = nlohmann::json;
+    using json = rsutils::json;
 
     template<class T>
     struct param_group
@@ -498,7 +498,7 @@ namespace librealsense
             {
                 try
                 {
-                    if (value.type() != nlohmann::basic_json<>::value_t::string)
+                    if( ! value.is_string() )
                     {
                         float val = value;
                         std::stringstream ss;

--- a/src/ds/d400/d400-auto-calibration.cpp
+++ b/src/ds/d400/d400-auto-calibration.cpp
@@ -2,7 +2,7 @@
 // Copyright(c) 2016 Intel Corporation. All Rights Reserved.
 
 #include <numeric>
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 #include "d400-device.h"
 #include "d400-private.h"
 #include "d400-thermal-monitor.h"
@@ -203,13 +203,11 @@ namespace librealsense
 
     std::map<std::string, int> auto_calibrated::parse_json(std::string json_content)
     {
-        using json = nlohmann::json;
-
-         auto j = json::parse(json_content);
+        auto j = rsutils::json::parse(json_content);
 
         std::map<std::string, int> values;
 
-        for (json::iterator it = j.begin(); it != j.end(); ++it)
+        for (auto it = j.begin(); it != j.end(); ++it)
         {
             values[it.key()] = it.value();
         }

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -36,7 +36,6 @@
 #include "d400-thermal-monitor.h"
 #include <common/fw/firmware-version.h>
 #include <src/fw-update/fw-update-unsigned.h>
-#include <nlohmann/json.hpp>
 
 #include <rsutils/string/hexdump.h>
 #include <regex>

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -37,7 +37,6 @@
 #include <rsutils/string/hexdump.h>
 #include <rsutils/version.h>
 
-#include <nlohmann/json.hpp>
 #include <vector>
 #include <string>
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -191,7 +191,7 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error) BEGIN_API_CA
 {
     verify_version_compatibility(api_version);
 
-    nlohmann::json settings;
+    rsutils::json settings;
     return new rs2_context{ context::make( settings ) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version)
@@ -2699,7 +2699,7 @@ NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(0)
 rs2_device* rs2_create_software_device(rs2_error** error) BEGIN_API_CALL
 {
     // We're not given a context...
-    auto ctx = context::make( nlohmann::json::object( { { "dds", false } } ) );
+    auto ctx = context::make( rsutils::json::object( { { "dds", false } } ) );
     auto dev_info = std::make_shared< software_device_info >( ctx );
     auto dev = std::make_shared< software_device >( dev_info );
     dev_info->set_device( dev );

--- a/src/rscore-pp-block-factory.cpp
+++ b/src/rscore-pp-block-factory.cpp
@@ -20,7 +20,7 @@ namespace librealsense {
 
 
 std::shared_ptr< processing_block_interface >
-rscore_pp_block_factory::create_pp_block( std::string const & name, nlohmann::json const & settings )
+rscore_pp_block_factory::create_pp_block( std::string const & name, rsutils::json const & settings )
 {
     // These filters do not accept settings (nor are settings recorded in ros_writer)
     (void *)&settings;

--- a/src/rscore-pp-block-factory.h
+++ b/src/rscore-pp-block-factory.h
@@ -12,7 +12,7 @@ class rscore_pp_block_factory : public pp_block_factory
 {
 public:
     std::shared_ptr< processing_block_interface > create_pp_block( std::string const & name,
-                                                                   nlohmann::json const & settings ) override;
+                                                                   rsutils::json const & settings ) override;
 };
 
 

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -401,10 +401,10 @@ void log_callback_end( uint32_t fps,
         , _raw_sensor( raw_sensor )
         , _options_watcher( _raw_sensor )
     {
-        nlohmann::json const & settings = device->get_context()->get_settings();
-        if( auto interval_j = rsutils::json::nested( settings, std::string( "options-update-interval", 23 ) ) )
+        rsutils::json const & settings = device->get_context()->get_settings();
+        if( auto interval_j = settings.nested( std::string( "options-update-interval", 23 ) ) )
         {
-            auto interval = interval_j.value< uint32_t >();  // NOTE: can throw!
+            auto interval = interval_j.get< uint32_t >();  // NOTE: can throw!
             _options_watcher.set_update_interval( std::chrono::milliseconds( interval ) );
         }
 

--- a/src/serialized-utilities.h
+++ b/src/serialized-utilities.h
@@ -1,11 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
+
 #include <string>
 #include <map>
 #include <types.h>
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 
 
 namespace librealsense
@@ -14,7 +14,7 @@ namespace librealsense
 
     namespace serialized_utilities
     {
-        using json = nlohmann::json;
+        using json = rsutils::json;
 
         struct device_info
         {

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -1,6 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include <realdds/dds-option.h>
@@ -8,7 +7,7 @@
 #include <realdds/dds-trinsics.h>
 
 #include <rsutils/concurrency/concurrency.h>
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 
 #include <map>
 #include <vector>
@@ -86,7 +85,7 @@ public:
     std::map< std::string, std::shared_ptr< dds_stream_server > > const & streams() const { return _stream_name_to_server; }
 
     void publish_notification( topics::flexible_msg && );
-    void publish_metadata( nlohmann::json && );
+    void publish_metadata( rsutils::json && );
 
     bool has_metadata_readers() const;
 
@@ -95,17 +94,17 @@ public:
     void on_set_option( set_option_callback callback ) { _set_option_callback = std::move( callback ); }
     void on_query_option( query_option_callback callback ) { _query_option_callback = std::move( callback ); }
 
-    typedef std::function< bool( std::string const &, nlohmann::json const &, nlohmann::json & ) > control_callback;
+    typedef std::function< bool( std::string const &, rsutils::json const &, rsutils::json & ) > control_callback;
     void on_control( control_callback callback ) { _control_callback = std::move( callback ); }
 
 private:
     void on_control_message_received();
     void handle_control_message( std::string const & id,
-                                 nlohmann::json const & control_message,
-                                 nlohmann::json & reply );
+                                 rsutils::json const & control_message,
+                                 rsutils::json & reply );
 
-    void handle_set_option( const nlohmann::json & msg, nlohmann::json & reply );
-    void handle_query_option( const nlohmann::json & msg, nlohmann::json & reply );
+    void handle_set_option( const rsutils::json & msg, rsutils::json & reply );
+    void handle_query_option( const rsutils::json & msg, rsutils::json & reply );
     std::shared_ptr< dds_option > find_option( const std::string & option_name, const std::string & stream_name ) const;
 
     std::shared_ptr< dds_publisher > _publisher;

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -1,6 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include "dds-defines.h"
@@ -8,7 +7,7 @@
 #include "dds-stream.h"
 
 #include <rsutils/subscription.h>
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 #include <memory>
 #include <vector>
 #include <functional>
@@ -50,7 +49,7 @@ public:
     // Utility function for checking replies:
     // If 'p_explanation' is nullptr, will throw if the reply status is not 'ok'.
     // Otherise will return a false if not 'ok', and the explanation will be filled out.
-    static bool check_reply( nlohmann::json const & reply, std::string * p_explanation = nullptr );
+    static bool check_reply( rsutils::json const & reply, std::string * p_explanation = nullptr );
 
     //----------- below this line, a device must be running!
 
@@ -64,22 +63,22 @@ public:
     void set_option_value( const std::shared_ptr< dds_option > & option, float new_value );
     float query_option_value( const std::shared_ptr< dds_option > & option );
 
-    void send_control( topics::flexible_msg &&, nlohmann::json * reply = nullptr );
+    void send_control( topics::flexible_msg &&, rsutils::json * reply = nullptr );
 
     bool has_extrinsics() const;
     std::shared_ptr< extrinsics > get_extrinsics( std::string const & from, std::string const & to ) const;
 
     bool supports_metadata() const;
 
-    typedef std::function< void( std::shared_ptr< const nlohmann::json > const & md ) > on_metadata_available_callback;
+    typedef std::function< void( std::shared_ptr< const rsutils::json > const & md ) > on_metadata_available_callback;
     rsutils::subscription on_metadata_available( on_metadata_available_callback && );
 
     typedef std::function< void(
-        dds_nsec timestamp, char type, std::string const & text, nlohmann::json const & data ) >
+        dds_nsec timestamp, char type, std::string const & text, rsutils::json const & data ) >
         on_device_log_callback;
     rsutils::subscription on_device_log( on_device_log_callback && cb );
 
-    typedef std::function< void( std::string const & id, nlohmann::json const & ) > on_notification_callback;
+    typedef std::function< void( std::string const & id, rsutils::json const & ) > on_notification_callback;
     rsutils::subscription on_notification( on_notification_callback && );
 
 private:

--- a/third-party/realdds/include/realdds/dds-metadata-syncer.h
+++ b/third-party/realdds/include/realdds/dds-metadata-syncer.h
@@ -1,9 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 
 #include <deque>
 #include <memory>
@@ -54,7 +53,7 @@ public:
     typedef std::unique_ptr< frame_type, on_frame_release_callback > frame_holder;
 
     // Metadata is intended to be JSON
-    typedef std::shared_ptr< const nlohmann::json > metadata_type;
+    typedef std::shared_ptr< const rsutils::json > metadata_type;
 
     // So our main callback gets this generic frame and metadata:
     typedef std::function< void( frame_holder &&, metadata_type const & metadata ) > on_frame_ready_callback;

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -1,10 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
-
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 
 #include <string>
 #include <vector>
@@ -31,7 +29,7 @@ class dds_option
     dds_option_range _range;
     std::string _description;
 
-    dds_option( nlohmann::json const & );
+    dds_option( rsutils::json const & );
 
     friend class dds_stream_base;
     std::weak_ptr< dds_stream_base > _stream;
@@ -49,8 +47,8 @@ public:
     const dds_option_range & get_range() const { return _range; }
     const std::string & get_description() const { return _description; }
 
-    nlohmann::json to_json() const;
-    static std::shared_ptr< dds_option > from_json( nlohmann::json const & j );
+    rsutils::json to_json() const;
+    static std::shared_ptr< dds_option > from_json( rsutils::json const & j );
 };
 
 typedef std::vector< std::shared_ptr< dds_option > > dds_options;

--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -1,12 +1,10 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include "dds-defines.h"
 
-#include <nlohmann/json.hpp>
-
+#include <rsutils/json.h>
 #include <memory>
 #include <functional>
 #include <string>
@@ -52,7 +50,7 @@ class dds_participant
 
     struct listener_impl;
 
-    nlohmann::json _settings;
+    rsutils::json _settings;
 
 public:
     dds_participant() = default;
@@ -64,7 +62,7 @@ public:
     // 
     // The domain ID may be -1: in this case the settings "domain" is queried and a default of 0 is used
     //
-    void init( dds_domain_id, std::string const & participant_name, nlohmann::json const & settings );
+    void init( dds_domain_id, std::string const & participant_name, rsutils::json const & settings );
 
     bool is_valid() const { return ( nullptr != _participant ); }
     bool operator!() const { return ! is_valid(); }
@@ -72,7 +70,7 @@ public:
     eprosima::fastdds::dds::DomainParticipant * get() const { return _participant; }
     eprosima::fastdds::dds::DomainParticipant * operator->() const { return get(); }
 
-    nlohmann::json const & settings() const { return _settings; }
+    rsutils::json const & settings() const { return _settings; }
 
     // RTPS 8.2.4.2 "Every Participant has GUID <prefix, ENTITYID_PARTICIPANT>, where the constant ENTITYID_PARTICIPANT
     //     is a special value defined by the RTPS protocol. Its actual value depends on the PSM."

--- a/third-party/realdds/include/realdds/dds-serialization.h
+++ b/third-party/realdds/include/realdds/dds-serialization.h
@@ -4,7 +4,7 @@
 
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 #include <iosfwd>
 
 
@@ -28,14 +28,17 @@ class DomainParticipantQos;
 
 namespace eprosima {
 namespace fastrtps {
+
 // Allow j["key"] = qos.lease_duration;
-void to_json( nlohmann::json &, Duration_t const & );
+void to_json( rsutils::json &, Duration_t const & );
 // Allow j.get< eprosima::fastrtps::Duration_t >();
-void from_json( nlohmann::json const &, Duration_t & );
+void from_json( rsutils::json const &, Duration_t & );
+
 namespace rtps {
 std::ostream & operator<<( std::ostream &, class WriterProxyData const & );
 std::ostream & operator<<( std::ostream &, class ReaderProxyData const & );
 }  // namespace rtps
+
 }  // namespace fastrtps
 }  // namespace eprosima
 
@@ -57,7 +60,7 @@ eprosima::fastrtps::rtps::MemoryManagementPolicy_t history_memory_policy_from_st
 //          "kind": "reliable"
 //          }
 //
-void override_reliability_qos_from_json( eprosima::fastdds::dds::ReliabilityQosPolicy & qos, nlohmann::json const & );
+void override_reliability_qos_from_json( eprosima::fastdds::dds::ReliabilityQosPolicy & qos, rsutils::json const & );
 
 // Override QoS durability from a JSON source.
 // The JSON can be a simple string indicating simple durability kind:
@@ -67,7 +70,7 @@ void override_reliability_qos_from_json( eprosima::fastdds::dds::ReliabilityQosP
 //          "kind": "persistent"
 //          }
 //
-void override_durability_qos_from_json( eprosima::fastdds::dds::DurabilityQosPolicy & qos, nlohmann::json const & );
+void override_durability_qos_from_json( eprosima::fastdds::dds::DurabilityQosPolicy & qos, rsutils::json const & );
 
 // Override QoS history from a JSON source.
 // The JSON can be a simple unsigned integer indicating simple history depth:
@@ -78,7 +81,7 @@ void override_durability_qos_from_json( eprosima::fastdds::dds::DurabilityQosPol
 //          "depth": 20
 //          }
 //
-void override_history_qos_from_json( eprosima::fastdds::dds::HistoryQosPolicy & qos, nlohmann::json const & );
+void override_history_qos_from_json( eprosima::fastdds::dds::HistoryQosPolicy & qos, rsutils::json const & );
 
 
 // Override QoS liveliness from a JSON source.
@@ -89,14 +92,14 @@ void override_history_qos_from_json( eprosima::fastdds::dds::HistoryQosPolicy & 
 //          "announcement-period": 3  // seconds
 //      }
 //
-void override_liveliness_qos_from_json( eprosima::fastdds::dds::LivelinessQosPolicy & qos, nlohmann::json const & );
+void override_liveliness_qos_from_json( eprosima::fastdds::dds::LivelinessQosPolicy & qos, rsutils::json const & );
 
 
 // Override QoS data-sharing from a JSON source.
 // The JSON can be a simple boolean indicating off or automatic mode:
 //      "data-sharing": true  // <-- the JSON is the true value
 //
-void override_data_sharing_qos_from_json( eprosima::fastdds::dds::DataSharingQosPolicy & qos, nlohmann::json const & );
+void override_data_sharing_qos_from_json( eprosima::fastdds::dds::DataSharingQosPolicy & qos, rsutils::json const & );
 
 // Override QoS endpoint from a JSON source.
 // The JSON is an object:
@@ -104,7 +107,7 @@ void override_data_sharing_qos_from_json( eprosima::fastdds::dds::DataSharingQos
 //          "history-memory-policy": "preallocated-with-realloc"
 //      }
 //
-void override_endpoint_qos_from_json( eprosima::fastdds::dds::RTPSEndpointQos & qos, nlohmann::json const & );
+void override_endpoint_qos_from_json( eprosima::fastdds::dds::RTPSEndpointQos & qos, rsutils::json const & );
 
 
 // Override participant QoS from a JSON source.
@@ -114,7 +117,7 @@ void override_endpoint_qos_from_json( eprosima::fastdds::dds::RTPSEndpointQos & 
 //          "lease-duration": 10,  // seconds
 //      }
 //
-void override_participant_qos_from_json( eprosima::fastdds::dds::DomainParticipantQos & qos, nlohmann::json const & );
+void override_participant_qos_from_json( eprosima::fastdds::dds::DomainParticipantQos & qos, rsutils::json const & );
 
 
 }  // namespace realdds

--- a/third-party/realdds/include/realdds/dds-stream-profile.h
+++ b/third-party/realdds/include/realdds/dds-stream-profile.h
@@ -1,10 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
-
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 
 #include <stdint.h>
 #include <string>
@@ -76,7 +74,7 @@ protected:
         : _frequency( frequency )
     {
     }
-    dds_stream_profile( nlohmann::json const &, int & index );
+    dds_stream_profile( rsutils::json const &, int & index );
 
 public:
     std::shared_ptr< dds_stream_base > stream() const { return _stream.lock(); }
@@ -90,13 +88,13 @@ public:
     virtual std::string details_to_string() const;
 
     // Serialization to a JSON array representation
-    virtual nlohmann::json to_json() const;
+    virtual rsutils::json to_json() const;
 
     // Build a profile from a json array object, e.g.:
     //      auto profile = dds_stream_profile::from_json< dds_video_stream_profile >( j );
     // This is the reverse of to_json() which returns a json array
     template< class final_stream_profile >
-    static std::shared_ptr< final_stream_profile > from_json( nlohmann::json const & j )
+    static std::shared_ptr< final_stream_profile > from_json( rsutils::json const & j )
     {
         int it = 0;
         auto profile = std::make_shared< final_stream_profile >( j, it );
@@ -105,7 +103,7 @@ public:
     }
 
 private:
-    static void verify_end_of_json( nlohmann::json const &, int index );
+    static void verify_end_of_json( rsutils::json const &, int index );
 };
 
 
@@ -131,7 +129,7 @@ public:
         , _encoding( encoding )
     {
     }
-    dds_video_stream_profile( nlohmann::json const &, int & index );
+    dds_video_stream_profile( rsutils::json const &, int & index );
 
     uint16_t width() const { return _width; }
     uint16_t height() const { return _height; }
@@ -139,7 +137,7 @@ public:
 
     std::string details_to_string() const override;
 
-    nlohmann::json to_json() const override;
+    rsutils::json to_json() const override;
 };
 
 
@@ -152,7 +150,7 @@ public:
         : super( frequency )
     {
     }
-    dds_motion_stream_profile( nlohmann::json const & j, int & index )
+    dds_motion_stream_profile( rsutils::json const & j, int & index )
         : super( j, index )
     {
     }

--- a/third-party/realdds/include/realdds/dds-topic-reader.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader.h
@@ -1,12 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 #include <functional>
 #include <memory>
 
@@ -76,7 +75,7 @@ public:
                = eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS );  // default is transient local
 
         // Override default values with JSON contents
-        void override_from_json( nlohmann::json const & );
+        void override_from_json( rsutils::json const & );
     };
 
     // The callbacks should be set before we actually create the underlying DDS objects, so the reader does not

--- a/third-party/realdds/include/realdds/dds-topic-writer.h
+++ b/third-party/realdds/include/realdds/dds-topic-writer.h
@@ -7,7 +7,7 @@
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include "dds-defines.h"
 
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 #include <memory>
 #include <atomic>
 
@@ -75,7 +75,7 @@ public:
                = eprosima::fastdds::dds::VOLATILE_DURABILITY_QOS );  // default is transient local
     
         // Override default values with JSON contents
-        void override_from_json( nlohmann::json const & );
+        void override_from_json( rsutils::json const & );
     };
 
     // The callbacks should be set before we actually create the underlying DDS objects, so the writer does not

--- a/third-party/realdds/include/realdds/dds-trinsics.h
+++ b/third-party/realdds/include/realdds/dds-trinsics.h
@@ -1,9 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 
 #include <array>
 #include <map>
@@ -33,8 +32,8 @@ struct video_intrinsics
         return width < rhs.width || ( width == rhs.width && height < rhs.height );
     }
 
-    nlohmann::json to_json() const;
-    static video_intrinsics from_json( nlohmann::json const & j );
+    rsutils::json to_json() const;
+    static video_intrinsics from_json( rsutils::json const & j );
 };
 
 // Internal properties of a motion stream.
@@ -45,8 +44,8 @@ struct motion_intrinsics
     std::array< float, 3 > noise_variances = { 0 };
     std::array< float, 3 > bias_variances = { 0 };
 
-    nlohmann::json to_json() const;
-    static motion_intrinsics from_json( nlohmann::json const & j );
+    rsutils::json to_json() const;
+    static motion_intrinsics from_json( rsutils::json const & j );
 };
 
 
@@ -56,8 +55,8 @@ struct extrinsics
     std::array< float, 9 > rotation = { 0 };     // Column-major 3x3 rotation matrix
     std::array< float, 3 > translation = { 0 };  // Three-element translation vector, in meters
 
-    nlohmann::json to_json() const;
-    static extrinsics from_json( nlohmann::json const & j );
+    rsutils::json to_json() const;
+    static extrinsics from_json( rsutils::json const & j );
 };
 
 

--- a/third-party/realdds/include/realdds/topics/device-info-msg.h
+++ b/third-party/realdds/include/realdds/topics/device-info-msg.h
@@ -2,8 +2,7 @@
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 #pragma once
 
-#include <nlohmann/json.hpp>
-
+#include <rsutils/json.h>
 #include <rsutils/string/slice.h>
 
 namespace realdds {
@@ -11,7 +10,7 @@ namespace topics {
 
 class device_info
 {
-    nlohmann::json _json;
+    rsutils::json _json;
 
 public:
     //std::string serial;
@@ -27,8 +26,8 @@ public:
     std::string const & serial_number() const;
     void set_serial_number( std::string const & );
 
-    nlohmann::json const & to_json() const;
-    static device_info from_json( nlohmann::json const & );
+    rsutils::json const & to_json() const;
+    static device_info from_json( rsutils::json const & );
 
     // Substring of information already stored in the device-info that can be used to print the device 'name'.
     // (mostly for use with debug messages)

--- a/third-party/realdds/include/realdds/topics/flexible-msg.h
+++ b/third-party/realdds/include/realdds/topics/flexible-msg.h
@@ -1,17 +1,14 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
-
 
 #include "flexible/flexible.h"
 #include <realdds/dds-defines.h>
 
+#include <rsutils/json-fwd.h>
 #include <string>
 #include <memory>
 #include <vector>
-
-#include <nlohmann/json_fwd.hpp>
 
 
 namespace eprosima {
@@ -82,10 +79,10 @@ public:
 
     flexible_msg() = default;
     flexible_msg( raw::flexible && );
-    flexible_msg( nlohmann::json const &, uint32_t version = 0 );
-    flexible_msg( data_format format, nlohmann::json const &, uint32_t version = 0 );
+    flexible_msg( rsutils::json const &, uint32_t version = 0 );
+    flexible_msg( data_format format, rsutils::json const &, uint32_t version = 0 );
 
-    nlohmann::json json_data() const;
+    rsutils::json json_data() const;
 
     // Get the custom data with casting to the desired type
     // Syntax: auto stream_info = msg.custom_data< STREAM_INFO >();

--- a/third-party/realdds/include/realdds/topics/flexible/flexible-writer.h
+++ b/third-party/realdds/include/realdds/topics/flexible/flexible-writer.h
@@ -1,13 +1,10 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
-
 
 #include <realdds/topics/flexible-msg.h>
 
-#include <nlohmann/json_fwd.hpp>
-
+#include <rsutils/json-fwd.h>
 #include <string>
 #include <memory>
 #include <chrono>
@@ -49,7 +46,7 @@ public:
 
     void wait_for_readers( int n_readers, std::chrono::seconds timeout = std::chrono::seconds( 3 ) );
 
-    void write( nlohmann::json && json );
+    void write( rsutils::json && json );
 
 private:
     void on_publication_matched( eprosima::fastdds::dds::PublicationMatchedStatus const & status );

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -13,7 +13,7 @@
 #include <fastdds/rtps/common/Guid.h>
 
 #include <rsutils/signal.h>
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 
 #include <map>
 #include <memory>
@@ -51,7 +51,7 @@ class dds_device::impl
 
 public:
     topics::device_info const _info;
-    nlohmann::json const _device_settings;
+    rsutils::json const _device_settings;
     dds_guid _server_guid;
     std::shared_ptr< dds_participant > const _participant;
     std::shared_ptr< dds_subscriber > _subscriber;
@@ -60,7 +60,7 @@ public:
 
     std::mutex _replies_mutex;
     std::condition_variable _replies_cv;
-    std::map< dds_sequence_number, nlohmann::json > _replies;
+    std::map< dds_sequence_number, rsutils::json > _replies;
     size_t _reply_timeout_ms;
 
     std::shared_ptr< dds_topic_reader > _notifications_reader;
@@ -82,12 +82,12 @@ public:
 
     void open( const dds_stream_profiles & profiles );
 
-    void write_control_message( topics::flexible_msg &&, nlohmann::json * reply = nullptr );
+    void write_control_message( topics::flexible_msg &&, rsutils::json * reply = nullptr );
 
     void set_option_value( const std::shared_ptr< dds_option > & option, float new_value );
     float query_option_value( const std::shared_ptr< dds_option > & option );
 
-    using on_metadata_available_signal = rsutils::signal< std::shared_ptr< const nlohmann::json > const & >;
+    using on_metadata_available_signal = rsutils::signal< std::shared_ptr< const rsutils::json > const & >;
     using on_metadata_available_callback = on_metadata_available_signal::callback;
     rsutils::subscription on_metadata_available( on_metadata_available_callback && cb )
     {
@@ -97,14 +97,14 @@ public:
     using on_device_log_signal = rsutils::signal< dds_nsec,                  // timestamp
                                                   char,                      // type
                                                   std::string const &,       // text
-                                                  nlohmann::json const & >;  // data
+                                                  rsutils::json const & >;   // data
     using on_device_log_callback = on_device_log_signal::callback;
     rsutils::subscription on_device_log( on_device_log_callback && cb )
     {
         return _on_device_log.subscribe( std::move( cb ) );
     }
 
-    using on_notification_signal = rsutils::signal< std::string const &, nlohmann::json const & >;
+    using on_notification_signal = rsutils::signal< std::string const &, rsutils::json const & >;
     using on_notification_callback = on_notification_signal::callback;
     rsutils::subscription on_notification( on_notification_callback && cb )
     {
@@ -117,20 +117,20 @@ private:
     void create_control_writer();
 
     // notification handlers
-    void on_option_value( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_known_notification( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_log( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_device_header( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_device_options( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_stream_header( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_stream_options( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_option_value( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_known_notification( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_log( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_device_header( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_device_options( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_stream_header( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_stream_options( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
 
     typedef std::map< std::string,
-                      void ( dds_device::impl::* )( nlohmann::json const &,
+                      void ( dds_device::impl::* )( rsutils::json const &,
                                                     eprosima::fastdds::dds::SampleInfo const & ) >
         notification_handlers;
     static notification_handlers const _notification_handlers;
-    void handle_notification( nlohmann::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void handle_notification( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
 
     on_metadata_available_signal _on_metadata_available;
     on_device_log_signal _on_device_log;

--- a/third-party/realdds/src/dds-device-watcher.cpp
+++ b/third-party/realdds/src/dds-device-watcher.cpp
@@ -51,7 +51,7 @@ dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const
                 }
 
                 auto j = msg.json_data();
-                if( j.find( "stopping" ) != j.end() )
+                if( j.nested( "stopping" ) )
                 {
                     // This device is stopping for whatever reason (e.g., HW reset); remove it
                     LOG_DEBUG( "DDS device (from " << _participant->print( guid ) << ") is stopping" );

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -94,7 +94,7 @@ float dds_device::query_option_value( const std::shared_ptr< dds_option > & opti
     return _impl->query_option_value( option );
 }
 
-void dds_device::send_control( topics::flexible_msg && msg, nlohmann::json * reply )
+void dds_device::send_control( topics::flexible_msg && msg, rsutils::json * reply )
 {
     _impl->write_control_message( std::move( msg ), reply );
 }
@@ -141,29 +141,29 @@ static std::string const explanation_key( "explanation", 11 );
 static std::string const id_key( "id", 2 );
 
 
-bool dds_device::check_reply( nlohmann::json const & reply, std::string * p_explanation )
+bool dds_device::check_reply( rsutils::json const & reply, std::string * p_explanation )
 {
-    auto status_j = rsutils::json::nested( reply, status_key );
+    auto status_j = reply.nested( status_key );
     if( ! status_j )
         return true;
     std::ostringstream os;
-    if( ! status_j->is_string() )
+    if( ! status_j.is_string() )
         os << "bad status " << status_j;
     else if( status_j.string_ref() == status_ok )
         return true;
     else
     {
         os << "[";
-        if( auto id = rsutils::json::nested( reply, id_key ) )
+        if( auto id = reply.nested( id_key ) )
         {
-            if( id->is_string() )
+            if( id.is_string() )
                 os << "\"" << id.string_ref() << "\" ";
         }
         os << status_j.string_ref() << "]";
-        if( auto explanation_j = rsutils::json::nested( reply, explanation_key ) )
+        if( auto explanation_j = reply.nested( explanation_key ) )
         {
             os << ' ';
-            if( ! explanation_j->is_string() || explanation_j.string_ref().empty() )
+            if( explanation_j.string_ref_or_empty().empty() )
                 os << "bad explanation " << explanation_j;
             else
                 os << explanation_j.string_ref();

--- a/third-party/realdds/src/dds-notification-server.cpp
+++ b/third-party/realdds/src/dds-notification-server.cpp
@@ -91,7 +91,7 @@ dds_notification_server::dds_notification_server( std::shared_ptr< dds_publisher
     // If history is too small writer will not be able to re-transmit needed samples.
     // Setting history to cover known use-cases plus some spare
     wqos.history().depth = 24;
-    wqos.override_from_json( rsutils::json::nested( publisher->get_participant()->settings(), "device", "notification" ) );
+    wqos.override_from_json( publisher->get_participant()->settings().nested( "device", "notification" ) );
 
     _writer->run( wqos );
 }

--- a/third-party/realdds/src/dds-option.cpp
+++ b/third-party/realdds/src/dds-option.cpp
@@ -5,7 +5,6 @@
 #include <realdds/dds-exceptions.h>
 
 #include <rsutils/json.h>
-using nlohmann::json;
 
 
 namespace realdds {
@@ -20,42 +19,42 @@ dds_option::dds_option( const std::string & name, dds_option_range const & range
 }
 
 
-dds_option::dds_option( nlohmann::json const & j )
+dds_option::dds_option( rsutils::json const & j )
 {
     int index = 0;
 
-    _name                = rsutils::json::get< std::string >( j, index++ );
-    _value               = rsutils::json::get< float >( j, index++ );
-    _range.min           = rsutils::json::get< float >( j, index++ );
-    _range.max           = rsutils::json::get< float >( j, index++ );
-    _range.step          = rsutils::json::get< float >( j, index++ );
-    _range.default_value = rsutils::json::get< float >( j, index++ );
-    _description         = rsutils::json::get< std::string >( j, index++ );
+    _name                = j[index++].string_ref();
+    _value               = j[index++].get< float >();
+    _range.min           = j[index++].get< float >();
+    _range.max           = j[index++].get< float >();
+    _range.step          = j[index++].get< float >();
+    _range.default_value = j[index++].get< float >();
+    _description         = j[index++].string_ref();
 
     if( index != j.size() )
-        DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
+        DDS_THROW( runtime_error, "expected end of json at index " << index );
 }
 
 
 void dds_option::init_stream( std::shared_ptr< dds_stream_base > const & stream )
 {
     if( _stream.lock() )
-        DDS_THROW( runtime_error, "option '" + get_name() + "' already has a stream" );
+        DDS_THROW( runtime_error, "option '" << get_name() << "' already has a stream" );
     if( ! stream )
         DDS_THROW( runtime_error, "null stream" );
     _stream = stream;
 }
 
 
-/* static  */ std::shared_ptr< dds_option > dds_option::from_json( nlohmann::json const & j )
+/*static*/ std::shared_ptr< dds_option > dds_option::from_json( rsutils::json const & j )
 {
     return std::shared_ptr< dds_option >( new dds_option( j ) );
 }
 
 
-nlohmann::json dds_option::to_json() const
+rsutils::json dds_option::to_json() const
 {
-    return json::array( { _name, _value, _range.min, _range.max, _range.step, _range.default_value, _description } );
+    return rsutils::json::array( { _name, _value, _range.min, _range.max, _range.step, _range.default_value, _description } );
 }
 
 }  // namespace realdds

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -186,7 +186,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
 };
 
 
-void dds_participant::init( dds_domain_id domain_id, std::string const & participant_name, nlohmann::json const & settings )
+void dds_participant::init( dds_domain_id domain_id, std::string const & participant_name, rsutils::json const & settings )
 {
     if( is_valid() )
     {
@@ -198,8 +198,7 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
     if( domain_id == -1 )
     {
         // Get it from settings and default to 0
-        if( ! rsutils::json::get_ex( settings, "domain", &domain_id ) )
-            domain_id = 0;
+        domain_id = settings.nested( "domain" ).default_value( 0 );
     }
 
     _domain_listener = std::make_shared< listener_impl >( *this );
@@ -245,7 +244,7 @@ void dds_participant::init( dds_domain_id domain_id, std::string const & partici
     if( settings.is_object() )
         _settings = settings;
     else if( settings.is_null() )
-        _settings = nlohmann::json::object();
+        _settings = rsutils::json::object();
     else
         DDS_THROW( runtime_error, "provided settings are invalid: " << settings );
 

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -6,8 +6,6 @@
 #include <realdds/dds-exceptions.h>
 
 #include <rsutils/json.h>
-using nlohmann::json;
-
 #include <map>
 
 
@@ -137,15 +135,15 @@ dds_video_encoding dds_video_encoding::from_rs2( int rs2_format )
 }
 
 
-dds_stream_profile::dds_stream_profile( json const & j, int & it )
-    : _frequency( rsutils::json::get< int16_t >( j, it++ ) )
+dds_stream_profile::dds_stream_profile( rsutils::json const & j, int & it )
+    : _frequency( j[it++].get< int16_t >() )
 {
     // NOTE: the order of construction is the order of declaration -- therefore the to_json() function
     // should use the same ordering!
 }
 
 
-/* static */ void dds_stream_profile::verify_end_of_json( nlohmann::json const & j, int index )
+/* static */ void dds_stream_profile::verify_end_of_json( rsutils::json const & j, int index )
 {
     if( index != j.size() )
         DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
@@ -189,23 +187,23 @@ void dds_stream_profile::init_stream( std::weak_ptr< dds_stream_base > const & s
 }
 
 
-json dds_stream_profile::to_json() const
+rsutils::json dds_stream_profile::to_json() const
 {
     // NOTE: same ordering as construction!
-    return json::array( { frequency() } );
+    return rsutils::json::array( { frequency() } );
 }
 
 
-dds_video_stream_profile::dds_video_stream_profile( nlohmann::json const & j, int & index )
+dds_video_stream_profile::dds_video_stream_profile( rsutils::json const & j, int & index )
     : super( j, index )
-    , _encoding( rsutils::json::get< std::string >( j, index++ ) )
+    , _encoding( j[index++].get< std::string >() )
 {
-    _width = rsutils::json::get< int16_t >( j, index++ );
-    _height = rsutils::json::get< int16_t >( j, index++ );
+    _width = j[index++].get< int16_t >();
+    _height = j[index++].get< int16_t >();
 }
 
 
-json dds_video_stream_profile::to_json() const
+rsutils::json dds_video_stream_profile::to_json() const
 {
     auto profile = super::to_json();
     profile += encoding().to_string();

--- a/third-party/realdds/src/dds-stream-sensor-bridge.cpp
+++ b/third-party/realdds/src/dds-stream-sensor-bridge.cpp
@@ -12,8 +12,6 @@
 #include <algorithm>
 #include <iostream>
 
-using nlohmann::json;
-
 
 namespace realdds {
 

--- a/third-party/realdds/src/dds-topic-reader.cpp
+++ b/third-party/realdds/src/dds-topic-reader.cpp
@@ -87,19 +87,16 @@ dds_topic_reader::qos::qos( eprosima::fastdds::dds::ReliabilityQosPolicyKind rel
 }
 
 
-void dds_topic_reader::qos::override_from_json( nlohmann::json const & qos_settings )
+void dds_topic_reader::qos::override_from_json( rsutils::json const & qos_settings )
 {
     // Default values should be set before we're called:
     // All we do here is override those - if specified!
-    if( qos_settings.is_null() )
-        return;
-
-    override_reliability_qos_from_json( reliability(), rsutils::json::nested( qos_settings, "reliability" ) );
-    override_durability_qos_from_json( durability(), rsutils::json::nested( qos_settings, "durability" ) );
-    override_history_qos_from_json( history(), rsutils::json::nested( qos_settings, "history" ) );
-    override_liveliness_qos_from_json( liveliness(), rsutils::json::nested( qos_settings, "liveliness" ) );
-    override_data_sharing_qos_from_json( data_sharing(), rsutils::json::nested( qos_settings, "data-sharing" ) );
-    override_endpoint_qos_from_json( endpoint(), rsutils::json::nested( qos_settings, "endpoint" ) );
+    override_reliability_qos_from_json( reliability(), qos_settings.nested( "reliability" ) );
+    override_durability_qos_from_json( durability(), qos_settings.nested( "durability" ) );
+    override_history_qos_from_json( history(), qos_settings.nested( "history" ) );
+    override_liveliness_qos_from_json( liveliness(), qos_settings.nested( "liveliness" ) );
+    override_data_sharing_qos_from_json( data_sharing(), qos_settings.nested( "data-sharing" ) );
+    override_endpoint_qos_from_json( endpoint(), qos_settings.nested( "endpoint" ) );
 }
 
 

--- a/third-party/realdds/src/dds-topic-writer.cpp
+++ b/third-party/realdds/src/dds-topic-writer.cpp
@@ -87,19 +87,16 @@ dds_topic_writer::qos::qos( eprosima::fastdds::dds::ReliabilityQosPolicyKind rel
 }
 
 
-void dds_topic_writer::qos::override_from_json( nlohmann::json const & qos_settings )
+void dds_topic_writer::qos::override_from_json( rsutils::json const & qos_settings )
 {
     // Default values should be set before we're called:
     // All we do here is override those - if specified!
-    if( qos_settings.is_null() )
-        return;
-
-    override_reliability_qos_from_json( reliability(), rsutils::json::nested( qos_settings, "reliability" ) );
-    override_durability_qos_from_json( durability(), rsutils::json::nested( qos_settings, "durability" ) );
-    override_history_qos_from_json( history(), rsutils::json::nested( qos_settings, "history" ) );
-    override_liveliness_qos_from_json( liveliness(), rsutils::json::nested( qos_settings, "liveliness" ) );
-    override_data_sharing_qos_from_json( data_sharing(), rsutils::json::nested( qos_settings, "data-sharing" ) );
-    override_endpoint_qos_from_json( endpoint(), rsutils::json::nested( qos_settings, "endpoint" ) );
+    override_reliability_qos_from_json( reliability(), qos_settings.nested( "reliability" ) );
+    override_durability_qos_from_json( durability(), qos_settings.nested( "durability" ) );
+    override_history_qos_from_json( history(), qos_settings.nested( "history" ) );
+    override_liveliness_qos_from_json( liveliness(), qos_settings.nested( "liveliness" ) );
+    override_data_sharing_qos_from_json( data_sharing(), qos_settings.nested( "data-sharing" ) );
+    override_endpoint_qos_from_json( endpoint(), qos_settings.nested( "endpoint" ) );
 }
 
 

--- a/third-party/realdds/src/dds-trinsics.cpp
+++ b/third-party/realdds/src/dds-trinsics.cpp
@@ -10,31 +10,31 @@
 namespace realdds {
 
 
-nlohmann::json video_intrinsics::to_json() const
+rsutils::json video_intrinsics::to_json() const
 {
-    return nlohmann::json::array( {
+    return rsutils::json::array( {
         width, height, principal_point_x, principal_point_y, focal_lenght_x, focal_lenght_y, distortion_model,
         distortion_coeffs[0], distortion_coeffs[1], distortion_coeffs[2], distortion_coeffs[3], distortion_coeffs[4]
     } );
 }
 
-/* static  */ video_intrinsics video_intrinsics::from_json( nlohmann::json const & j )
+/* static  */ video_intrinsics video_intrinsics::from_json( rsutils::json const & j )
 {
     video_intrinsics ret;
     int index = 0;
 
-    ret.width = rsutils::json::get< int >( j, index++ );
-    ret.height = rsutils::json::get< int >( j, index++ );
-    ret.principal_point_x = rsutils::json::get< float >( j, index++ );
-    ret.principal_point_y = rsutils::json::get< float >( j, index++ );
-    ret.focal_lenght_x = rsutils::json::get< float >( j, index++ );
-    ret.focal_lenght_y = rsutils::json::get< float >( j, index++ );
-    ret.distortion_model = rsutils::json::get< int >( j, index++ );
-    ret.distortion_coeffs[0] = rsutils::json::get< float >( j, index++ );
-    ret.distortion_coeffs[1] = rsutils::json::get< float >( j, index++ );
-    ret.distortion_coeffs[2] = rsutils::json::get< float >( j, index++ );
-    ret.distortion_coeffs[3] = rsutils::json::get< float >( j, index++ );
-    ret.distortion_coeffs[4] = rsutils::json::get< float >( j, index++ );
+    ret.width = j[index++].get< int >();
+    ret.height = j[index++].get< int >();
+    ret.principal_point_x = j[index++].get< float >();
+    ret.principal_point_y = j[index++].get< float >();
+    ret.focal_lenght_x = j[index++].get< float >();
+    ret.focal_lenght_y = j[index++].get< float >();
+    ret.distortion_model = j[index++].get< int >();
+    ret.distortion_coeffs[0] = j[index++].get< float >();
+    ret.distortion_coeffs[1] = j[index++].get< float >();
+    ret.distortion_coeffs[2] = j[index++].get< float >();
+    ret.distortion_coeffs[3] = j[index++].get< float >();
+    ret.distortion_coeffs[4] = j[index++].get< float >();
 
     if( index != j.size() )
         DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
@@ -42,9 +42,9 @@ nlohmann::json video_intrinsics::to_json() const
     return ret;
 }
 
-nlohmann::json motion_intrinsics::to_json() const
+rsutils::json motion_intrinsics::to_json() const
 {
-    return nlohmann::json::array( {
+    return rsutils::json::array( {
         data[0][0], data[0][1], data[0][2], data[0][3],
         data[1][0], data[1][1], data[1][2], data[1][3],
         data[2][0], data[2][1], data[2][2], data[2][3],
@@ -53,29 +53,29 @@ nlohmann::json motion_intrinsics::to_json() const
     } );
 }
 
-/* static  */ motion_intrinsics motion_intrinsics::from_json( nlohmann::json const & j )
+/* static  */ motion_intrinsics motion_intrinsics::from_json( rsutils::json const & j )
 {
     motion_intrinsics ret;
     int index = 0;
 
-    ret.data[0][0] = rsutils::json::get< float >( j, index++ );
-    ret.data[0][1] = rsutils::json::get< float >( j, index++ );
-    ret.data[0][2] = rsutils::json::get< float >( j, index++ );
-    ret.data[0][3] = rsutils::json::get< float >( j, index++ );
-    ret.data[1][0] = rsutils::json::get< float >( j, index++ );
-    ret.data[1][1] = rsutils::json::get< float >( j, index++ );
-    ret.data[1][2] = rsutils::json::get< float >( j, index++ );
-    ret.data[1][3] = rsutils::json::get< float >( j, index++ );
-    ret.data[2][0] = rsutils::json::get< float >( j, index++ );
-    ret.data[2][1] = rsutils::json::get< float >( j, index++ );
-    ret.data[2][2] = rsutils::json::get< float >( j, index++ );
-    ret.data[2][3] = rsutils::json::get< float >( j, index++ );
-    ret.noise_variances[0] = rsutils::json::get< float >( j, index++ );
-    ret.noise_variances[1] = rsutils::json::get< float >( j, index++ );
-    ret.noise_variances[2] = rsutils::json::get< float >( j, index++ );
-    ret.bias_variances[0] = rsutils::json::get< float >( j, index++ );
-    ret.bias_variances[1] = rsutils::json::get< float >( j, index++ );
-    ret.bias_variances[2] = rsutils::json::get< float >( j, index++ );
+    ret.data[0][0] = j[index++].get< float >();
+    ret.data[0][1] = j[index++].get< float >();
+    ret.data[0][2] = j[index++].get< float >();
+    ret.data[0][3] = j[index++].get< float >();
+    ret.data[1][0] = j[index++].get< float >();
+    ret.data[1][1] = j[index++].get< float >();
+    ret.data[1][2] = j[index++].get< float >();
+    ret.data[1][3] = j[index++].get< float >();
+    ret.data[2][0] = j[index++].get< float >();
+    ret.data[2][1] = j[index++].get< float >();
+    ret.data[2][2] = j[index++].get< float >();
+    ret.data[2][3] = j[index++].get< float >();
+    ret.noise_variances[0] = j[index++].get< float >();
+    ret.noise_variances[1] = j[index++].get< float >();
+    ret.noise_variances[2] = j[index++].get< float >();
+    ret.bias_variances[0] = j[index++].get< float >();
+    ret.bias_variances[1] = j[index++].get< float >();
+    ret.bias_variances[2] = j[index++].get< float >();
 
     if( index != j.size() )
         DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
@@ -83,9 +83,9 @@ nlohmann::json motion_intrinsics::to_json() const
     return ret;
 }
 
-nlohmann::json extrinsics::to_json() const
+rsutils::json extrinsics::to_json() const
 {
-    return nlohmann::json::array( {
+    return rsutils::json::array( {
         rotation[0], rotation[1], rotation[2],
         rotation[3], rotation[4], rotation[5],
         rotation[6], rotation[7], rotation[8],
@@ -93,23 +93,23 @@ nlohmann::json extrinsics::to_json() const
     } );
 }
 
-/* static  */ extrinsics extrinsics::from_json( nlohmann::json const & j )
+/* static  */ extrinsics extrinsics::from_json( rsutils::json const & j )
 {
     extrinsics ret;
     int index = 0;
 
-    ret.rotation[0] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[1] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[2] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[3] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[4] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[5] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[6] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[7] = rsutils::json::get< float >( j, index++ );
-    ret.rotation[8] = rsutils::json::get< float >( j, index++ );
-    ret.translation[0] = rsutils::json::get< float >( j, index++ );
-    ret.translation[1] = rsutils::json::get< float >( j, index++ );
-    ret.translation[2] = rsutils::json::get< float >( j, index++ );
+    ret.rotation[0] = j[index++].get< float >();
+    ret.rotation[1] = j[index++].get< float >();
+    ret.rotation[2] = j[index++].get< float >();
+    ret.rotation[3] = j[index++].get< float >();
+    ret.rotation[4] = j[index++].get< float >();
+    ret.rotation[5] = j[index++].get< float >();
+    ret.rotation[6] = j[index++].get< float >();
+    ret.rotation[7] = j[index++].get< float >();
+    ret.rotation[8] = j[index++].get< float >();
+    ret.translation[0] = j[index++].get< float >();
+    ret.translation[1] = j[index++].get< float >();
+    ret.translation[2] = j[index++].get< float >();
 
     if( index != j.size() )
         DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );

--- a/third-party/realdds/src/topics/device-info-msg.cpp
+++ b/third-party/realdds/src/topics/device-info-msg.cpp
@@ -5,7 +5,6 @@
 #include <realdds/topics/dds-topic-names.h>
 #include <realdds/dds-exceptions.h>
 
-#include <rsutils/json.h>
 #include <rsutils/easylogging/easyloggingpp.h>
 
 namespace realdds {
@@ -17,7 +16,7 @@ static std::string topic_root_key( "topic-root", 10 );
 static std::string serial_number_key( "serial", 6 );
 
 
-/* static  */ device_info device_info::from_json( nlohmann::json const & j )
+/* static  */ device_info device_info::from_json( rsutils::json const & j )
 {
     device_info ret;
     ret._json = j;
@@ -32,7 +31,7 @@ static std::string serial_number_key( "serial", 6 );
 }
 
 
-nlohmann::json const & device_info::to_json() const
+rsutils::json const & device_info::to_json() const
 {
     return _json;
 }
@@ -40,7 +39,7 @@ nlohmann::json const & device_info::to_json() const
 
 std::string const & device_info::name() const
 {
-    return rsutils::json::nested( _json, name_key ).string_ref_or_empty();
+    return _json.nested( name_key ).string_ref_or_empty();
 }
 
 void device_info::set_name( std::string const & v )
@@ -51,7 +50,7 @@ void device_info::set_name( std::string const & v )
 
 std::string const & device_info::topic_root() const
 {
-    return rsutils::json::nested( _json, topic_root_key ).string_ref_or_empty();
+    return _json.nested( topic_root_key ).string_ref_or_empty();
 }
 
 void device_info::set_topic_root( std::string const & v )
@@ -62,7 +61,7 @@ void device_info::set_topic_root( std::string const & v )
 
 std::string const & device_info::serial_number() const
 {
-    return rsutils::json::nested( _json, serial_number_key ).string_ref_or_empty();
+    return _json.nested( serial_number_key ).string_ref_or_empty();
 }
 
 void device_info::set_serial_number( std::string const & v )

--- a/third-party/realdds/src/topics/flexible-msg.cpp
+++ b/third-party/realdds/src/topics/flexible-msg.cpp
@@ -13,8 +13,7 @@
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
 
-#include <nlohmann/json.hpp>
-using nlohmann::json;
+#include <rsutils/json.h>
 
 
 namespace realdds {
@@ -29,7 +28,7 @@ flexible_msg::flexible_msg( raw::flexible && main )
 }
 
 
-flexible_msg::flexible_msg( json const & j, uint32_t version )
+flexible_msg::flexible_msg( rsutils::json const & j, uint32_t version )
     : _data_format( data_format::JSON )
     , _version( version )
 {
@@ -39,13 +38,13 @@ flexible_msg::flexible_msg( json const & j, uint32_t version )
 }
 
 
-flexible_msg::flexible_msg( data_format format, json const & j, uint32_t version )
+flexible_msg::flexible_msg( data_format format, rsutils::json const & j, uint32_t version )
     : _data_format( format )
     , _version( version )
 {
     if( data_format::CBOR == format )
     {
-        _data = std::move( json::to_cbor( j ) );
+        _data = std::move( rsutils::json::to_cbor( j ) );
     }
     else if( data_format::JSON == format )
     {
@@ -101,17 +100,17 @@ flexible_msg::take_next( dds_topic_reader & reader, flexible_msg * output, epros
 }
 
 
-json flexible_msg::json_data() const
+rsutils::json flexible_msg::json_data() const
 {
     if( _data_format == data_format::JSON )
     {
         char const * begin = (char const *)_data.data();
         char const * end = begin + _data.size();
-        return json::parse( begin, end );
+        return rsutils::json::parse( begin, end );
     }
     if( _data_format == data_format::CBOR )
     {
-        return json::from_cbor( _data.begin(), _data.end() );
+        return rsutils::json::from_cbor( _data.begin(), _data.end() );
     }
     DDS_THROW( runtime_error, "non-json flexible data is still unsupported" );
 }

--- a/third-party/realdds/src/topics/flexible-reader.cpp
+++ b/third-party/realdds/src/topics/flexible-reader.cpp
@@ -10,7 +10,7 @@
 
 #include <fastdds/dds/topic/Topic.hpp>
 
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 
 
 namespace realdds {

--- a/third-party/realdds/src/topics/flexible-writer.cpp
+++ b/third-party/realdds/src/topics/flexible-writer.cpp
@@ -11,7 +11,7 @@
 #include <fastdds/dds/topic/Topic.hpp>
 
 #include <rsutils/time/timer.h>
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 
 
 namespace realdds {
@@ -46,7 +46,7 @@ void flexible_writer::wait_for_readers( int n_readers, std::chrono::seconds time
 }
 
 
-void flexible_writer::write( nlohmann::json && json )
+void flexible_writer::write( rsutils::json && json )
 {
     std::string json_string = json.dump();
     flexible_msg msg( std::move( json ) );

--- a/third-party/rsutils/include/rsutils/json-config.h
+++ b/third-party/rsutils/include/rsutils/json-config.h
@@ -1,0 +1,26 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <rsutils/json-fwd.h>
+
+
+namespace rsutils {
+namespace json_config {
+
+
+// Load the contents of a file into a JSON object.
+json load_from_file( std::string const & filename );
+
+// Loads configuration settings from 'global' content
+json load_app_settings( json const & global,
+                        std::string const & application,
+                        json_key const & subkey,
+                        std::string const & error_context );
+
+// Same as above, but automatically takes the application name from the executable-name
+json load_settings( json const & global, json_key const & subkey, std::string const & error_context );
+
+
+}  // namespace json_config
+}  // namespace rsutils

--- a/third-party/rsutils/include/rsutils/json-fwd.h
+++ b/third-party/rsutils/include/rsutils/json-fwd.h
@@ -1,0 +1,76 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <nlohmann/json_fwd.hpp>
+
+
+namespace rsutils {
+
+
+using json_key = std::string;  // default of basic_json
+
+
+class json_ref;   // Our 'nested' json const reference wrapper
+class json_base;  // The 'json' base class
+
+
+// We use a custom base class to inject our own functionality into every 'json' object:
+//     json <- nlohmann::basic_json<...> <- json_base
+// 
+// NOTE: everything here is templated or forward-declared: neither 'json' nor 'json_ref' are defined yet, and 'json'
+// can't even be referred to because there's a circular dependency (it derives from json_base).
+// 
+// This class defines new functionality that the basic 'json' doesn't have that we want (like nested()), but the actual
+// implementations are always in 'json_ref'!
+// 
+// WARNING: we cannot override already-existing 'json' functions! In fact, it's the other way around: 'json' functions
+// will override ours, so, for example, if we defined find() it would not be usable.
+//
+class json_base
+{
+    // Since we know how we're derived from, we can get the json, or the reference to it, from this:
+    inline json_ref _ref() const;
+
+public:
+    inline bool exists() const;
+
+    template< class T > inline T default_value( T const & default_value ) const;
+
+    template< class T > inline bool get_ex( T & value ) const;
+
+    inline json_ref default_object() const;
+    inline json_ref default_string() const;
+
+    inline std::string const & string_ref() const;
+    inline std::string const & string_ref_or_empty() const;
+
+    template< typename... Rest > inline json_ref nested( Rest... rest ) const;
+
+    // Recursively patches with contents of 'overrides', which must be a JSON object
+    void override( json_ref overrides, std::string const & what = {} );
+
+};
+
+
+using json = nlohmann::basic_json< std::map,  // all template arguments are defaults
+                                   std::vector,
+                                   json_key,
+                                   bool,
+                                   std::int64_t,
+                                   std::uint64_t,
+                                   double,
+                                   std::allocator,
+                                   nlohmann::adl_serializer,
+                                   std::vector< std::uint8_t >,
+                                   json_base >;  // except custom base class!
+
+
+// We can't put these inside json, unfortunately...
+extern json const null_json;     // default json state
+extern json const missing_json;  // i.e., not there: exists() will be 'false'
+extern json const empty_json_string;
+extern json const empty_json_object;
+
+
+}  // namespace rsutils

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -2,260 +2,228 @@
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 #pragma once
 
+#include "json-fwd.h"
 #include <nlohmann/json.hpp>
-#include <string>
 
 
 namespace rsutils {
-namespace json {
-
-
-extern nlohmann::json const null_json;
-extern nlohmann::json const empty_json_string;
-extern nlohmann::json const empty_json_object;
-
-
-// Returns true if the json has a certain key.
-// Does not check the value at all, so it could be any type or null.
-inline bool has( nlohmann::json const & j, std::string const & key )
-{
-    auto it = j.find( key );
-    if( it == j.end() )
-        return false;
-    return true;
-}
-
-
-// Returns true if the json has a certain key and its value is not null.
-// Does not check the value type.
-inline bool has_value( nlohmann::json const & j, std::string const & key )
-{
-    auto it = j.find( key );
-    if( it == j.end() || it->is_null() )
-        return false;
-    return true;
-}
-
-
-// Get the JSON as a value (copy involved); it must exist
-template < class T >
-T value( nlohmann::json const & j )
-{
-    return j.get< T >();
-}
-// Get the JSON as a value, or a default if not there (copy involved)
-template < class T >
-T value( nlohmann::json const & j, T const & default_value )
-{
-    if( j.is_null() )
-        return default_value;
-    return j.get< T >();
-}
-// Get a JSON string by reference (zero copy); it must be a string or it'll throw
-inline std::string const & string_ref( nlohmann::json const & j )
-{
-    return j.get_ref< const nlohmann::json::string_t & >();
-}
-
-
-// If there, gets the value at the given key and returns true; otherwise false.
-// Turns json exceptions into runtime errors with additional info.
-template< class T >
-bool get_ex( nlohmann::json const & j, std::string const & key, T * pv )
-{
-    auto it = j.find( key );
-    if( it == j.end() || it->is_null() )
-        return false;
-    try
-    {
-        // This will throw for type mismatches, etc.
-        it->get_to( *pv );
-    }
-    catch( nlohmann::json::exception & e )
-    {
-        throw std::runtime_error( "[while getting '" + key + "']" + e.what() );
-    }
-    return true;
-}
-
-
-// If there, returns the value at the given key; otherwise returns a default value.
-template < class T >
-T get( nlohmann::json const & j, std::string const & key, T const & default_value )
-{
-    if( ! j.is_object() )
-        return default_value;
-    return j.value( key, default_value );
-}
-
-
-// If there, returns the value at the given key; otherwise throws!
-// Turns json exceptions into runtime errors with additional info.
-template < class T >
-T get( nlohmann::json const & j, std::string const & key )
-{
-    // This will throw for type mismatches, etc.
-    // Does not check for existence: will throw, too!
-    return j.at(key).get< T >();
-}
-
-
-// If there, returns the value at the given index (in an array); otherwise throws!
-// Turns json exceptions into runtime errors with additional info.
-template < class T >
-T get( nlohmann::json const & j, int index )
-{
-    // This will throw for type mismatches, etc.
-    // Does not check for existence: will throw, too!
-    return j.at( index ).get< T >();
-}
-
-
-// If there, returns the value at the given iterator; otherwise throws!
-// Turns json exceptions into runtime errors with additional info.
-template < class T >
-T get( nlohmann::json const & j, nlohmann::json::const_iterator const & it )
-{
-    if( it == j.end() )
-        throw std::runtime_error( "unexpected end of json" );
-    // This will throw for type mismatches, etc.
-    // Does not check for existence: will throw, too!
-    return it->get< T >();
-}
 
 
 template< typename... Rest >
-nlohmann::json const & _nested( nlohmann::json const & j )
-{
-    return j;
-}
+json_ref _nested_json( json const & j );
 template< typename... Rest >
-nlohmann::json const & _nested( nlohmann::json const & j, std::string const & inner, Rest... rest )
-{
-    auto it = j.find( inner );
-    if( it == j.end() )
-        return null_json;
-    return _nested( *it, std::forward< Rest >( rest )... );
-}
+json_ref _nested_json( json const & j, bool ( json::*is_fn )() const );
+template< typename... Rest >
+json_ref _nested_json( json const & j, json_key const & inner, Rest... rest );
+template< typename... Rest >
+json_ref _nested_json( json const & j, json::size_type index, Rest... rest );
 
 
-// Allow easy read-only lookup of nested json hierarchies:
-//      j["one"]["two"]["three"]            // undefined; will throw/assert if a hierarchy isn't there
-// But:
-//      nested( j, "one", "two", "three" )  // will not throw; does not copy!
-// The result is either a null JSON object or a valid one. The boolean operator can be used as an easy check:
-//      if( auto inside = nested( j, "one", "two" ) )
-//          { ... }
+// A copyable reference to a read-only NON-OWNED json.
+// I.e., this is for temporary use and is only valid as long as the original json object is alive!
+// 
+// As this is a read-only reference, no non-const functionality is exposed here.
+// 
+// This is used as the result of any 'nested' searches inside another JSON. As such, it is also used to communicate
+// 'not-found' via the exists() call, so we're castable to bool.
+// 
+// We also use this together with json_base to supply json functionality before json is defined.
 //
-class nested
+class json_ref
 {
-    nlohmann::json const & _j;
+    json const & _j;
 
 public:
-    nested() : _j( null_json ) {}
+    constexpr json_ref() : _j( missing_json ) {}
+    constexpr json_ref( json const & j ) : _j( j ) {}
 
     template< typename... Rest >
-    nested( nlohmann::json const & j, Rest... rest )
-        : _j( _nested( j, std::forward< Rest >( rest )... ) )
+    json_ref( json const & j, Rest... rest )
+        : _j( _nested_json( j, std::forward< Rest >( rest )... ) )
     {}
 
-    nlohmann::json const * operator->() const { return &_j; }
+    // A json value can be null, so we use the internal 'discarded' flag to denote a non-existent one
+    bool exists() const noexcept { return ! _j.is_discarded(); }
+    operator bool() const noexcept { return exists(); }
 
-    bool exists() const { return ! _j.is_null(); }
-    operator bool() const { return exists(); }
+    constexpr json const & get_json() const noexcept { return _j; }
+    constexpr operator json const &() const noexcept { return get_json(); }
 
-    nlohmann::json const & get() const { return _j; }
-    operator nlohmann::json const & () const { return get(); }
+    bool is_null() const noexcept { return _j.is_null(); }
+    bool is_array() const noexcept { return _j.is_array(); }
+    bool is_object() const noexcept { return _j.is_object(); }
+    bool is_string() const noexcept { return _j.is_string(); }
+    bool is_boolean() const noexcept { return _j.is_boolean(); }
+    bool is_number() const noexcept { return _j.is_number(); }
+    bool is_number_float() const noexcept { return _j.is_number_float(); }
+    bool is_number_integer() const noexcept { return _j.is_number_integer(); }
+    bool is_number_unsigned() const noexcept { return _j.is_number_unsigned(); }
+    bool is_primitive() const noexcept { return _j.is_primitive(); }
+    bool is_structured() const noexcept { return _j.is_structured(); }
 
-    bool is_array() const { return _j.is_array(); }
-    bool is_object() const { return _j.is_object(); }
-    bool is_string() const { return _j.is_string(); }
+    bool empty() const noexcept { return _j.empty(); }
+    json::size_type size() const noexcept { return _j.size(); }
+    json::const_iterator begin() const noexcept { return _j.begin(); }
+    json::const_iterator end() const noexcept { return _j.end(); }
 
-    // Dig deeper
+    std::string dump( const int indent = -1 ) const { return _j.dump( indent ); }
+
+    // Allow easy read-only lookup of nested json hierarchies:
+    //      j["one"]["two"]["three"]           // undefined; will throw/assert if a hierarchy isn't there
+    // But:
+    //      j.nested( "one", "two", "three" )  // will not throw; does not copy!
+    // The result is either a null JSON object or a valid one. The boolean operator can be used as an easy check:
+    //      if( auto inside = j.nested( "one", "two" ) )
+    //          { ... }
+    //
     template< typename... Rest >
-    inline nested find( Rest... rest ) const
+    inline json_ref nested( Rest... rest ) const
     {
-        return nested( _j, std::forward< Rest >( rest )... );
+        return _nested_json( _j, std::forward< Rest >( rest )... );
     }
-    inline nested operator[]( std::string const & key ) const { return find( key ); }
 
-    // Get the JSON as a value
-    template< class T > T value() const { return json::value< T >( get() ); }
+    template< class Key > inline json::const_reference at( Key key ) const { return _j.at( std::forward< Key >( key ) ); }
+    template< class Key > inline json::const_reference operator[]( Key key ) const { return _j.operator[]( key ); }
+    template< class T > inline T get() const { return _j.get< T >(); }
+    template< class T > inline void get_to( T & value ) const { _j.get_to( value ); }
+
+    // If there, gets the value at the given key and returns true; otherwise false
+    template< class T >
+    bool get_ex( T & value ) const
+    {
+        if( ! exists() )
+            return false;
+        _j.get_to( value );
+        return true;
+    }
+
     // Get the JSON as a value, or a default if not there (throws if wrong type)
-    template < class T > T default_value( T const & default_value ) const { return json::value< T >( get(), default_value ); }
+    template< class T >
+    T default_value( T const & default_value ) const
+    {
+        return exists() ? _j.get< T >() : default_value;
+    }
+
     // Get the object, with a default being an empty one; does not throw
-    nlohmann::json const & default_object() const { return is_object() ? _j : empty_json_object; }
-    // Get the object, with a default being an empty one; does not throw
-    nlohmann::json const & default_string() const { return is_string() ? _j : empty_json_string; }
+    inline json const & default_object() const noexcept { return is_object() ? _j : empty_json_object; }
+
+    // Get the string object, with a default being an empty one; does not throw
+    inline json const & default_string() const noexcept { return is_string() ? _j : empty_json_string; }
+
     // Get a JSON string by reference (zero copy); it must be a string or it'll throw
-    inline std::string const & string_ref() const { return json::string_ref( get() ); }
+    inline std::string const & string_ref() const { return _j.get_ref< const json::string_t & >(); }
+
     // Get a JSON string by reference (zero copy); does not throw
-    inline std::string const & string_ref_or_empty() const { return json::string_ref( default_string() ); }
+    inline std::string const & string_ref_or_empty() const { return default_string().get_ref< const json::string_t & >(); }
 };
 
 
-// Recursively patches existing 'j' with contents of 'patches', which must be a JSON object.
-// A 'null' value inside erases previous contents. Any other value overrides.
-// See: https://json.nlohmann.me/api/basic_json/merge_patch/
-// Example below, for load_app_settings.
-// Use 'what' to denote what it is we're patching in, if a failure happens. The std::runtime_error will populate with
-// it.
+inline std::ostream & operator<<( std::ostream & os, json_ref const & j )
+{
+    return operator<<( os, static_cast< json const & >( j ) );
+}
+
+
+template< typename... Rest >
+json_ref _nested_json( json const & j )
+{
+    // j.nested()
+    return j;
+}
+template< typename... Rest >
+json_ref _nested_json( json const & j, bool ( json::*is_fn )() const )
+{
+    // j.nested( &json::is_string )
+    if( ! ( j.*is_fn )() )
+        return missing_json;
+    return j;
+}
+template< typename... Rest >
+json_ref _nested_json( json const & j, json_key const & inner, Rest... rest )
+{
+    // j.nested( "key", ... )
+    auto it = j.find( inner );
+    if( it == j.end() )
+        return missing_json;
+    return _nested_json( *it, std::forward< Rest >( rest )... );
+}
+template< typename... Rest >
+json_ref _nested_json( json const & j, json::size_type index, Rest... rest )
+{
+    // j.nested( index, ... )
+    if( ! j.is_array() )
+        return missing_json;
+    if( index >= j.size() )
+        return missing_json;
+    return _nested_json( j[index], std::forward< Rest >( rest )... );
+}
+
+
+// Since we know how we're derived from, we can get the json, or the reference to it, from this:
+//     json <- nlohmann::basic_json<...> <- json_base
+inline json_ref json_base::_ref() const
+{
+    return static_cast< json const & >( *this );
+}
+
+
+// Returns false if the object wasn't found
+inline bool json_base::exists() const
+{
+    return _ref().exists();
+}
+
+// Get the JSON as a value, or a default if not there (throws if wrong type)
+template< class T >
+inline T json_base::default_value( T const & default_value ) const
+{
+    return _ref().default_value( default_value );
+}
+
+// If there, gets the value at the given key and returns true; otherwise false
+template< class T >
+inline bool json_base::get_ex( T & value ) const
+{
+    return _ref().get_ex( value );
+}
+
+// Get the object, with a default being an empty one; does not throw
+inline json_ref json_base::default_object() const
+{
+    return _ref().default_object();
+}
+
+// Get the string object, with a default being an empty one; does not throw
+inline json_ref json_base::default_string() const
+{
+    return _ref().default_string();
+}
+
+// Get a JSON string by reference (zero copy); it must be a string or it'll throw
+inline std::string const & json_base::string_ref() const
+{
+    return _ref().string_ref();
+}
+
+// Get a JSON string by reference (zero copy); does not throw
+inline std::string const & json_base::string_ref_or_empty() const
+{
+    return default_string().string_ref();
+}
+
+// Allow easy read-only lookup of nested json hierarchies:
+//      j["one"]["two"]["three"]           // undefined; will throw/assert if a hierarchy isn't there
+// But:
+//      j.nested( "one", "two", "three" )  // will not throw; does not copy!
+// The result is either a null JSON object or a valid one. The boolean operator can be used as an easy check:
+//      if( auto inside = j.nested( "one", "two" ) )
+//          { ... }
 //
-void patch( nlohmann::json & j, nlohmann::json const & patches, std::string const & what = {} );
+template< typename... Rest >
+inline json_ref json_base::nested( Rest... rest ) const
+{
+    return _ref().nested( std::forward< Rest >( rest )... );
+}
 
 
-// Loads configuration settings from 'global' content.
-// E.g., a configuration file may contain:
-//     {
-//         "context": {
-//             "dds": {
-//                 "enabled": false,
-//                 "domain" : 5
-//             }
-//         },
-//         ...
-//     }
-// This function will load a specific key 'context' inside and return it. The result will be a disabling of dds:
-// Besides this "global" key, application-specific settings can override the global settings, e.g.:
-//     {
-//         "context": {
-//             "dds": {
-//                 "enabled": false,
-//                 "domain" : 5
-//             }
-//         },
-//         "realsense-viewer": {
-//             "context": {
-//                 "dds": { "enabled": null }
-//             }
-//         },
-//         ...
-//     }
-// If the current application is 'realsense-viewer', then the global 'context' settings will be patched with the
-// application-specific 'context' and returned:
-//     {
-//         "dds": {
-//             "domain" : 5
-//         }
-//     }
-// See rules for patching in patch().
-// The 'application' is usually any single-word executable name (without extension).
-// The 'subkey' is mandatory.
-// The 'error_context' is used for error reporting, to show what failed. Like application, it should be a single word
-// that can be used to denote hierarchy within the global json.
-//
-nlohmann::json load_app_settings( nlohmann::json const & global,
-                                  std::string const & application,
-                                  std::string const & subkey,
-                                  std::string const & error_context );
-
-
-// Same as above, but automatically takes the application name from the executable-name.
-//
-nlohmann::json load_settings( nlohmann::json const & global,
-                              std::string const & subkey,
-                              std::string const & error_context );
-
-
-}  // namespace json
 }  // namespace rsutils

--- a/third-party/rsutils/include/rsutils/py/pybind11.h
+++ b/third-party/rsutils/include/rsutils/py/pybind11.h
@@ -32,6 +32,42 @@ constexpr auto json_to_py = pyjson::from_json;
 constexpr auto py_to_json = pyjson::to_json;
 
 
+// pybind11 caster specifically for rsutils::json
+// This is a copy of the code for nlohmann, in pybind11_json.hpp above
+#include <rsutils/json.h>
+namespace pybind11 {
+namespace detail {
+
+template<>
+struct type_caster< rsutils::json >
+{
+public:
+    PYBIND11_TYPE_CASTER( rsutils::json, _( "json" ) );
+
+    bool load( handle src, bool )
+    {
+        try
+        {
+            value = pyjson::to_json( src );
+            return true;
+        }
+        catch( ... )
+        {
+            return false;
+        }
+    }
+
+    static handle cast( rsutils::json src, return_value_policy /* policy */, handle /* parent */ )
+    {
+        object obj = pyjson::from_json( src );
+        return obj.release();
+    }
+};
+
+}  // namespace detail
+}  // namespace pybind11
+
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 

--- a/third-party/rsutils/include/rsutils/string/hexarray.h
+++ b/third-party/rsutils/include/rsutils/string/hexarray.h
@@ -1,9 +1,8 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
-#include <nlohmann/json_fwd.hpp>
+#include <rsutils/json-fwd.h>
 
 #include <vector>
 #include <string>
@@ -37,7 +36,7 @@ class hexarray
 private:
     bytes _bytes;
 
-    friend void from_json( nlohmann::json const &, hexarray & );
+    friend void from_json( rsutils::json const &, hexarray & );
 
 public:
     hexarray() = default;
@@ -72,9 +71,9 @@ inline std::ostream & operator<<( std::ostream & os, hexarray const & hexa )
 
 
 // Allow j["key"] = hexarray( bytes );
-void to_json( nlohmann::json &, const hexarray & );
+void to_json( rsutils::json &, const hexarray & );
 // Allow j.get< hexarray >();
-void from_json( nlohmann::json const &, hexarray & );
+void from_json( rsutils::json const &, hexarray & );
 // See https://github.com/nlohmann/json#arbitrary-types-conversions
 
 

--- a/third-party/rsutils/py/pyrsutils.cpp
+++ b/third-party/rsutils/py/pyrsutils.cpp
@@ -40,7 +40,7 @@ PYBIND11_MODULE(NAME, m) {
         py::arg( "max-length" ) = 96 );
     m.def(
         "shorten_json_string",
-        []( nlohmann::json const & j, size_t max_length )
+        []( rsutils::json const & j, size_t max_length )
         { return rsutils::string::shorten_json_string( j.dump(), max_length ).to_string(); },
         py::arg( "json" ),
         py::arg( "max-length" ) = 96 );

--- a/third-party/rsutils/src/hexarray.cpp
+++ b/third-party/rsutils/src/hexarray.cpp
@@ -6,7 +6,7 @@
 #include <rsutils/string/slice.h>
 #include <rsutils/string/hexdump.h>
 
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 
 
 namespace rsutils {
@@ -25,32 +25,32 @@ namespace string {
 }
 
 
-void to_json( nlohmann::json & j, const hexarray & hexa )
+void to_json( rsutils::json & j, const hexarray & hexa )
 {
     j = hexa.to_string();
 }
 
 
-void from_json( nlohmann::json const & j, hexarray & hexa )
+void from_json( rsutils::json const & j, hexarray & hexa )
 {
     if( j.is_array() )
     {
         hexa._bytes.resize( j.size() );
         std::transform( j.begin(), j.end(), std::begin( hexa._bytes ),
-                        []( nlohmann::json const & elem )
+                        []( rsutils::json const & elem )
                         {
                             if( ! elem.is_number_unsigned() )
-                                throw nlohmann::json::type_error::create( 302, "array value not an unsigned integer", &elem );
+                                throw rsutils::json::type_error::create( 302, "array value not an unsigned integer", &elem );
                             auto v = elem.template get< uint64_t >();
                             if( v > 255 )
-                                throw nlohmann::json::out_of_range::create( 401, "array value out of range", &elem );
+                                throw rsutils::json::out_of_range::create( 401, "array value out of range", &elem );
                             return uint8_t( v );
                         } );
     }
     else if( j.is_string() )
         hexa = hexarray::from_string( j.get< std::string >() );
     else
-        throw nlohmann::json::type_error::create( 317, "hexarray should be a string", &j );
+        throw rsutils::json::type_error::create( 317, "hexarray should be a string", &j );
 }
 
 

--- a/third-party/rsutils/src/json.cpp
+++ b/third-party/rsutils/src/json.cpp
@@ -2,18 +2,32 @@
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
 #include <rsutils/json.h>
+#include <rsutils/json-config.h>
 #include <rsutils/os/executable-name.h>
 
+#include <fstream>
+
+
 namespace rsutils {
-namespace json {
 
 
-nlohmann::json const null_json = {};
-nlohmann::json const empty_json_string = nlohmann::json::value_type( nlohmann::json::value_t::string );
-nlohmann::json const empty_json_object = nlohmann::json::object();
+json const null_json = {};
+json const missing_json = json::value_t::discarded;
+json const empty_json_string = json::value_t::string;
+json const empty_json_object = json::object();
 
 
-void patch( nlohmann::json & j, nlohmann::json const & patches, std::string const & what )
+// Recursively patches existing JSON with contents of 'overrides', which must be a JSON object.
+// A 'null' value inside erases previous contents. Any other value overrides.
+// See: https://json.nlohmann.me/api/basic_json/merge_patch/
+// Example below, for load_app_settings.
+// Use 'what' to denote what it is we're patching in, if a failure happens. The std::runtime_error will populate with
+// it.
+// 
+// NOTE: called 'override' to agree with terminology elsewhere, and to avoid collisions with the json patch(),
+// merge_patch(), existing functions.
+//
+void json_base::override( json_ref patches, std::string const & what )
 {
     if( ! patches.is_object() )
     {
@@ -23,7 +37,7 @@ void patch( nlohmann::json & j, nlohmann::json const & patches, std::string cons
 
     try
     {
-        j.merge_patch( patches );
+        static_cast< json * >( this )->merge_patch( patches );
     }
     catch( std::exception const & e )
     {
@@ -33,30 +47,97 @@ void patch( nlohmann::json & j, nlohmann::json const & patches, std::string cons
 }
 
 
-nlohmann::json load_app_settings( nlohmann::json const & global,
-                                  std::string const & application,
-                                  std::string const & subkey,
-                                  std::string const & error_context )
+// Load the contents of a file into a JSON object.
+// 
+// Throws if any errors are encountered with the file or its contents.
+// Returns the contents. If the file wasn't there, returns missing_json.
+//
+json json_config::load_from_file( std::string const & filename )
+{
+    std::ifstream f( filename );
+    if( f.good() )
+    {
+        try
+        {
+            return json::parse( f );
+        }
+        catch( std::exception const & e )
+        {
+            throw std::runtime_error( "failed to load configuration file (" + filename
+                                      + "): " + std::string( e.what() ) );
+        }
+    }
+    return missing_json;
+}
+
+
+
+// Loads configuration settings from 'global' content (loaded by load_from_file()?).
+// E.g., a configuration file may contain:
+//     {
+//         "context": {
+//             "dds": {
+//                 "enabled": false,
+//                 "domain" : 5
+//             }
+//         },
+//         ...
+//     }
+// This function will load a specific key 'context' inside and return it. The result will be a disabling of dds:
+// Besides this "global" key, application-specific settings can override the global settings, e.g.:
+//     {
+//         "context": {
+//             "dds": {
+//                 "enabled": false,
+//                 "domain" : 5
+//             }
+//         },
+//         "realsense-viewer": {
+//             "context": {
+//                 "dds": { "enabled": null }
+//             }
+//         },
+//         ...
+//     }
+// If the current application is 'realsense-viewer', then the global 'context' settings will be patched with the
+// application-specific 'context' and returned:
+//     {
+//         "dds": {
+//             "domain" : 5
+//         }
+//     }
+// See rules for patching in patch().
+// The 'application' is usually any single-word executable name (without extension).
+// The 'subkey' is mandatory.
+// The 'error_context' is used for error reporting, to show what failed. Like application, it should be a single word
+// that can be used to denote hierarchy within the global json.
+//
+json json_config::load_app_settings( json const & global,
+                                     std::string const & application,
+                                     json_key const & subkey,
+                                     std::string const & error_context )
 {
     // Take the global subkey settings out of the configuration
-    nlohmann::json settings;
-    if( auto global_subkey = rsutils::json::nested( global, subkey ) )
-        patch( settings, global_subkey, "global " + error_context + '/' + subkey );
+    json settings;
+    if( auto global_subkey = global.nested( subkey ) )
+        settings.override( global_subkey, "global " + error_context + '/' + subkey );
 
     // Patch any application-specific subkey settings
-    if( auto application_subkey = rsutils::json::nested( global, application, subkey ) )
-        patch( settings, application_subkey, error_context + '/' + application + '/' + subkey );
+    if( auto application_subkey = global.nested( application, subkey ) )
+        settings.override( application_subkey, error_context + '/' + application + '/' + subkey );
 
     return settings;
 }
 
 
-nlohmann::json
-load_settings( nlohmann::json const & global, std::string const & subkey, std::string const & error_context )
+// Same as above, but automatically takes the application name from the executable-name
+//
+json json_config::load_settings( json const & global,
+                                 json_key const & subkey,
+                                 std::string const & error_context )
 {
     return load_app_settings( global, rsutils::os::executable_name(), subkey, error_context );
 }
 
 
-}  // namespace json
 }  // namespace rsutils

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -20,7 +20,7 @@ using rsutils::string::hexarray;
 #include <algorithm>
 #include <iostream>
 
-using nlohmann::json;
+using rsutils::json;
 using namespace realdds;
 using tools::lrs_device_controller;
 
@@ -337,7 +337,7 @@ extrinsics_map get_extrinsics_map( const rs2::device & dev )
 }
 
 
-std::shared_ptr< dds_stream_profile > create_dds_stream_profile( std::string const & type_string, nlohmann::json const & j )
+std::shared_ptr< dds_stream_profile > create_dds_stream_profile( std::string const & type_string, rsutils::json const & j )
 {
     if( "motion" == type_string )
         return dds_stream_profile::from_json< dds_motion_stream_profile >( j );
@@ -503,7 +503,7 @@ lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< 
         return query_option( option );
     } );
     _dds_device_server->on_control(
-        [this]( std::string const & id, nlohmann::json const & control, nlohmann::json & reply )
+        [this]( std::string const & id, rsutils::json const & control, rsutils::json & reply )
         { return on_control( id, control, reply ); } );
 
     _device_sn = _rs_dev.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
@@ -599,7 +599,7 @@ lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< 
     _bridge.on_error(
         [this]( std::string const & error_string )
         {
-            nlohmann::json j = nlohmann::json::object( {
+            rsutils::json j = rsutils::json::object( {
                 { "id", "error" },
                 { "error", error_string },
             } );
@@ -622,7 +622,7 @@ lrs_device_controller::~lrs_device_controller()
 }
 
 
-bool lrs_device_controller::on_open_streams( nlohmann::json const & control, nlohmann::json & reply )
+bool lrs_device_controller::on_open_streams( rsutils::json const & control, rsutils::json & reply )
 {
     // Note that this function is called "start-streaming" but it's really a response to "open-streams" so does not
     // actually start streaming. It simply sets and locks in which streams should be open when streaming starts.
@@ -630,7 +630,7 @@ bool lrs_device_controller::on_open_streams( nlohmann::json const & control, nlo
     // out, a sensor is reset back to its default state using implicit stream selection.
     // (For example, the 'Stereo Module' sensor controls Depth, IR1, IR2: but turning on all 3 has performance
     // implications and may not be desirable. So you can open only Depth and IR1/2 will stay inactive...)
-    if( rsutils::json::get< bool >( control, "reset", true ) )
+    if( control.nested( "reset" ).default_value( true ) )
         _bridge.reset();
 
     auto const & msg_profiles = control["stream-profiles"];
@@ -653,7 +653,7 @@ bool lrs_device_controller::on_open_streams( nlohmann::json const & control, nlo
     }
 
     // We're here so all the profiles were acceptable; lock them in -- with no implicit profiles!
-    if( rsutils::json::get< bool >( control, "commit", true ) )
+    if( control.nested( "commit" ).default_value( true ) )
         _bridge.commit();
 
     // We don't touch the reply - it's already filled in for us
@@ -666,7 +666,7 @@ void lrs_device_controller::publish_frame_metadata( const rs2::frame & f, realdd
     if( ! _dds_device_server->has_metadata_readers() )
         return;
 
-    nlohmann::json md_header = nlohmann::json::object( {
+    rsutils::json md_header = rsutils::json::object( {
         { "frame-number", f.get_frame_number() },               // communicated; up to client to pick up
         { "timestamp", timestamp.to_ns() },                     // syncer key: needs to match the image timestamp, bit-for-bit!
         { "timestamp-domain", f.get_frame_timestamp_domain() }  // needed if we're dealing with different domains!
@@ -674,7 +674,7 @@ void lrs_device_controller::publish_frame_metadata( const rs2::frame & f, realdd
     if( f.is< rs2::depth_frame >() )
         md_header["depth-units"] = f.as< rs2::depth_frame >().get_units();
 
-    nlohmann::json metadata = nlohmann::json::object();
+    rsutils::json metadata = rsutils::json::object();
     for( size_t i = 0; i < static_cast< size_t >( RS2_FRAME_METADATA_COUNT ); ++i )
     {
         rs2_frame_metadata_value val = static_cast< rs2_frame_metadata_value >( i );
@@ -682,7 +682,7 @@ void lrs_device_controller::publish_frame_metadata( const rs2::frame & f, realdd
             metadata[rs2_frame_metadata_to_string( val )] = f.get_frame_metadata( val );
     }
 
-    nlohmann::json md_msg = nlohmann::json::object( {
+    rsutils::json md_msg = rsutils::json::object( {
         { "stream-name", stream_name_from_rs2( f.get_profile() ) },
         { "header", std::move( md_header ) },
         { "metadata", std::move( metadata ) },
@@ -838,9 +838,9 @@ size_t lrs_device_controller::get_index_of_profile( const realdds::dds_stream_pr
 }
 
 
-bool lrs_device_controller::on_control( std::string const & id, nlohmann::json const & control, nlohmann::json & reply )
+bool lrs_device_controller::on_control( std::string const & id, rsutils::json const & control, rsutils::json & reply )
 {
-    static std::map< std::string, bool ( lrs_device_controller::* )( nlohmann::json const &, nlohmann::json & ) > const
+    static std::map< std::string, bool ( lrs_device_controller::* )(rsutils::json const &, rsutils::json & ) > const
         control_handlers{
             { "hw-reset", &lrs_device_controller::on_hardware_reset },
             { "open-streams", &lrs_device_controller::on_open_streams },
@@ -854,14 +854,14 @@ bool lrs_device_controller::on_control( std::string const & id, nlohmann::json c
 }
 
 
-bool lrs_device_controller::on_hardware_reset( nlohmann::json const & control, nlohmann::json & reply )
+bool lrs_device_controller::on_hardware_reset( rsutils::json const & control, rsutils::json & reply )
 {
     _rs_dev.hardware_reset();
     return true;
 }
 
 
-bool lrs_device_controller::on_hwm( nlohmann::json const & control, nlohmann::json & reply )
+bool lrs_device_controller::on_hwm( rsutils::json const & control, rsutils::json & reply )
 {
     rs2::debug_protocol dp( _rs_dev );
     if( ! dp )
@@ -870,22 +870,22 @@ bool lrs_device_controller::on_hwm( nlohmann::json const & control, nlohmann::js
     rsutils::string::hexarray data;
 
     uint32_t opcode;
-    if( rsutils::json::get_ex( control, "opcode", &opcode ) )
+    if( control.nested( "opcode" ).get_ex( opcode ) )
     {
         // In the presence of 'opcode', we're asked to build the command using optional parameters
         uint32_t param1 = 0, param2 = 0, param3 = 0, param4 = 0;
-        rsutils::json::get_ex( control, "param1", &param1 );
-        rsutils::json::get_ex( control, "param2", &param2 );
-        rsutils::json::get_ex( control, "param3", &param3 );
-        rsutils::json::get_ex( control, "param4", &param4 );
+        control.nested( "param1" ).get_ex( param1 );
+        control.nested( "param2" ).get_ex( param2 );
+        control.nested( "param3" ).get_ex( param3 );
+        control.nested( "param4" ).get_ex( param4 );
 
-        rsutils::json::get_ex( control, "data", &data );  // optional
+        control.nested( "data" ).get_ex( data );  // optional
 
         // Build the HWM command
         data = dp.build_command( opcode, param1, param2, param3, param4, data.get_bytes() );
 
         // And, if told to not actually run it, we return the HWM command
-        if( rsutils::json::get< bool >( control, "build-command", false ) )
+        if( control.nested( "build-command" ).default_value( false ) )
         {
             reply["data"] = data;
             return true;
@@ -893,7 +893,7 @@ bool lrs_device_controller::on_hwm( nlohmann::json const & control, nlohmann::js
     }
     else
     {
-        if( ! rsutils::json::get_ex( control, "data", &data ) )
+        if( ! control.nested( "data" ).get_ex( data ) )
             throw std::runtime_error( "no 'data' in HWM control" );
     }
 

--- a/tools/dds/dds-adapter/lrs-device-controller.h
+++ b/tools/dds/dds-adapter/lrs-device-controller.h
@@ -1,12 +1,12 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
 #pragma once
+
 #include <librealsense2/rs.hpp>  // Include RealSense Cross Platform API
 #include <realdds/dds-stream-sensor-bridge.h>
 #include <realdds/dds-stream-profile.h>
-#include <nlohmann/json_fwd.hpp>
 
+#include <rsutils/json-fwd.h>
 #include <unordered_map>
 #include <vector>
 
@@ -40,10 +40,10 @@ private:
 
     void publish_frame_metadata( const rs2::frame & f, realdds::dds_time const & );
 
-    bool on_control( std::string const & id, nlohmann::json const & control, nlohmann::json & reply );
-    bool on_hardware_reset( nlohmann::json const &, nlohmann::json & );
-    bool on_hwm( nlohmann::json const &, nlohmann::json & );
-    bool on_open_streams( nlohmann::json const &, nlohmann::json & );
+    bool on_control( std::string const & id, rsutils::json const & control, rsutils::json & reply );
+    bool on_hardware_reset( rsutils::json const &, rsutils::json & );
+    bool on_hwm( rsutils::json const &, rsutils::json & );
+    bool on_open_streams( rsutils::json const &, rsutils::json & );
 
     void override_default_profiles( const std::map< std::string, realdds::dds_stream_profiles > & stream_name_to_profiles,
                                     std::map< std::string, size_t > & stream_name_to_default_profile ) const;

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -11,8 +11,8 @@
 #include <limits>
 #include <thread>
 
-#include <nlohmann/json.hpp>
-using nlohmann::json;
+#include <rsutils/json.h>
+using rsutils::json;
 
 #include "tclap/CmdLine.h"
 

--- a/tools/realsense-viewer/realsense-viewer.cpp
+++ b/tools/realsense-viewer/realsense-viewer.cpp
@@ -332,7 +332,7 @@ int main(int argc, const char** argv) try
 
     std::shared_ptr<device_models_list> device_models = std::make_shared<device_models_list>();
 
-    nlohmann::json settings = nlohmann::json::object();
+    rsutils::json settings = rsutils::json::object();
     if( only_sw_arg.getValue() )
     {
 #if defined( BUILD_WITH_DDS )

--- a/tools/terminal/rs-terminal.cpp
+++ b/tools/terminal/rs-terminal.cpp
@@ -12,7 +12,7 @@
 #include "parser.hpp"
 #include "auto-complete.h"
 
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 #include <thread>
 
 
@@ -197,9 +197,9 @@ int main(int argc, char** argv)
     // parse command.xml
     rs2::log_to_file(RS2_LOG_SEVERITY_WARN, "librealsense.log");
 
-    nlohmann::json settings;
+    rsutils::json settings;
 #ifdef BUILD_WITH_DDS
-    nlohmann::json dds;
+    rsutils::json dds;
     if( domain_arg.isSet() )
         dds["domain"] = domain_arg.getValue();
     if( only_sw_arg.isSet() )

--- a/unit-tests/dds/test-control-reply.py
+++ b/unit-tests/dds/test-control-reply.py
@@ -36,7 +36,7 @@ with test.remote.fork( nested_indent=None ) as remote:
                 reply['sequence'] = n_replies            # to show that we've processed it
                 reply['nested-json'] = { 'more': True }  # to show off
                 return True  # otherwise the control will be flagged as error
-            server.on_control( _on_control )
+            subscription = server.on_control( _on_control )
 
         raise StopIteration()  # exit the 'with' statement
 

--- a/unit-tests/rsutils/string/test-hexarray.cpp
+++ b/unit-tests/rsutils/string/test-hexarray.cpp
@@ -8,7 +8,7 @@
 #include <rsutils/string/hexdump.h>
 #include <rsutils/string/from.h>
 #include <rsutils/string/slice.h>
-#include <nlohmann/json.hpp>
+#include <rsutils/json.h>
 #include <ostream>
 
 using rsutils::string::hexdump;
@@ -399,30 +399,30 @@ TEST_CASE( "hexarray", "[hexarray]" )
     }
     SECTION( "to json" )
     {
-        nlohmann::json j;
+        rsutils::json j;
         j["blah"] = hexarray( std::move( ba ) );
         CHECK( j.dump() == "{\"blah\":\"00010203040506070809\"}");
     }
     SECTION( "(same as using hexarray::to_string)" )
     {
-        nlohmann::json j;
+        rsutils::json j;
         j["blah"] = hexarray::to_string( ba );
         CHECK( j.dump() == "{\"blah\":\"00010203040506070809\"}" );
     }
     SECTION( "from json" )
     {
-        auto j = nlohmann::json::parse( "{\"blah\":\"00010203040506070809\"}" );
+        auto j = rsutils::json::parse( "{\"blah\":\"00010203040506070809\"}" );
         CHECK( j["blah"].get< hexarray >().get_bytes() == ba );
     }
     SECTION( "from json shuld accept bytearrays, too" )
     {
-        auto j = nlohmann::json::parse( "{\"blah\":[0,1,2,3,4,5,6,7,8,9]}" );
+        auto j = rsutils::json::parse( "{\"blah\":[0,1,2,3,4,5,6,7,8,9]}" );
         CHECK( j["blah"].get< hexarray >().get_bytes() == ba );
 
-        j = nlohmann::json::parse( "{\"blah\":[0,1,256]}" );  // out-of-range
+        j = rsutils::json::parse( "{\"blah\":[0,1,256]}" );  // out-of-range
         CHECK_THROWS( j["blah"].get< hexarray >().get_bytes() );
 
-        j = nlohmann::json::parse( "{\"blah\":[0,1,2.0]}" );  // must be integer
+        j = rsutils::json::parse( "{\"blah\":[0,1,2.0]}" );  // must be integer
         CHECK_THROWS( j["blah"].get< hexarray >().get_bytes() );
     }
 }

--- a/wrappers/python/pyrs_context.cpp
+++ b/wrappers/python/pyrs_context.cpp
@@ -18,7 +18,7 @@ void init_context(py::module &m) {
 
     py::class_< rs2::context >( m, "context", "Librealsense context class. Includes realsense API version." )
         .def( py::init< char const * >(), py::arg( "json-settings" ) = nullptr )
-        .def( py::init<>( []( nlohmann::json const & j ) { return rs2::context( j.dump() ); } ), py::arg( "json-settings" ) )
+        .def( py::init<>( []( rsutils::json const & j ) { return rs2::context( j.dump() ); } ), py::arg( "json-settings" ) )
         .def("query_devices", (rs2::device_list(rs2::context::*)() const) &rs2::context::query_devices, "Create a static"
              " snapshot of all connected devices at the time of the call.")
         .def( "query_devices", ( rs2::device_list( rs2::context::* )(int) const ) & rs2::context::query_devices, "Create a static"


### PR DESCRIPTION
This cleans up and standardizes all json functionality around `rsutils::json` instead of `nlohmann::json`:
* rsutils now has its own `json.h` and `json-fwd.h`
* common functionality added using `json_base` base class
* reverted `find()` back to `nested()` because it was impossible to override
* separated `json_config` functionality for loading json configuration files into own header
    * per Nir's request, errors now show the configuration file path
* fixes the json download to not take the latest
* changes the nesting logic to use `discarded` value rather than `null` for `exists()`, as json that exists can still be null

All instances of `nlohmann` in the code were replaced, hence the large number of files.
