### PR TITLE
Frame queue per stream, not per extension

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -489,7 +489,13 @@ namespace rs2
     subdevice_model::~subdevice_model()
     {
         _destructing = true;
-        s->on_options_changed( []( const options_list & list ) {} );
+        try
+        {
+            s->on_options_changed( []( const options_list & list ) {} );
+        }
+        catch( ... )
+        {
+        }
     }
 
     void subdevice_model::sort_resolutions(std::vector<std::pair<int, int>>& resolutions) const

--- a/src/archive.cpp
+++ b/src/archive.cpp
@@ -1,13 +1,15 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#include "archive.h"
-#include "metadata-parser.h"
-#include "frame-archive.h"
-#include "core/pose-frame.h"
-#include "core/motion-frame.h"
-#include "core/disparity-frame.h"
-#include "composite-frame.h"
-#include "points.h"
+
+
+#include <src/archive.h>
+#include <src/frame-archive.h>
+#include <src/core/video-frame.h>
+#include <src/core/pose-frame.h>
+#include <src/core/motion-frame.h>
+#include <src/core/disparity-frame.h>
+#include <src/composite-frame.h>
+#include <src/points.h>
 
 
 namespace librealsense

--- a/src/archive.h
+++ b/src/archive.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "core/stream-profile.h"
 #include "core/frame-additional-data.h"
 #include "callback-invocation.h"
 
@@ -23,7 +22,7 @@ namespace librealsense
         virtual std::shared_ptr<metadata_parser_map> get_md_parsers() const = 0;
 
         virtual std::shared_ptr< sensor_interface > get_sensor() const = 0;
-        virtual void set_sensor( std::shared_ptr< sensor_interface > ) = 0;
+        virtual void set_sensor( const std::weak_ptr< sensor_interface > & ) = 0;
 
         virtual void flush() = 0;
 

--- a/src/core/pose-frame.h
+++ b/src/core/pose-frame.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include <src/frame.h>
-#include "extension.h"
+#include <src/types.h>
 
