### PR TITLE
fix slowness with viewer get_option_values() while drawing

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2918,7 +2918,7 @@ namespace rs2
                     label = rsutils::string::from() << "Controls ##" << sub->s->get_info(RS2_CAMERA_INFO_NAME) << "," << id;
                     if (ImGui::TreeNode(label.c_str()))
                     {
-                        std::vector<rs2_option> supported_options = sub->s->get_supported_options();
+                        auto const & supported_options = sub->options_metadata;
 
                         // moving the color dedicated options to the end of the vector
                         std::vector<rs2_option> color_options = {
@@ -2935,23 +2935,26 @@ namespace rs2
 
                         std::vector<rs2_option> so_ordered;
 
-                        for (auto&& i : supported_options)
+                        for (auto const & id_model : supported_options)
                         {
-                            auto it = find(color_options.begin(), color_options.end(), i);
+                            auto it = find( color_options.begin(), color_options.end(), id_model.first );
                             if (it == color_options.end())
-                                so_ordered.push_back(i);
+                                so_ordered.push_back( id_model.first );
                         }
 
-                        std::for_each(color_options.begin(), color_options.end(), [&](rs2_option opt) {
-                            auto it = std::find(supported_options.begin(), supported_options.end(), opt);
-                            if (it != supported_options.end())
-                                so_ordered.push_back(opt);
-                            });
+                        std::for_each( color_options.begin(),
+                                       color_options.end(),
+                                       [&]( rs2_option opt )
+                                       {
+                                           if( viewer.is_option_skipped( opt ) )
+                                               return;
+                                           auto it = supported_options.find( opt );
+                                           if( it != supported_options.end() )
+                                               so_ordered.push_back( opt );
+                                       } );
 
-                        for (auto&& i : so_ordered)
+                        for (auto opt : so_ordered)
                         {
-                            auto opt = static_cast<rs2_option>(i);
-                            if (viewer.is_option_skipped(opt)) continue;
                             if (std::find(drawing_order.begin(), drawing_order.end(), opt) == drawing_order.end())
                             {
                                 if (serialize && opt == RS2_OPTION_VISUAL_PRESET)

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -147,7 +147,7 @@ namespace rs2
         device dev;
         std::shared_ptr< atomic_objects_in_frame > detected_objects;
 
-        std::map<int, option_model> options_metadata;
+        std::map< rs2_option, option_model > options_metadata;
         std::vector<std::string> resolutions;
         std::map<int, std::vector<std::string>> fpses_per_stream;
         std::vector<std::string> shared_fpses;

--- a/src/option.cpp
+++ b/src/option.cpp
@@ -41,7 +41,16 @@ void option_base::enable_recording(std::function<void(const option&)> recording_
 
 json option::get_value() const noexcept
 {
-    return query();
+    json value;
+    try
+    {
+        value = query();
+    }
+    catch( ... )
+    {
+        // Sometimes option values may not be available, meaning the value stays null
+    }
+    return value;
 }
 
 

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -872,15 +872,8 @@ rs2_options_list* rs2_get_options_list(const rs2_options* options, rs2_error** e
     {
         auto & option = options->options->get_option( option_id );
         std::shared_ptr< const json > value;
-        try
-        {
-            if( option.is_enabled() )
-                value = std::make_shared< const json >( option.get_value() );
-        }
-        catch( ... )
-        {
-            // Sometimes option values may not be available, meaning the value stays null (is_valid=false)
-        }
+        if( option.is_enabled() )
+            value = std::make_shared< const json >( option.get_value() );
         auto wrapper = new rs2_option_value_wrapper( option_id, option.get_value_type(), value );
         rs2_list->list.push_back( wrapper );
     }

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -79,8 +79,8 @@ public:
 
     std::shared_ptr< dds_stream_base > stream() const { return _stream.lock(); }
 
-    rsutils::json const & get_value() const { return _value; }
-    bool is_valid() const { return ! get_value().is_null(); }
+    rsutils::json const & get_value() const noexcept { return _value; }
+    bool is_valid() const noexcept { return ! get_value().is_null(); }
 
     rsutils::json const & get_minimum_value() const { return _minimum_value; }
     rsutils::json const & get_maximum_value() const { return _maximum_value; }


### PR DESCRIPTION
PR #12708 introduced slowness because `rs2_get_options_list` is called when drawing controls.

- Instead of calling the API, draw the controls already stored in `options_metadata`, populated with `rs2_get_options_list` during creation in subdevice-model

