### PR TITLE
Enable blocking advanced mode setting

### DIFF
--- a/src/core/advanced_mode.h
+++ b/src/core/advanced_mode.h
@@ -149,6 +149,9 @@ namespace librealsense
         static const uint16_t HW_MONITOR_COMMAND_SIZE = 1000;
         static const uint16_t HW_MONITOR_BUFFER_SIZE = 1024;
 
+        void block( const std::string & exception_message );
+        void unblock();
+
     private:
         friend class auto_calibrated;
         void set_exposure(synthetic_sensor& sensor, const exposure_control& val);
@@ -204,6 +207,8 @@ namespace librealsense
         rsutils::lazy< bool > _enabled;
         std::shared_ptr<advanced_mode_preset_option> _preset_opt;
         rsutils::lazy< bool > _amplitude_factor_support;
+        bool _blocked = false;
+        std::string _block_message;
 
         preset get_all() const;
         void set_all( const preset & p );
@@ -216,6 +221,9 @@ namespace librealsense
         template<class T>
         void set(const T& strct, EtAdvancedModeRegGroup cmd) const
         {
+            if( _blocked )
+                throw std::runtime_error( _block_message );
+
             auto ptr = (uint8_t*)(&strct);
             std::vector<uint8_t> data(ptr, ptr + sizeof(T));
 

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -695,6 +695,18 @@ namespace librealsense
             (*_color_sensor)->get_option(RS2_OPTION_POWER_LINE_FREQUENCY).set((float)val.power_line_frequency);
     }
 
+    void ds_advanced_mode_base::block( const std::string & exception_message )
+    {
+        _blocked = true;
+        _block_message = exception_message;
+    }
+
+    void ds_advanced_mode_base::unblock()
+    {
+        _blocked = false;
+        _block_message.clear();
+    }
+
     std::vector<uint8_t> ds_advanced_mode_base::serialize_json() const
     {
         if (!is_enabled())

--- a/src/ds/advanced_mode/presets.h
+++ b/src/ds/advanced_mode/presets.h
@@ -6,97 +6,98 @@
 
 namespace librealsense
 {
-    typedef struct laser_power_control
+    struct laser_power_control
     {
         float laser_power;
         bool was_set = false;
-    }laser_power_control;
+    };
 
-    typedef struct laser_state_control
+    struct laser_state_control
     {
         int laser_state;
         bool was_set = false;
-    }laser_state_control;
+    };
 
-    typedef struct exposure_control
+    struct exposure_control
     {
         float exposure;
         bool was_set = false;
-    }exposure_control;
+    };
 
-    typedef struct auto_exposure_control
+    struct auto_exposure_control
     {
         int auto_exposure;
         bool was_set = false;
-    }auto_exposure_control;
+    };
 
-    typedef struct gain_control
+    struct gain_control
     {
         float gain;
         bool was_set = false;
-    }gain_control;
+    };
 
-    typedef struct backlight_compensation_control
+    struct backlight_compensation_control
     {
         int backlight_compensation;
         bool was_set = false;
-    }backlight_compensation_control;
+    };
 
-    typedef struct brightness_control
+    struct brightness_control
     {
         float brightness;
         bool was_set = false;
-    }brightness_control;
+    };
 
-    typedef struct contrast_control
+    struct contrast_control
     {
         float contrast;
         bool was_set = false;
-    }contrast_control;
+    };
 
-    typedef struct gamma_control
+    struct gamma_control
     {
         float gamma;
         bool was_set = false;
-    }gamma_control;
+    };
 
-    typedef struct hue_control
+    struct hue_control
     {
         float hue;
         bool was_set = false;
-    }hue_control;
+    };
 
-    typedef struct saturation_control
+    struct saturation_control
     {
         float saturation;
         bool was_set = false;
-    }saturation_control;
+    };
 
-    typedef struct sharpness_control
+    struct sharpness_control
     {
         float sharpness;
         bool was_set = false;
-    }sharpness_control;
+    };
 
-    typedef struct white_balance_control
+    struct white_balance_control
     {
         float white_balance;
         bool was_set = false;
-    }white_balance_control;
+    };
 
-    typedef struct auto_white_balance_control
+    struct auto_white_balance_control
     {
         int auto_white_balance;
         bool was_set = false;
-    }auto_white_balance_control;
+    };
 
-    typedef struct power_line_frequency_control
+    struct power_line_frequency_control
     {
         int power_line_frequency;
         bool was_set = false;
-    }power_line_frequency_control;
+    };
 
-    struct preset{
+    struct preset
+    {
         STDepthControlGroup            depth_controls;
         STRsm                          rsm;
         STRauSupportVectorControl      rsvc;
@@ -131,18 +132,18 @@ namespace librealsense
         power_line_frequency_control   color_power_line_frequency;
     };
 
-    void default_400(preset& p);
-    void default_405u(preset& p);
-    void default_405(preset& p);
-    void default_410(preset& p);
-    void default_420(preset& p);
-    void default_430(preset& p);
-    void default_450_high_res(preset& p);
-    void default_450_mid_low_res(preset& p);
-    void high_accuracy(preset& p);
-    void high_density(preset& p);
-    void mid_density(preset& p);
-    void hand_gesture(preset& p);
-    void d415_remove_ir(preset& p);
-    void d460_remove_ir(preset& p);
-}
+    void default_400( preset & p );
+    void default_405u( preset & p );
+    void default_405( preset & p );
+    void default_410( preset & p );
+    void default_420( preset & p );
+    void default_430( preset & p );
+    void default_450_high_res( preset & p );
+    void default_450_mid_low_res( preset & p );
+    void high_accuracy( preset & p );
+    void high_density( preset & p );
+    void mid_density( preset & p );
+    void hand_gesture( preset & p );
+    void d415_remove_ir( preset & p );
+    void d460_remove_ir( preset & p );
+}  // namespace librealsense

