### PR TITLE
[LRS-GL] Support for Align-SSE

### DIFF
--- a/src/gl/rs-gl.cpp
+++ b/src/gl/rs-gl.cpp
@@ -150,7 +150,7 @@ rs2_processing_block* rs2_gl_create_align(int api_version, rs2_stream to, rs2_er
 {
     verify_version_compatibility(api_version);
     auto block = std::make_shared<librealsense::gl::align_gl>(to);
-    auto backup = std::make_shared<librealsense::align>(to);
+    auto backup = align::create_align(to);
     auto dual = std::make_shared<librealsense::gl::dual_processing_block>();
     dual->add(block);
     dual->add(backup);

--- a/src/proc/align.cpp
+++ b/src/proc/align.cpp
@@ -11,10 +11,9 @@
 #include "align.h"
 #include "stream.h"
 
-#ifdef RS2_USE_CUDA
+#if defined(RS2_USE_CUDA)
 #include "proc/cuda/cuda-align.h"
-#endif
-#ifdef __SSSE3__
+#elif defined(__SSSE3__)
 #include "proc/sse/sse-align.h"
 #endif
 
@@ -24,14 +23,12 @@ namespace librealsense
 
     std::shared_ptr<align> align::create_align(rs2_stream align_to)
     {
-        #ifdef RS2_USE_CUDA
+        #if defined(RS2_USE_CUDA)
             return std::make_shared<librealsense::align_cuda>(align_to);
-        #else
-        #ifdef __SSSE3__
+        #elif defined(__SSSE3__)
             return std::make_shared<librealsense::align_sse>(align_to);
         #else
             return std::make_shared<librealsense::align>(align_to);
-        #endif
         #endif
     }
 

--- a/src/proc/align.cpp
+++ b/src/proc/align.cpp
@@ -11,9 +11,29 @@
 #include "align.h"
 #include "stream.h"
 
+#ifdef RS2_USE_CUDA
+#include "proc/cuda/cuda-align.h"
+#endif
+#ifdef __SSSE3__
+#include "proc/sse/sse-align.h"
+#endif
+
 namespace librealsense
 {
     template<int N> struct bytes { uint8_t b[N]; };
+
+    std::shared_ptr<align> align::create_align(rs2_stream align_to)
+    {
+        #ifdef RS2_USE_CUDA
+            return std::make_shared<librealsense::align_cuda>(align_to);
+        #else
+        #ifdef __SSSE3__
+            return std::make_shared<librealsense::align_sse>(align_to);
+        #else
+            return std::make_shared<librealsense::align>(align_to);
+        #endif
+        #endif
+    }
 
     template<class GET_DEPTH, class TRANSFER_PIXEL>
     void align_images(const rs2_intrinsics& depth_intrin, const rs2_extrinsics& depth_to_other,

--- a/src/proc/align.h
+++ b/src/proc/align.h
@@ -15,6 +15,7 @@ namespace librealsense
     {
     public:
         align(rs2_stream to_stream);
+        static std::shared_ptr<align> create_align(rs2_stream align_to);
 
     protected:
         align(rs2_stream to_stream, const char* name)

--- a/src/proc/processing-blocks-factory.cpp
+++ b/src/proc/processing-blocks-factory.cpp
@@ -3,32 +3,10 @@
 
 #include "processing-blocks-factory.h"
 
-#include "sse/sse-align.h"
-#include "cuda/cuda-align.h"
-
 #include "stream.h"
 
 namespace librealsense
 {
-#ifdef RS2_USE_CUDA
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
-    {
-        return std::make_shared<librealsense::align_cuda>(align_to);
-    }
-#else
-#ifdef __SSSE3__
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
-    {
-        return std::make_shared<librealsense::align_sse>(align_to);
-    }
-#else // No optimizations
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to)
-    {
-        return std::make_shared<librealsense::align>(align_to);
-    }
-#endif // __SSSE3__
-#endif // RS2_USE_CUDA
-
     processing_block_factory::processing_block_factory(const std::vector<stream_profile>& from, const std::vector<stream_profile>& to, std::function<std::shared_ptr<processing_block>(void)> generate_func) :
         _source_info(from), _target_info(to), generate_processing_block(generate_func)
     {}

--- a/src/proc/processing-blocks-factory.h
+++ b/src/proc/processing-blocks-factory.h
@@ -8,14 +8,12 @@
 
 #include <vector>
 
-#include "align.h"
 #include "../types.h"
 
 #include "identity-processing-block.h"
 
 namespace librealsense
 {
-    std::shared_ptr<librealsense::align> create_align(rs2_stream align_to);
 
     class processing_block_factory
     {

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -24,6 +24,7 @@
 #include "proc/processing-blocks-factory.h"
 #include "proc/colorizer.h"
 #include "proc/pointcloud.h"
+#include "proc/align.h"
 #include "proc/threshold.h"
 #include "proc/units-transform.h"
 #include "proc/disparity-transform.h"
@@ -2461,7 +2462,7 @@ rs2_processing_block* rs2_create_align(rs2_stream align_to, rs2_error** error) B
 {
     VALIDATE_ENUM(align_to);
 
-    auto block = create_align(align_to);
+    auto block = align::create_align(align_to);
 
     return new rs2_processing_block{ block };
 }


### PR DESCRIPTION
Tracked on LRS-1007

With LRS-GL library, in case if user chooses CPU acceleration ('SSE3' is enabled during build), create _librealsense::align_sse_ class object instead of _librealsense::align_.