### PR TITLE
DDS bulk query & reply changes, and options-watcher

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -411,7 +411,7 @@ return __p.invoke(func);\
     #define VALIDATE_FIXED_SIZE(ARG, SIZE) if((ARG) != (SIZE)) { std::ostringstream ss; ss << "Unsupported size provided { " << ARG << " }," " expecting { " << SIZE << " }"; throw librealsense::invalid_value_exception(ss.str()); }
     #define VALIDATE_NOT_NULL(ARG) if(!(ARG)) throw std::runtime_error("null pointer passed for argument \"" #ARG "\"");
     #define VALIDATE_ENUM(ARG) if(!librealsense::is_valid(ARG)) { std::ostringstream ss; ss << "invalid enum value for argument \"" #ARG "\""; throw librealsense::invalid_value_exception(ss.str()); }
-#define VALIDATE_OPTION( OBJ, OPT_ID )                                                                                 \
+#define VALIDATE_OPTION_ENABLED( OBJ, OPT_ID )                                                                         \
     if( ! OBJ->options->supports_option( OPT_ID ) )                                                                    \
     {                                                                                                                  \
         std::ostringstream ss;                                                                                         \

--- a/src/core/options-container.cpp
+++ b/src/core/options-container.cpp
@@ -16,7 +16,7 @@ const option & options_container::get_option( rs2_option id ) const
     if( it == _options.end() )
     {
         throw invalid_value_exception( rsutils::string::from()
-                                       << "Device does not support option " << get_option_name( id ) << "!" );
+                                       << "option '" << get_option_name( id ) << "' not supported" );
     }
     return *it->second;
 }

--- a/src/dds/rs-dds-depth-sensor-proxy.cpp
+++ b/src/dds/rs-dds-depth-sensor-proxy.cpp
@@ -1,18 +1,16 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include "rs-dds-depth-sensor-proxy.h"
 #include "rs-dds-option.h"
