### PR TITLE
Options: add BOOLEAN & ENUM

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include "post-processing-filters-list.h"
 #include "post-processing-block-model.h"
@@ -89,7 +89,10 @@ namespace rs2
                     if( it != options_metadata.end() && ! _destructing ) // Callback runs in different context, check options_metadata still valid
                     {
                         if( RS2_OPTION_TYPE_FLOAT == changed_option->type )
-                            it->second.value = changed_option->as_float;
+                        {
+                            if( changed_option->is_valid )
+                                it->second.value = changed_option->as_float;
+                        }
                     }
                 }
             } );

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -163,7 +163,8 @@ extern "C" {
     typedef struct rs2_option_value
     {
         rs2_option id;
-        rs2_option_type type;             /**< RS2_OPTION_TYPE_COUNT if no value is available */
+        int is_valid;                     /**< 0 if no value available; 1 otherwise */
+        rs2_option_type type;
         union {
             char const * as_string;       /**< valid only while rs2_option_value is alive! */
             float as_float;

--- a/include/librealsense2/h/rs_option.h
+++ b/include/librealsense2/h/rs_option.h
@@ -147,6 +147,7 @@ extern "C" {
         RS2_OPTION_TYPE_INTEGER, /**< 64-bit signed integer value */
         RS2_OPTION_TYPE_FLOAT,
         RS2_OPTION_TYPE_STRING,
+        RS2_OPTION_TYPE_BOOLEAN,
 
         RS2_OPTION_TYPE_COUNT
 
@@ -168,7 +169,7 @@ extern "C" {
         union {
             char const * as_string;       /**< valid only while rs2_option_value is alive! */
             float as_float;
-            int64_t as_integer;
+            int64_t as_integer;           /**< including boolean value */
         };
     } rs2_option_value;
 

--- a/src/core/option-interface.h
+++ b/src/core/option-interface.h
@@ -1,10 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include "extension.h"
-
 #include <src/basics.h>
+#include <librealsense2/h/rs_option.h>
+#include <rsutils/json-fwd.h>
 
 
 namespace librealsense {
@@ -23,6 +24,14 @@ class LRS_EXTENSION_API option : public recordable< option >
 public:
     virtual void set( float value ) = 0;
     virtual float query() const = 0;
+
+    // Return the value currently assigned to the option
+    // By default, this is the result of query()
+    virtual rsutils::json get_value() const noexcept;
+
+    // Return the type of the option value
+    virtual rs2_option_type get_value_type() const noexcept;
+
     virtual option_range get_range() const = 0;
     virtual bool is_enabled() const = 0;
     virtual bool is_read_only() const { return false; }

--- a/src/dds/rs-dds-depth-sensor-proxy.cpp
+++ b/src/dds/rs-dds-depth-sensor-proxy.cpp
@@ -16,13 +16,8 @@ namespace librealsense {
 float dds_depth_sensor_proxy::get_depth_scale() const
 {
     if( auto opt = get_option_handler( RS2_OPTION_DEPTH_UNITS ) )
-    {
-        // We don't want to do a long control-reply cycle on a value that gets updated automatically
-        if( auto dds_option = std::dynamic_pointer_cast< rs_dds_option >( opt ) )
-            return dds_option->get_last_known_value();
-        else
-            return opt->query();
-    }
+        return opt->get_value();
+
     // Rather than throwing an exception, we try to be a little more helpful: without depth units, the depth image will
     // show black, prompting bug reports. The D400 units min/max are taken from the HW, but the default is set to:
     return 0.001f;

--- a/src/dds/rs-dds-option.h
+++ b/src/dds/rs-dds-option.h
@@ -1,6 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2024 Intel Corporation. All Rights Reserved.
-
 #pragma once
 
 #include <src/option.h>
@@ -21,6 +20,7 @@ namespace librealsense {
 class rs_dds_option : public option_base
 {
     std::shared_ptr< realdds::dds_option > _dds_opt;
+    rs2_option_type const _rs_type;
 
 public:
     typedef std::function< void( const std::string & name, float value ) > set_option_callback;
@@ -35,15 +35,17 @@ public:
                    set_option_callback set_opt_cb,
                    query_option_callback query_opt_cb );
 
-    void set( float value ) override;
+    rsutils::json get_value() const noexcept override;
+    rs2_option_type get_value_type() const noexcept override { return _rs_type; }
 
-    float get_last_known_value() const;
+    void set( float value ) override;
 
     float query() const override;
 
     bool is_read_only() const override;
     bool is_enabled() const override;
     const char * get_description() const override;
+    const char * get_value_description( float ) const override;
 };
 
 

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -5,6 +5,9 @@
 #include "sensor.h"
 
 #include <rsutils/string/from.h>
+#include <rsutils/json.h>
+
+using rsutils::json;
 
 
 namespace librealsense {
@@ -35,6 +38,19 @@ void option_base::enable_recording(std::function<void(const option&)> recording_
 {
     _recording_function = recording_action;
 }
+
+json option::get_value() const noexcept
+{
+    return query();
+}
+
+
+rs2_option_type option::get_value_type() const noexcept
+{
+    // By default, all options are floats
+    return RS2_OPTION_TYPE_FLOAT;
+}
+
 
 void option::create_snapshot(std::shared_ptr<option>& snapshot) const
 {

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -124,6 +124,13 @@ struct rs2_option_value_wrapper : rs2_option_value
                 p_json->get_to( as_integer );
                 break;
 
+            case RS2_OPTION_TYPE_BOOLEAN:
+                if( ! p_json->is_boolean() )
+                    throw invalid_value_exception( get_string( option_id )
+                                                   + " value is not a boolean: " + p_json->dump() );
+                as_integer = p_json->get< bool >();
+                break;
+
             case RS2_OPTION_TYPE_STRING:
                 if( ! p_json->is_string() )
                     throw invalid_value_exception( get_string( option_id )

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -733,6 +733,7 @@ std::string const & get_string( rs2_option_type value )
         CASE( FLOAT )
         CASE( STRING )
         CASE( INTEGER )
+        CASE( BOOLEAN )
 #undef CASE
             return arr;
     }();

--- a/third-party/realdds/doc/initialization.md
+++ b/third-party/realdds/doc/initialization.md
@@ -94,7 +94,7 @@ This is optional: not all devices have options. See [device](device.md).
                 * Booleans can be expressed as a range with `minimum=0`, `maximum=1`, `stepping=1`
             * Free string options would likewise have no range, e.g. `["Name", "Bob", "", "The customer's name"]`
                 * `"IPv4"` is a string option that conforms to `W.X.Y.Z` (IP address) format
-            * Choice options are strings with an array of choices, e.g. `["Preset", "Maximum Quality", ["Maximum Range", "Maximum Quality", "Maximum Speed"], "Maximum Speed", "Standard preset combination of options"]`
+            * Enum options are strings with an array of choices, e.g. `["Preset", "Maximum Quality", ["Maximum Range", "Maximum Quality", "Maximum Speed"], "Maximum Speed", "Standard preset combination of options"]`
         * A `default-value` which also adheres to the range
             * If this and the range are missing, the option is read-only
         * A user-friendly description that describes the option, to be shown in any tooltip
@@ -102,7 +102,8 @@ This is optional: not all devices have options. See [device](device.md).
             * `"optional"` to note that it's possible for it to not have a value; lack of a value is denoted as `null` in the JSON
                 * If optional, a type must be deducible or present in the properties
                 * E.g., `["name", null, "description", ["optional", "string"]]` is an optional read-only string value that's currently unset
-            * `"string"`, `"int"`, `"boolean"`, `"float"`, `"IPv4"` can (and sometime must) indicate the value type
+                * Enums cannot be optional
+            * `"string"`, `"int"`, `"boolean"`, `"float"`, `"IPv4"`, `"enum"` can (and sometime must) indicate the value type
                 * If missing, the type will be deduced, if possible, from the values
             * `"read-only"` options are not settable
                 * `set-option` will fail for these, though their value may change on the server side

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -65,7 +65,7 @@ public:
     virtual void init( std::string name, std::string description );
     virtual void init_properties( option_properties && );
     virtual void init_default_value( rsutils::json );
-    virtual void init_range( rsutils::json const & min, rsutils::json const & max, rsutils::json const & step );
+    virtual void init_range( rsutils::json min, rsutils::json max, rsutils::json step );
     virtual void init_value( rsutils::json );
 
     bool is_read_only() const { return _flags & flag::read_only; }
@@ -87,7 +87,7 @@ public:
 
     void set_value( rsutils::json );
     virtual void check_value( rsutils::json & ) const;
-    virtual void check_type( rsutils::json const & ) const = 0;
+    virtual void check_type( rsutils::json & ) const = 0;
 
     rsutils::json const & get_default_value() const { return _default_value; }
     bool is_default_valid() const { return ! get_default_value().is_null(); }
@@ -116,7 +116,7 @@ public:
 
     char const * value_type() const override { return "float"; }
 
-    void check_type( rsutils::json const & value ) const override;
+    void check_type( rsutils::json & value ) const override;
     static type check_float( rsutils::json const & );
 };
 
@@ -133,8 +133,25 @@ public:
 
     char const * value_type() const override { return "int"; }
 
-    void check_type( rsutils::json const & ) const override;
+    void check_type( rsutils::json & ) const override;
     static type check_integer( rsutils::json const & );
+};
+
+
+class dds_boolean_option : public dds_integer_option
+{
+    using super = dds_integer_option;
+
+public:
+    using type = rsutils::json::boolean_t;
+
+    char const * value_type() const override { return "boolean"; }
+
+    void init_range( rsutils::json, rsutils::json, rsutils::json ) override;
+    void check_type( rsutils::json & ) const override;
+    static type check_boolean( rsutils::json const & );
+
+    type get_boolean() const { return get_value().get< type >(); }
 };
 
 
@@ -145,7 +162,7 @@ class dds_string_option : public dds_option
 public:
     char const * value_type() const override { return "string"; }
 
-    void check_type( rsutils::json const & ) const override;
+    void check_type( rsutils::json & ) const override;
 
     std::string get_string() const { return get_value().get< std::string >(); }
 };
@@ -160,7 +177,7 @@ public:
 
     char const * value_type() const override { return "ip-address"; }
 
-    void check_type( rsutils::json const & ) const override;
+    void check_type( rsutils::json & ) const override;
     static ip_address check_ip( rsutils::json const & );
 
     ip_address get_ip() const { return ip_address( get_value().string_ref() ); }

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -168,6 +168,26 @@ public:
 };
 
 
+class dds_enum_option : public dds_string_option
+{
+    using super = dds_string_option;
+
+    std::vector< std::string > _choices;
+
+public:
+    virtual void init_choices( rsutils::json );
+
+    char const * value_type() const override { return "enum"; }
+
+    void check_value( rsutils::json & ) const override;
+    int get_value_index( std::string const & ) const;
+
+    std::vector< std::string > const & get_choices() const { return _choices; }
+
+    rsutils::json to_json() const override;
+};
+
+
 class dds_ip_option : public dds_string_option
 {
     using super = dds_string_option;

--- a/third-party/realdds/src/dds-option.cpp
+++ b/third-party/realdds/src/dds-option.cpp
@@ -160,7 +160,7 @@ void dds_option::check_value( json & value ) const
     if( value.is_null() )
     {
         if( ! is_optional() )
-            DDS_THROW( runtime_error, "option '" << _name << "' is not optional" );
+            DDS_THROW( runtime_error, "value is not optional" );
     }
     else
     {
@@ -262,6 +262,8 @@ static std::string parse_type( json const & j, size_t size, dds_option::option_p
         case 4:
             if( p == "IPv4" )
                 return props.erase( p ), p;
+            if( 5 == size && p == "enum" )
+                return props.erase( p ), p;
             break;
         }
     }
@@ -284,6 +286,11 @@ static std::string parse_type( json const & j, size_t size, dds_option::option_p
             return type;
         break;
 
+    case 5:  // [name,value,[choices],default,description]
+        if( type_from_value( type, j[1], j[3] ) && type != "string" )
+            DDS_THROW( runtime_error, "non-string enum values" );
+        return "enum";
+
     default:
         DDS_THROW( runtime_error, "unexected size " << size << " of option json" );
     }
@@ -303,6 +310,8 @@ static std::string parse_type( json const & j, size_t size, dds_option::option_p
         return std::make_shared< dds_boolean_option >();
     if( type == "IPv4" )
         return std::make_shared< dds_ip_option >();
+    if( type == "enum" )
+        return std::make_shared< dds_enum_option >();
     return {};
 }
 
@@ -359,9 +368,13 @@ static std::string parse_type( json const & j, size_t size, dds_option::option_p
         option->init_range( j[2], j[3], j[4] );
         break;
 
-    case 5:  // [name,value,[choices],default,description] -> TODO
+    case 5:  // [name,value,[choices],default,description]
+        std::dynamic_pointer_cast< dds_enum_option >( option )->init_choices( j[2] );
+        option->init_default_value( j[3] );
+        break;
+
     default:
-        DDS_THROW( runtime_error, "unexected option json size " << size );
+        DDS_THROW( runtime_error, "unexpected option json size " << size );
     }
 
     // Finally, set the actual value
@@ -497,6 +510,54 @@ void dds_string_option::check_type( json & value ) const
 {
     if( ! value.is_string() )
         DDS_THROW( runtime_error, "not a string: " << value );
+}
+
+
+void dds_enum_option::init_choices( rsutils::json choices )
+{
+    verify_uninitialized();
+
+    if( ! choices.is_array() )
+        DDS_THROW( runtime_error, "enum option requires a choices array" );
+    if( ! _minimum_value.is_null() || ! _maximum_value.is_null() || ! _stepping.is_null() )
+        DDS_THROW( runtime_error, "enum options cannot have a range" );
+
+    _choices.clear();
+    for( auto const & choice : choices )
+    {
+        if( ! choice.is_string() )
+            DDS_THROW( runtime_error, "enum choices must be strings" );
+        _choices.push_back( choice.string_ref() );
+    }
+}
+
+
+int dds_enum_option::get_value_index( std::string const & value ) const
+{
+    for( int i = 0; i < _choices.size(); ++i )
+        if( _choices[i] == value )
+            return i;
+    return -1;
+}
+
+
+void dds_enum_option::check_value( json & value ) const
+{
+    super::check_value( value );
+
+    if( ! value.is_null() )
+    {
+        if( get_value_index( value ) < 0 )
+            DDS_THROW( runtime_error, "invalid enum value: " << value );
+    }
+}
+
+
+json dds_enum_option::to_json() const
+{
+    auto j = super::to_json();
+    j.insert( j.begin() + 2, get_choices() );
+    return j;
 }
 
 

--- a/third-party/realdds/src/dds-option.cpp
+++ b/third-party/realdds/src/dds-option.cpp
@@ -66,9 +66,9 @@ void dds_option::init_default_value( json value )
 }
 
 
-void dds_option::init_range( rsutils::json const & minimum_value,
-                             rsutils::json const & maximum_value,
-                             rsutils::json const & stepping )
+void dds_option::init_range( rsutils::json minimum_value,
+                             rsutils::json maximum_value,
+                             rsutils::json stepping )
 {
     verify_uninitialized();
 
@@ -90,20 +90,20 @@ void dds_option::init_range( rsutils::json const & minimum_value,
         check_type( minimum_value );
         if( ! get_default_value().is_null() && get_default_value() < minimum_value )
             DDS_THROW( runtime_error, "default value " << get_default_value() << " < " << minimum_value << " minimum" );
-        _minimum_value = minimum_value;
+        _minimum_value = std::move( minimum_value );
     }
     if( ! maximum_value.is_null() )
     {
         check_type( maximum_value );
         if( ! get_default_value().is_null() && get_default_value() > maximum_value )
             DDS_THROW( runtime_error, "default value " << get_default_value() << " > " << maximum_value << " maximum" );
-        _maximum_value = maximum_value;
+        _maximum_value = std::move( maximum_value );
     }
     if( ! stepping.is_null() )
     {
         check_type( stepping );
         // TODO check default against stepping?
-        _stepping = stepping;
+        _stepping = std::move( stepping );
     }
 }
 
@@ -299,8 +299,8 @@ static std::string parse_type( json const & j, size_t size, dds_option::option_p
         return std::make_shared< dds_string_option >();
     if( type == "int" )
         return std::make_shared< dds_integer_option >();
-    //if( type == "boolean" )
-    //    return std::make_shared< dds_boolean_option >();
+    if( type == "boolean" )
+        return std::make_shared< dds_boolean_option >();
     if( type == "IPv4" )
         return std::make_shared< dds_ip_option >();
     return {};
@@ -422,8 +422,9 @@ json dds_option::props_to_json() const
 }
 
 
-void dds_float_option::check_type( json const & value ) const
+void dds_float_option::check_type( json & value ) const
 {
+    // We do not reset the value: "1.1" will become 1.100000023841858
     check_float( value );
 }
 
@@ -449,13 +450,50 @@ void dds_float_option::check_type( json const & value ) const
 }
 
 
-void dds_integer_option::check_type( json const & value ) const
+void dds_integer_option::check_type( json & value ) const
 {
-    check_integer( value );
+    value = check_integer( value );
 }
 
 
-void dds_string_option::check_type( json const & value ) const
+void dds_boolean_option::init_range( rsutils::json minimum_value,
+                                     rsutils::json maximum_value,
+                                     rsutils::json stepping )
+{
+    if( ! minimum_value.is_null() || ! maximum_value.is_null() || ! stepping.is_null() )
+        DDS_THROW( runtime_error, "boolean options cannot have a range" );
+    super::init_range( std::move( minimum_value ), std::move( maximum_value ), std::move( stepping ) );
+}
+
+
+/*static*/ dds_boolean_option::type dds_boolean_option::check_boolean( json const & value )
+{
+    switch( value.type() )
+    {
+    case json::value_t::boolean:
+        return value.get< type >();
+
+    case json::value_t::number_integer:
+    case json::value_t::number_unsigned:
+        switch( auto i = value.get< super::type >() )
+        {
+        case 0:
+        case 1:
+            return i != 0;
+        }
+        break;
+    }
+    DDS_THROW( runtime_error, "not convertible to a boolean: " << value );
+}
+
+
+void dds_boolean_option::check_type( json & value ) const
+{
+    value = check_boolean( value );
+}
+
+
+void dds_string_option::check_type( json & value ) const
 {
     if( ! value.is_string() )
         DDS_THROW( runtime_error, "not a string: " << value );
@@ -471,7 +509,7 @@ void dds_string_option::check_type( json const & value ) const
 }
 
 
-void dds_ip_option::check_type( json const & value ) const
+void dds_ip_option::check_type( json & value ) const
 {
     check_ip( value );
 }

--- a/third-party/realdds/src/dds-topic-reader.cpp
+++ b/third-party/realdds/src/dds-topic-reader.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include <realdds/dds-topic-reader.h>
 #include <realdds/dds-topic.h>
@@ -142,10 +142,17 @@ void dds_topic_reader::on_data_available( eprosima::fastdds::dds::DataReader * )
     // Called when a new Data Message is received
     if( _on_data_available )
     {
-        rsutils::time::stopwatch stopwatch;
-        _on_data_available();
-        if( stopwatch.get_elapsed() > std::chrono::milliseconds( 500 ) )
-            LOG_WARNING( "<---- '" << _topic->get()->get_name() << "' callback took too long!" );
+        try
+        {
+            rsutils::time::stopwatch stopwatch;
+            _on_data_available();
+            if( stopwatch.get_elapsed() > std::chrono::milliseconds( 500 ) )
+                LOG_WARNING( _topic->get()->get_name() << "' callback took too long!" );
+        }
+        catch( std::exception const & e )
+        {
+            LOG_ERROR( "[" << _topic->get()->get_name() << "] exception: " << e.what() );
+        }
     }
 }
 

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -690,25 +690,29 @@ lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< 
                             continue;
                         }
                         json value;
-                        switch( changed_option->type )
+                        if( changed_option->is_valid )
                         {
-                        case RS2_OPTION_TYPE_FLOAT:
-                            value = changed_option->as_float;
-                            break;
-                        case RS2_OPTION_TYPE_STRING:
-                            value = changed_option->as_string;
-                            break;
-                        case RS2_OPTION_TYPE_INTEGER:
-                            value = changed_option->as_integer;
-                            break;
-                        case RS2_OPTION_TYPE_COUNT:
+                            switch( changed_option->type )
+                            {
+                            case RS2_OPTION_TYPE_FLOAT:
+                                value = changed_option->as_float;
+                                break;
+                            case RS2_OPTION_TYPE_STRING:
+                                value = changed_option->as_string;
+                                break;
+                            case RS2_OPTION_TYPE_INTEGER:
+                                value = changed_option->as_integer;
+                                break;
+                            default:
+                                LOG_ERROR( "Unknown option '" << option_name << "' type: "
+                                                              << rs2_option_type_to_string( changed_option->type ) );
+                                continue;
+                            }
+                        }
+                        else
+                        {
                             // No value available
                             value = rsutils::null_json;
-                            break;
-                        default:
-                            LOG_ERROR( "Unknown option '" << option_name << "' type: "
-                                                          << rs2_option_type_to_string( changed_option->type ) );
-                            continue;
                         }
                         dds_option->set_value( std::move( value ) );
                         option_values[stream_name][option_name] = dds_option->get_value();

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -703,6 +703,9 @@ lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< 
                             case RS2_OPTION_TYPE_INTEGER:
                                 value = changed_option->as_integer;
                                 break;
+                            case RS2_OPTION_TYPE_BOOLEAN:
+                                value = (bool)changed_option->as_integer;
+                                break;
                             default:
                                 LOG_ERROR( "Unknown option '" << option_name << "' type: "
                                                               << rs2_option_type_to_string( changed_option->type ) );

--- a/unit-tests/dds/test-option-value.py
+++ b/unit-tests/dds/test-option-value.py
@@ -20,6 +20,24 @@ with test.closure( 'read-only options' ):
         dds.option.from_json( ['a', 1.1, 'desc'] ).get_value(),
         1.1 )
 
+with test.closure( 'boolean' ):
+    test.check_equal( dds.option.from_json( ['b', True, 'bool'] ).value_type(), 'boolean' )
+    test.check_equal( dds.option.from_json( ['b', False, 'bool'] ).value_type(), 'boolean' )
+    test.check_equal( dds.option.from_json( ['b', 0, 'bool', ['boolean']] ).value_type(), 'boolean' )
+    test.check_equal( dds.option.from_json( ['b', 0, 'bool', ['boolean']] ).get_value(), False )
+    test.check_equal( dds.option.from_json( ['b', 1, 'bool', ['boolean']] ).get_value(), True )
+    test.check_equal_lists(
+        dds.option.from_json( ['b', 1, 'bool', ['boolean']] ).to_json(),
+        ['b', True, 'bool'] )
+    test.check_throws( lambda:
+        dds.option.from_json( ['b', 1., 'bool', ['boolean']] ),
+        RuntimeError, 'not convertible to a boolean: 1.0' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['b', 2, 'bool', ['boolean']] ),
+        RuntimeError, 'not convertible to a boolean: 2' )
+    test.check_equal( dds.option.from_json( ['b', False, True, 'bool'] ).value_type(), 'boolean' )
+    test.check_equal( dds.option.from_json( ['b', False, None, 'bool', ['optional']] ).value_type(), 'boolean' )
+
 with test.closure( 'r/o options are still settable' ):
     # NOTE: the DDS options do not enforce logic post initialization; they serve only to COMMUNICATE any state and limits
     test.check_equal( dds.option.from_json( ['1', 0, 'desc'] ).value_type(), 'int' )

--- a/unit-tests/dds/test-option-value.py
+++ b/unit-tests/dds/test-option-value.py
@@ -38,6 +38,35 @@ with test.closure( 'boolean' ):
     test.check_equal( dds.option.from_json( ['b', False, True, 'bool'] ).value_type(), 'boolean' )
     test.check_equal( dds.option.from_json( ['b', False, None, 'bool', ['optional']] ).value_type(), 'boolean' )
 
+with test.closure( 'enum' ):
+    test.check_equal( dds.option.from_json( ['e1', 'a', ['a','b','c'], 'c', 'enum'] ).value_type(), 'enum' )
+    test.check_equal( dds.option.from_json( ['e1', 'a', ['a','a','c'], 'c', 'enum'] ).value_type(), 'enum' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['e1', 'd', [], 'c', 'enum'] ),
+        RuntimeError, 'invalid enum value: "c"' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['e1', 'a', None, 'c', 'enum'] ),
+        RuntimeError, 'enum option requires a choices array' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['e1', 'd', ['a','b','c'], 'c', 'enum'] ),
+        RuntimeError, 'invalid enum value: "d"' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['e1', 'a', ['a','b','c'], 'd', 'enum'] ),
+        RuntimeError, 'invalid enum value: "d"' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['e1', 'a', [None,'b','c'], 'd', 'enum'] ),
+        RuntimeError, 'enum choices must be strings' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['e1', 1, [1,2,3], 3, 'enum'] ),
+        RuntimeError, 'non-string enum values' )
+    test.check_throws( lambda:
+        dds.option.from_json( ['e1', None, ['a','b','c'], 'c', 'enum'] ),
+        RuntimeError, 'value is not optional' )
+    test.check_equal( dds.option.from_json( ['e1', None, ['a','b','c'], 'c', 'enum', ['optional']] ).value_type(), 'enum' )
+    test.check_equal_lists(
+        dds.option.from_json( ['e1', None, ['a','b','c'], 'c', 'enum', ['optional']] ).to_json(),
+        ['e1', None, ['a','b','c'], 'c', 'enum', ['optional']] )
+
 with test.closure( 'r/o options are still settable' ):
     # NOTE: the DDS options do not enforce logic post initialization; they serve only to COMMUNICATE any state and limits
     test.check_equal( dds.option.from_json( ['1', 0, 'desc'] ).value_type(), 'int' )

