### PR TITLE
Add more logs to MD alive test to debug failures

### DIFF
--- a/unit-tests/live/metadata/test-alive.py
+++ b/unit-tests/live/metadata/test-alive.py
@@ -73,14 +73,12 @@ def are_metadata_values_different(metadata_type_1, metadata_type_2, number_frame
         f = frame_queue.wait_for_frame()
         current_md_1_value = f.get_frame_metadata(metadata_type_1)
         current_md_2_value = f.get_frame_metadata(metadata_type_2)
-        if current_md_1_value == current_md_2_value:
-            return False
-
+        test.info(metadata_type_1, current_md_1_value)
+        test.info(metadata_type_2, current_md_2_value)
+        test.check( current_md_1_value != current_md_2_value )
         number_frames_to_test -= 1
 
-    return True
-
-def is_value_keep_increasing(metadata_value, number_frames_to_test=50) -> bool:
+def is_value_keep_increasing(metadata_type, number_frames_to_test=50) -> bool:
     """
     Check that a given counter in metadata increases
     :param metadata_value: that we need to check
@@ -92,16 +90,13 @@ def is_value_keep_increasing(metadata_value, number_frames_to_test=50) -> bool:
 
     while number_frames_to_test > 0:
         f = frame_queue.wait_for_frame()
-        current_value = f.get_frame_metadata(metadata_value)
-
-        if prev_metadata_value >= current_value:
-            return False
-
+        current_value = f.get_frame_metadata(metadata_type)
+        test.info('metadata_type', metadata_type)
+        test.info('prev_metadata_value', prev_metadata_value)
+        test.info('current_value', current_value)
+        test.check( prev_metadata_value < current_value)
         prev_metadata_value = current_value
         number_frames_to_test -= 1
-
-    return True
-
 
 queue_capacity = 1
 frame_queue = None
@@ -121,29 +116,29 @@ for profile, sensor in testing_profiles.items():
     # Test #1 Increasing frame counter
     if is_frame_support_metadata(frame_queue.wait_for_frame(), rs.frame_metadata_value.frame_counter):
         test.start('Verifying increasing counter for profile ', profile)
-        test.check(is_value_keep_increasing(rs.frame_metadata_value.frame_counter))
+        is_value_keep_increasing(rs.frame_metadata_value.frame_counter)
         test.finish()
 
     # Test #2 Increasing frame timestamp
     if is_frame_support_metadata(frame_queue.wait_for_frame(), rs.frame_metadata_value.frame_timestamp):
         test.start('Verifying increasing time for profile ', profile)
-        test.check(is_value_keep_increasing(rs.frame_metadata_value.frame_timestamp))
+        is_value_keep_increasing(rs.frame_metadata_value.frame_timestamp)
         test.finish()
 
     # Test #3 Increasing sensor timestamp
     if is_frame_support_metadata(frame_queue.wait_for_frame(), rs.frame_metadata_value.sensor_timestamp):
         test.start('Verifying increasing sensor timestamp for profile ', profile)
-        test.check(is_value_keep_increasing(rs.frame_metadata_value.sensor_timestamp))
+        is_value_keep_increasing(rs.frame_metadata_value.sensor_timestamp)
         test.finish()
 
         # On D457, sensor timestamp == frame timestamp, so we ignore it
         camera_name = device.get_info(rs.camera_info.name)
         if 'D457' not in camera_name:
             test.start('Verifying sensor timestamp is different than frame timestamp for profile ', profile)
-            test.check(are_metadata_values_different(rs.frame_metadata_value.frame_timestamp, rs.frame_metadata_value.sensor_timestamp))
+            are_metadata_values_different(rs.frame_metadata_value.frame_timestamp, rs.frame_metadata_value.sensor_timestamp)
             test.finish()
 
     close_resources(sensor)
-    time.sleep(0.3)  # better sleep before stopping/starting streaming, so we can let the device recover properly.
+    time.sleep( 1 )  # better sleep before stopping/starting streaming, so we can let the device recover properly.
 
 test.print_results_and_exit()


### PR DESCRIPTION
* Since we get occasional failures on metadata alive test, this PR add some more info on the checked data
* Increase sleep between iterations, they may relax some failures
* Some cosmetics