+
+#include <realdds/topics/dds-topic-names.h>
 
 #include <src/librealsense-exception.h>
 #include <rsutils/json.h>
 
 
 namespace librealsense {
-
-
-static const std::string metadata_header_key( "header", 6 );
-static const std::string depth_units_key( "depth-units", 11 );
 
 
 float dds_depth_sensor_proxy::get_depth_scale() const
@@ -40,7 +38,7 @@ void dds_depth_sensor_proxy::add_no_metadata( frame * const f, streaming_impl & 
 
 void dds_depth_sensor_proxy::add_frame_metadata( frame * const f, rsutils::json const & dds_md, streaming_impl & streaming )
 {
-    if( auto du = dds_md.nested( metadata_header_key, depth_units_key ) )
+    if( auto du = dds_md.nested( realdds::topics::metadata::key::header, realdds::topics::metadata::header::key::depth_units ) )
     {
         try
         {

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include "rs-dds-device-proxy.h"
 #include "rs-dds-color-sensor-proxy.h"
@@ -13,6 +13,7 @@
 
 #include <realdds/topics/device-info-msg.h>
 #include <realdds/topics/flexible-msg.h>
+#include <realdds/topics/dds-topic-names.h>
 
 #include <src/stream.h>
 #include <src/environment.h>
@@ -23,10 +24,6 @@
 
 
 namespace librealsense {
-
-
-// Constants for Json lookups
-static const std::string stream_name_key( "stream-name", 11 );
 
 
 static rs2_stream to_rs2_stream_type( std::string const & type_string )
@@ -299,7 +296,7 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
         _metadata_subscription = _dds_dev->on_metadata_available(
             [this]( std::shared_ptr< const rsutils::json > const & dds_md )
             {
-                std::string const & stream_name = dds_md->nested( stream_name_key ).string_ref();
+                auto & stream_name = dds_md->nested( realdds::topics::metadata::key::stream_name ).string_ref();
                 auto it = _stream_name_to_owning_sensor.find( stream_name );
                 if( it != _stream_name_to_owning_sensor.end() )
                     it->second->handle_new_metadata( stream_name, dds_md );

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include "rs-dds-sensor-proxy.h"
 #include "rs-dds-option.h"
@@ -12,6 +12,7 @@
 #include <realdds/topics/device-info-msg.h>
 #include <realdds/topics/image-msg.h>
 #include <realdds/topics/imu-msg.h>
+#include <realdds/topics/dds-topic-names.h>
 
 #include <src/core/options-registry.h>
 #include <src/core/frame-callback.h>
@@ -20,17 +21,10 @@
 #include <src/proc/color-formats-converter.h>
 
 #include <rsutils/json.h>
+using rsutils::json;
 
 
 namespace librealsense {
-
-
-// Constants for Json lookups
-static const std::string frame_number_key( "frame-number", 12 );
-static const std::string metadata_key( "metadata", 8 );
-static const std::string timestamp_key( "timestamp", 9 );
-static const std::string timestamp_domain_key( "timestamp-domain", 16 );
-static const std::string metadata_header_key( "header", 6 );
 
 
 dds_sensor_proxy::dds_sensor_proxy( std::string const & sensor_name,
@@ -338,7 +332,7 @@ void dds_sensor_proxy::handle_motion_data( realdds::topics::imu_msg && imu,
 
 
 void dds_sensor_proxy::handle_new_metadata( std::string const & stream_name,
-                                            std::shared_ptr< const rsutils::json > const & dds_md )
+                                            std::shared_ptr< const json > const & dds_md )
 {
     if( ! _md_enabled )
         return;
@@ -346,7 +340,8 @@ void dds_sensor_proxy::handle_new_metadata( std::string const & stream_name,
     auto it = _streaming_by_name.find( stream_name );
     if( it != _streaming_by_name.end() )
     {
-        if( auto timestamp = dds_md->nested( metadata_header_key, timestamp_key ) )
+        if( auto timestamp = dds_md->nested( realdds::topics::metadata::key::header,
+                                             realdds::topics::metadata::header::key::timestamp ) )
             it->second.syncer.enqueue_metadata( timestamp.get< realdds::dds_nsec >(), dds_md );
         else
             throw std::runtime_error( "missing metadata header/timestamp" );
@@ -366,17 +361,18 @@ void dds_sensor_proxy::add_no_metadata( frame * const f, streaming_impl & stream
 
 
 void dds_sensor_proxy::add_frame_metadata( frame * const f,
-                                           rsutils::json const & dds_md,
+                                           json const & dds_md,
                                            streaming_impl & streaming )
 {
-    auto md_header = dds_md.nested( metadata_header_key );
-    auto md = dds_md.nested( metadata_key );
+    auto md_header = dds_md.nested( realdds::topics::metadata::key::header );
+    auto md = dds_md.nested( realdds::topics::metadata::key::metadata );
 
     // A frame number is "optional". If the server supplies it, we try to use it for the simple fact that,
     // otherwise, we have no way of detecting drops without some advanced heuristic tracking the FPS and
     // timestamps. If not supplied, we use an increasing counter.
     // Note that if we have no metadata, we have no frame-numbers! So we need a way of generating them
-    if( md_header.nested( frame_number_key ).get_ex( f->additional_data.frame_number ) )
+    if( md_header.nested( realdds::topics::metadata::header::key::frame_number )
+            .get_ex( f->additional_data.frame_number ) )
     {
         f->additional_data.last_frame_number = streaming.last_frame_number.exchange( f->additional_data.frame_number );
         if( f->additional_data.frame_number != f->additional_data.last_frame_number + 1
@@ -396,7 +392,8 @@ void dds_sensor_proxy::add_frame_metadata( frame * const f,
     // purposes, so we ignore here. The domain is optional, and really only rs-dds-adapter communicates it
     // because the source is librealsense...
     f->additional_data.timestamp;
-    md_header.nested( timestamp_domain_key ).get_ex( f->additional_data.timestamp_domain );
+    md_header.nested( realdds::topics::metadata::header::key::timestamp_domain )
+        .get_ex( f->additional_data.timestamp_domain );
 
     if( ! md.empty() )
     {
@@ -408,10 +405,10 @@ void dds_sensor_proxy::add_frame_metadata( frame * const f,
             std::string const & keystr = librealsense::get_string( key );
             try
             {
-                if( auto value_j = md.nested( keystr, &rsutils::json::is_number_integer ) )
+                if( auto value_j = md.nested( keystr, &json::is_number_integer ) )
                     metadata[key] = { true, value_j.get< rs2_metadata_type >() };
             }
-            catch( rsutils::json::exception const & )
+            catch( json::exception const & )
             {
                 // The metadata key doesn't exist or the value isn't the right type... we ignore it!
                 // (all metadata is not there when we create the frame, so no need to erase)
@@ -437,7 +434,7 @@ void dds_sensor_proxy::start( rs2_frame_callback_sptr callback )
         auto & streaming = _streaming_by_name[dds_stream->name()];
         streaming.syncer.on_frame_release( frame_releaser );
         streaming.syncer.on_frame_ready(
-            [this, &streaming]( syncer_type::frame_holder && fh, std::shared_ptr< const rsutils::json > const & md )
+            [this, &streaming]( syncer_type::frame_holder && fh, std::shared_ptr< const json > const & md )
             {
                 if( _is_streaming ) // stop was not called
                 {

--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -1,13 +1,12 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-
 #pragma once
-
 
 #include "sid_index.h"
 #include <src/frame.h>
 #include <src/software-sensor.h>
 #include <src/proc/formats-converter.h>
+#include <src/core/options-watcher.h>
 
 #include <realdds/dds-metadata-syncer.h>
 
@@ -42,6 +41,7 @@ class dds_sensor_proxy : public software_sensor
     std::shared_ptr< realdds::dds_device > const _dev;
     std::string const _name;
     bool const _md_enabled;
+    options_watcher _options_watcher;
 
     typedef realdds::dds_metadata_syncer syncer_type;
     static void frame_releaser( syncer_type::frame_type * f ) { static_cast< frame * >( f )->release(); }
@@ -79,6 +79,10 @@ public:
     void add_processing_block( std::string const & filter_name );
 
     const std::map< sid_index, std::shared_ptr< realdds::dds_stream > > & streams() const { return _streams; }
+
+    // sensor_interface
+public:
+    rsutils::subscription register_options_changed_callback( options_watcher::callback && ) override;
 
 protected:
     void register_basic_converters();

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -691,7 +691,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(0, options, option)
 float rs2_get_option(const rs2_options* options, rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_OPTION(options, option);
+    VALIDATE_OPTION_ENABLED(options, option);
     return options->options->get_option(option).query();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(0.0f, options, option)
@@ -699,7 +699,7 @@ HANDLE_EXCEPTIONS_AND_RETURN(0.0f, options, option)
 rs2_option_value const * rs2_get_option_value( const rs2_options * options, rs2_option option_id, rs2_error ** error ) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL( options );
-    VALIDATE_OPTION( options, option_id );
+    VALIDATE_OPTION_ENABLED( options, option_id );
     auto wrapper = new rs2_option_value_wrapper(
         option_id,
         std::make_shared< const rsutils::json >( options->options->get_option( option_id ).query() ) );
@@ -719,7 +719,7 @@ NOEXCEPT_RETURN( , p_value )
 void rs2_set_option(const rs2_options* options, rs2_option option, float value, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_OPTION(options, option);
+    VALIDATE_OPTION_ENABLED(options, option);
     auto& option_ref = options->options->get_option(option);
     auto range = option_ref.get_range();
     VALIDATE_RANGE(value, range.min, range.max);
@@ -792,7 +792,6 @@ void rs2_get_option_range(const rs2_options* options, rs2_option option,
     float* min, float* max, float* step, float* def, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_OPTION(options, option);
     VALIDATE_NOT_NULL(min);
     VALIDATE_NOT_NULL(max);
     VALIDATE_NOT_NULL(step);
@@ -1258,7 +1257,6 @@ NOEXCEPT_RETURN(, frame)
 const char* rs2_get_option_description(const rs2_options* options, rs2_option option, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_OPTION(options, option);
     return options->options->get_option(option).get_description();
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, options, option)
@@ -1273,7 +1271,6 @@ HANDLE_EXCEPTIONS_AND_RETURN(, frame)
 const char* rs2_get_option_value_description(const rs2_options* options, rs2_option option, float value, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
-    VALIDATE_OPTION(options, option);
     return options->options->get_option(option).get_value_description(value);
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, options, option, value)

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -102,14 +102,16 @@ public:
     void on_control( control_callback callback ) { _control_callback = std::move( callback ); }
 
 private:
-    void on_control_message_received();
-    void handle_control_message( std::string const & id,
-                                 rsutils::json const & control_message,
-                                 rsutils::json & reply );
+    struct control_sample;
 
-    void handle_set_option( const rsutils::json & msg, rsutils::json & reply );
-    void handle_query_option( const rsutils::json & msg, rsutils::json & reply );
+    void on_control_message_received();
+    void on_set_option( control_sample const &, rsutils::json & reply );
+    void on_query_option( control_sample const &, rsutils::json & reply );
+    void on_query_options( control_sample const &, rsutils::json & reply );
+
     std::shared_ptr< dds_option > find_option( const std::string & option_name, const std::string & stream_name ) const;
+    std::shared_ptr< dds_option > get_option( const std::string & option_name, const std::string & stream_name ) const;
+    float query_option( std::shared_ptr< dds_option > const & ) const;
 
     std::shared_ptr< dds_publisher > _publisher;
     std::shared_ptr< dds_subscriber > _subscriber;

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include <realdds/dds-option.h>
@@ -101,6 +101,11 @@ public:
     typedef std::function< bool( std::string const &, rsutils::json const &, rsutils::json & ) > control_callback;
     void on_control( control_callback callback ) { _control_callback = std::move( callback ); }
 
+    // Locate an option based on stream name (empty for device option) and option name
+    std::shared_ptr< dds_option > find_option( std::string const & option_name, std::string const & stream_name ) const;
+    // Same as find_options, except throws if not found
+    std::shared_ptr< dds_option > get_option( std::string const & option_name, std::string const & stream_name ) const;
+
 private:
     struct control_sample;
 
@@ -109,8 +114,6 @@ private:
     void on_query_option( control_sample const &, rsutils::json & reply );
     void on_query_options( control_sample const &, rsutils::json & reply );
 
-    std::shared_ptr< dds_option > find_option( const std::string & option_name, const std::string & stream_name ) const;
-    std::shared_ptr< dds_option > get_option( const std::string & option_name, const std::string & stream_name ) const;
     float query_option( std::shared_ptr< dds_option > const & ) const;
 
     std::shared_ptr< dds_publisher > _publisher;

--- a/third-party/realdds/include/realdds/topics/dds-topic-names.h
+++ b/third-party/realdds/include/realdds/topics/dds-topic-names.h
@@ -1,10 +1,13 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 #pragma once
+
+#include <string>
+
 
 namespace realdds {
 namespace topics {
+
 
 // The character used to separate topic path elements
 constexpr char SEPARATOR = '/';
@@ -20,6 +23,180 @@ constexpr char const * DEVICE_INFO_TOPIC_NAME = "realsense/device-info";
 constexpr char const * NOTIFICATION_TOPIC_NAME = "/notification";
 constexpr char const * CONTROL_TOPIC_NAME = "/control";
 constexpr char const * METADATA_TOPIC_NAME = "/metadata";
+
+
+namespace notification {
+    namespace key {
+        extern std::string const id;
+    }
+    namespace device_header {
+        extern std::string const id;
+        namespace key {
+            extern std::string const n_streams;
+            extern std::string const extrinsics;
+        }
+    }
+    namespace device_options {
+        extern std::string const id;
+        namespace key {
+            extern std::string const options;
+        }
+    }
+    namespace stream_header {
+        extern std::string const id;
+        namespace key {
+            extern std::string const type;
+            extern std::string const name;
+            extern std::string const sensor_name;
+            extern std::string const profiles;
+            extern std::string const default_profile_index;
+            extern std::string const metadata_enabled;
+        }
+    }
+    namespace stream_options {
+        extern std::string const id;
+        namespace key {
+            extern std::string const stream_name;
+            extern std::string const options;
+            extern std::string const intrinsics;
+            extern std::string const recommended_filters;
+        }
+        namespace intrinsics {
+            namespace key {
+                extern std::string const accel;
+                extern std::string const gyro;
+            }
+        }
+    }
+    namespace log {
+        extern std::string const id;
+        namespace key {
+            extern std::string const entries;
+        }
+    }
+    namespace query_options {
+        extern std::string const id;
+        namespace key {
+            extern std::string const option_values;
+        }
+    }
+}
+
+namespace control {
+    namespace key {
+        using notification::key::id;
+    }
+    namespace set_option {
+        extern std::string const id;
+        namespace key {
+            extern std::string const value;
+            extern std::string const option_name;
+            extern std::string const stream_name;
+        }
+    }
+    namespace query_option {
+        extern std::string const id;
+        namespace key {
+            using control::set_option::key::option_name;
+            using control::set_option::key::stream_name;
+        }
+    }
+    namespace query_options {
+        using notification::query_options::id;
+        namespace key {
+            using control::set_option::key::option_name;
+            using control::set_option::key::stream_name;
+            extern std::string const sensor_name;
+        }
+    }
+    namespace open_streams {
+        extern std::string const id;
+        namespace key {
+            extern std::string const stream_profiles;
+            extern std::string const reset;
+            extern std::string const commit;
+        }
+    }
+    namespace hwm {
+        extern std::string const id;
+        namespace key {
+            extern std::string const opcode;
+            extern std::string const param1;
+            extern std::string const param2;
+            extern std::string const param3;
+            extern std::string const param4;
+            extern std::string const data;
+            extern std::string const build_command;
+        }
+    }
+    namespace hw_reset {
+        extern std::string const id;
+    }
+}
+
+namespace reply {
+    namespace key {
+        using control::key::id;
+        extern std::string const sample;
+        extern std::string const control;
+        extern std::string const status;
+        extern std::string const explanation;
+    }
+    namespace status {
+        extern std::string const ok;
+    }
+    namespace set_option {
+        using control::set_option::id;
+        namespace key {
+            using control::set_option::key::value;
+        }
+    }
+    namespace query_option {
+        using control::query_option::id;
+        namespace key {
+            using control::set_option::key::value;
+        }
+    }
+    namespace query_options {
+        using control::query_options::id;
+        namespace key {
+            using notification::query_options::key::option_values;
+        }
+    }
+    namespace open_streams {
+        using control::open_streams::id;
+        namespace key {
+            using control::open_streams::key::stream_profiles;
+        }
+    }
+    namespace hwm {
+        using control::hwm::id;
+        namespace key {
+            using control::hwm::key::data;
+        }
+    }
+}
+
+namespace metadata {
+    namespace key {
+        extern std::string const stream_name;
+        extern std::string const header;
+        extern std::string const metadata;
+    }
+    namespace header {
+        namespace key {
+            extern std::string const frame_number;
+            extern std::string const timestamp;
+            extern std::string const timestamp_domain;
+            extern std::string const depth_units;
+        }
+    }
+    namespace metadata {
+        namespace key {
+        }
+    }
+}
+
 
 }  // namespace topics
 }  // namespace realdds

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -22,37 +22,18 @@
 
 #include <cassert>
 
-
-static std::string const id_key( "id", 2 );
-static std::string const id_set_option( "set-option", 10 );
-static std::string const id_query_option( "query-option", 12 );
-static std::string const id_open_streams( "open-streams", 12 );
-static std::string const id_device_header( "device-header", 13 );
-static std::string const id_device_options( "device-options", 14 );
-static std::string const id_stream_header( "stream-header", 13 );
-static std::string const id_stream_options( "stream-options", 14 );
-static std::string const value_key( "value", 5 );
-static std::string const option_values_key( "option-values", 13 );
-static std::string const sample_key( "sample", 6 );
-static std::string const option_name_key( "option-name", 11 );
-static std::string const stream_name_key( "stream-name", 11 );
-static std::string const control_key( "control", 7 );
-
-static std::string const id_log( "log", 3 );
-static std::string const entries_key( "entries", 7 );
-
-static std::string const id_hwm( "hwm", 3 );
+using rsutils::json;
 
 
 namespace {
 
 
-rsutils::json device_settings( std::shared_ptr< realdds::dds_participant > const & participant )
+json device_settings( std::shared_ptr< realdds::dds_participant > const & participant )
 {
     auto settings = participant->settings().nested( "device" );
     if( ! settings )
         // Nothing there: default is empty object
-        return rsutils::json::object();
+        return json::object();
     if( ! settings.is_object() )
         // Device settings, if they exist, must be an object!
         DDS_THROW( runtime_error, "participant 'device' settings must be an object: " << settings );
@@ -95,19 +76,6 @@ void dds_device::impl::set_state( state_t new_state )
 
     _state = new_state;
 }
-
-
-/*static*/ dds_device::impl::notification_handlers const dds_device::impl::_notification_handlers{
-    { id_set_option, &dds_device::impl::on_option_value },
-    { id_query_option, &dds_device::impl::on_option_value },
-    { id_device_header, &dds_device::impl::on_device_header },
-    { id_device_options, &dds_device::impl::on_device_options },
-    { id_stream_header, &dds_device::impl::on_stream_header },
-    { id_stream_options, &dds_device::impl::on_stream_options },
-    { id_open_streams, &dds_device::impl::on_known_notification },
-    { id_log, &dds_device::impl::on_log },
-    { id_hwm, &dds_device::impl::on_known_notification },
-};
 
 
 dds_device::impl::impl( std::shared_ptr< dds_participant > const & participant,
@@ -155,16 +123,34 @@ std::string dds_device::impl::debug_name() const
 }
 
 
-void dds_device::impl::handle_notification( rsutils::json const & j,
-                                            eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_notification( json && j, eprosima::fastdds::dds::SampleInfo const & notification_sample )
 {
+    typedef std::map< std::string,
+                      void ( dds_device::impl::* )( json const &,
+                                                    eprosima::fastdds::dds::SampleInfo const & ) >
+        notification_handlers;
+    static notification_handlers const _notification_handlers{
+        { topics::reply::set_option::id, &dds_device::impl::on_set_option },
+        { topics::reply::query_option::id, &dds_device::impl::on_set_option },  // Same handling as on_set_option
+        { topics::reply::query_options::id, &dds_device::impl::on_query_options },
+        { topics::notification::device_header::id, &dds_device::impl::on_device_header },
+        { topics::notification::device_options::id, &dds_device::impl::on_device_options },
+        { topics::notification::stream_header::id, &dds_device::impl::on_stream_header },
+        { topics::notification::stream_options::id, &dds_device::impl::on_stream_options },
+        { topics::notification::log::id, &dds_device::impl::on_log },
+    };
+
+    auto const control = j.nested( topics::reply::key::control );
+    auto const control_sample = control ? j.nested( topics::reply::key::sample ) : rsutils::json_ref( rsutils::missing_json );
+
     try
     {
         // First handle the notification
-        auto id = j.at( id_key ).get< std::string >();
+        // An 'id' is mandatory, but if it's a response to a control it can be contained there
+        auto id = ( control_sample ? control.get_json() : j ).nested( topics::notification::key::id ).string_ref();
         auto it = _notification_handlers.find( id );
         if( it != _notification_handlers.end() )
-            ( this->*( it->second ) )( j, sample );
+            ( this->*( it->second ) )( j, notification_sample );
         _on_notification.raise( id, j );
     }
     catch( std::exception const & e )
@@ -179,17 +165,17 @@ void dds_device::impl::handle_notification( rsutils::json const & j,
     try
     {
         // Check if this is a reply - maybe someone's waiting on it...
-        if( auto sample = j.nested( sample_key ) )
+        if( control_sample )
         {
             // ["<prefix>.<entity>", <sequence-number>]
-            if( sample.size() == 2 && sample.is_array() )
+            if( control_sample.size() == 2 && control_sample.is_array() )
             {
                 // We have to be the ones who sent the control!
-                auto const reply_guid = guid_from_string( sample[0].get< std::string >() );
+                auto const reply_guid = guid_from_string( control_sample[0].get< std::string >() );
                 auto const control_guid = _control_writer->guid();
                 if( reply_guid == control_guid )
                 {
-                    auto const sequence_number = sample[1].get< uint64_t >();
+                    auto const sequence_number = control_sample[1].get< uint64_t >();
                     std::unique_lock< std::mutex > lock( _replies_mutex );
                     auto replyit = _replies.find( sequence_number );
                     if( replyit != _replies.end() )
@@ -217,7 +203,7 @@ void dds_device::impl::handle_notification( rsutils::json const & j,
 }
 
 
-void dds_device::impl::on_option_value( rsutils::json const & j, eprosima::fastdds::dds::SampleInfo const & )
+void dds_device::impl::on_set_option( json const & j, eprosima::fastdds::dds::SampleInfo const & )
 {
     if( ! is_ready() )
         return;
@@ -225,17 +211,17 @@ void dds_device::impl::on_option_value( rsutils::json const & j, eprosima::fastd
     // This is the notification for "set-option" or "query-option", meaning someone sent a control request to set/get an
     // option value. In either case a value will be sent; we want to update ours accordingly to reflect the latest:
 
-    // Ignore errors
-    dds_device::check_reply( j );
+    dds_device::check_reply( j );  // throws
 
     // We need the original control request as part of the reply, otherwise we can't know what option this is for
-    auto control = j.nested( control_key );
+    auto control = j.nested( topics::reply::key::control );
     if( ! control.is_object() )
         throw std::runtime_error( "missing control object" );
 
     // Find the relevant (stream) options to update
     dds_options const * options = &_options;
-    std::string const & stream_name = control.nested( stream_name_key ).string_ref_or_empty();  // default = empty = device option
+    std::string const & stream_name =  // default = empty = device option
+        control.nested( topics::control::set_option::key::stream_name ).string_ref_or_empty();
     if( ! stream_name.empty() )
     {
         auto stream_it = _streams.find( stream_name );
@@ -244,59 +230,13 @@ void dds_device::impl::on_option_value( rsutils::json const & j, eprosima::fastd
         options = &stream_it->second->options();
     }
 
-    // This little function is used in all use-cases below:
-    auto update_option = [&]( std::string const & option_name, float const new_value )
-    {
-        // Find the option and set its value
-        for( auto & option : *options )
-        {
-            if( option->get_name() == option_name )
-            {
-                option->set_value( new_value );
-                return;
-            }
-        }
-        LOG_DEBUG( "[" << debug_name() << "] option '" << option_name << "': not found" );
-    };
-
-    auto value_j = j.nested( value_key );
+    auto value_j = j.nested( topics::reply::set_option::key::value );
     if( ! value_j.exists() )
-    {
-        // Use case:
-        //      Bulk query without ANY option names supplied, { "option-name": [] }
-        // There is no 'value' key; instead, the server returns option-value pairs in 'option-values':
-        auto option_values = j.nested( option_values_key );
-        if( ! option_values.is_object() )
-            throw std::runtime_error( "missing value or option-values" );
-        for( auto it = option_values.begin(); it != option_values.end(); ++it )
-            update_option( it.key(), it.value().get< float >() );
-        return;
-    }
+        throw std::runtime_error( "missing value" );
 
-    auto option_name_j = control.nested( option_name_key );
+    auto option_name_j = control.nested( topics::control::set_option::key::option_name );
     if( ! option_name_j.exists() )
         throw std::runtime_error( "missing option-name" );
-
-    if( value_j.is_array() )
-    {
-        // Use case:
-        //      Bulk query, but specific option names were given, { "option-name": ["opt1", ...] }
-        // The 'option-name' should be an array of options for which values are returned
-        // The 'value' should be a similarly-sized array
-        if( ! option_name_j.is_array() )
-            throw std::runtime_error( "'option-name' does not match 'value' array type" );
-        if( value_j.size() != option_name_j.size() )
-            throw std::runtime_error( "'option-name' does not match 'value' array size" );
-
-        auto size = value_j.size();
-        for( auto x = 0; x < size; ++x )
-        {
-            auto const & option_name = option_name_j[x].string_ref();
-            auto const new_value = value_j[x].get< float >();
-            update_option( option_name, new_value );
-        }
-        return;
-    }
 
     // Use case:
     //      Simple single-option value update, { "option-name": "opt1" }
@@ -305,21 +245,95 @@ void dds_device::impl::on_option_value( rsutils::json const & j, eprosima::fastd
     if( ! option_name_j.is_string() )
         throw std::runtime_error( "option-name is not a string" );
     auto & option_name = option_name_j.string_ref();
-    update_option( option_name, value_j.get< float >() );
+    for( auto & option : *options )
+    {
+        if( option->get_name() == option_name )
+        {
+            option->set_value( value_j.get< float >() );
+            return;
+        }
+    }
+    LOG_DEBUG( "[" << debug_name() << "] option '" << option_name << "': not found" );
 }
 
 
-void dds_device::impl::on_known_notification( rsutils::json const & j, eprosima::fastdds::dds::SampleInfo const & )
+void dds_device::impl::on_query_options( json const & j, eprosima::fastdds::dds::SampleInfo const & )
+{
+    if( ! is_ready() )
+        return;
+
+    // This is the notification for "query-options", which can get sent as a reply to a control or independently by the
+    // device. It takes the same form & handling either way.
+    // 
+    // E.g.:
+    //   {
+    //     "id": "query-options",
+    //     "option-values" : {
+    //       "IP address": "1.2.3.4",  // device-level
+    //       "Color": {
+    //         "Exposure": 8.0,
+    //       },
+    //       "Depth" : {
+    //         "Exposure": 20.0
+    //       }
+    //     }
+    //   }
+
+    dds_device::check_reply( j );  // throws
+
+    // This little function is used either for device or stream options
+    auto update_option = [this]( dds_options const & options, std::string const & option_name, json const & new_value )
+    {
+        // Find the option and set its value
+        for( auto & option : options )
+        {
+            if( option->get_name() == option_name )
+            {
+                option->set_value( new_value.get< float >() );
+                return;
+            }
+        }
+        //LOG_DEBUG( "[" << debug_name() << "] option '" << option_name << "': not found" );
+        throw std::runtime_error( "option '" + option_name + "' not found" );
+    };
+
+    auto option_values = j.nested( topics::reply::query_options::key::option_values );
+    if( ! option_values.is_object() )
+        throw std::runtime_error( "missing option-values" );
+
+    for( auto it = option_values.begin(); it != option_values.end(); ++it )
+    {
+        if( it->is_object() )
+        {
+            // Stream name
+            auto & stream_name = it.key();
+            auto stream_it = _streams.find( stream_name );
+            if( stream_it == _streams.end() )
+                throw std::runtime_error( "stream '" + stream_name + "' not found" );
+            auto & option_names = it.value();
+            for( auto option_it = option_names.begin(); option_it != option_names.end(); ++option_it )
+                update_option( stream_it->second->options(), option_it.key(), option_it.value() );
+        }
+        else
+        {
+            // Device-level option name
+            update_option( _options, it.key(), it.value() );
+        }
+    }
+}
+
+
+void dds_device::impl::on_known_notification( json const & j, eprosima::fastdds::dds::SampleInfo const & )
 {
     // This is a known notification, but we don't want to do anything for it
 }
 
 
-void dds_device::impl::on_log( rsutils::json const & j, eprosima::fastdds::dds::SampleInfo const & )
+void dds_device::impl::on_log( json const & j, eprosima::fastdds::dds::SampleInfo const & )
 {
     // This is the notification for "log"  (see docs/notifications.md#Logging)
     //     - `entries` is an array containing 1 or more log entries
-    auto entries = j.nested( entries_key );
+    auto entries = j.nested( topics::notification::log::key::entries );
     if( ! entries )
         throw std::runtime_error( "log entries not found" );
     if( ! entries.is_array() )
@@ -364,7 +378,7 @@ void dds_device::impl::open( const dds_stream_profiles & profiles )
     if( profiles.empty() )
         DDS_THROW( runtime_error, "must provide at least one profile" );
 
-    rsutils::json stream_profiles;
+    json stream_profiles;
     for( auto & profile : profiles )
     {
         auto stream = profile->stream();
@@ -376,12 +390,12 @@ void dds_device::impl::open( const dds_stream_profiles & profiles )
         stream_profiles[stream->name()] = profile->to_json();
     }
 
-    rsutils::json j = {
-        { id_key, id_open_streams },
-        { "stream-profiles", stream_profiles },
+    json j = {
+        { topics::control::key::id, topics::control::open_streams::id },
+        { topics::control::open_streams::key::stream_profiles, std::move( stream_profiles ) },
     };
 
-    rsutils::json reply;
+    json reply;
     write_control_message( j, &reply );
 }
 
@@ -391,15 +405,15 @@ void dds_device::impl::set_option_value( const std::shared_ptr< dds_option > & o
     if( ! option )
         DDS_THROW( runtime_error, "must provide an option to set" );
 
-    rsutils::json j = rsutils::json::object({
-        { id_key, id_set_option },
-        { option_name_key, option->get_name() },
-        { value_key, new_value }
+    json j = json::object({
+        { topics::control::key::id, topics::control::set_option::id },
+        { topics::control::set_option::key::option_name, option->get_name() },
+        { topics::control::set_option::key::value, new_value }
     });
     if( auto stream = option->stream() )
-        j[stream_name_key] = stream->name();
+        j[topics::control::set_option::key::stream_name] = stream->name();
 
-    rsutils::json reply;
+    json reply;
     write_control_message( j, &reply );
     // the reply will contain the new value (which may be different) and will update the cached one
 }
@@ -410,21 +424,21 @@ float dds_device::impl::query_option_value( const std::shared_ptr< dds_option > 
     if( ! option )
         DDS_THROW( runtime_error, "must provide an option to query" );
 
-    rsutils::json j = rsutils::json::object({
-        { id_key, id_query_option },
-        { option_name_key, option->get_name() }
+    json j = json::object({
+        { topics::control::key::id, topics::control::query_option::id },
+        { topics::control::query_option::key::option_name, option->get_name() }
     });
     if( auto stream = option->stream() )
-        j[stream_name_key] = stream->name();
+        j[topics::control::query_option::key::stream_name] = stream->name();
 
-    rsutils::json reply;
+    json reply;
     write_control_message( j, &reply );
 
-    return reply.at( value_key ).get< float >();
+    return reply.at( topics::reply::query_option::key::value ).get< float >();
 }
 
 
-void dds_device::impl::write_control_message( topics::flexible_msg && msg, rsutils::json * reply )
+void dds_device::impl::write_control_message( topics::flexible_msg && msg, json * reply )
 {
     assert( _control_writer != nullptr );
     auto this_sequence_number = std::move( msg ).write_to( *_control_writer );
@@ -483,11 +497,11 @@ void dds_device::impl::create_notifications_reader()
                 if( j.is_array() )
                 {
                     for( unsigned x = 0; x < j.size(); ++x )
-                        handle_notification( j[x], sample );
+                        on_notification( std::move( j[x] ), sample );
                 }
                 else
                 {
-                    handle_notification( j, sample );
+                    on_notification( std::move( j ), sample );
                 }
             }
         } );
@@ -512,7 +526,7 @@ void dds_device::impl::create_metadata_reader()
                 {
                     try
                     {
-                        auto sptr = std::make_shared< const rsutils::json >( message.json_data() );
+                        auto sptr = std::make_shared< const json >( message.json_data() );
                         _on_metadata_available.raise( sptr );
                     }
                     catch( std::exception const & e )
@@ -540,7 +554,7 @@ void dds_device::impl::create_control_writer()
 }
 
 
-void dds_device::impl::on_device_header( rsutils::json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_device_header( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
 {
     if( _state != state_t::ONLINE )
         return;
@@ -552,10 +566,10 @@ void dds_device::impl::on_device_header( rsutils::json const & j, eprosima::fast
     // with a server.
     eprosima::fastrtps::rtps::iHandle2GUID( _server_guid, sample.publication_handle );
 
-    _n_streams_expected = j.at( "n-streams" ).get< size_t >();
-    LOG_DEBUG( "[" << debug_name() << "] ... " << id_device_header << ": " << _n_streams_expected << " streams expected" );
+    _n_streams_expected = j.at( topics::notification::device_header::key::n_streams ).get< size_t >();
+    LOG_DEBUG( "[" << debug_name() << "] ... " << topics::notification::device_header::id << ": " << _n_streams_expected << " streams expected" );
 
-    if( auto extrinsics_j = j.nested( "extrinsics" ) )
+    if( auto extrinsics_j = j.nested( topics::notification::device_header::key::extrinsics ) )
     {
         for( auto & ex : extrinsics_j )
         {
@@ -571,14 +585,14 @@ void dds_device::impl::on_device_header( rsutils::json const & j, eprosima::fast
 }
 
 
-void dds_device::impl::on_device_options( rsutils::json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_device_options( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
 {
     if( _state != state_t::WAIT_FOR_DEVICE_OPTIONS )
         return;
 
-    if( auto options_j = j.nested( "options" ) )
+    if( auto options_j = j.nested( topics::notification::device_options::key::options ) )
     {
-        LOG_DEBUG( "[" << debug_name() << "] ... " << id_device_options << ": " << options_j.size() << " options received" );
+        LOG_DEBUG( "[" << debug_name() << "] ... " << topics::notification::device_options::id << ": " << options_j.size() << " options received" );
 
         for( auto & option_json : options_j )
         {
@@ -594,28 +608,28 @@ void dds_device::impl::on_device_options( rsutils::json const & j, eprosima::fas
 }
 
 
-void dds_device::impl::on_stream_header( rsutils::json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_stream_header( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
 {
     if( _state != state_t::WAIT_FOR_STREAM_HEADER )
         return;
 
     if( _streams.size() >= _n_streams_expected )
         DDS_THROW( runtime_error, "more streams than expected (" << _n_streams_expected << ") received" );
-    auto & stream_type = j.at( "type" ).string_ref();
-    auto & stream_name = j.at( "name" ).string_ref();
+    auto & stream_type = j.at( topics::notification::stream_header::key::type ).string_ref();
+    auto & stream_name = j.at( topics::notification::stream_header::key::name ).string_ref();
 
     auto & stream = _streams[stream_name];
     if( stream )
         DDS_THROW( runtime_error, "stream '" << stream_name << "' already exists" );
 
-    auto & sensor_name = j.at( "sensor-name" ).string_ref();
+    auto & sensor_name = j.at( topics::notification::stream_header::key::sensor_name ).string_ref();
     size_t default_profile_index = j.at( "default-profile-index" ).get< size_t >();
     dds_stream_profiles profiles;
 
 #define TYPE2STREAM( S, P )                                                                                            \
     if( stream_type == #S )                                                                                            \
     {                                                                                                                  \
-        for( auto & profile : j["profiles"] )                                                                          \
+        for( auto & profile : j[topics::notification::stream_header::key::profiles] )                                  \
             profiles.push_back( dds_stream_profile::from_json< dds_##P##_stream_profile >( profile ) );                \
         stream = std::make_shared< dds_##S##_stream >( stream_name, sensor_name );                                     \
     }                                                                                                                  \
@@ -630,7 +644,7 @@ void dds_device::impl::on_stream_header( rsutils::json const & j, eprosima::fast
 
 #undef TYPE2STREAM
 
-    if( j.at( "metadata-enabled" ).get< bool >() )
+    if( j.at( topics::notification::stream_header::key::metadata_enabled ).get< bool >() )
     {
         create_metadata_reader();
         stream->enable_metadata();  // Call before init_profiles
@@ -655,29 +669,31 @@ void dds_device::impl::on_stream_header( rsutils::json const & j, eprosima::fast
 }
 
 
-void dds_device::impl::on_stream_options( rsutils::json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_stream_options( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
 {
     if( _state != state_t::WAIT_FOR_STREAM_OPTIONS )
         return;
 
-    auto & stream_name = j.at( "stream-name" ).string_ref();
+    auto & stream_name = j.at( topics::notification::stream_options::key::stream_name ).string_ref();
     auto stream_it = _streams.find( stream_name );
     if( stream_it == _streams.end() )
         DDS_THROW( runtime_error,
                    "Received stream options for stream '" << stream_name << "' whose header was not received yet" );
 
-    if( auto options_j = j.nested( "options" ) )
+    if( auto options_j = j.nested( topics::notification::stream_options::key::options ) )
     {
         dds_options options;
-        for( auto & option : options_j )
+        for( auto & option_j : options_j )
         {
-            options.push_back( dds_option::from_json( option ) );
+            LOG_DEBUG( "[" << debug_name() << "]     ... " << option_j );
+            auto option = dds_option::from_json( option_j );
+            options.push_back( option );
         }
 
         stream_it->second->init_options( options );
     }
 
-    if( auto j_int = j.nested( "intrinsics" ) )
+    if( auto j_int = j.nested( topics::notification::stream_options::key::intrinsics ) )
     {
         if( auto video_stream = std::dynamic_pointer_cast< dds_video_stream >( stream_it->second ) )
         {
@@ -688,12 +704,14 @@ void dds_device::impl::on_stream_options( rsutils::json const & j, eprosima::fas
         }
         else if( auto motion_stream = std::dynamic_pointer_cast< dds_motion_stream >( stream_it->second ) )
         {
-            motion_stream->set_accel_intrinsics( motion_intrinsics::from_json( j_int.at( "accel" ) ) );
-            motion_stream->set_gyro_intrinsics( motion_intrinsics::from_json( j_int.at( "gyro" ) ) );
+            motion_stream->set_accel_intrinsics( motion_intrinsics::from_json(
+                j_int.at( topics::notification::stream_options::intrinsics::key::accel ) ) );
+            motion_stream->set_gyro_intrinsics( motion_intrinsics::from_json(
+                j_int.at( topics::notification::stream_options::intrinsics::key::gyro ) ) );
         }
     }
 
-    if( auto filters_j = j.nested( "recommended-filters" ) )
+    if( auto filters_j = j.nested( topics::notification::stream_options::key::recommended_filters ) )
     {
         std::vector< std::string > filter_names;
         for( auto & filter : filters_j )

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -120,7 +120,8 @@ private:
     void create_control_writer();
 
     // notification handlers
-    void on_option_value( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_set_option( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_query_options( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
     void on_known_notification( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
     void on_log( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
     void on_device_header( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
@@ -128,12 +129,7 @@ private:
     void on_stream_header( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
     void on_stream_options( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
 
-    typedef std::map< std::string,
-                      void ( dds_device::impl::* )( rsutils::json const &,
-                                                    eprosima::fastdds::dds::SampleInfo const & ) >
-        notification_handlers;
-    static notification_handlers const _notification_handlers;
-    void handle_notification( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_notification( rsutils::json &&, eprosima::fastdds::dds::SampleInfo const & );
 
     on_metadata_available_signal _on_metadata_available;
     on_device_log_signal _on_device_log;

--- a/third-party/realdds/src/topics/dds-topic-names.cpp
+++ b/third-party/realdds/src/topics/dds-topic-names.cpp
@@ -1,0 +1,186 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#include <realdds/topics/dds-topic-names.h>
+
+
+namespace realdds {
+namespace topics {
+
+
+namespace notification {
+    namespace key {
+        std::string const id( "id", 2 );
+    }
+    namespace device_header {
+        std::string const id( "device-header", 13 );
+        namespace key {
+            std::string const n_streams( "n-streams", 9 );
+            std::string const extrinsics( "extrinsics", 10 );
+        }
+    }
+    namespace device_options {
+        std::string const id( "device-options", 14 );
+        namespace key {
+            std::string const options( "options", 7 );
+        }
+    }
+    namespace stream_header {
+        std::string const id( "stream-header", 13 );
+        namespace key {
+            std::string const type( "type", 4 );
+            std::string const name( "name", 4 );
+            std::string const sensor_name( "sensor-name", 11 );
+            std::string const profiles( "profiles", 8 );
+            std::string const default_profile_index( "default-profile-index", 21 );
+            std::string const metadata_enabled( "metadata-enabled", 16 );
+        }
+    }
+    namespace stream_options {
+        std::string const id( "stream-options", 14 );
+        namespace key {
+            std::string const stream_name( "stream-name", 11 );
+            std::string const options( "options", 7 );
+            std::string const intrinsics( "intrinsics", 10 );
+            std::string const recommended_filters( "recommended-filters", 19 );
+        }
+        namespace intrinsics {
+            namespace key {
+                std::string const accel( "accel", 5 );
+                std::string const gyro( "gyro", 4 );
+            }
+        }
+    }
+    namespace log {
+        std::string const id( "log", 3 );
+        namespace key {
+            std::string const entries( "entries", 7 );
+        }
+    }
+    namespace query_options {
+        std::string const id( "query-options", 13 );
+        namespace key {
+            std::string const option_values( "option-values", 13 );
+        }
+    }
+}
+
+namespace control {
+    namespace key {
+        //using notification::key::id;
+    }
+    namespace set_option {
+        std::string const id( "set-option", 10 );
+        namespace key {
+            std::string const value( "value", 5 );
+            std::string const option_name( "option-name", 11 );
+            std::string const stream_name( "stream-name", 11 );
+        }
+    }
+    namespace query_option {
+        std::string const id( "query-option", 12 );
+        namespace key {
+            //using control::set_option::key::option_name;
+            //using control::set_option::key::stream_name;
+        }
+    }
+    namespace query_options {
+        //using notification::query_options::id;
+        namespace key {
+            //using control::set_option::key::option_name;
+            //using control::set_option::key::stream_name;
+            //using notification::query_options::key::option_values;
+            std::string const sensor_name( "sensor-name", 11 );
+        }
+    }
+    namespace open_streams {
+        std::string const id( "open-streams", 12 );
+        namespace key {
+            std::string const stream_profiles( "stream-profiles", 15 );
+            std::string const reset( "reset", 5 );
+            std::string const commit( "commit", 6 );
+        }
+    }
+    namespace hwm {
+        std::string const id( "hwm", 3 );
+        namespace key {
+            std::string const opcode( "opcode", 6 );
+            std::string const param1( "param1", 6 );
+            std::string const param2( "param2", 6 );
+            std::string const param3( "param3", 6 );
+            std::string const param4( "param4", 6 );
+            std::string const data( "data", 4 );
+            std::string const build_command( "build-command", 13 );
+        }
+    }
+    namespace hw_reset {
+        std::string const id( "hw-reset", 8 );
+    }
+}
+
+namespace reply {
+    namespace key {
+        //using control::key::id;
+        std::string const sample( "sample", 6 );
+        std::string const control( "control", 7 );
+        std::string const status( "status", 6 );
+        std::string const explanation( "explanation", 11 );
+    }
+    namespace status {
+        std::string const ok( "ok", 2 );
+    }
+    namespace set_option {
+        //using control::set_option::id;
+        namespace key {
+            //using control::set_option::key::value;
+        }
+    }
+    namespace query_option {
+        //using control::query_option::id;
+        namespace key {
+            //using control::set_option::key::value;
+        }
+    }
+    namespace query_options {
+        //using control::query_options::id;
+        namespace key {
+            //using notification::query_options::key::option_values;
+        }
+    }
+    namespace open_streams {
+        //using control::open_streams::id;
+        namespace key {
+            //using control::open_streams::key::stream_profiles;
+        }
+    }
+    namespace hwm {
+        //using control::hwm::id;
+        namespace key {
+            //using control::hwm::key::data;
+        }
+    }
+}
+
+namespace metadata {
+    namespace key {
+        std::string const stream_name( "stream-name", 11 );
+        std::string const header( "header", 6 );
+        std::string const metadata( "metadata", 8 );
+    }
+    namespace header {
+        namespace key {
+            std::string const frame_number( "frame-number", 12 );
+            std::string const timestamp( "timestamp", 9 );
+            std::string const timestamp_domain( "timestamp-domain", 16 );
+            std::string const depth_units( "depth-units", 11 );
+        }
+    }
+    namespace metadata {
+        namespace key {
+        }
+    }
+}
+
+
+}  // namespace topics
+}  // namespace realdds

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -130,7 +130,7 @@ inline std::ostream & operator<<( std::ostream & os, json_ref const & j )
 // operator=() get called. But the implementation is a copy-and-swap one, meaning it attempts to construct a json value
 // from the argument. Since the argument isn't a json object (doesn't matter that it has a conversion operator), it does
 // this by attempting to deserialize it with to_json()! We need to avoid this, for this usage and others...
-inline void to_json( rsutils::json & j, json_ref const & jr )
+inline void to_json( json & j, json_ref const & jr )
 {
     j = jr.get_json();
 }

--- a/third-party/rsutils/src/hexarray.cpp
+++ b/third-party/rsutils/src/hexarray.cpp
@@ -48,7 +48,7 @@ void from_json( rsutils::json const & j, hexarray & hexa )
                         } );
     }
     else if( j.is_string() )
-        hexa = hexarray::from_string( j.get< std::string >() );
+        hexa = hexarray::from_string( j.string_ref() );
     else
         throw rsutils::json::type_error::create( 317, "hexarray should be a string", &j );
 }

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -14,6 +14,7 @@ using rsutils::string::hexarray;
 #include <realdds/topics/imu-msg.h>
 #include <realdds/topics/ros2/ros2vector3.h>
 #include <realdds/topics/flexible-msg.h>
+#include <realdds/topics/dds-topic-names.h>
 #include <realdds/dds-device-server.h>
 #include <realdds/dds-stream-server.h>
 
@@ -107,6 +108,21 @@ static std::string stream_name_from_rs2( const rs2::stream_profile & profile )
         break;
     }
     return stream_name;
+}
+
+
+static std::string stream_name_from_rs2( rs2::sensor const & sensor )
+{
+    static std::map< std::string, std::string > sensor_stream_name{
+        { "Stereo Module", rs2_stream_to_string( RS2_STREAM_DEPTH ) },
+        { "RGB Camera", rs2_stream_to_string( RS2_STREAM_COLOR ) },
+        { "Motion Module", "Motion" },
+    };
+
+    auto it = sensor_stream_name.find( sensor.get_info( RS2_CAMERA_INFO_NAME ) );
+    if( it == sensor_stream_name.end() )
+        return {};
+    return it->second;
 }
 
 
@@ -613,6 +629,70 @@ lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< 
 
     // Initialize the DDS device server with the supported streams
     _dds_device_server->init( supported_streams, options, extrinsics );
+
+    for( auto & name_sensor : _rs_sensors )
+    {
+        auto & sensor = name_sensor.second;
+        sensor.on_options_changed(
+            [this, weak_sensor = std::weak_ptr< rs2_sensor >( sensor.get() )]( rs2::options_list const & options )
+            {
+                if( auto strong_sensor = weak_sensor.lock() )
+                {
+                    rs2::sensor sensor( strong_sensor );
+                    json option_values = json::object();
+                    for( auto changed_option : options )
+                    {
+                        std::string const option_name = sensor.get_option_name( changed_option->id );
+                        std::string const stream_name = stream_name_from_rs2( sensor );
+                        if( stream_name.empty() )
+                        {
+                            LOG_ERROR( "Unknown option '" << option_name
+                                                          << "' stream: " << sensor.get_info( RS2_CAMERA_INFO_NAME ) );
+                            continue;
+                        }
+                        auto dds_option = _dds_device_server->find_option( option_name, stream_name );
+                        if( ! dds_option )
+                        {
+                            LOG_ERROR( "Missing option '" << option_name
+                                                          << "' stream: " << sensor.get_info( RS2_CAMERA_INFO_NAME ) );
+                            continue;
+                        }
+                        json value;
+                        switch( changed_option->type )
+                        {
+                        case RS2_OPTION_TYPE_FLOAT:
+                            value = changed_option->as_float;
+                            break;
+                        case RS2_OPTION_TYPE_STRING:
+                            value = changed_option->as_string;
+                            break;
+                        case RS2_OPTION_TYPE_NUMBER:
+                            value = changed_option->as_number_signed;
+                            break;
+                        case RS2_OPTION_TYPE_COUNT:
+                            // No value available
+                            value = rsutils::null_json;
+                            break;
+                        default:
+                            LOG_ERROR( "Unknown option '" << option_name << "' type: "
+                                                          << rs2_option_type_to_string( changed_option->type ) );
+                            continue;
+                        }
+                        dds_option->set_value( std::move( value ) );
+                        option_values[stream_name][option_name] = dds_option->get_value();
+                    }
+                    if( option_values.size() )
+                    {
+                        json j = json::object( {
+                            { realdds::topics::notification::key::id, realdds::topics::reply::query_options::id },
+                            { realdds::topics::reply::query_options::key::option_values, std::move( option_values ) },
+                        } );
+                        LOG_DEBUG( "[" << _dds_device_server->debug_name() << "] options changed: " << j.dump( 4 ) );
+                        _dds_device_server->publish_notification( std::move( j ) );
+                    }
+                }
+            } );
+    }
 }
 
 
@@ -630,10 +710,10 @@ bool lrs_device_controller::on_open_streams( json const & control, json & reply 
     // out, a sensor is reset back to its default state using implicit stream selection.
     // (For example, the 'Stereo Module' sensor controls Depth, IR1, IR2: but turning on all 3 has performance
     // implications and may not be desirable. So you can open only Depth and IR1/2 will stay inactive...)
-    if( control.nested( "reset" ).default_value( true ) )
+    if( control.nested( topics::control::open_streams::key::reset ).default_value( true ) )
         _bridge.reset();
 
-    auto const & msg_profiles = control["stream-profiles"];
+    auto const & msg_profiles = control[topics::control::open_streams::key::stream_profiles];
     for( auto const & name2profile : msg_profiles.items() )
     {
         std::string const & stream_name = name2profile.key();
@@ -653,7 +733,7 @@ bool lrs_device_controller::on_open_streams( json const & control, json & reply 
     }
 
     // We're here so all the profiles were acceptable; lock them in -- with no implicit profiles!
-    if( control.nested( "commit" ).default_value( true ) )
+    if( control.nested( topics::control::open_streams::key::commit ).default_value( true ) )
         _bridge.commit();
 
     // We don't touch the reply - it's already filled in for us
@@ -667,12 +747,12 @@ void lrs_device_controller::publish_frame_metadata( const rs2::frame & f, realdd
         return;
 
     json md_header = json::object( {
-        { "frame-number", f.get_frame_number() },               // communicated; up to client to pick up
-        { "timestamp", timestamp.to_ns() },                     // syncer key: needs to match the image timestamp, bit-for-bit!
-        { "timestamp-domain", f.get_frame_timestamp_domain() }  // needed if we're dealing with different domains!
+        { topics::metadata::header::key::frame_number, f.get_frame_number() },               // communicated; up to client to pick up
+        { topics::metadata::header::key::timestamp, timestamp.to_ns() },                     // syncer key: needs to match the image timestamp, bit-for-bit!
+        { topics::metadata::header::key::timestamp_domain, f.get_frame_timestamp_domain() }  // needed if we're dealing with different domains!
     } );
     if( f.is< rs2::depth_frame >() )
-        md_header["depth-units"] = f.as< rs2::depth_frame >().get_units();
+        md_header[topics::metadata::header::key::depth_units] = f.as< rs2::depth_frame >().get_units();
 
     json metadata = json::object();
     for( size_t i = 0; i < static_cast< size_t >( RS2_FRAME_METADATA_COUNT ); ++i )
@@ -683,9 +763,9 @@ void lrs_device_controller::publish_frame_metadata( const rs2::frame & f, realdd
     }
 
     json md_msg = json::object( {
-        { "stream-name", stream_name_from_rs2( f.get_profile() ) },
-        { "header", std::move( md_header ) },
-        { "metadata", std::move( metadata ) },
+        { topics::metadata::key::stream_name, stream_name_from_rs2( f.get_profile() ) },
+        { topics::metadata::key::header, std::move( md_header ) },
+        { topics::metadata::key::metadata, std::move( metadata ) },
     } );
     _dds_device_server->publish_metadata( std::move( md_msg ) );
 }
@@ -840,12 +920,11 @@ size_t lrs_device_controller::get_index_of_profile( const realdds::dds_stream_pr
 
 bool lrs_device_controller::on_control( std::string const & id, json const & control, json & reply )
 {
-    static std::map< std::string, bool ( lrs_device_controller::* )( json const &, json & ) > const
-        control_handlers{
-            { "hw-reset", &lrs_device_controller::on_hardware_reset },
-            { "open-streams", &lrs_device_controller::on_open_streams },
-            { "hwm", &lrs_device_controller::on_hwm },
-        };
+    static std::map< std::string, bool ( lrs_device_controller::* )( json const &, json & ) > const control_handlers{
+        { realdds::topics::control::hw_reset::id, &lrs_device_controller::on_hardware_reset },
+        { realdds::topics::control::open_streams::id, &lrs_device_controller::on_open_streams },
+        { realdds::topics::control::hwm::id, &lrs_device_controller::on_hwm },
+    };
     auto it = control_handlers.find( id );
     if( it == control_handlers.end() )
         return false;
@@ -870,35 +949,35 @@ bool lrs_device_controller::on_hwm( json const & control, json & reply )
     rsutils::string::hexarray data;
 
     uint32_t opcode;
-    if( control.nested( "opcode" ).get_ex( opcode ) )
+    if( control.nested( topics::control::hwm::key::opcode ).get_ex( opcode ) )
     {
         // In the presence of 'opcode', we're asked to build the command using optional parameters
         uint32_t param1 = 0, param2 = 0, param3 = 0, param4 = 0;
-        control.nested( "param1" ).get_ex( param1 );
-        control.nested( "param2" ).get_ex( param2 );
-        control.nested( "param3" ).get_ex( param3 );
-        control.nested( "param4" ).get_ex( param4 );
+        control.nested( topics::control::hwm::key::param1 ).get_ex( param1 );
+        control.nested( topics::control::hwm::key::param2 ).get_ex( param2 );
+        control.nested( topics::control::hwm::key::param3 ).get_ex( param3 );
+        control.nested( topics::control::hwm::key::param4 ).get_ex( param4 );
 
-        control.nested( "data" ).get_ex( data );  // optional
+        control.nested( topics::control::hwm::key::data ).get_ex( data );  // optional
 
         // Build the HWM command
         data = dp.build_command( opcode, param1, param2, param3, param4, data.get_bytes() );
 
         // And, if told to not actually run it, we return the HWM command
-        if( control.nested( "build-command" ).default_value( false ) )
+        if( control.nested( topics::control::hwm::key::build_command ).default_value( false ) )
         {
-            reply["data"] = data;
+            reply[topics::reply::hwm::key::data] = data;
             return true;
         }
     }
     else
     {
-        if( ! control.nested( "data" ).get_ex( data ) )
+        if( ! control.nested( topics::control::hwm::key::data ).get_ex( data ) )
             throw std::runtime_error( "no 'data' in HWM control" );
     }
 
     data = dp.send_and_receive_raw_data( data.get_bytes() );
-    reply["data"] = data;
+    reply[topics::reply::hwm::key::data] = data;
     return true;
 }
 

--- a/unit-tests/dds/test-control-reply.py
+++ b/unit-tests/dds/test-control-reply.py
@@ -99,9 +99,10 @@ with test.remote.fork( nested_indent=None ) as remote:
             server_sequence += 1
             expect_notifications( n )
             reply = device.send_control( json, True )  # Wait for reply
-            test.check_equal( reply['id'], json['id'] )
             if test.check( reply.get('control') is not None ):
                 test.check_equal( reply['control']['id'], json['id'] )
+            else:
+                test.check_equal( reply['id'], json['id'] )
             test.check_equal( reply['sequence'], server_sequence )
             test.check_equal( reply['sample'][0], str(device.guid()) )
             notifications.wait( 3 )  # We may get the reply before the other notifications are received


### PR DESCRIPTION
Previous `query-option` was simplified and split into a separate `query-options` (plural).
This allows implementation of proper sensor-based bulk queries from a DDS device (that, funnily enough, are still not being used.: in my next PR, they're not needed -- the adapter sends updates directly to the client and the client just caches everything).

* topic JSON structure is now reflected in `dds-topic-names.h`
* reply `id` field is now taken from the embedded `control`

