### PR TITLE
Viewer add control to number of logs kept

### DIFF
--- a/common/output-model.h
+++ b/common/output-model.h
@@ -180,6 +180,8 @@ namespace rs2
 
         animated<int> search_width { 0, std::chrono::milliseconds(400) };
         bool search_open = false;
+        bool set_number_open = false;
+        size_t max_notifications_kept = 1000;
 
         std::deque<std::string> autocomplete;
 


### PR DESCRIPTION
Currently only 1000 notifications are kept in queue. Sometimes we want to keep more so it won't be lost while viewing and new logs are received.
