### PR TITLE
Separate frame archives for IR streams

### DIFF
--- a/src/hid-sensor.cpp
+++ b/src/hid-sensor.cpp
@@ -236,10 +236,11 @@ void hid_sensor::start( rs2_frame_callback_sptr callback )
 
             last_frame_number = frame_counter;
             last_timestamp = timestamp;
-            frame_holder frame = _source.alloc_frame( { request->get_stream_type(), RS2_EXTENSION_MOTION_FRAME },
-                                                      data_size,
-                                                      std::move( fr->additional_data ),
-                                                      true );
+            frame_holder frame = _source.alloc_frame(
+                { request->get_stream_type(), request->get_stream_index(), RS2_EXTENSION_MOTION_FRAME },
+                data_size,
+                std::move( fr->additional_data ),
+                true );
             memcpy( (void *)frame->get_frame_data(),
                     sensor_data.fo.pixels,
                     sizeof( uint8_t ) * sensor_data.fo.frame_size );

--- a/src/media/ros/ros_reader.cpp
+++ b/src/media/ros/ros_reader.cpp
@@ -435,7 +435,7 @@ namespace librealsense
         }
 
         frame_interface * frame = m_frame_source->alloc_frame(
-            { stream_id.stream_type, frame_source::stream_to_frame_types( stream_id.stream_type ) },
+            { stream_id.stream_type, stream_id.stream_index, frame_source::stream_to_frame_types( stream_id.stream_type ) },
             msg->data.size(),
             std::move( additional_data ),
             true );
@@ -488,10 +488,11 @@ namespace librealsense
             get_frame_metadata(m_file, info_topic, stream_id, motion_data, additional_data);
         }
 
