### PR TITLE
option-value and usage in options-changed notifications

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -82,12 +82,13 @@ namespace rs2
             {
                 s->on_options_changed( [this]( const options_list & list )
                 {
-                    for( auto opt_id : list )
+                    for( auto changed_option : list )
                     {
-                        auto it = options_metadata.find( opt_id );
+                        auto it = options_metadata.find( changed_option->id );
                         if( it != options_metadata.end() && ! _destructing ) // Callback runs in different context, check options_metadata still valid
                         {
-                            it->second.value = it->second.endpoint->get_option( opt_id );
+                            if( RS2_OPTION_TYPE_FLOAT == changed_option->type )
+                                it->second.value = changed_option->as_float;
                         }
                     }
                 } );

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -10,6 +10,10 @@ Copyright(c) 2017 Intel Corporation. All Rights Reserved. */
 #ifndef LIBREALSENSE_RS2_OPTION_H
 #define LIBREALSENSE_RS2_OPTION_H
 
+
+#include <stdint.h>
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -136,6 +140,38 @@ extern "C" {
     */
     rs2_option rs2_option_from_string( const char * option_name );
 
+    /** \brief Defines known option value types.
+    */
+    typedef enum rs2_option_type
+    {
+        RS2_OPTION_TYPE_NUMBER, /**< 64-bit integer value, either as_number_signed or as_number_unsigned */
+        RS2_OPTION_TYPE_FLOAT,
+        RS2_OPTION_TYPE_STRING,
+
+        RS2_OPTION_TYPE_COUNT
+
+    } rs2_option_type;
+
+    /**
+    * Returns the option type as a string, or "UNKNOWN" otherwise.
+    * \param[in] type    the option type identifier
+    */
+    const char * rs2_option_type_to_string( rs2_option_type type );
+
+    /** \brief The value of an option, in a known option type.
+    */
+    typedef struct rs2_option_value
+    {
+        rs2_option id;
+        rs2_option_type type;             /**< RS2_OPTION_TYPE_COUNT if no value is available */
+        union {
+            char const * as_string;       /**< valid only while rs2_option_value is alive! */
+            float as_float;
+            int64_t as_number_signed;
+            uint64_t as_number_unsigned;
+        };
+    } rs2_option_value;
+
     /** \brief For SR300 devices: provides optimized settings (presets) for specific types of usage. */
     typedef enum rs2_sr300_visual_preset
     {
@@ -256,6 +292,15 @@ extern "C" {
     float rs2_get_option(const rs2_options* options, rs2_option option, rs2_error** error);
 
     /**
+    * read option value from the sensor
+    * \param[in] options    the options container
+    * \param[in] option_id  option id to be queried
+    * \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return pointer to the value structure of the option; use rs2_delete_option_value to clean up
+    */
+    rs2_option_value const * rs2_get_option_value( const rs2_options * options, rs2_option option_id, rs2_error ** error );
+
+    /**
     * write new value to sensor option
     * \param[in] options    the options container
     * \param[in] option     option id to be queried
@@ -291,8 +336,23 @@ extern "C" {
     * get the specific option from options list
     * \param[in] i    the index of the option
     * \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return the option ID
     */
     rs2_option rs2_get_option_from_list(const rs2_options_list* options, int i, rs2_error** error);
+
+    /**
+    * get the specific option from options list
+    * \param[in] i    the index of the option
+    * \param[out] error     if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+    * \return temporary (goes away with the options-list) pointer to the option-value struct
+    */
+    rs2_option_value const * rs2_get_option_value_from_list( const rs2_options_list * options, int i, rs2_error ** error );
+
+    /**
+    * Clean up a value and all it points to
+    * \param[in] handle value to delete
+    */
+    void rs2_delete_option_value( rs2_option_value const * handle );
 
     /**
     * Deletes options list

--- a/include/librealsense2/hpp/rs_options.hpp
+++ b/include/librealsense2/hpp/rs_options.hpp
@@ -11,66 +11,77 @@
 
 
 namespace rs2
-{    
+{
+    class option_value
+    {
+        std::shared_ptr< const rs2_option_value > _value;
+
+    public:
+        option_value( rs2_option_value const * handle )
+            : _value( handle, rs2_delete_option_value )
+        {
+        }
+        option_value( option_value const & ) = default;
+        option_value( option_value && ) = default;
+        option_value() = default;
+
+        rs2_option_value const * operator->() const { return _value.get(); }
+    };
+
     class options_list
     {
     public:
+        options_list( options_list const & ) = default;
+        options_list( options_list && ) = default;
+
         explicit options_list( std::shared_ptr< rs2_options_list > list )
             : _list( std::move( list ) )
         {
+            rs2_error * e = nullptr;
+            _size = rs2_get_options_list_size( _list.get(), &e );
+            error::handle( e );
         }
 
         options_list()
             : _list( nullptr )
+            , _size( 0 )
         {
         }
 
-        options_list & operator=( std::shared_ptr< rs2_options_list > list )
-        {
-            _list = std::move( list );
-            return *this;
-        }
-
-        rs2_option operator[]( size_t index ) const
+        option_value operator[]( size_t index ) const
         {
             rs2_error * e = nullptr;
-            rs2_option opt = rs2_get_option_from_list( _list.get(), static_cast< int >( index ), &e );
+            auto value = rs2_get_option_value_from_list( _list.get(), static_cast< int >( index ), &e );
             error::handle( e );
-            return opt;
+            return value;
         }
 
-        size_t size() const
-        {
-            rs2_error * e = nullptr;
-            auto size = rs2_get_options_list_size( _list.get(), &e );
-            error::handle( e );
-            return size;
-        }
+        size_t size() const { return _size; }
 
-        rs2_option front() const { return ( *this )[0]; }
-        rs2_option back() const { return ( *this )[size() - 1]; }
+        option_value front() const { return ( *this )[0]; }
+        option_value back() const { return ( *this )[size() - 1]; }
 
-        class options_list_iterator
+        class iterator
         {
-            options_list_iterator( const options_list & list, size_t index )
+            iterator( const options_list & list, size_t index )
                 : _list( list )
                 , _index( index )
             {
             }
 
         public:
-            rs2_option operator*() const { return _list[_index]; }
-            bool operator!=( const options_list_iterator & other ) const
+            option_value operator*() const { return _list[_index]; }
+            
+            bool operator!=( const iterator & other ) const
             {
                 return other._index != _index || &other._list != &_list;
             }
-
-            bool operator==( const options_list_iterator & other ) const
+            bool operator==( const iterator & other ) const
             {
                 return ! ( *this != other );
             }
 
-            options_list_iterator & operator++()
+            iterator & operator++()
             {
                 _index++;
                 return *this;
@@ -82,13 +93,14 @@ namespace rs2
             size_t _index;
         };
 
-        options_list_iterator begin() const { return options_list_iterator( *this, 0 ); }
-        options_list_iterator end() const { return options_list_iterator( *this, size() ); }
+        iterator begin() const { return iterator( *this, 0 ); }
+        iterator end() const { return iterator( *this, size() ); }
 
-        operator std::shared_ptr< rs2_options_list >() { return _list; };
+        std::shared_ptr< rs2_options_list > get() const { return _list; };
 
     private:
         std::shared_ptr< rs2_options_list > _list;
+        size_t _size;
     };
     
     class options_changed_callback : public rs2_options_changed_callback
@@ -168,7 +180,7 @@ namespace rs2
         }
 
         /**
-        * read option's value
+        * read option's float value
         * \param[in] option   option id to be queried
         * \return value of the option
         */
@@ -178,6 +190,19 @@ namespace rs2
             auto res = rs2_get_option(_options, option, &e);
             error::handle(e);
             return res;
+        }
+
+        /**
+        * read option's value
+        * \param[in] option_id   option id to be queried
+        * \return                option value
+        */
+        option_value get_option_value( rs2_option option_id ) const
+        {
+            rs2_error * e = nullptr;
+            auto value = rs2_get_option_value( _options, option_id, &e );
+            error::handle( e );
+            return value;
         }
 
         /**

--- a/src/core/enum-helpers.h
+++ b/src/core/enum-helpers.h
@@ -47,6 +47,7 @@ bool is_valid( rs2_option value );
 std::ostream & operator<<( std::ostream & out, rs2_option option );
 bool try_parse( const std::string & option_name, rs2_option & result );
 
+RS2_ENUM_HELPERS_CUSTOMIZED( rs2_option_type, 0, RS2_OPTION_TYPE_COUNT - 1, std::string const & )
 RS2_ENUM_HELPERS( rs2_stream, STREAM )
 LRS_EXTENSION_API char const * get_abbr_string( rs2_stream );
 RS2_ENUM_HELPERS( rs2_format, FORMAT )

--- a/src/core/options-watcher.cpp
+++ b/src/core/options-watcher.cpp
@@ -1,9 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
-
 #include <src/core/options-watcher.h>
 #include <proc/synthetic-stream.h>
+#include <rsutils/json.h>
+
+using rsutils::json;
 
 
 namespace librealsense {
@@ -23,11 +25,9 @@ options_watcher::~options_watcher()
 
 void options_watcher::register_option( rs2_option id, std::shared_ptr< option > option )
 {
-    registered_option opt = { option, 0.0f }; //Option actual value will be queried in start if needed.
-
     {
         std::lock_guard< std::mutex > lock( _mutex );
-        _options[id] = std::move( opt );
+        _options[id] = { option };
     }
 
     if( should_start() )
@@ -106,7 +106,7 @@ void options_watcher::thread_loop()
         if( should_stop() )
             break;
 
-        std::map< rs2_option, std::shared_ptr< option > > updated_options = update_options();
+        auto updated_options = update_options();
 
         // Checking stop conditions after update, if stop requested no need to notify.
         if( should_stop() )
@@ -116,9 +116,9 @@ void options_watcher::thread_loop()
     }
 }
 
-std::map< rs2_option, std::shared_ptr< option > > options_watcher::update_options()
+options_watcher::options_and_values options_watcher::update_options()
 {
-    std::map< rs2_option, std::shared_ptr< option > > updated_options;
+    options_and_values updated_options;
 
     std::lock_guard< std::mutex > lock( _mutex );
 
@@ -129,12 +129,12 @@ std::map< rs2_option, std::shared_ptr< option > > options_watcher::update_option
     {
         try
         {
-            auto curr_val = opt.second.sptr->query();
+            json curr_val = opt.second.sptr->query();
 
-            if( opt.second.last_known_value != curr_val )
+            if( ! opt.second.p_last_known_value || *opt.second.p_last_known_value != curr_val )
             {
-                opt.second.last_known_value = curr_val;
-                updated_options[opt.first] = opt.second.sptr;
+                opt.second.p_last_known_value = std::make_shared< const json >( std::move( curr_val ) );
+                updated_options[opt.first] = opt.second;
             }
         }
         catch( ... )
@@ -150,7 +150,7 @@ std::map< rs2_option, std::shared_ptr< option > > options_watcher::update_option
     return updated_options;
 }
 
-void options_watcher::notify( const std::map< rs2_option, std::shared_ptr< option > > & updated_options )
+void options_watcher::notify( options_and_values const & updated_options )
 {
     if( ! updated_options.empty() )
         _on_values_changed.raise( updated_options );

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -86,6 +86,8 @@ EXPORTS
     rs2_extract_target_dimensions
 
     rs2_get_option
+    rs2_get_option_value
+    rs2_delete_option_value
     rs2_set_option
     rs2_supports_option
     rs2_get_option_range
@@ -95,6 +97,7 @@ EXPORTS
     rs2_is_option_read_only
     rs2_get_options_list
     rs2_get_option_from_list
+    rs2_get_option_value_from_list
     rs2_get_options_list_size
     rs2_delete_options_list
     rs2_set_options_changed_callback
@@ -141,6 +144,7 @@ EXPORTS
     rs2_format_to_string
     rs2_distortion_to_string
     rs2_option_to_string
+    rs2_option_type_to_string
     rs2_option_from_string
     rs2_camera_info_to_string
     rs2_frame_metadata_to_string

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -84,9 +84,39 @@ struct rs2_device_list
     std::vector< std::shared_ptr< librealsense::device_info > > list;
 };
 
+struct rs2_option_value_wrapper : rs2_option_value
+{
+    // Keep the original json value, so we can refer to it (e.g., with as_string)
+    std::shared_ptr< const rsutils::json > p_json;
+
+    // Add a reference count to control lifetime
+    mutable std::atomic< int > ref_count;
+
+    rs2_option_value_wrapper( rs2_option option_id, std::shared_ptr< const rsutils::json > const & p_json_value )
+        : ref_count( 1 )
+        , p_json( p_json_value )
+    {
+        id = option_id;
+        type = RS2_OPTION_TYPE_COUNT;
+        if( p_json )
+        {
+            if( p_json->is_number_float() )
+            {
+                type = RS2_OPTION_TYPE_FLOAT;
+                as_float = p_json->get< float >();
+            }
+            else if( p_json->is_string() )
+            {
+                type = RS2_OPTION_TYPE_STRING;
+                as_string = p_json->string_ref().c_str();
+            }
+        }
+    }
+};
+
 struct rs2_options_list
 {
-    std::vector< rs2_option > list;
+    std::vector< rs2_option_value_wrapper const * > list;
 };
 
 struct rs2_sensor : public rs2_options
@@ -666,6 +696,26 @@ float rs2_get_option(const rs2_options* options, rs2_option option, rs2_error** 
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0.0f, options, option)
 
+rs2_option_value const * rs2_get_option_value( const rs2_options * options, rs2_option option_id, rs2_error ** error ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( options );
+    VALIDATE_OPTION( options, option_id );
+    auto wrapper = new rs2_option_value_wrapper(
+        option_id,
+        std::make_shared< const rsutils::json >( options->options->get_option( option_id ).query() ) );
+    return wrapper;
+}
+HANDLE_EXCEPTIONS_AND_RETURN( nullptr, options, option_id )
+
+void rs2_delete_option_value( rs2_option_value const * p_value ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( p_value );
+    auto wrapper = static_cast< rs2_option_value_wrapper const * >( p_value );
+    if( wrapper && ! --wrapper->ref_count )
+        delete wrapper;
+}
+NOEXCEPT_RETURN( , p_value )
+
 void rs2_set_option(const rs2_options* options, rs2_option option, float value, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
@@ -680,7 +730,15 @@ HANDLE_EXCEPTIONS_AND_RETURN(, options, option, value)
 rs2_options_list* rs2_get_options_list(const rs2_options* options, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    return new rs2_options_list{ options->options->get_supported_options() };
+    auto rs2_list = new rs2_options_list;
+    auto option_ids = options->options->get_supported_options();
+    rs2_list->list.reserve( option_ids.size() );
+    for( auto option_id : option_ids )
+    {
+        auto wrapper = new rs2_option_value_wrapper( option_id, {} );  // empty json
+        rs2_list->list.push_back( wrapper );
+    }
+    return rs2_list;
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, options)
 
@@ -701,13 +759,24 @@ HANDLE_EXCEPTIONS_AND_RETURN(0, options)
 rs2_option rs2_get_option_from_list(const rs2_options_list* options, int i, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    return options->list[i];
+    return options->list.at( i )->id;
 }
-HANDLE_EXCEPTIONS_AND_RETURN(RS2_OPTION_COUNT, options)
+HANDLE_EXCEPTIONS_AND_RETURN(RS2_OPTION_COUNT, options, i)
+
+rs2_option_value const * rs2_get_option_value_from_list( const rs2_options_list * options, int i, rs2_error ** error ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( options );
+    auto const p_option_value = options->list.at( i );
+    ++p_option_value->ref_count;
+    return p_option_value;
+}
+HANDLE_EXCEPTIONS_AND_RETURN( nullptr, options, i )
 
 void rs2_delete_options_list(rs2_options_list* list) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(list);
+    for( auto wrapper : list->list )
+        rs2_delete_option_value( wrapper );
     delete list;
 }
 NOEXCEPT_RETURN(, list)
@@ -1209,6 +1278,17 @@ const char* rs2_get_option_value_description(const rs2_options* options, rs2_opt
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, options, option, value)
 
+static void populate_options_list( rs2_options_list * updated_options_list,
+                                   options_watcher::options_and_values const & updated_options )
+{
+    for( auto id_value : updated_options )
+    {
+        options_watcher::option_and_value const & option_and_value = id_value.second;
+        updated_options_list->list.push_back(
+            new rs2_option_value_wrapper( id_value.first, option_and_value.p_last_known_value ) );
+    }
+}
+
 void rs2_set_options_changed_callback( rs2_options * options,
                                        rs2_options_changed_callback_ptr callback,
                                        rs2_error ** error ) BEGIN_API_CALL
@@ -1218,11 +1298,10 @@ void rs2_set_options_changed_callback( rs2_options * options,
     auto sens = dynamic_cast< rs2_sensor * >( options );
     VALIDATE_NOT_NULL( sens );
     sens->subscription = sens->sensor->register_options_changed_callback(
-        [callback]( const std::map< rs2_option, std::shared_ptr< option > > & updated_options )
+        [callback]( options_watcher::options_and_values const & updated_options )
         {
             rs2_options_list * updated_options_list = new rs2_options_list(); // Should be on heap if user will choose to save for later use.
-            for( auto option : updated_options )
-                updated_options_list->list.push_back( option.first );
+            populate_options_list( updated_options_list, updated_options );
             callback( updated_options_list );
         } );
 }
@@ -1243,11 +1322,10 @@ void rs2_set_options_changed_callback_cpp( rs2_options * options,
     auto sens = dynamic_cast< rs2_sensor * >( options );
     VALIDATE_NOT_NULL( sens );
     sens->subscription = sens->sensor->register_options_changed_callback(
-        [cb]( const std::map< rs2_option, std::shared_ptr< option > > & updated_options )
+        [cb]( options_watcher::options_and_values const & updated_options )
         {
             rs2_options_list * updated_options_list = new rs2_options_list(); // Should be on heap if user will choose to save for later use.
-            for( auto option : updated_options )
-                updated_options_list->list.push_back( option.first );
+            populate_options_list( updated_options_list, updated_options );
             cb->on_value_changed( updated_options_list );
         } );
 }

--- a/src/synthetic-options-watcher.cpp
+++ b/src/synthetic-options-watcher.cpp
@@ -14,9 +14,9 @@ synthetic_options_watcher::synthetic_options_watcher( const std::shared_ptr< raw
 {
 }
 
-std::map< rs2_option, std::shared_ptr< option > > synthetic_options_watcher::update_options()
+synthetic_options_watcher::options_and_values synthetic_options_watcher::update_options()
 {
-    std::map< rs2_option, std::shared_ptr< option > > updated_options;
+    options_and_values updated_options;
 
     std::shared_ptr< raw_sensor_base > strong = _raw_sensor.lock();
     if( ! strong )

--- a/src/synthetic-options-watcher.h
+++ b/src/synthetic-options-watcher.h
@@ -17,7 +17,7 @@ public:
     synthetic_options_watcher( const std::shared_ptr< raw_sensor_base > & raw_sensor );
 
 protected:
-    std::map< rs2_option, std::shared_ptr< option > > update_options() override;
+    options_and_values update_options() override;
 
     std::weak_ptr< raw_sensor_base > _raw_sensor;
 };

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -724,6 +724,24 @@ const char * get_string( rs2_l500_visual_preset value )
 }
 
 
+std::string const & get_string( rs2_option_type value )
+{
+    static auto str_array = []()
+    {
+        std::vector< std::string > arr( RS2_OPTION_TYPE_COUNT );
+#define CASE( X ) STRARR( arr, OPTION_TYPE, X );
+        CASE( FLOAT )
+        CASE( STRING )
+        CASE( NUMBER )
+#undef CASE
+            return arr;
+    }();
+    if( ! is_valid( value ) )
+        return unknown_value_str;
+    return str_array[value];
+}
+
+
 }  // namespace librealsense
 
 const char * rs2_stream_to_string( rs2_stream stream ) { return librealsense::get_string( stream ); }
@@ -742,6 +760,7 @@ rs2_option rs2_option_from_string( char const * option_name )
         : RS2_OPTION_COUNT;
 }
 
+const char * rs2_option_type_to_string( rs2_option_type type ) { return librealsense::get_string( type ).c_str(); }
 const char * rs2_camera_info_to_string( rs2_camera_info info ) { return librealsense::get_string( info ); }
 const char * rs2_timestamp_domain_to_string( rs2_timestamp_domain info ) { return librealsense::get_string( info ); }
 const char * rs2_notification_category_to_string( rs2_notification_category category ) { return librealsense::get_string( category ); }

--- a/unit-tests/live/options/test-options-watcher.py
+++ b/unit-tests/live/options/test-options-watcher.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 # test:device D400*
 
@@ -15,10 +15,10 @@ changed_options = 0
 
 def notification_callback( opt_list ):
     global changed_options
-    log.d( "notification_callback called with {} options".format( len( opt_list ) ) )
+    log.d( f"notification_callback called with {len(opt_list)} options" )
     for opt in opt_list:
-        log.d( "    Changed option {}".format( opt ) )
-        if not depth_sensor.is_option_read_only( opt ): # Ignore accidental temperature changes
+        log.d( f"    {opt.id} -> {opt.value}" )
+        if not depth_sensor.is_option_read_only( opt.id ): # Ignore accidental temperature changes
             changed_options = changed_options + 1
 
 depth_sensor.on_options_changed( notification_callback )

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -58,6 +58,7 @@ void init_c_files(py::module &m) {
 
     m.def( "option_from_string", &rs2_option_from_string );
 
+    BIND_ENUM(m, rs2_option_type, RS2_OPTION_TYPE_COUNT, "The different types option values can take on")
     BIND_ENUM(m, rs2_l500_visual_preset, RS2_L500_VISUAL_PRESET_COUNT, "For L500 devices: provides optimized settings (presets) for specific types of usage.")
     BIND_ENUM(m, rs2_rs400_visual_preset, RS2_RS400_VISUAL_PRESET_COUNT, "For D400 devices: provides optimized settings (presets) for specific types of usage.")
     BIND_ENUM(m, rs2_playback_status, RS2_PLAYBACK_STATUS_COUNT, "") // No docsDtring in C++

--- a/wrappers/python/pyrs_sensor.cpp
+++ b/wrappers/python/pyrs_sensor.cpp
@@ -42,8 +42,6 @@ void init_sensor(py::module &m) {
              "Check if specific camera info is supported.", "info")
         .def("supports", (bool (rs2::sensor::*)(rs2_option) const) &rs2::options::supports,
              "Check if specific camera info is supported.", "info")
-        .def( "on_options_changed", &rs2::options::on_options_changed,
-              "Sets a callback to notify in case options in this container change value", "callback"_a )
         .def("get_info", &rs2::sensor::get_info, "Retrieve camera specific information, "
              "like versions of various internal components.", "info"_a)
         .def("set_notifications_callback", [](const rs2::sensor& self, std::function<void(rs2::notification)> callback) {


### PR DESCRIPTION
Prequel to DDS-related bulk-query changes:
* the `rs2::options_list` object now returns `rs2::option_value` rather than just the `rs2_option`
* `rs2::option_value` now holds a `rs2_option_value const *`
* `rs2_option_value` is a struct containing a `type`, `id`, and union of `as_float` etc.
* added `rs2_option_type`
* new APIs: `rs2_get_option_value`, `rs2_delete_option_value`, `rs2_option_type_to_string`, `rs2_get_option_value_from_list`
* `on_options_changed` notifications therefore now return the actual values seen so you don't need to query them again...
