### PR TITLE
Extended HWM commands refactor

### DIFF
--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -84,23 +84,6 @@ namespace librealsense
             max_id = -1
         };
 
-        const std::map<ds::d500_calibration_table_id, uint32_t> d500_calibration_tables_size =
-        {
-            {d500_calibration_table_id::depth_eeprom_toc_id, 640},
-            {d500_calibration_table_id::module_info_id, 512},
-            {d500_calibration_table_id::rgb_lens_shading_id, 1088},
-            {d500_calibration_table_id::left_lens_shading_id, 576},
-            {d500_calibration_table_id::right_lens_shading_id, 512},
-            {d500_calibration_table_id::depth_calibration_id, 512},
-            {d500_calibration_table_id::left_x_lut_id, 4160},
-            {d500_calibration_table_id::left_y_lut_id, 4160},
-            {d500_calibration_table_id::right_x_lut_id, 4160},
-            {d500_calibration_table_id::right_y_lut_id, 4160},
-            {d500_calibration_table_id::rgb_calibration_id, 256},
-            {d500_calibration_table_id::rgb_lut_id, 8256},
-            {d500_calibration_table_id::imu_calibration_id, 192}
-        };
-
         struct d500_undist_configuration
         {
             uint32_t     fx;

--- a/src/ds/d500/hw_monitor_extended_buffers.cpp
+++ b/src/ds/d500/hw_monitor_extended_buffers.cpp
@@ -67,8 +67,8 @@ namespace librealsense
 
         if (recv_msg_length > HW_MONITOR_BUFFER_SIZE)
         {
-            // currently we assume HKR send only the table size when sending 0/0 chanks command above.
-            // in the future the FW should send chunk 1 in 0/0 command and than we can use it here.
+            // currently we assume HKR sends only the table size when sending 0/0 chunks command above.
+            // in the future the FW should send chunk 1 in 0/0 command and then we can use it here.
             // meaning remove the 'clear' and start the loop from 1
 
             recv_msg.clear();

--- a/src/ds/d500/hw_monitor_extended_buffers.cpp
+++ b/src/ds/d500/hw_monitor_extended_buffers.cpp
@@ -2,45 +2,29 @@
 // Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
 #include "hw_monitor_extended_buffers.h"
-#include "ds/d500/d500-private.h"
+#include <ds/ds-private.h>
 
 
 namespace librealsense
 {
-    int hw_monitor_extended_buffers::get_msg_length(command cmd) const
-    {
-        int msg_length = HW_MONITOR_BUFFER_SIZE;
-        if (cmd.cmd == ds::fw_cmd::GET_HKR_CONFIG_TABLE || cmd.cmd == ds::fw_cmd::SET_HKR_CONFIG_TABLE)
-        {
-            auto calib_table_id = static_cast<ds::d500_calibration_table_id>(cmd.param2);
-            auto it = ds::d500_calibration_tables_size.find(calib_table_id);
-            if (it == ds::d500_calibration_tables_size.end())
-                throw std::runtime_error(rsutils::string::from() << " hwm command with wrong param2");
 
-            msg_length = it->second;
-        }
-        return msg_length;
-    }
-
-    int hw_monitor_extended_buffers::get_number_of_chunks(int msg_length) const
+    int hw_monitor_extended_buffers::get_number_of_chunks(size_t msg_length) const
     {
-        return static_cast<int>(std::ceil(msg_length / 1024.0f));
+        return static_cast<int>(std::ceil(msg_length / (float)HW_MONITOR_BUFFER_SIZE));
     }
 
     hw_monitor_extended_buffers::hwm_buffer_type hw_monitor_extended_buffers::get_buffer_type(command cmd) const
     {
-        if (cmd.cmd == ds::fw_cmd::GET_HKR_CONFIG_TABLE || cmd.cmd == ds::fw_cmd::SET_HKR_CONFIG_TABLE)
+        bool provide_whole_table = (cmd.param4 == 0);
+        switch( cmd.cmd)
         {
-            auto calibration_table_size = get_msg_length(cmd);
-
-            bool provide_whole_table = (cmd.param4 == 0);
-            if (calibration_table_size <= HW_MONITOR_COMMAND_SIZE || !provide_whole_table)
-                return hwm_buffer_type::standard;
-            if (cmd.cmd == ds::fw_cmd::GET_HKR_CONFIG_TABLE)
-                return hwm_buffer_type::big_buffer_to_receive;
-            return hwm_buffer_type::big_buffer_to_send;
+        case ds::fw_cmd::GET_HKR_CONFIG_TABLE:
+            return provide_whole_table ? hwm_buffer_type::extended_receive : hwm_buffer_type::standard;
+        case ds::fw_cmd::SET_HKR_CONFIG_TABLE:
+            return provide_whole_table ? hwm_buffer_type::extended_send : hwm_buffer_type::standard;
+        default:
+            return hwm_buffer_type::standard;
         }
-        return hwm_buffer_type::standard;
     }
 
     // 3 cases are foreseen in this method:
@@ -50,43 +34,62 @@ namespace librealsense
     std::vector<uint8_t> hw_monitor_extended_buffers::send(command const & cmd, hwmon_response* p_response, bool locked_transfer) const
     {
         hwm_buffer_type buffer_type = get_buffer_type(cmd);
-        if (buffer_type == hwm_buffer_type::standard)
+        switch( buffer_type)
+        {
+        case hwm_buffer_type::standard:
             return hw_monitor::send(cmd, p_response, locked_transfer);
-
-        if (buffer_type == hwm_buffer_type::big_buffer_to_receive)
-            return send_big_buffer_to_receive(cmd, p_response, locked_transfer);
-
-        // hwm_buffer_type::big_buffer_to_send is the last remaining option
-        send_big_buffer_to_send(cmd, p_response, locked_transfer);
+        case hwm_buffer_type::extended_receive:
+            return extended_receive(cmd, p_response, locked_transfer);
+        case  hwm_buffer_type::extended_send:
+            extended_send(cmd, p_response, locked_transfer);
+        default:
+            return std::vector<uint8_t>();
+        }
         return std::vector<uint8_t>();
     }
 
-    std::vector<uint8_t> hw_monitor_extended_buffers::send_big_buffer_to_receive(command cmd, hwmon_response* p_response, bool locked_transfer) const
+    std::vector<uint8_t> hw_monitor_extended_buffers::extended_receive(command cmd, hwmon_response* p_response, bool locked_transfer) const
     {
-        int recv_msg_length = get_msg_length(cmd);
-        uint16_t overall_chunks = get_number_of_chunks(recv_msg_length);
-
         std::vector< uint8_t > recv_msg;
-        for (int i = 0; i < overall_chunks; ++i)
+
+        // send first command with 0/0 on param4, as we don't know the table size
+        // actual size will be returned as part for the response header and will be used
+        // to calculate the extended loop range
+        auto ans = hw_monitor::send(cmd, p_response, locked_transfer);
+        recv_msg.insert(recv_msg.end(), ans.begin(), ans.end());
+
+        if (recv_msg.size() < sizeof(ds::table_header))
+            throw std::runtime_error(rsutils::string::from() << "Table data has invalid size = " << recv_msg.size());
+
+
+        ds::table_header* th = reinterpret_cast<ds::table_header*>( ans.data() );
+        size_t recv_msg_length = sizeof(ds::table_header) + th->table_size;
+
+        if (recv_msg_length > HW_MONITOR_BUFFER_SIZE)
         {
-            // chunk number is in param4
-            cmd.param4 = compute_chunks_param(overall_chunks, i);
-        
-            auto ans = hw_monitor::send(cmd, p_response, locked_transfer);
-            recv_msg.insert(recv_msg.end(), ans.begin(), ans.end());
+            // currently we assume HKR send only the table size when sending 0/0 chanks command above.
+            // in the future the FW should send chunk 1 in 0/0 command and than we can use it here.
+            // meaning remove the 'clear' and start the loop from 1
+
+            recv_msg.clear();
+            uint16_t overall_chunks = get_number_of_chunks( recv_msg_length );
+            for( int i = 0; i < overall_chunks; ++i )
+            {
+                // chunk number is in param4
+                cmd.param4 = compute_chunks_param( overall_chunks, i );
+
+                auto ans = hw_monitor::send( cmd, p_response, locked_transfer );
+                recv_msg.insert( recv_msg.end(), ans.begin(), ans.end() );
+            }
         }
         return recv_msg;
     }
 
-    void hw_monitor_extended_buffers::send_big_buffer_to_send(command cmd, hwmon_response* p_response, bool locked_transfer) const
+    void hw_monitor_extended_buffers::extended_send(command cmd, hwmon_response* p_response, bool locked_transfer) const
     {
-        int send_msg_length = get_msg_length(cmd);
-        uint16_t overall_chunks = get_number_of_chunks(send_msg_length);
-
-        // copying the data, so that this param can be overrien for the sending via hwm
+        // copying the data, so that this param can be reused for the sending via HWM
         auto table_data = cmd.data;
-        if (table_data.size() != send_msg_length)
-            throw std::runtime_error(rsutils::string::from() << "Table data has size = " << table_data.size() << ", it should be: " << send_msg_length);
+        uint16_t overall_chunks = get_number_of_chunks(table_data.size());
 
         std::vector<uint8_t> answer;
         for (int i = 0; i < overall_chunks; ++i)

--- a/src/ds/d500/hw_monitor_extended_buffers.h
+++ b/src/ds/d500/hw_monitor_extended_buffers.h
@@ -17,8 +17,8 @@ namespace librealsense
         enum class hwm_buffer_type
         {
             standard,
-            big_buffer_to_receive,
-            big_buffer_to_send
+            extended_receive,
+            extended_send
         };
 
         explicit hw_monitor_extended_buffers(std::shared_ptr<locked_transfer> locked_transfer)
@@ -29,11 +29,10 @@ namespace librealsense
         virtual std::vector<uint8_t> send(command const & cmd, hwmon_response* = nullptr, bool locked_transfer = false) const override;
 
     private:
-        int get_msg_length(command cmd) const;
-        int get_number_of_chunks(int msg_length) const;
+        int get_number_of_chunks(size_t msg_length) const;
         hwm_buffer_type get_buffer_type(command cmd) const;
-        std::vector<uint8_t> send_big_buffer_to_receive(command cmd, hwmon_response* p_response, bool locked_transfer) const;
-        void send_big_buffer_to_send(command cmd, hwmon_response* p_response, bool locked_transfer) const;
+        std::vector<uint8_t> extended_receive(command cmd, hwmon_response* p_response, bool locked_transfer) const;
+        void extended_send(command cmd, hwmon_response* p_response, bool locked_transfer) const;
 
         // The following method prepares the param4 of the command for extended buffers
         // The aim of this param is to send the chunk number out of max of expected chunks for the current command


### PR DESCRIPTION
When we get config table we get the size in the header.
This PR remove the hard coded tables sizes, and leverage the header size value.
Also did some renaming

Tracked on [RSDEV-1735]