### PR TITLE
Improve test.remote reliability

### DIFF
--- a/third-party/realdds/include/realdds/dds-topic-reader.h
+++ b/third-party/realdds/include/realdds/dds-topic-reader.h
@@ -57,11 +57,17 @@ public:
     typedef std::function< void() > on_data_available_callback;
     typedef std::function< void( eprosima::fastdds::dds::SubscriptionMatchedStatus const & ) >
         on_subscription_matched_callback;
+    typedef std::function< void( eprosima::fastdds::dds::SampleLostStatus const & ) >
+        on_sample_lost_callback;
 
     void on_data_available( on_data_available_callback callback ) { _on_data_available = std::move( callback ); }
     void on_subscription_matched( on_subscription_matched_callback callback )
     {
         _on_subscription_matched = std::move( callback );
+    }
+    void on_sample_lost( on_sample_lost_callback callback )
+    {
+        _on_sample_lost = std::move( callback );
     }
 
     class qos : public eprosima::fastdds::dds::DataReaderQos
@@ -91,9 +97,12 @@ protected:
 
     void on_data_available( eprosima::fastdds::dds::DataReader * ) override;
 
+    void on_sample_lost( eprosima::fastdds::dds::DataReader *, const eprosima::fastdds::dds::SampleLostStatus & ) override;
+
 protected:
     on_data_available_callback _on_data_available;
     on_subscription_matched_callback _on_subscription_matched;
+    on_sample_lost_callback _on_sample_lost;
 };
 
 

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -313,6 +313,11 @@ PYBIND11_MODULE(NAME, m) {
                       (dds_topic_reader &, int),
                       ( eprosima::fastdds::dds::SubscriptionMatchedStatus const & status ),
                       callback( self, status.current_count_change ); ) )
+        .def( FN_FWD( dds_topic_reader,
+                      on_sample_lost,
+                      (dds_topic_reader &, int, int),
+                      (eprosima::fastdds::dds::SampleLostStatus const & status),
+                      callback( self, status.total_count, status.total_count_change ); ) )
         .def( "topic", &dds_topic_reader::topic )
         .def( "run", &dds_topic_reader::run )
         .def( "qos", []() { return reader_qos(); } )

--- a/third-party/realdds/src/dds-topic-reader-thread.cpp
+++ b/third-party/realdds/src/dds-topic-reader-thread.cpp
@@ -6,8 +6,6 @@
 #include <realdds/dds-subscriber.h>
 #include <realdds/dds-utilities.h>
 
-#include <rsutils/time/stopwatch.h>
-
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
@@ -41,17 +39,17 @@ void dds_topic_reader_thread::run( qos const & rqos )
     if( ! _on_data_available )
         DDS_THROW( runtime_error, "on-data-available must be provided" );
 
-    eprosima::fastdds::dds::StatusMask status_mask;
-    status_mask << eprosima::fastdds::dds::StatusMask::subscription_matched();
-    //status_mask << eprosima::fastdds::dds::StatusMask::data_available();
-    _reader = DDS_API_CALL( _subscriber->get()->create_datareader( _topic->get(), rqos, this, status_mask ) );
+    eprosima::fastdds::dds::StatusMask listener_mask;
+    listener_mask << eprosima::fastdds::dds::StatusMask::subscription_matched();
+    _reader = DDS_API_CALL( _subscriber->get()->create_datareader( _topic->get(), rqos, this, listener_mask ) );
     
     _th = std::thread(
         [this, name = _topic->get()->get_name()]()
         {
             eprosima::fastdds::dds::WaitSet wait_set;
             auto & condition = _reader->get_statuscondition();
-            condition.set_enabled_statuses( eprosima::fastdds::dds::StatusMask::data_available() );
+            condition.set_enabled_statuses( eprosima::fastdds::dds::StatusMask::data_available()
+                                            << eprosima::fastdds::dds::StatusMask::sample_lost() );
             wait_set.attach_condition( condition );
 
             wait_set.attach_condition( _stopped );
@@ -64,10 +62,17 @@ void dds_topic_reader_thread::run( qos const & rqos )
                 if( _stopped.get_trigger_value() )
                     break;
 
-                rsutils::time::stopwatch stopwatch;
-                _on_data_available();
-                if( stopwatch.get_elapsed() > std::chrono::milliseconds( 500 ) )
-                    LOG_WARNING( "<---- '" << name << "' callback took too long!" );
+                auto & changed = _reader->get_status_changes();
+                if( changed.is_active( eprosima::fastdds::dds::StatusMask::sample_lost() ) )
+                {
+                    eprosima::fastdds::dds::SampleLostStatus status;
+                    _reader->get_sample_lost_status( status );
+                    on_sample_lost( _reader, status );
+                }
+                if( changed.is_active( eprosima::fastdds::dds::StatusMask::data_available() ) )
+                {
+                    on_data_available( _reader );
+                }
             }
         } );
 }

--- a/unit-tests/dds/test-options.py
+++ b/unit-tests/dds/test-options.py
@@ -176,6 +176,23 @@ with test.remote.fork( nested_indent=None ) as remote:
         device.set_option_value( option, 12. )  # updates server & client
         test.check_equal( option.get_value(), 12. )
 
+    device = None
+    stream = None
+
+
+    #############################################################################################
+    with test.closure( "New device should get the new option value" ):
+        test.check( option is not None )
+        test.check( option.stream() is None )  # Because we removed the device & stream references
+        device = dds.device( participant, info )
+        device.wait_until_ready()
+        if test.check_equal( device.n_streams(), 1 ):
+            stream = device.streams()[0]
+            options = stream.options();
+            test.check_equal( len( options ), 3 )
+            option = options[1]
+            test.check_equal( option.get_value(), 12. )  # The new value - not the default
+
         remote.run( 'close_server()' )
     device = None
 


### PR DESCRIPTION
During development I noticed many cases, even locally, of tests failing with output like this:
```
[C  ] -D- 11:55:48.216 client: +writer (server.903) publishing 'realsense/device-info' [realdds::topics::raw::flexible reliable] (dds-participant.cpp:144 [20052])
___rea[  S] -D- 11:55:48.216 broadcasting discovery notifications (dds-notification-server.cpp:161 [16444])
[  S] dy
[  S] -D- 11:55:48.278 server: broadcasting (dds-device-broadcaster.cpp:81 [7116])
```

`test.remote` uses a specific string `___ready\n` to signify to the client that it's in a ready state.
Notice how, in the above, this string is split by a line that's output from another thread! This breaks it up, the client doesn't realize it's ready, and times out - failing the test.

This attempts to identify such cases and deal with them. So far it's worked in my testing. Hopefully it will help in GHA, too.

Likewise:
```
-I- Test passed
-D- waiting for remote to finish...
-D- 12:31:51.518 client: -writer (.203) publishing 'server/device/control' (dds-participant.cpp:151 [140585218340608])
terminate called after throwing an instance of 'std::system_error'
  what():  Resource deadlock avoided
-D-     test took 1.2171788215637207 seconds
-E- test-dds-control-reply: exited with non-zero value (-6)
```

Googling this shows this is the result of "when a thread tries to join itself." Try to avoid this, too...

Added some minor DDS stuff, in own commits that should be self-contained. No new functionality (sample-lost callbacks don't work yet because of an eProsima bug -- I reported it and they fixed it).
