### PR TITLE
Minimal CMake GHA test fix

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -119,6 +119,7 @@ jobs:
           git checkout 687dc56e1cf52c865cebf6ac94ad67906d6e1369
           
           echo "Install LibRealSense pre-installed packages requirements"
+          sudo apt-get update 
           sudo apt-get install libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev at
           
           python3 -mvenv venv


### PR DESCRIPTION
GHA minimal CMake test started failing today:
![image](https://github.com/IntelRealSense/librealsense/assets/64067618/5649317b-953b-4dbe-ba48-b2b8100ed602)

Started getting package install errors on this line:
`sudo apt-get install libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev at`

`Err:17 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libgl1-mesa-dev amd64 23.0.4-0ubuntu1~22.04.1
  404  Not Found [IP: 20.106.104.242 80]`

Updating the APT cache seems to fix that