--- a/wrappers/python/pyrs_options.cpp
+++ b/wrappers/python/pyrs_options.cpp
@@ -11,12 +11,16 @@ void init_options(py::module &m) {
     struct option_value
     {
         rs2_option id;
+        rs2_option_type type;
         py::object value;
 
         option_value( rs2::option_value const & value_ )
             : id( value_->id )
+            , type( value_->type )
         {
-            if( RS2_OPTION_TYPE_FLOAT == value_->type )
+            if( ! value_->is_valid )
+                value = py::cast< py::none >( Py_None );
+            else if( RS2_OPTION_TYPE_FLOAT == value_->type )
                 value = py::float_( value_->as_float );
             else if( RS2_OPTION_TYPE_STRING == value_->type )
                 value = py::str( value_->as_string );
@@ -29,6 +33,7 @@ void init_options(py::module &m) {
     py::class_< option_value >( m, "option_value" )
         .def_readwrite( "id", &option_value::id )
         .def_readwrite( "value", &option_value::value )  // None if no value available
+        .def_readwrite( "type", &option_value::type )
         .def( "__repr__",
               []( option_value const & self )
               {
@@ -68,6 +73,10 @@ void init_options(py::module &m) {
     options.def("is_option_read_only", &rs2::options::is_option_read_only, "Check if particular option "
                 "is read only.", "option"_a)
         .def("get_option", &rs2::options::get_option, "Read option value from the device.", "option"_a, py::call_guard<py::gil_scoped_release>())
+        .def( "get_option_value",
+            []( rs2::options const & self, rs2_option option_id ) -> option_value
+                { return self.get_option_value( option_id ); },
+            py::call_guard< py::gil_scoped_release >() )
         .def("get_option_range", &rs2::options::get_option_range, "Retrieve the available range of values "
              "of a supported option", "option"_a, py::call_guard<py::gil_scoped_release>())
         .def("set_option", &rs2::options::set_option, "Write new value to device option", "option"_a, "value"_a, py::call_guard<py::gil_scoped_release>())

--- a/wrappers/python/pyrs_options.cpp
+++ b/wrappers/python/pyrs_options.cpp
@@ -26,6 +26,8 @@ void init_options(py::module &m) {
                 value = py::str( value_->as_string );
             else if( RS2_OPTION_TYPE_INTEGER == value_->type )
                 value = py::int_( value_->as_integer );
+            else if( RS2_OPTION_TYPE_BOOLEAN == value_->type )
+                value = py::bool_( value_->as_integer );
             else
                 value = py::cast< py::none >( Py_None );
         }


### PR DESCRIPTION
Followup to previous options PR:
* add `is_valid` member to `rs2_option_value`
* add `BOOLEAN` and `ENUM` option types
* added tests for librealsense interoperability
* options not have `get_value()` returning json and `get_value_type()`

Still not final:
* You can get booleans and enums with the old APIs (to get them as floats)
* Still cannot set values - but figured I'd submit the PR for this to get in

But the APIs shouldn't need any more massaging, so should be better.