+#include "extension.h"
 
 namespace librealsense {
 

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -19,6 +19,7 @@
 
 #include <rsutils/json.h>
 #include <rsutils/string/hexarray.h>
+#include <rsutils/string/from.h>
 
 
 namespace librealsense {

--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -5,6 +5,7 @@
 
 
 #include "sid_index.h"
+#include <src/frame.h>
 #include <src/software-sensor.h>
 #include <src/proc/formats-converter.h>
 

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -12,6 +12,7 @@
 #include <src/backend.h>
 #include <src/platform/platform-utils.h>
 #include <src/fourcc.h>
+#include <src/metadata-parser.h>
 
 #include <src/ds/features/auto-exposure-roi-feature.h>
 

--- a/src/ds/d400/d400-motion.cpp
+++ b/src/ds/d400/d400-motion.cpp
@@ -20,6 +20,7 @@
 #include "proc/motion-transform.h"
 #include "proc/auto-exposure-processor.h"
 #include <src/fourcc.h>
+#include <src/metadata-parser.h>
 
 using namespace librealsense;
 namespace librealsense

--- a/src/ds/d500/d500-color.cpp
+++ b/src/ds/d500/d500-color.cpp
@@ -12,6 +12,7 @@
 #include "backend.h"
 #include "platform/platform-utils.h"
 #include <src/fourcc.h>
+#include <src/metadata-parser.h>
 
 #include <src/ds/features/auto-exposure-roi-feature.h>
 

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -18,6 +18,7 @@
 #include "proc/motion-transform.h"
 #include "proc/auto-exposure-processor.h"
 #include "backend.h"
+#include <src/metadata-parser.h>
 
 using namespace librealsense;
 namespace librealsense

--- a/src/ds/ds-color-common.cpp
+++ b/src/ds/ds-color-common.cpp
@@ -7,6 +7,7 @@
 
 #include <src/platform/uvc-option.h>
 #include <src/ds/features/auto-exposure-roi-feature.h>
+#include <src/metadata-parser.h>
 
 #include <cstddef>
 

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -23,6 +23,7 @@
 #include "ds-private.h"
 #include <src/stream.h>
 #include <src/fourcc.h>
+#include <src/metadata-parser.h>
 
 #include <cstddef>
 

--- a/src/ds/ds-timestamp.cpp
+++ b/src/ds/ds-timestamp.cpp
@@ -3,6 +3,8 @@
 
 #include "ds-private.h"
 #include "ds-timestamp.h"
+#include <src/frame.h>
+#include <src/core/time-service.h>
 
 #include <mutex>
 #include <chrono>

--- a/src/frame-archive.h
+++ b/src/frame-archive.h
@@ -3,6 +3,10 @@
 #pragma once
 
 #include "archive.h"
+#include <src/core/frame-interface.h>
+
+#include <atomic>
+#include <vector>
 
 namespace librealsense
 {
@@ -25,7 +29,7 @@ namespace librealsense
 
         std::weak_ptr<sensor_interface> _sensor;
         std::shared_ptr<sensor_interface> get_sensor() const override { return _sensor.lock(); }
-        void set_sensor(std::shared_ptr<sensor_interface> s) override { _sensor = s; }
+        void set_sensor( const std::weak_ptr< sensor_interface > & s ) override { _sensor = s; }
 
         T alloc_frame(const size_t size, frame_additional_data && additional_data, bool requires_memory)
         {
@@ -79,14 +83,14 @@ namespace librealsense
             return nullptr;
         }
 
-        void unpublish_frame(frame_interface* frame) override
+        void unpublish_frame(frame_interface * fi) override
         {
-            if (frame)
+            if( fi )
             {
-                auto f = (T*)frame;
+                auto f = (T *)fi;
                 std::unique_lock<std::recursive_mutex> lock(mutex);
 
-                frame->keep();
+                fi->keep();
 
                 if (recycle_frames)
                 {
@@ -106,9 +110,9 @@ namespace librealsense
             --published_frames_count;
         }
 
-        frame_interface* publish_frame(frame_interface* frame) override
+        frame_interface * publish_frame( frame_interface * fi ) override
         {
-            auto f = (T*)frame;
+            auto f = (T *)fi;
 
             unsigned int max_frames = *max_frame_queue_size;
 

--- a/src/hid-sensor.cpp
+++ b/src/hid-sensor.cpp
@@ -8,6 +8,8 @@
 #include "metadata.h"
 #include "platform/stream-profile-impl.h"
 #include "fourcc.h"
+#include <src/metadata-parser.h>
+#include <src/core/time-service.h>
 
 
 namespace librealsense {
@@ -234,8 +236,10 @@ void hid_sensor::start( rs2_frame_callback_sptr callback )
 
             last_frame_number = frame_counter;
             last_timestamp = timestamp;
-            frame_holder frame
-                = _source.alloc_frame( RS2_EXTENSION_MOTION_FRAME, data_size, std::move( fr->additional_data ), true );
+            frame_holder frame = _source.alloc_frame( { request->get_stream_type(), RS2_EXTENSION_MOTION_FRAME },
+                                                      data_size,
+                                                      std::move( fr->additional_data ),
+                                                      true );
             memcpy( (void *)frame->get_frame_data(),
                     sensor_data.fo.pixels,
                     sizeof( uint8_t ) * sensor_data.fo.frame_size );

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -435,10 +435,11 @@ namespace librealsense
         }
 
         frame_interface * frame = m_frame_source->alloc_frame(
-            frame_source::stream_to_frame_types(stream_id.stream_type),
+            { stream_id.stream_type, frame_source::stream_to_frame_types( stream_id.stream_type ) },
             msg->data.size(),
             std::move( additional_data ),
             true );
+
         if (frame == nullptr)
         {
             LOG_WARNING("Failed to allocate new frame");
@@ -487,7 +488,7 @@ namespace librealsense
             get_frame_metadata(m_file, info_topic, stream_id, motion_data, additional_data);
         }
 
-        frame_interface * frame = m_frame_source->alloc_frame( RS2_EXTENSION_MOTION_FRAME,
+        frame_interface * frame = m_frame_source->alloc_frame( { stream_id.stream_type, RS2_EXTENSION_MOTION_FRAME },
                                                                3 * sizeof( float ),
                                                                std::move( additional_data ),
                                                                true );
@@ -636,7 +637,11 @@ namespace librealsense
 
         additional_data.timestamp = timestamp_ms.count();
 
-        frame_interface* new_frame = m_frame_source->alloc_frame(frame_type, frame_size, std::move( additional_data ), true);
+        frame_interface * new_frame = m_frame_source->alloc_frame( { stream_id.stream_type, frame_type },
+                                                                   frame_size,
+                                                                   std::move( additional_data ),
+                                                                   true );
+
         if (new_frame == nullptr)
         {
             LOG_WARNING("Failed to allocate new frame");

--- a/src/pipeline/config.cpp
+++ b/src/pipeline/config.cpp
@@ -6,6 +6,7 @@
 #include "platform/platform-device-info.h"
 #include "media/playback/playback-device-info.h"
 #include "context.h"
+#include <rsutils/string/from.h>
 
 
 namespace librealsense

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -9,6 +9,7 @@
 #include "backend.h"
 #include "platform/platform-utils.h"
 #include <src/fourcc.h>
+#include <src/metadata-parser.h>
 
 
 namespace librealsense {

--- a/src/proc/auto-exposure-processor.cpp
+++ b/src/proc/auto-exposure-processor.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2019 Intel Corporation. All Rights Reserved.
 
 #include "auto-exposure-processor.h"
+#include <src/frame.h>
 
 librealsense::auto_exposure_processor::auto_exposure_processor(rs2_stream stream, enable_auto_exposure_option& enable_ae_option)
     : auto_exposure_processor("Auto Exposure Processor", stream, enable_ae_option) {}

--- a/src/proc/hole-filling-filter.h
+++ b/src/proc/hole-filling-filter.h
@@ -3,6 +3,8 @@
 // Enhancing the input video frame by filling missing data.
 #pragma once
 
+#include <rsutils/string/from.h>
+
 namespace librealsense
 {
     enum holes_filling_types : uint8_t

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -12,6 +12,7 @@
 #include "option.h"
 #include "stream.h"
 #include "types.h"
+#include <src/core/time-service.h>
 
 #include <rsutils/string/from.h>
 
@@ -39,7 +40,8 @@ namespace librealsense
 
     void processing_block::invoke(frame_holder f)
     {
-        auto callback = _source.begin_callback();
+        frame_source::archive_id id = { f->get_stream()->get_stream_type(), RS2_EXTENSION_VIDEO_FRAME };
+        auto callback = _source.begin_callback( id );
         try
         {
             if (_callback)
@@ -348,11 +350,11 @@ namespace librealsense
             data.timestamp = original->get_frame_timestamp();
             data.timestamp_domain = original->get_frame_timestamp_domain();
             data.metadata_size = 0;
-            data.system_time = _actual_source.get_time();
+            data.system_time = time_service::get_time();
             data.is_blocking = original->is_blocking();
 
             auto res
-                = _actual_source.alloc_frame( frame_type,
+                = _actual_source.alloc_frame( { vid_stream->get_stream_type(), frame_type },
                                               vid_stream->get_width() * vid_stream->get_height() * sizeof( float ) * 5,
                                               std::move( data ),
                                               true );
@@ -419,7 +421,10 @@ namespace librealsense
             throw std::runtime_error("Can not cast frame interface to frame");
 
         frame_additional_data data = of->additional_data;
-        auto res = _actual_source.alloc_frame( frame_type, stride * height, std::move( data ), true );
+        auto res = _actual_source.alloc_frame( { stream->get_stream_type(), frame_type },
+                                               stride * height,
+                                               std::move( data ),
+                                               true );
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
         vf = dynamic_cast<video_frame*>(res);
         if (!vf)
@@ -451,7 +456,10 @@ namespace librealsense
             throw std::runtime_error("Frame interface is not frame");
 
         frame_additional_data data = of->additional_data;
-        auto res = _actual_source.alloc_frame( frame_type, of->get_frame_data_size(), std::move( data ), true );
+        auto res = _actual_source.alloc_frame( { stream->get_stream_type(), frame_type },
+                                               of->get_frame_data_size(),
+                                               std::move( data ),
+                                               true );
         if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
 
         auto mf = dynamic_cast<motion_frame*>(res);
@@ -501,7 +509,7 @@ namespace librealsense
         for (auto&& f : holders)
             req_size += get_embeded_frames_size(f.frame);
 
-        auto res = _actual_source.alloc_frame( RS2_EXTENSION_COMPOSITE_FRAME,
+        auto res = _actual_source.alloc_frame( { RS2_STREAM_ANY, RS2_EXTENSION_COMPOSITE_FRAME }, // Special case for composite frames
                                                req_size * sizeof( rs2_frame * ),
                                                std::move( d ),
                                                true );

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -59,6 +59,7 @@
 #include "composite-frame.h"
 #include "points.h"
 
+#include <src/core/time-service.h>
 #include <rsutils/string/from.h>
 
 ////////////////////////

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -16,6 +16,8 @@
 #include "core/stream-profile-interface.h"
 #include "core/frame-callback.h"
 #include "core/notification.h"
+#include <src/metadata-parser.h>
+
 
 #include <rsutils/string/from.h>
 #include <rsutils/json.h>

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -8,6 +8,8 @@
 #include "core/extension.h"
 #include "proc/formats-converter.h"
 #include <src/synthetic-options-watcher.h>
+#include <src/platform/stream-profile.h>
+#include <src/platform/frame-object.h>
 
 #include <rsutils/lazy.h>
 #include <rsutils/signal.h>
@@ -45,6 +47,7 @@ namespace librealsense
     };
 
     class notifications_processor;
+    class frame;
 
     class sensor_base
         : public std::enable_shared_from_this< sensor_base >

--- a/src/software-sensor.cpp
+++ b/src/software-sensor.cpp
@@ -8,6 +8,7 @@
 #include "core/video-frame.h"
 #include "core/notification.h"
 #include "depth-sensor.h"
+#include <src/metadata-parser.h>
 
 #include <rsutils/string/from.h>
 #include <rsutils/deferred.h>
@@ -218,10 +219,10 @@ frame_interface * software_sensor::allocate_new_frame( rs2_extension extension,
                                                        frame_additional_data && data )
 {
     auto frame_number = data.frame_number; // For logging
-    auto frame = _source.alloc_frame( extension, 0, std::move( data ), false );
+    auto frame = _source.alloc_frame( { profile->get_stream_type(), extension }, 0, std::move( data ), false );
     if( ! frame )
     {
-        LOG_WARNING( "Failed to allocate frame " << frame_number << " type " << extension );
+        LOG_WARNING( "Failed to allocate frame " << frame_number << " type " << profile->get_stream_type() );
     }
     else
     {

--- a/src/source.h
+++ b/src/source.h
@@ -3,66 +3,76 @@
 
 #pragma once
 
-#include "metadata-parser.h"
-#include "frame-archive.h"
-#include "core/time-service.h"
+
+#include <librealsense2/hpp/rs_types.hpp>
+#include <src/frame-archive.h>
 
 
 namespace librealsense
 {
     class option;
     class frame_holder;
+    class archive_interface;
 
     class LRS_EXTENSION_API frame_source
     {
     public:
-        frame_source(uint32_t max_publish_list_size = 16);
+        //using stream_uid = std::pair< rs2_stream, int >; // Stream type and index
+        using archive_id = std::pair< rs2_stream, rs2_extension >;
 
-        void init(std::shared_ptr<metadata_parser_map> metadata_parsers);
+        frame_source( uint32_t max_publish_list_size = 16 );
 
-        callback_invocation_holder begin_callback();
+        void init( std::shared_ptr< metadata_parser_map > metadata_parsers );
+
+        callback_invocation_holder begin_callback( archive_id id );
 
         void reset();
 
-        std::shared_ptr<option> get_published_size_option();
+        std::shared_ptr< option > get_published_size_option();
 
-        frame_interface * alloc_frame( rs2_extension type,
+        frame_interface * alloc_frame( archive_id id,
                                        size_t size,
                                        frame_additional_data && additional_data,
-                                       bool requires_memory ) const;
+                                       bool requires_memory );
 
-        void set_callback(rs2_frame_callback_sptr callback);
+        void set_callback( rs2_frame_callback_sptr callback );
         rs2_frame_callback_sptr get_callback() const;
 
-        void invoke_callback(frame_holder frame) const;
+        void invoke_callback( frame_holder frame ) const;
 
         void flush() const;
 
         virtual ~frame_source() { flush(); }
 
-        double get_time() const { return time_service::get_time(); }
-
-        void set_sensor(const std::shared_ptr<sensor_interface>& s);
+        void set_sensor( const std::weak_ptr< sensor_interface > & s );
 
         template<class T>
-        void add_extension(rs2_extension ex)
+        void add_extension( rs2_extension ex )
         {
-            _archive[ex] = std::make_shared<frame_archive<T>>(&_max_publish_list_size, _metadata_parsers);
+            archive_id special_index = { RS2_STREAM_COUNT, ex };
+            
+            std::lock_guard< std::recursive_mutex > lock( _mutex );
+
+            _archive[special_index] = std::make_shared< frame_archive< T > >( &_max_publish_list_size, _metadata_parsers );
         }
 
-        void set_max_publish_list_size(int qsize) {_max_publish_list_size = qsize; }
+        void set_max_publish_list_size( int qsize ) { _max_publish_list_size = qsize; }
 
-        static rs2_extension stream_to_frame_types(rs2_stream stream);
+        static rs2_extension stream_to_frame_types( rs2_stream stream );
 
     private:
         friend class syncer_process_unit;
 
-        mutable std::mutex _callback_mutex;
+        void create_archive( archive_id id );
 
-        std::map<rs2_extension, std::shared_ptr<archive_interface>> _archive;
+        mutable std::recursive_mutex _mutex;
 
-        std::atomic<uint32_t> _max_publish_list_size;
+        std::map< archive_id, std::shared_ptr< archive_interface > > _archive;
+        std::vector< rs2_extension > _supported_extensions;
+
+        std::atomic< uint32_t > _max_publish_list_size;
         rs2_frame_callback_sptr _callback;
-        std::shared_ptr<metadata_parser_map> _metadata_parsers;
+        std::shared_ptr< metadata_parser_map > _metadata_parsers;
+        std::weak_ptr< sensor_interface > _sensor;
     };
 }

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -9,6 +9,8 @@
 #include "core/notification.h"
 #include "platform/uvc-option.h"
 #include "platform/stream-profile-impl.h"
+#include <src/metadata-parser.h>
+#include <src/core/time-service.h>
 
 
 namespace librealsense {
@@ -180,8 +182,9 @@ void uvc_sensor::open( const stream_profiles & requests )
                     if( val_in_range( req_profile_base->get_format(), { RS2_FORMAT_MJPEG, RS2_FORMAT_Z16H } ) )
                         expected_size = static_cast< int >( f.frame_size );
 
+                    auto extension = frame_source::stream_to_frame_types( req_profile_base->get_stream_type() );
                     frame_holder fh = _source.alloc_frame(
-                        frame_source::stream_to_frame_types( req_profile_base->get_stream_type() ),
+                        { req_profile_base->get_stream_type(), extension },
                         expected_size,
                         std::move( fr->additional_data ),
                         true );

--- a/unit-tests/unit-tests-common.cpp
+++ b/unit-tests/unit-tests-common.cpp
@@ -155,7 +155,6 @@ bool wait_for_reset( std::function< bool( void ) > func, std::shared_ptr< rs2::d
     }
     catch( ... )
     {
-        int x = 5;
     }
     return func();
 }


### PR DESCRIPTION
Currently frame archives are created per extension type. There are several streams that use `RS2_EXTENSION_VIDEO_FRAME` and the queue might get full, especially if a syncher is involved.

This PR creates archives also based on the stream type, so IR1+2 still share a queue but they come together and don't have to wait in the syncher.

Tracked on [RSDEV-599]