-        frame_interface * frame = m_frame_source->alloc_frame( { stream_id.stream_type, RS2_EXTENSION_MOTION_FRAME },
-                                                               3 * sizeof( float ),
-                                                               std::move( additional_data ),
-                                                               true );
+        frame_interface * frame = m_frame_source->alloc_frame(
+            { stream_id.stream_type, stream_id.stream_index, RS2_EXTENSION_MOTION_FRAME },
+            3 * sizeof( float ),
+            std::move( additional_data ),
+            true );
         if (frame == nullptr)
         {
             LOG_WARNING("Failed to allocate new frame");
@@ -637,10 +638,11 @@ namespace librealsense
 
         additional_data.timestamp = timestamp_ms.count();
 
-        frame_interface * new_frame = m_frame_source->alloc_frame( { stream_id.stream_type, frame_type },
-                                                                   frame_size,
-                                                                   std::move( additional_data ),
-                                                                   true );
+        frame_interface * new_frame = m_frame_source->alloc_frame(
+            { stream_id.stream_type, stream_id.stream_index, frame_type },
+            frame_size,
+            std::move( additional_data ),
+            true );
 
         if (new_frame == nullptr)
         {

--- a/src/proc/synthetic-stream.cpp
+++ b/src/proc/synthetic-stream.cpp
@@ -40,7 +40,8 @@ namespace librealsense
 
     void processing_block::invoke(frame_holder f)
     {
-        frame_source::archive_id id = { f->get_stream()->get_stream_type(), RS2_EXTENSION_VIDEO_FRAME };
+        frame_source::archive_id id
+            = { f->get_stream()->get_stream_type(), f->get_stream()->get_stream_index(), RS2_EXTENSION_VIDEO_FRAME };
         auto callback = _source.begin_callback( id );
         try
         {
@@ -353,11 +354,11 @@ namespace librealsense
             data.system_time = time_service::get_time();
             data.is_blocking = original->is_blocking();
 
-            auto res
-                = _actual_source.alloc_frame( { vid_stream->get_stream_type(), frame_type },
-                                              vid_stream->get_width() * vid_stream->get_height() * sizeof( float ) * 5,
-                                              std::move( data ),
-                                              true );
+            auto res = _actual_source.alloc_frame(
+                { vid_stream->get_stream_type(), vid_stream->get_stream_index(), frame_type },
+                vid_stream->get_width() * vid_stream->get_height() * sizeof( float ) * 5,
+                std::move( data ),
+                true );
             if (!res) throw wrong_api_call_sequence_exception("Out of frame resources!");
             res->set_sensor(original->get_sensor());
             res->set_stream(stream);
@@ -421,7 +422,7 @@ namespace librealsense
             throw std::runtime_error("Can not cast frame interface to frame");
 
         frame_additional_data data = of->additional_data;
-        auto res = _actual_source.alloc_frame( { stream->get_stream_type(), frame_type },
+        auto res = _actual_source.alloc_frame( { stream->get_stream_type(), stream->get_stream_index(), frame_type },
                                                stride * height,
                                                std::move( data ),
                                                true );
@@ -456,7 +457,7 @@ namespace librealsense
             throw std::runtime_error("Frame interface is not frame");
 
         frame_additional_data data = of->additional_data;
-        auto res = _actual_source.alloc_frame( { stream->get_stream_type(), frame_type },
+        auto res = _actual_source.alloc_frame( { stream->get_stream_type(), stream->get_stream_index(), frame_type },
                                                of->get_frame_data_size(),
                                                std::move( data ),
                                                true );
@@ -509,7 +510,7 @@ namespace librealsense
         for (auto&& f : holders)
             req_size += get_embeded_frames_size(f.frame);
 
-        auto res = _actual_source.alloc_frame( { RS2_STREAM_ANY, RS2_EXTENSION_COMPOSITE_FRAME }, // Special case for composite frames
+        auto res = _actual_source.alloc_frame( { RS2_STREAM_ANY, 0, RS2_EXTENSION_COMPOSITE_FRAME }, // Special case for composite frames
                                                req_size * sizeof( rs2_frame * ),
                                                std::move( d ),
                                                true );

--- a/src/software-sensor.cpp
+++ b/src/software-sensor.cpp
@@ -219,7 +219,10 @@ frame_interface * software_sensor::allocate_new_frame( rs2_extension extension,
                                                        frame_additional_data && data )
 {
     auto frame_number = data.frame_number; // For logging
-    auto frame = _source.alloc_frame( { profile->get_stream_type(), extension }, 0, std::move( data ), false );
+    auto frame = _source.alloc_frame( { profile->get_stream_type(), profile->get_stream_index(), extension },
+                                      0,
+                                      std::move( data ),
+                                      false );
     if( ! frame )
     {
         LOG_WARNING( "Failed to allocate frame " << frame_number << " type " << profile->get_stream_type() );

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -72,14 +72,14 @@ namespace librealsense
     {
         std::lock_guard< std::recursive_mutex > lock( _mutex );
 
-        auto it = std::find( _supported_extensions.begin(), _supported_extensions.end(), id.second );
+        rs2_extension & ex = std::get< rs2_extension >( id );
+        auto it = std::find( _supported_extensions.begin(), _supported_extensions.end(), ex );
         if( it == _supported_extensions.end() )
             throw wrong_api_call_sequence_exception( "Requested frame type is not supported!" );
 
-        auto ret = _archive.insert( { id, make_archive( id.second, &_max_publish_list_size, _metadata_parsers ) } );
+        auto ret = _archive.insert( { id, make_archive( ex, &_max_publish_list_size, _metadata_parsers ) } );
         if( ! ret.second || ! ret.first->second ) // Check insertion success and allocation success
-            throw std::runtime_error( rsutils::string::from()
-                                      << "Failed to create archive of type " << get_string( id.second ) );
+            throw std::runtime_error( rsutils::string::from() << "Failed to create archive of type " << get_string( ex ) );
 
         ret.first->second->set_sensor( _sensor );
 
@@ -89,8 +89,8 @@ namespace librealsense
     callback_invocation_holder frame_source::begin_callback( archive_id id )
     {
         // We use a special index for extensions, like GPU accelerated frames. See add_extension.
-        if( id.second >= RS2_EXTENSION_COUNT )
-            id.first = RS2_STREAM_COUNT;
+        if( std::get< rs2_extension >( id ) >= RS2_EXTENSION_COUNT )
+            std::get< rs2_stream >( id ) = RS2_STREAM_COUNT;  // For added extensions like GPU accelerated frames
 
         std::lock_guard< std::recursive_mutex > lock( _mutex );
 
@@ -116,8 +116,8 @@ namespace librealsense
                                                  bool requires_memory )
     {
         // We use a special index for extensions, like GPU accelerated frames. See add_extension.
-        if( id.second >= RS2_EXTENSION_COUNT )
-            id.first = RS2_STREAM_COUNT;  // For added extensions like GPU accelerated frames
+        if( std::get< rs2_extension>( id ) >= RS2_EXTENSION_COUNT )
+            std::get< rs2_stream >( id ) = RS2_STREAM_COUNT;  // For added extensions like GPU accelerated frames
 
         std::lock_guard< std::recursive_mutex > lock( _mutex );
 

--- a/src/source.h
+++ b/src/source.h
@@ -7,6 +7,7 @@
 #include <librealsense2/hpp/rs_types.hpp>
 #include <src/frame-archive.h>
 
+#include <tuple>
 
 namespace librealsense
 {
@@ -17,7 +18,7 @@ namespace librealsense
     class LRS_EXTENSION_API frame_source
     {
     public:
-        using archive_id = std::pair< rs2_stream, rs2_extension >;
+        using archive_id = std::tuple< rs2_stream, int, rs2_extension >; // Stream type, stream index, extention type.
 
         frame_source( uint32_t max_publish_list_size = 16 );
 
@@ -58,7 +59,7 @@ namespace librealsense
 
             // We use a special index for extensions since we don't know the stream type here.
             // We can't wait with the allocation because we need the type T in the creation.
-            archive_id special_index = { RS2_STREAM_COUNT, ex };
+            archive_id special_index = { RS2_STREAM_COUNT, 0, ex };
             _archive[special_index] = std::make_shared< frame_archive< T > >( &_max_publish_list_size, _metadata_parsers );
         }
 

--- a/src/uvc-sensor.cpp
+++ b/src/uvc-sensor.cpp
@@ -184,7 +184,7 @@ void uvc_sensor::open( const stream_profiles & requests )
 
                     auto extension = frame_source::stream_to_frame_types( req_profile_base->get_stream_type() );
                     frame_holder fh = _source.alloc_frame(
-                        { req_profile_base->get_stream_type(), extension },
+                        { req_profile_base->get_stream_type(), req_profile_base->get_stream_index(), extension },
                         expected_size,
                         std::move( fr->additional_data ),
                         true );


### PR DESCRIPTION
Supplement for [PR#12575](https://github.com/IntelRealSense/librealsense/pull/12575).

Separating frame archives based on stream type are not always enough, the bug might still occur when IR1+IR2 are active together. This also separates the archives based on the stream index.

Tracked on [RSDEV-599]