### PR TITLE
[PointCloud] Set texel intrinsic & extrinsic based on selected stream

### DIFF
--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -142,7 +142,7 @@ namespace librealsense
                                         for( auto const & sp : s.get_active_streams() )
                                         {
                                             if(( sp->get_stream_type() == RS2_STREAM_COLOR ) &&
-                                               ( _prev_stream_filter.stream == RS2_STREAM_COLOR ))
+                                               ( _stream_filter.stream == RS2_STREAM_COLOR ))
                                             {
                                                 auto vspi = As< video_stream_profile_interface >(
                                                     sp.get() );

--- a/src/proc/pointcloud.cpp
+++ b/src/proc/pointcloud.cpp
@@ -141,7 +141,8 @@ namespace librealsense
                                         sensor_interface & s = dev->get_sensor( x );
                                         for( auto const & sp : s.get_active_streams() )
                                         {
-                                            if( sp->get_stream_type() == RS2_STREAM_COLOR )
+                                            if(( sp->get_stream_type() == RS2_STREAM_COLOR ) &&
+                                               ( _prev_stream_filter.stream == RS2_STREAM_COLOR ))
                                             {
                                                 auto vspi = As< video_stream_profile_interface >(
                                                     sp.get() );


### PR DESCRIPTION
The PointCloud filter supports generating `rs2::points` for below two scenarios:
1. Input: `Depth` frame and `Color `frame
2. Input: `Depth` frame and `Colorized depth` frame

**Overview of the issue:**
- Scenario 2 works fine if only `Depth `stream is enabled. 
- If the user enables both `Color` and `Depth` streams and want to generate pointcloud for scenario 2, then the output doesn't look good. 

**Rootcause:**
- Whenever `Color` stream is enabled, `Color` sensor's texel intrinsic and extrinsic is getting used instead of `Depth` sensor's.