### PR TITLE
backend-v4l2: relax mipi filter

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -998,7 +998,7 @@ namespace librealsense
                     else if(mipi_rs_enum_nodes.empty()) //video4linux devices that are not USB devices and not previously enumerated by rs links
                     {
                         // filter out all posible codecs, work only with compatible driver
-                        static const std::regex rs_mipi_compatible("[.]vi:|ipu6");
+                        static const std::regex rs_mipi_compatible(".vi:|ipu6");
                         info = get_info_from_mipi_device_path(video_path, name);
                         if (!regex_search(info.unique_id, rs_mipi_compatible)) {
                             continue;


### PR DESCRIPTION
Found issue with customer platform where device was reported as "-vi:5" instead of ".vi:5".

Fixes #12713
