### PR TITLE
Fix intrinsics calculation for non BROWN D500 models

### DIFF
--- a/src/ds/d500/d500-private.cpp
+++ b/src/ds/d500/d500-private.cpp
@@ -230,6 +230,8 @@ namespace librealsense
             intrinsics.height = height;
 
             // For D555e, model will be brown and we need the unrectified intrinsics
+            // We use reserved[3] as a flag here to indicate the full distortion module is not
+            // really brown but we treat it as such because the HW fixes fisheye distortion.
             bool use_base_intrinsics
                 = ( table->rgb_coefficients_table.distortion_model == RS2_DISTORTION_BROWN_CONRADY
                     && table->rgb_coefficients_table.reserved[3] == 0 );

--- a/src/ds/d500/d500-private.cpp
+++ b/src/ds/d500/d500-private.cpp
@@ -198,7 +198,8 @@ namespace librealsense
             // Since we override the table we need an indication that the table had changed from
             // outside this function Decided to use a reserve field for that
             if( rgb_coefficients_table.reserved[3] != 0 )
-                LOG_ERROR( "reserved field expected to be zero - expect bad distortion model" );
+                throw invalid_value_exception( "reserved field read from RGB distortion model table is expected to be zero" );
+
             rgb_coefficients_table.reserved[3] = 1;
 
             rgb_coefficients_table.distortion_coeffs[5] = 0;


### PR DESCRIPTION
Currently if the coefficients table is not BROWN, we override it with BROWN parameters.
If we do that we need to remember it for next time as the original table was not brown.

This PR use a reserve place in the table the flag this change for next time we use the intrinsics