--- a/unit-tests/live/d400/test-depth_ae_mode.py
+++ b/unit-tests/live/d400/test-depth_ae_mode.py
@@ -6,11 +6,13 @@
 import pyrealsense2 as rs
 import pyrsutils as rsutils
 from rspy import test, log
+from rspy import tests_wrapper as tw
 
 ctx = rs.context()
 device = test.find_first_device_or_exit();
 depth_sensor = device.first_depth_sensor()
 fw_version = rsutils.version( device.get_info( rs.camera_info.firmware_version ))
+tw.start_wrapper( device )
 
 if fw_version < rsutils.version(5,15,0,0):
     log.i(f"FW version {fw_version} does not support DEPTH_AUTO_EXPOSURE_MODE option, skipping test...")
@@ -68,4 +70,5 @@ depth_sensor.close()
 test.finish()
 
 ################################################################################################
+tw.stop_wrapper( device )
 test.print_results_and_exit()

--- a/unit-tests/live/frames/test-depth.py
+++ b/unit-tests/live/frames/test-depth.py
@@ -5,6 +5,7 @@
 
 import pyrealsense2 as rs
 from rspy import test, log
+from rspy import tests_wrapper as tw
 import os
 import math
 
@@ -22,6 +23,7 @@ DETAIL_LEVEL = 10
 FRAMES_TO_CHECK = 30
 
 dev = test.find_first_device_or_exit()
+tw.start_wrapper( dev )
 
 cfg = rs.config()
 cfg.enable_stream(rs.stream.depth, rs.format.z16, 30)
@@ -185,4 +187,5 @@ for frame_num in range(FRAMES_TO_CHECK):
 test.check(is_there_depth is True)
 test.finish()
 
+tw.stop_wrapper( dev )
 test.print_results_and_exit()

--- a/unit-tests/live/options/test-presets.py
+++ b/unit-tests/live/options/test-presets.py
@@ -6,12 +6,14 @@
 import pyrealsense2 as rs
 from rspy import test
 from rspy import log
+from rspy import tests_wrapper as tw
 
 dev = test.find_first_device_or_exit()
 depth_sensor = dev.first_depth_sensor()
 color_sensor = dev.first_color_sensor()
 product_line = dev.get_info(rs.camera_info.product_line)
 
+tw.start_wrapper( dev )
 
 with test.closure( 'visual preset support', on_fail=test.ABORT ): # No use continuing the test if there is no preset support
     test.check( depth_sensor.supports( rs.option.visual_preset ) )
@@ -51,6 +53,6 @@ with test.closure( 'setting color options' ):
             test.check( color_sensor.get_option( rs.option.hue ) == 123 )
         else:
             raise RuntimeError( 'unsupported product line' )
-    
-    
+
+tw.stop_wrapper( dev )    
 test.print_results_and_exit()

--- a/unit-tests/live/options/test-set-gain-stress-test.py
+++ b/unit-tests/live/options/test-set-gain-stress-test.py
@@ -8,6 +8,7 @@ import pyrealsense2 as rs
 from rspy import test, log
 import time
 import datetime
+from rspy import tests_wrapper as tw
 
 # Test multiple set_pu commands checking that the set control event polling works as expected.
 # We expect no exception thrown -  See [DSO-17185]
@@ -15,16 +16,19 @@ import datetime
 test_iterations = 200
 gain_values = [16,74,132,190,248]
 
+dev = test.find_first_device_or_exit()
+time.sleep( 3 ) # The device starts at D0 (Operational) state, allow time for it to get into idle state
+tw.start_wrapper( dev )
+
 ################################################################################################
 test.start("Stress test for setting a PU (gain) option")
 
-dev = test.find_first_device_or_exit()
-time.sleep( 3 ) # The device starts at D0 (Operational) state, allow time for it to get into idle state
 depth_ir_sensor = dev.first_depth_sensor()
 
 # Test only devices that supports set gain option
 if not depth_ir_sensor.supports(rs.option.gain):
     test.finish()
+    tw.stop_wrapper( dev )
     test.print_results_and_exit()
 
 
@@ -54,4 +58,5 @@ for i in range(test_iterations):
 test.finish()
 
 ################################################################################################
+tw.stop_wrapper( dev )
 test.print_results_and_exit()

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -1,0 +1,14 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+# Some future models might need to wrap the tests in setup and teardown steps.
+# Don't remove this file even if current implementation is empty...
+
+import pyrealsense2 as rs
+
+# Many operations, such as setting options, can take place only in safety service mode
+def start_wrapper( dev = None ):
+    return
+
+def stop_wrapper( dev = None ):
+    return


### PR DESCRIPTION
Also, unit tests can have a wrapper to setup/teardown environment.

Tracked on [RSDEV-1490]