### PR TITLE
fix skipped options showing in viewer

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2946,8 +2946,6 @@ namespace rs2
                                        color_options.end(),
                                        [&]( rs2_option opt )
                                        {
-                                           if( viewer.is_option_skipped( opt ) )
-                                               return;
                                            auto it = supported_options.find( opt );
                                            if( it != supported_options.end() )
                                                so_ordered.push_back( opt );
@@ -2955,6 +2953,8 @@ namespace rs2
 
                         for (auto opt : so_ordered)
                         {
+                            if( viewer.is_option_skipped( opt ) )
+                                continue;
                             if (std::find(drawing_order.begin(), drawing_order.end(), opt) == drawing_order.end())
                             {
                                 if (serialize && opt == RS2_OPTION_VISUAL_PRESET)


### PR DESCRIPTION
(cherry picked from commit ead857b9b03926db9d4c8da62a2cfa3f98f1644b)
