### PR TITLE
DDS scaled intrinsics

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -37,6 +37,23 @@ device::device( std::shared_ptr< const device_info > const & dev_info,
     : _dev_info( dev_info )
     , _is_alive( std::make_shared< std::atomic< bool > >( true ) )
     , _profiles_tags( [this]() { return get_profiles_tags(); } )
+    , _format_conversion(
+          [this]
+          {
+              auto context = get_context();
+              if( ! context )
+                  return format_conversion::full;
+              std::string const format_conversion( "format-conversion", 17 );
+              std::string const full( "full", 4 );
+              auto const value = context->get_settings().nested( format_conversion ).default_value( full );
+              if( value == full )
+                  return format_conversion::full;
+              if( value == "basic" )
+                  return format_conversion::basic;
+              if( value == "raw" )
+                  return format_conversion::raw;
+              throw invalid_value_exception( "invalid " + format_conversion + " value '" + value + "'" );
+          } )
 {
     if( device_changed_notifications )
     {
@@ -199,19 +216,7 @@ std::vector<rs2_format> device::map_supported_color_formats(rs2_format source_fo
 
 format_conversion device::get_format_conversion() const
 {
-    auto context = get_context();
-    if( ! context )
-        return format_conversion::full;
-    std::string const format_conversion( "format-conversion", 17 );
-    std::string const full( "full", 4 );
-    auto const value = context->get_settings().nested( format_conversion ).default_value( full );
-    if( value == full )
-        return format_conversion::full;
-    if( value == "basic" )
-        return format_conversion::basic;
-    if( value == "raw" )
-        return format_conversion::raw;
-    throw invalid_value_exception( "invalid " + format_conversion + " value '" + value + "'" );
+    return *_format_conversion;
 }
 
 void device::tag_profiles(stream_profiles profiles) const

--- a/src/device.h
+++ b/src/device.h
@@ -86,6 +86,7 @@ private:
     std::shared_ptr< std::atomic< bool > > _is_alive;
     rsutils::subscription _device_change_subscription;
     rsutils::lazy< std::vector< tagged_profile > > _profiles_tags;
+    rsutils::lazy< format_conversion > _format_conversion;
 };
 
 

--- a/src/ds/d400/d400-color.cpp
+++ b/src/ds/d400/d400-color.cpp
@@ -129,6 +129,14 @@ namespace librealsense
             register_feature( std::make_shared< auto_exposure_roi_feature >( get_color_sensor(), _hw_monitor, true ) );
     }
 
+    rs2_format d400_color::get_color_format() const
+    {
+        auto const format_conversion = get_format_conversion();
+        rs2_format const color_format
+            = (format_conversion == format_conversion::full) ? RS2_FORMAT_RGB8 : RS2_FORMAT_YUYV;
+        return color_format;
+    }
+
     void d400_color::init()
     {
         auto& color_ep = get_color_sensor();

--- a/src/ds/d400/d400-color.h
+++ b/src/ds/d400/d400-color.h
@@ -33,6 +33,8 @@ namespace librealsense
     protected:
         void register_color_features();
 
+        rs2_format get_color_format() const;
+
         std::shared_ptr<stream_interface> _color_stream;
         std::shared_ptr<ds_color_common> _ds_color_common;
 

--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -1203,6 +1203,13 @@ namespace librealsense
     }
 
 
+    rs2_format d400_device::get_ir_format() const
+    {
+        auto const format_conversion = get_format_conversion();
+        return ( format_conversion == format_conversion::raw ) ? RS2_FORMAT_Y8I : RS2_FORMAT_Y8;
+    }
+
+
     double d400_device::get_device_time_ms()
     {
         //// TODO: Refactor the following query with an extension.

--- a/src/ds/d400/d400-device.h
+++ b/src/ds/d400/d400-device.h
@@ -79,6 +79,8 @@ namespace librealsense
 
         ds::ds_caps parse_device_capabilities( const std::vector<uint8_t> &gvd_buf ) const;
 
+        rs2_format get_ir_format() const;
+
         //TODO - add these to device class as pure virtual methods
         command get_firmware_logs_command() const;
         command get_flash_logs_command() const;

--- a/src/ds/d400/d400-factory.cpp
+++ b/src/ds/d400/d400-factory.cpp
@@ -193,13 +193,13 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_COLOR, -1, 1280, 720, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 1280, 720, get_color_format(), 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 1280, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, -1, 1280, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
-                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
             }
@@ -289,13 +289,13 @@ namespace librealsense
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 720, 720, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, 1, 720, 720, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
             }
             return tags;
@@ -561,13 +561,13 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, -1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
-                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
             }
@@ -602,7 +602,7 @@ namespace librealsense
         {
             std::vector<tagged_profile> tags;
 
-            tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
 
             return tags;
@@ -638,13 +638,13 @@ namespace librealsense
             auto usb_spec = get_usb_spec();
             if (usb_spec >= platform::usb3_type || usb_spec == platform::usb_undefined)
             {
-                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 848, 480, RS2_FORMAT_Z16, 30, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, -1, 848, 480, RS2_FORMAT_Y8, 30, profile_tag::PROFILE_TAG_SUPERSET });
             }
             else
             {
-                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, RS2_FORMAT_RGB8, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+                tags.push_back({ RS2_STREAM_COLOR, -1, 640, 480, get_color_format(), 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_DEPTH, -1, 640, 480, RS2_FORMAT_Z16, 15, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
                 tags.push_back({ RS2_STREAM_INFRARED, -1, 640, 480, RS2_FORMAT_Y8, 15, profile_tag::PROFILE_TAG_SUPERSET });
             }
@@ -692,7 +692,7 @@ namespace librealsense
             int color_height = usb3mode ?      720 : 480;
             int fps    = usb3mode ?            30 :  15;
 
-            tags.push_back({ RS2_STREAM_COLOR, -1, color_width, color_height, RS2_FORMAT_RGB8, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_COLOR, -1, color_width, color_height, get_color_format(), fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_DEPTH, -1, depth_width, depth_height, RS2_FORMAT_Z16, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_INFRARED, -1, depth_width, depth_height, RS2_FORMAT_Y8, fps, profile_tag::PROFILE_TAG_SUPERSET });
             tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
@@ -935,12 +935,10 @@ namespace librealsense
             int color_height = 480;
             int fps = usb3mode ?  30 : 10;
 
-            auto format_conversion = get_format_conversion();
-
             tags.push_back( { RS2_STREAM_COLOR,
                               -1,  // index
                               color_width, color_height,
-                              ( format_conversion == format_conversion::full ) ? RS2_FORMAT_RGB8 : RS2_FORMAT_YUYV,
+                              get_color_format(),
                               fps,
                               profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT } );
             tags.push_back( { RS2_STREAM_DEPTH,
@@ -952,7 +950,7 @@ namespace librealsense
             tags.push_back( { RS2_STREAM_INFRARED,
                               -1,  // index
                               depth_width, depth_height,
-                              ( format_conversion == format_conversion::raw ) ? RS2_FORMAT_Y8I : RS2_FORMAT_Y8,
+                              get_ir_format(),
                               fps,
                               profile_tag::PROFILE_TAG_SUPERSET } );
 
@@ -1028,9 +1026,9 @@ namespace librealsense
             int color_height = usb3mode ?    720 : 480;
             int fps          = usb3mode ?     30 :  15;
 
-            tags.push_back({ RS2_STREAM_COLOR, -1, color_width, color_height, RS2_FORMAT_RGB8, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
+            tags.push_back({ RS2_STREAM_COLOR, -1, color_width, color_height, get_color_format(), fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({ RS2_STREAM_DEPTH, -1, depth_width, depth_height, RS2_FORMAT_Z16, fps, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
-            tags.push_back({ RS2_STREAM_INFRARED, -1, depth_width, depth_height, RS2_FORMAT_Y8, fps, profile_tag::PROFILE_TAG_SUPERSET });
+            tags.push_back({ RS2_STREAM_INFRARED, -1, depth_width, depth_height, get_ir_format(), fps, profile_tag::PROFILE_TAG_SUPERSET });
             tags.push_back({RS2_STREAM_GYRO, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_200, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_63, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });
             tags.push_back({RS2_STREAM_ACCEL, -1, 0, 0, RS2_FORMAT_MOTION_XYZ32F, (int)odr::IMU_FPS_100, profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT });

--- a/src/ds/d500/d500-private.cpp
+++ b/src/ds/d500/d500-private.cpp
@@ -157,8 +157,8 @@ namespace librealsense
         {
             auto& rgb_coefficients_table = rgb_calib_table.rgb_coefficients_table;
 
-            // checking if the fisheye distortion is needed
-            if (rgb_coefficients_table.distortion_model == RS2_DISTORTION_BROWN_CONRADY)
+            // checking if the fisheye distortion (2 in calibration table) is needed
+            if( rgb_coefficients_table.distortion_model != d500_calibration_distortion::brown_and_fisheye )
                 return;
 
             // matrix with the intrinsics - after they have been adapted to required resolution
@@ -191,13 +191,11 @@ namespace librealsense
             intrinsics.ppy = k_brown.z.y;
             intrinsics.fx = k_brown.x.x;
             intrinsics.fy = k_brown.y.y;
-            intrinsics.model = RS2_DISTORTION_BROWN_CONRADY;
 
             // update values in the distortion params of the calibration table
-            rgb_coefficients_table.distortion_model = RS2_DISTORTION_BROWN_CONRADY;
+            rgb_coefficients_table.distortion_model = d500_calibration_distortion::brown;
 
-            // Since we override the table we need an indication that the table had changed from
-            // outside this function Decided to use a reserve field for that
+            // Since we override the table we need an indication that the table has changed
             if( rgb_coefficients_table.reserved[3] != 0 )
                 throw invalid_value_exception( "reserved field read from RGB distortion model table is expected to be zero" );
 
@@ -231,11 +229,12 @@ namespace librealsense
             intrinsics.height = height;
 
             // For D555e, model will be brown and we need the unrectified intrinsics
-            // We use reserved[3] as a flag here to indicate the full distortion module is not
-            // really brown but we treat it as such because the HW fixes fisheye distortion.
+            // For SC, model will be brown_and_fisheye and we need the rectified
+            // NOTE that update_table_to_correct_fisheye_distortion() changes the model to brown, so we use reserved[3]
+            // as a flag to indicate this happened
             bool use_base_intrinsics
-                = ( table->rgb_coefficients_table.distortion_model == RS2_DISTORTION_BROWN_CONRADY
-                    && table->rgb_coefficients_table.reserved[3] == 0 );
+                = table->rgb_coefficients_table.distortion_model == d500_calibration_distortion::brown
+               && table->rgb_coefficients_table.reserved[3] == 0;
 
             auto rect_params = compute_rect_params_from_resolution(
                 use_base_intrinsics ? table->rgb_coefficients_table.base_instrinsics
@@ -248,7 +247,7 @@ namespace librealsense
             intrinsics.fy = rect_params[1];
             intrinsics.ppx = rect_params[2];
             intrinsics.ppy = rect_params[3];
-            intrinsics.model = table->rgb_coefficients_table.distortion_model;
+            intrinsics.model = RS2_DISTORTION_BROWN_CONRADY;
             std::memcpy( intrinsics.coeffs,
                          table->rgb_coefficients_table.distortion_coeffs,
                          sizeof( intrinsics.coeffs ) );

--- a/src/ds/d500/d500-private.h
+++ b/src/ds/d500/d500-private.h
@@ -107,12 +107,20 @@ namespace librealsense
             float       fy;             /**< Focal length of the image plane, as a multiple of pixel height */
         };
 
+        // These are the possible values for the calibration table 'distortion_model' field
+        enum class d500_calibration_distortion
+        {
+            none = 0,
+            brown = 1,
+            brown_and_fisheye = 2
+        };
+
         struct single_sensor_coef_table
         {
             mini_intrinsics           base_instrinsics;
             uint32_t                  distortion_non_parametric;
-            rs2_distortion            distortion_model;          /**< Distortion model of the image */
-            float                     distortion_coeffs[13];     /**< Distortion coefficients. Order for Brown-Conrady: [k1, k2, p1, p2, k3]. Order for F-Theta Fish-eye: [k1, k2, k3, k4, 0]. Other models are subject to their own interpretations */
+            d500_calibration_distortion distortion_model;
+            float distortion_coeffs[13];  // [k1,k2,p1,p2,k3] for Brown, followed by [k1,k2,k3,k4] with fisheye
             uint8_t                   reserved[4];
             float                     radial_distortion_lut_range_degs;
             float                     radial_distortion_lut_focal_length;

--- a/third-party/realdds/include/realdds/dds-trinsics.h
+++ b/third-party/realdds/include/realdds/dds-trinsics.h
@@ -1,40 +1,73 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include <rsutils/json-fwd.h>
+#include <rsutils/number/float3.h>
 
 #include <array>
 #include <map>
 #include <memory>
 #include <string>
+#include <iosfwd>
 
 
 namespace realdds {
+
+
+// Like rs2_distortion
+//
+enum class distortion_model
+{
+    none = 0,   // No un/distort
+    brown,
+
+    // These are to support librealsense legacy devices (for use in the adapter)
+    modified_brown,
+    inverse_brown
+};
+
+std::ostream & operator<<( std::ostream &, distortion_model );
+
+
+struct distortion_parameters
+{
+    distortion_model model;
+    std::array< float, 5 > coeffs;
+};
+
+std::ostream & operator<<( std::ostream &, distortion_parameters const & );
+
 
 
 // Internal properties of a video stream.
 // The sensor has a lens and thus has properties such as a focal point, distortion, and principal point.
 struct video_intrinsics
 {
+    using float2 = rsutils::number::float2;
+
     int width = 0;                                     // Horizontal resolution, in pixels
     int height = 0;                                    // Vertical resolution, in pixels
-    float principal_point_x = 0.0f;                    // Pixel offset from the left edge
-    float principal_point_y = 0.0f;                    // Pixel offset from the top edge
-    float focal_lenght_x = 0.0f;                       // As a multiple of pixel width
-    float focal_lenght_y = 0.0f;                       // As a multiple of pixel height
-    int distortion_model = 0;                          // Distortion model of the image
-    std::array< float, 5 > distortion_coeffs = { 0 };  // Distortion model coefficients
+    float2 principal_point = { 0, 0 };                 // Pixel offset from top-left edge
+    float2 focal_length = { 0, 0 };                    // As a multiple of pixel width and height
+    distortion_parameters distortion = { distortion_model::none, { 0 } };
 
-    bool is_valid() const { return focal_lenght_x > 0 && focal_lenght_y > 0; }
+    bool is_valid() const { return focal_length.x > 0 && focal_length.y > 0; }
+
     bool operator<( const video_intrinsics & rhs ) const
     {
+        // Arrange the intrinsics in order of increasing resolution (width then height)
         return width < rhs.width || ( width == rhs.width && height < rhs.height );
     }
+
+    video_intrinsics scaled_to( int width, int height ) const;
 
     rsutils::json to_json() const;
     static video_intrinsics from_json( rsutils::json const & j );
 };
+
+std::ostream & operator<<( std::ostream &, video_intrinsics const & );
+
 
 // Internal properties of a motion stream.
 // Contain scale, bias and variances for each dimension.

--- a/third-party/realdds/include/realdds/topics/dds-topic-names.h
+++ b/third-party/realdds/include/realdds/topics/dds-topic-names.h
@@ -66,6 +66,13 @@ namespace notification {
             namespace key {
                 extern std::string const accel;
                 extern std::string const gyro;
+                extern std::string const width;
+                extern std::string const height;
+                extern std::string const principal_point;
+                extern std::string const focal_length;
+                extern std::string const model;
+                extern std::string const coefficients;
+                extern std::string const force_symmetry;
             }
         }
     }

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -794,6 +794,7 @@ PYBIND11_MODULE(NAME, m) {
         video_stream_server_base( m, "video_stream_server", stream_server_base );
     video_stream_server_base
         .def( "set_intrinsics", &dds_video_stream_server::set_intrinsics )
+        .def( "get_intrinsics", &dds_video_stream_server::get_intrinsics )
         .def( "start_streaming",
               []( dds_video_stream_server & self, dds_video_encoding encoding, int width, int height ) {
                   self.start_streaming( { encoding, height, width } );

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -256,17 +256,47 @@ PYBIND11_MODULE(NAME, m) {
     topics.attr( "device_metadata" ) = realdds::topics::METADATA_TOPIC_NAME;
     topics.attr( "device_dfu" ) = realdds::topics::DFU_TOPIC_NAME;
 
+    using realdds::distortion_model;
+    py::enum_< distortion_model >( m, "distortion_model" )
+        .value( "none", distortion_model::none )
+        .value( "brown", distortion_model::brown )
+        .value( "inverse_brown", distortion_model::inverse_brown )
+        .value( "modified_brown", distortion_model::modified_brown );
+
+    using realdds::distortion_parameters;
+    py::class_< distortion_parameters >( m, "distortion_parameters" )
+        .def( py::init<>() )
+        .def_readwrite( "model", &distortion_parameters::model )
+        .def_readwrite( "coeffs", &distortion_parameters::coeffs )
+        .def( "__repr__",
+              []( distortion_parameters const & self ) -> std::string
+              { return rsutils::string::from() << "<" SNAME ".distortion_parameters " << self << ">"; } );
+
+    py::class_< rsutils::number::float2 >( m, "float2" )
+        .def( py::init<>() )
+        .def( py::init< float, float >() )
+        .def_readwrite( "x", &rsutils::number::float2::x )
+        .def_readwrite( "y", &rsutils::number::float2::y )
+        .def( "length", &rsutils::number::float2::length )
+        .def( "normalized", &rsutils::number::float2::normalized )
+        .def( "__repr__",
+              []( rsutils::number::float2 const & self ) -> std::string
+              { return rsutils::string::from() << self.x << ',' << self.y; } );
+
     using realdds::video_intrinsics;
     py::class_< video_intrinsics, std::shared_ptr< video_intrinsics > >( m, "video_intrinsics" )
         .def( py::init<>() )
         .def_readwrite( "width", &video_intrinsics::width )
         .def_readwrite( "height", &video_intrinsics::height )
-        .def_readwrite( "principal_point_x", &video_intrinsics::principal_point_x )
-        .def_readwrite( "principal_point_y", &video_intrinsics::principal_point_y )
-        .def_readwrite( "focal_lenght_x", &video_intrinsics::focal_lenght_x )
-        .def_readwrite( "focal_lenght_y", &video_intrinsics::focal_lenght_y )
-        .def_readwrite( "distortion_model", &video_intrinsics::distortion_model )
-        .def_readwrite( "distortion_coeffs", &video_intrinsics::distortion_coeffs );
+        .def_readwrite( "principal_point", &video_intrinsics::principal_point )
+        .def_readwrite( "focal_length", &video_intrinsics::focal_length )
+        .def_readwrite( "distortion", &video_intrinsics::distortion )
+        .def( "__repr__",
+              []( video_intrinsics const & self ) -> std::string
+              { return rsutils::string::from() << "<" SNAME ".video_intrinsics " << self << ">"; } )
+        .def( "to_json", &video_intrinsics::to_json )
+        .def( "scaled_to", &video_intrinsics::scaled_to )
+        .def( "is_valid", &video_intrinsics::is_valid );
 
     using realdds::motion_intrinsics;
     py::class_< motion_intrinsics, std::shared_ptr< motion_intrinsics > >( m, "motion_intrinsics" )

--- a/third-party/realdds/src/dds-trinsics.cpp
+++ b/third-party/realdds/src/dds-trinsics.cpp
@@ -1,50 +1,196 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include <realdds/dds-trinsics.h>
 #include <realdds/dds-utilities.h>
+#include <realdds/topics/dds-topic-names.h>
 
 #include <rsutils/json.h>
+using rsutils::json;
+
+#include <ostream>
 
 
 namespace realdds {
 
 
-rsutils::json video_intrinsics::to_json() const
+std::ostream & operator<<( std::ostream & os, distortion_model model )
 {
-    return rsutils::json::array( {
-        width, height, principal_point_x, principal_point_y, focal_lenght_x, focal_lenght_y, distortion_model,
-        distortion_coeffs[0], distortion_coeffs[1], distortion_coeffs[2], distortion_coeffs[3], distortion_coeffs[4]
-    } );
+    switch( model )
+    {
+    case distortion_model::none:
+        os << "none";
+        break;
+
+    case distortion_model::brown:
+        os << "brown";
+        break;
+
+    case distortion_model::inverse_brown:
+        os << "inverse-brown";
+        break;
+
+    case distortion_model::modified_brown:
+        os << "modified-brown";
+        break;
+
+    default:
+        DDS_THROW( runtime_error, "unknown distortion model: " << int( model ) );
+    }
+    return os;
 }
 
-/* static  */ video_intrinsics video_intrinsics::from_json( rsutils::json const & j )
+
+std::ostream & operator<<( std::ostream & os, distortion_parameters const & p )
+{
+    os << p.model;
+    switch( p.model )
+    {
+    case distortion_model::brown:
+    case distortion_model::inverse_brown:
+    case distortion_model::modified_brown:
+        os << ":" << p.coeffs[0] << ',' << p.coeffs[1] << ',' << p.coeffs[2] << ',' << p.coeffs[3] << ',' << p.coeffs[4];
+        break;
+    }
+    return os;
+}
+
+
+std::ostream & operator<<( std::ostream & os, video_intrinsics const & self )
+{
+    return os << self.width << 'x' << self.height << " pp[" << self.principal_point.x << ',' << self.principal_point.y
+              << "] fl[" << self.focal_length.x << ',' << self.focal_length.y << "] distortion[" << self.distortion << "]";
+}
+
+
+json video_intrinsics::to_json() const
+{
+    json j = json::object( {
+        { topics::notification::stream_options::intrinsics::key::width, width },
+        { topics::notification::stream_options::intrinsics::key::height, height },
+        { topics::notification::stream_options::intrinsics::key::principal_point, principal_point },
+        { topics::notification::stream_options::intrinsics::key::focal_length, focal_length },
+    } );
+    switch( distortion.model )
+    {
+    case distortion_model::none:
+        break;
+
+    case distortion_model::brown:
+        j[topics::notification::stream_options::intrinsics::key::coefficients] = distortion.coeffs;
+        break;
+
+    case distortion_model::inverse_brown:
+        j[topics::notification::stream_options::intrinsics::key::model] = "inverse-brown";
+        j[topics::notification::stream_options::intrinsics::key::coefficients] = distortion.coeffs;
+        break;
+
+    case distortion_model::modified_brown:
+        j[topics::notification::stream_options::intrinsics::key::model] = "modified-brown";
+        j[topics::notification::stream_options::intrinsics::key::coefficients] = distortion.coeffs;
+        break;
+
+    default:
+        DDS_THROW( runtime_error, "unknown distortion model: " << int( distortion.model ) );
+    }
+    return j;
+}
+
+/* static  */ video_intrinsics video_intrinsics::from_json( json const & j )
 {
     video_intrinsics ret;
-    int index = 0;
+    if( j.is_array() )
+    {
+        int index = 0;
 
-    ret.width = j[index++].get< int >();
-    ret.height = j[index++].get< int >();
-    ret.principal_point_x = j[index++].get< float >();
-    ret.principal_point_y = j[index++].get< float >();
-    ret.focal_lenght_x = j[index++].get< float >();
-    ret.focal_lenght_y = j[index++].get< float >();
-    ret.distortion_model = j[index++].get< int >();
-    ret.distortion_coeffs[0] = j[index++].get< float >();
-    ret.distortion_coeffs[1] = j[index++].get< float >();
-    ret.distortion_coeffs[2] = j[index++].get< float >();
-    ret.distortion_coeffs[3] = j[index++].get< float >();
-    ret.distortion_coeffs[4] = j[index++].get< float >();
+        ret.width = j[index++].get< int >();
+        ret.height = j[index++].get< int >();
+        ret.principal_point.x = j[index++].get< float >();
+        ret.principal_point.y = j[index++].get< float >();
+        ret.focal_length.x = j[index++].get< float >();
+        ret.focal_length.y = j[index++].get< float >();
+        ret.distortion.model = (distortion_model)j[index++].get< int >();
+        ret.distortion.coeffs[0] = j[index++].get< float >();
+        ret.distortion.coeffs[1] = j[index++].get< float >();
+        ret.distortion.coeffs[2] = j[index++].get< float >();
+        ret.distortion.coeffs[3] = j[index++].get< float >();
+        ret.distortion.coeffs[4] = j[index++].get< float >();
 
-    if( index != j.size() )
-        DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
+        if( index != j.size() )
+            DDS_THROW( runtime_error, "expected end of json at index " << index );
+    }
+    else if( j.is_object() )
+    {
+        // The intrinsics are communicated in an object:
+        //    - A `width` and `height` are for the native stream resolution, as 16 - bit integer values
+        //    - A `principal-point` defined as `[<x>, <y>]` floating point values
+        //    - A `focal-length`, also as `[<x>, <y>]` floats
+        j.nested( topics::notification::stream_options::intrinsics::key::width ).get_to( ret.width );
+        j.nested( topics::notification::stream_options::intrinsics::key::height ).get_to( ret.height );
+        j.nested( topics::notification::stream_options::intrinsics::key::principal_point ).get_to( ret.principal_point );
+        j.nested( topics::notification::stream_options::intrinsics::key::focal_length ).get_to( ret.focal_length );
+        // A distortion model may be applied:
+        //    - The `model` would specify which model is to be used, with the default of `brown`
+        //    - The `coefficients` is an array of floating point values, the number and meaning which depend on the `model`
+        //    - For `brown`, 5 points [k1, k2, p1, p2, k3] are needed
+        auto coeffs_j = j.nested( topics::notification::stream_options::intrinsics::key::coefficients );
+        auto model_j = j.nested( topics::notification::stream_options::intrinsics::key::model );
+        switch( model_j.type() )
+        {
+        case json::value_t::discarded:
+            if( coeffs_j.is_array() && coeffs_j.size() == 5 )
+                ret.distortion.model = distortion_model::brown;
+            else
+                ret.distortion.model = distortion_model::none;
+            break;
+
+        case json::value_t::string:
+            if( "brown" == model_j.string_ref() )
+                ret.distortion.model = distortion_model::brown;
+            else if( "none" == model_j.string_ref() )
+                ret.distortion.model = distortion_model::none;
+            else if( "inverse-brown" == model_j.string_ref() )
+                ret.distortion.model = distortion_model::inverse_brown;
+            else if( "modified-brown" == model_j.string_ref() )
+                ret.distortion.model = distortion_model::modified_brown;
+            else
+                DDS_THROW( runtime_error, "unknown distortion model: " << model_j );
+            break;
+
+        default:
+            DDS_THROW( runtime_error, "invalid distortion model: " << model_j );
+        }
+        switch( ret.distortion.model )
+        {
+        case distortion_model::none:
+            if( coeffs_j )
+                DDS_THROW( runtime_error, "distortion coefficients without a model" );
+            ret.distortion.coeffs = { 0 };
+            break;
+
+        case distortion_model::brown:
+        case distortion_model::inverse_brown:
+        case distortion_model::modified_brown:
+            if( ! coeffs_j.is_array() )
+                DDS_THROW( runtime_error, "invalid distortion coefficients: " << coeffs_j );
+            if( coeffs_j.size() != 5 )
+                DDS_THROW( runtime_error, "distortion coefficients expected [k1,k2,p1,p2,k3]: " << coeffs_j );
+            coeffs_j.get_to( ret.distortion.coeffs );
+            break;
+
+        default:
+            DDS_THROW( runtime_error, "invalid distortion model" );
+        }
+    }
+    else
+        DDS_THROW( runtime_error, "unspected intrinsics json: " << j );
 
     return ret;
 }
 
-rsutils::json motion_intrinsics::to_json() const
+json motion_intrinsics::to_json() const
 {
-    return rsutils::json::array( {
+    return json::array( {
         data[0][0], data[0][1], data[0][2], data[0][3],
         data[1][0], data[1][1], data[1][2], data[1][3],
         data[2][0], data[2][1], data[2][2], data[2][3],
@@ -53,7 +199,7 @@ rsutils::json motion_intrinsics::to_json() const
     } );
 }
 
-/* static  */ motion_intrinsics motion_intrinsics::from_json( rsutils::json const & j )
+/* static  */ motion_intrinsics motion_intrinsics::from_json( json const & j )
 {
     motion_intrinsics ret;
     int index = 0;
@@ -83,9 +229,9 @@ rsutils::json motion_intrinsics::to_json() const
     return ret;
 }
 
-rsutils::json extrinsics::to_json() const
+json extrinsics::to_json() const
 {
-    return rsutils::json::array( {
+    return json::array( {
         rotation[0], rotation[1], rotation[2],
         rotation[3], rotation[4], rotation[5],
         rotation[6], rotation[7], rotation[8],
@@ -93,7 +239,7 @@ rsutils::json extrinsics::to_json() const
     } );
 }
 
-/* static  */ extrinsics extrinsics::from_json( rsutils::json const & j )
+/* static  */ extrinsics extrinsics::from_json( json const & j )
 {
     extrinsics ret;
     int index = 0;
@@ -115,6 +261,43 @@ rsutils::json extrinsics::to_json() const
         DDS_THROW( runtime_error, "expected end of json at index " + std::to_string( index ) );
 
     return ret;
+}
+
+
+video_intrinsics video_intrinsics::scaled_to( int const new_width, int const new_height ) const
+{
+    if( ! width || ! height )
+        DDS_THROW( runtime_error, "cannot scale with 0 width/height" );
+
+    video_intrinsics scaled( *this );
+
+    bool const force_symmetry = false;  // TODO
+    if( force_symmetry )
+    {
+        // Cropping the frame so that the principal point is at the middle
+        scaled.width = 1 + 2 * static_cast< int >( std::min( principal_point.x, width - 1 - principal_point.x ) );
+        scaled.height = 1 + 2 * static_cast< int >( std::min( principal_point.y, height - 1 - principal_point.y ) );
+        scaled.principal_point.x = ( scaled.width - 1 ) / 2.f;
+        scaled.principal_point.y = ( scaled.height - 1 ) / 2.f;
+    }
+
+    auto const scale_ratio_x = static_cast< float >( new_width ) / scaled.width;
+    auto const scale_ratio_y = static_cast< float >( new_height ) / scaled.height;
+    auto const scale_ratio = std::max( scale_ratio_x, scale_ratio_y );
+
+    auto const crop_x = ( scaled.width * scale_ratio - new_width ) * 0.5f;
+    auto const crop_y = ( scaled.height * scale_ratio - new_height ) * 0.5f;
+
+    scaled.width = new_width;
+    scaled.height = new_height;
+
+    scaled.principal_point.x = ( scaled.principal_point.x + 0.5f ) * scale_ratio - crop_x - 0.5f;
+    scaled.principal_point.y = ( scaled.principal_point.y + 0.5f ) * scale_ratio - crop_y - 0.5f;
+
+    scaled.focal_length.x *= scale_ratio;
+    scaled.focal_length.y *= scale_ratio;
+
+    return scaled;
 }
 
 

--- a/third-party/realdds/src/topics/dds-topic-names.cpp
+++ b/third-party/realdds/src/topics/dds-topic-names.cpp
@@ -48,6 +48,13 @@ namespace notification {
             namespace key {
                 std::string const accel( "accel", 5 );
                 std::string const gyro( "gyro", 4 );
+                std::string const width( "width", 5 );
+                std::string const height( "height", 6 );
+                std::string const principal_point( "principal-point", 15 );
+                std::string const focal_length( "focal-length", 12 );
+                std::string const model( "model", 5 );
+                std::string const coefficients( "coefficients", 12 );
+                std::string const force_symmetry( "force-symmetry", 14 );
             }
         }
     }

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -63,6 +63,7 @@ public:
 
     bool empty() const noexcept { return _j.empty(); }
     json::size_type size() const noexcept { return _j.size(); }
+    json::value_t type() const noexcept { return _j.type(); }
     json::const_iterator begin() const noexcept { return _j.begin(); }
     json::const_iterator end() const noexcept { return _j.end(); }
 

--- a/third-party/rsutils/include/rsutils/number/float3.h
+++ b/third-party/rsutils/include/rsutils/number/float3.h
@@ -2,6 +2,8 @@
 // Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 #pragma once
 
+#include <rsutils/json-fwd.h>
+
 #include <iosfwd>
 #include <cassert>
 
@@ -140,6 +142,15 @@ inline float3x3 transpose( const float3x3 & a )
 std::ostream & operator<<( std::ostream &, const float3 & );
 std::ostream & operator<<( std::ostream &, const float4 & );
 std::ostream & operator<<( std::ostream &, const float3x3 & );
+
+
+// Allow j["key"] = hexarray( bytes );
+void to_json( json &, float2 const & );
+void to_json( json &, float3 const & );
+// Allow j.get< hexarray >();
+void from_json( json const &, float2 & );
+void from_json( json const &, float3 & );
+// See https://github.com/nlohmann/json#arbitrary-types-conversions
 
 
 }  // namespace number

--- a/third-party/rsutils/src/float3.cpp
+++ b/third-party/rsutils/src/float3.cpp
@@ -2,9 +2,12 @@
 // Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include <rsutils/number/float3.h>
+#include <rsutils/json.h>
 
 #include <cmath>  // sqrt, sqrtf
 #include <ostream>
+
+using rsutils::json;
 
 
 namespace rsutils {
@@ -56,6 +59,37 @@ float3 float3::normalized() const
     if( l <= 0.f )
         return *this;
     return { x / l, y / l, z / l };
+}
+
+
+void to_json( json & j, float2 const & f2 )
+{
+    j = json::array( { f2.x, f2.y } );
+}
+
+
+void to_json( json & j, float3 const & f3 )
+{
+    j = json::array( { f3.x, f3.y, f3.z } );
+}
+
+
+void from_json( json const & j, float2 & f2 )
+{
+    if( ! j.is_array() || 2 != j.size() )
+        throw rsutils::json::type_error::create( 317, "expected float2 array [x,y]", &j );
+    j[0].get_to( f2.x );
+    j[1].get_to( f2.y );
+}
+
+
+void from_json( json const & j, float3 & f3 )
+{
+    if( ! j.is_array() || 3 != j.size() )
+        throw rsutils::json::type_error::create( 317, "expected float3 array [x,y,z]", &j );
+    j[0].get_to( f3.x );
+    j[1].get_to( f3.y );
+    j[2].get_to( f3.z );
 }
 
 

--- a/unit-tests/dds/d405.py
+++ b/unit-tests/dds/d405.py
@@ -271,67 +271,67 @@ def color_stream_intrinsics():
     intr = dds.video_intrinsics();
     intr.width = 424
     intr.height = 240
-    intr.principal_point_x = 210.73512268066406
-    intr.principal_point_y = 118.6335678100586
-    intr.focal_lenght_x = 215.58554077148438
-    intr.focal_lenght_y = 214.98973083496094
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
+    intr.principal_point.x = 210.73512268066406
+    intr.principal_point.y = 118.6335678100586
+    intr.focal_length.x = 215.58554077148438
+    intr.focal_length.y = 214.98973083496094
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 480
     intr.height = 270
-    intr.principal_point_x = 238.57701110839844
-    intr.principal_point_y = 133.4627685546875
-    intr.focal_lenght_x = 242.53375244140625
-    intr.focal_lenght_y = 241.86343383789063
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
+    intr.principal_point.x = 238.57701110839844
+    intr.principal_point.y = 133.4627685546875
+    intr.focal_length.x = 242.53375244140625
+    intr.focal_length.y = 241.86343383789063
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 480
-    intr.principal_point_x = 318.1026916503906
-    intr.principal_point_y = 177.95034790039063
-    intr.focal_lenght_x = 323.3783264160156
-    intr.focal_lenght_y = 322.4845886230469
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
+    intr.principal_point.x = 318.1026916503906
+    intr.principal_point.y = 177.95034790039063
+    intr.focal_length.x = 323.3783264160156
+    intr.focal_length.y = 322.4845886230469
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 480
-    intr.principal_point_x = 317.4702453613281
-    intr.principal_point_y = 237.2671356201172
-    intr.focal_lenght_x = 431.1711120605469
-    intr.focal_lenght_y = 429.9794616699219
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
+    intr.principal_point.x = 317.4702453613281
+    intr.principal_point.y = 237.2671356201172
+    intr.focal_length.x = 431.1711120605469
+    intr.focal_length.y = 429.9794616699219
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 848
     intr.height = 480
-    intr.principal_point_x = 421.4702453613281
-    intr.principal_point_y = 237.2671356201172
-    intr.focal_lenght_x = 431.17108154296875
-    intr.focal_lenght_y = 429.9794616699219
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
+    intr.principal_point.x = 421.4702453613281
+    intr.principal_point.y = 237.2671356201172
+    intr.focal_length.x = 431.17108154296875
+    intr.focal_length.y = 429.9794616699219
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 1280
     intr.height = 720
-    intr.principal_point_x = 636.2053833007813
-    intr.principal_point_y = 355.90069580078125
-    intr.focal_lenght_x = 646.7566528320313
-    intr.focal_lenght_y = 644.9691772460938
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
+    intr.principal_point.x = 636.2053833007813
+    intr.principal_point.y = 355.90069580078125
+    intr.focal_length.x = 646.7566528320313
+    intr.focal_length.y = 644.9691772460938
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [-0.05454780161380768,0.056755296885967255,0.0010132350726053119,0.0003381881397217512,-0.01852494664490223]
     intrinsics.append( intr )
 
     return set( intrinsics )
@@ -343,67 +343,67 @@ def depth_ir_common_intrinsics():
     intr = dds.video_intrinsics();
     intr.width = 424
     intr.height = 240
-    intr.principal_point_x = 214.33639526367188
-    intr.principal_point_y = 119.0371322631836
-    intr.focal_lenght_x = 210.80271911621094
-    intr.focal_lenght_y = 210.80271911621094
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 214.33639526367188
+    intr.principal_point.y = 119.0371322631836
+    intr.focal_length.x = 210.80271911621094
+    intr.focal_length.y = 210.80271911621094
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 480
     intr.height = 270
-    intr.principal_point_x = 242.6449737548828
-    intr.principal_point_y = 133.9099578857422
-    intr.focal_lenght_x = 238.64459228515625
-    intr.focal_lenght_y = 238.64459228515625
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 242.6449737548828
+    intr.principal_point.y = 133.9099578857422
+    intr.focal_length.x = 238.64459228515625
+    intr.focal_length.y = 238.64459228515625
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 360
-    intr.principal_point_x = 323.5266418457031
-    intr.principal_point_y = 178.54661560058594
-    intr.focal_lenght_x = 318.1927795410156
-    intr.focal_lenght_y = 318.1927795410156
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 323.5266418457031
+    intr.principal_point.y = 178.54661560058594
+    intr.focal_length.x = 318.1927795410156
+    intr.focal_length.y = 318.1927795410156
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 480
-    intr.principal_point_x = 324.21624755859375
-    intr.principal_point_y = 238.26242065429688
-    intr.focal_lenght_x = 380.41363525390625
-    intr.focal_lenght_y = 380.41363525390625
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 324.21624755859375
+    intr.principal_point.y = 238.26242065429688
+    intr.focal_length.x = 380.41363525390625
+    intr.focal_length.y = 380.41363525390625
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 848
     intr.height = 480
-    intr.principal_point_x = 428.67279052734375
-    intr.principal_point_y = 238.0742645263672
-    intr.focal_lenght_x = 421.6054382324219
-    intr.focal_lenght_y = 421.6054382324219
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 428.67279052734375
+    intr.principal_point.y = 238.0742645263672
+    intr.focal_length.x = 421.6054382324219
+    intr.focal_length.y = 421.6054382324219
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 1280
     intr.height = 720
-    intr.principal_point_x = 647.0532836914063
-    intr.principal_point_y = 357.0932312011719
-    intr.focal_lenght_x = 636.3855590820313
-    intr.focal_lenght_y = 636.3855590820313
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 647.0532836914063
+    intr.principal_point.y = 357.0932312011719
+    intr.focal_length.x = 636.3855590820313
+    intr.focal_length.y = 636.3855590820313
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     return intrinsics
@@ -415,12 +415,12 @@ def depth_stream_intrinsics():
     intr = dds.video_intrinsics();
     intr.width = 256
     intr.height = 144
-    intr.principal_point_x = 135.05328369140625
-    intr.principal_point_y = 69.09323120117188
-    intr.focal_lenght_x = 636.3855590820313
-    intr.focal_lenght_y = 636.3855590820313
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 135.05328369140625
+    intr.principal_point.y = 69.09323120117188
+    intr.focal_length.x = 636.3855590820313
+    intr.focal_length.y = 636.3855590820313
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intrinsics.extend( depth_ir_common_intrinsics() )

--- a/unit-tests/dds/d435i.py
+++ b/unit-tests/dds/d435i.py
@@ -315,100 +315,100 @@ def color_stream_intrinsics():
     intr = dds.video_intrinsics();
     intr.width = 320
     intr.height = 180
-    intr.principal_point_x = 161.7417755126953
-    intr.principal_point_y = 90.47455596923828
-    intr.focal_lenght_x = 227.0221710205078
-    intr.focal_lenght_y = 227.1049346923828
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 161.7417755126953
+    intr.principal_point.y = 90.47455596923828
+    intr.focal_length.x = 227.0221710205078
+    intr.focal_length.y = 227.1049346923828
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 320
     intr.height = 240
-    intr.principal_point_x = 162.32237243652344
-    intr.principal_point_y = 120.63274383544922
-    intr.focal_lenght_x = 302.69622802734375
-    intr.focal_lenght_y = 302.80657958984375
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 162.32237243652344
+    intr.principal_point.y = 120.63274383544922
+    intr.focal_length.x = 302.69622802734375
+    intr.focal_length.y = 302.80657958984375
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 424
     intr.height = 240
-    intr.principal_point_x = 214.32235717773438
-    intr.principal_point_y = 120.63274383544922
-    intr.focal_lenght_x = 302.69622802734375
-    intr.focal_lenght_y = 302.80657958984375
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 214.32235717773438
+    intr.principal_point.y = 120.63274383544922
+    intr.focal_length.x = 302.69622802734375
+    intr.focal_length.y = 302.80657958984375
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 360
-    intr.principal_point_x = 323.4835510253906
-    intr.principal_point_y = 180.94911193847656
-    intr.focal_lenght_x = 454.0443420410156
-    intr.focal_lenght_y = 454.2098693847656
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 323.4835510253906
+    intr.principal_point.y = 180.94911193847656
+    intr.focal_length.x = 454.0443420410156
+    intr.focal_length.y = 454.2098693847656
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 480
-    intr.principal_point_x = 324.6447448730469
-    intr.principal_point_y = 241.26548767089844
-    intr.focal_lenght_x = 605.3924560546875
-    intr.focal_lenght_y = 605.6131591796875
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 324.6447448730469
+    intr.principal_point.y = 241.26548767089844
+    intr.focal_length.x = 605.3924560546875
+    intr.focal_length.y = 605.6131591796875
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 848
     intr.height = 480
-    intr.principal_point_x = 428.64471435546875
-    intr.principal_point_y = 241.26548767089844
-    intr.focal_lenght_x = 605.3924560546875
-    intr.focal_lenght_y = 605.6131591796875
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 428.64471435546875
+    intr.principal_point.y = 241.26548767089844
+    intr.focal_length.x = 605.3924560546875
+    intr.focal_length.y = 605.6131591796875
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 960
     intr.height = 540
-    intr.principal_point_x = 485.2253112792969
-    intr.principal_point_y = 271.4236755371094
-    intr.focal_lenght_x = 681.0665283203125
-    intr.focal_lenght_y = 681.3148193359375
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 485.2253112792969
+    intr.principal_point.y = 271.4236755371094
+    intr.focal_length.x = 681.0665283203125
+    intr.focal_length.y = 681.3148193359375
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 1280
     intr.height = 720
-    intr.principal_point_x = 646.9671020507813
-    intr.principal_point_y = 361.8982238769531
-    intr.focal_lenght_x = 908.0886840820313
-    intr.focal_lenght_y = 908.4197387695313
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 646.9671020507813
+    intr.principal_point.y = 361.8982238769531
+    intr.focal_length.x = 908.0886840820313
+    intr.focal_length.y = 908.4197387695313
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 1920
     intr.height = 1080
-    intr.principal_point_x = 970.4506225585938
-    intr.principal_point_y = 542.8473510742188
-    intr.focal_lenght_x = 1362.133056640625
-    intr.focal_lenght_y = 1362.629638671875
-    intr.distortion_model = 2
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 970.4506225585938
+    intr.principal_point.y = 542.8473510742188
+    intr.focal_length.x = 1362.133056640625
+    intr.focal_length.y = 1362.629638671875
+    intr.distortion.model = dds.distortion_model.inverse_brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     return set( intrinsics )
@@ -420,78 +420,78 @@ def depth_ir_common_intrinsics():
     intr = dds.video_intrinsics();
     intr.width = 424
     intr.height = 240
-    intr.principal_point_x = 212.0788116455078
-    intr.principal_point_y = 119.07991790771484
-    intr.focal_lenght_x = 209.13233947753906
-    intr.focal_lenght_y = 209.13233947753906
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 212.0788116455078
+    intr.principal_point.y = 119.07991790771484
+    intr.focal_length.x = 209.13233947753906
+    intr.focal_length.y = 209.13233947753906
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 480
     intr.height = 270
-    intr.principal_point_x = 240.08921813964844
-    intr.principal_point_y = 134.00367736816406
-    intr.focal_lenght_x = 236.7535858154297
-    intr.focal_lenght_y = 236.7535858154297
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 240.08921813964844
+    intr.principal_point.y = 134.00367736816406
+    intr.focal_length.x = 236.7535858154297
+    intr.focal_length.y = 236.7535858154297
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 360
-    intr.principal_point_x = 320.11895751953125
-    intr.principal_point_y = 178.67156982421875
-    intr.focal_lenght_x = 315.67144775390625
-    intr.focal_lenght_y = 315.67144775390625
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 320.11895751953125
+    intr.principal_point.y = 178.67156982421875
+    intr.focal_length.x = 315.67144775390625
+    intr.focal_length.y = 315.67144775390625
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 640
     intr.height = 480
-    intr.principal_point_x = 320.14276123046875
-    intr.principal_point_y = 238.4058837890625
-    intr.focal_lenght_x = 378.80572509765625
-    intr.focal_lenght_y = 378.80572509765625
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 320.14276123046875
+    intr.principal_point.y = 238.4058837890625
+    intr.focal_length.x = 378.80572509765625
+    intr.focal_length.y = 378.80572509765625
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 848
     intr.height = 100
-    intr.principal_point_x = 424.1576232910156
-    intr.principal_point_y = 48.239837646484375
-    intr.focal_lenght_x = 418.2646789550781
-    intr.focal_lenght_y = 418.2646789550781
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 424.1576232910156
+    intr.principal_point.y = 48.239837646484375
+    intr.focal_length.x = 418.2646789550781
+    intr.focal_length.y = 418.2646789550781
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 848
     intr.height = 480
-    intr.principal_point_x = 424.1576232910156
-    intr.principal_point_y = 238.23983764648438
-    intr.focal_lenght_x = 418.2646789550781
-    intr.focal_lenght_y = 418.2646789550781
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 424.1576232910156
+    intr.principal_point.y = 238.23983764648438
+    intr.focal_length.x = 418.2646789550781
+    intr.focal_length.y = 418.2646789550781
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intr = dds.video_intrinsics();
     intr.width = 1280
     intr.height = 720
-    intr.principal_point_x = 640.2379150390625
-    intr.principal_point_y = 357.3431396484375
-    intr.focal_lenght_x = 631.3428955078125
-    intr.focal_lenght_y = 631.3428955078125
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 640.2379150390625
+    intr.principal_point.y = 357.3431396484375
+    intr.focal_length.x = 631.3428955078125
+    intr.focal_length.y = 631.3428955078125
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     return intrinsics
@@ -503,12 +503,12 @@ def depth_stream_intrinsics():
     intr = dds.video_intrinsics();
     intr.width = 256
     intr.height = 144
-    intr.principal_point_x = 128.2379150390625
-    intr.principal_point_y = 69.3431396484375
-    intr.focal_lenght_x = 631.3428955078125
-    intr.focal_lenght_y = 631.3428955078125
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 128.2379150390625
+    intr.principal_point.y = 69.3431396484375
+    intr.focal_length.x = 631.3428955078125
+    intr.focal_length.y = 631.3428955078125
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     intrinsics.extend( depth_ir_common_intrinsics() )
@@ -522,12 +522,12 @@ def ir_stream_intrinsics():
     intr = dds.video_intrinsics();
     intr.width = 1280
     intr.height = 800
-    intr.principal_point_x = 640.2379150390625
-    intr.principal_point_y = 397.3431396484375
-    intr.focal_lenght_x = 631.3428955078125
-    intr.focal_lenght_y = 631.3428955078125
-    intr.distortion_model = 4
-    intr.distortion_coeffs = [0.0,0.0,0.0,0.0,0.0]
+    intr.principal_point.x = 640.2379150390625
+    intr.principal_point.y = 397.3431396484375
+    intr.focal_length.x = 631.3428955078125
+    intr.focal_length.y = 631.3428955078125
+    intr.distortion.model = dds.distortion_model.brown
+    intr.distortion.coeffs = [0.0,0.0,0.0,0.0,0.0]
     intrinsics.append( intr )
 
     return set( intrinsics )

--- a/unit-tests/dds/test-control-reply.py
+++ b/unit-tests/dds/test-control-reply.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
 #test:retries:gha 2
@@ -44,7 +44,6 @@ with test.remote.fork( nested_indent=None ) as remote:
     ###############################################################################################################
     # The client is a device from which we send controls
     #
-    from dds import wait_for_devices
 
     with test.closure( 'Start the client participant' ):
         participant = dds.participant()

--- a/unit-tests/dds/test-librs-connections.py
+++ b/unit-tests/dds/test-librs-connections.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
 #test:retries:gha 2
@@ -9,13 +9,10 @@ log.nested = 'C  '
 
 import d435i
 import d405
-import dds
-import pyrealsense2 as rs
+import librs as rs
 if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
-
-only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 import os.path
 cwd = os.path.dirname(os.path.realpath(__file__))
@@ -33,49 +30,49 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'librs' }} )
         # The DDS devices take time to be recognized and we just created the context; we
         # should not see them yet!
-        #test.check( len( context.query_devices( only_sw_devices )) != 2 )
+        #test.check( len( context.query_devices( rs.only_sw_devices )) != 2 )
         # Wait for them
-        dds.wait_for_devices( context, only_sw_devices, n=2. )
+        rs.wait_for_devices( context, rs.only_sw_devices, n=2. )
     #
     #############################################################################################
     #
     with test.closure( "Start a third", on_fail=test.ABORT ):
         remote.run( 'instance3 = broadcast_device( d455, d455.device_info )' )
-        dds.wait_for_devices( context, only_sw_devices, n=3. )
+        rs.wait_for_devices( context, rs.only_sw_devices, n=3. )
     #
     #############################################################################################
     #
     with test.closure( "Close the first", on_fail=test.ABORT ):
-        dds.devices_updated.clear()
+        rs._devices_updated.clear()
         remote.run( 'close_server( instance )' )
         remote.run( 'instance = None', timeout=1 )
-        dds.wait_for_devices( context, only_sw_devices, n=2. )
+        rs.wait_for_devices( context, rs.only_sw_devices, n=2. )
     #
     #############################################################################################
     #
     with test.closure( "Add a fourth", on_fail=test.ABORT ):
         remote.run( 'instance4 = broadcast_device( d435i, d435i.device_info )' )
-        dds.wait_for_devices( context, only_sw_devices, n=3. )
+        rs.wait_for_devices( context, rs.only_sw_devices, n=3. )
     #
     #############################################################################################
     #
     with test.closure( "Close the second", on_fail=test.ABORT ):
         remote.run( 'close_server( instance2 )' )
         remote.run( 'instance2 = None', timeout=1 )
-        dds.wait_for_devices( context, only_sw_devices, n=2. )
+        rs.wait_for_devices( context, rs.only_sw_devices, n=2. )
     #
     #############################################################################################
     #
     with test.closure( "Close the third", on_fail=test.ABORT ):
         remote.run( 'close_server( instance3 )' )
         remote.run( 'instance2 = None', timeout=1 )
-        dds.wait_for_devices( context, only_sw_devices, n=1. )
+        rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
     #
     #############################################################################################
     #
     with test.closure( "Close the last", on_fail=test.ABORT ):
         remote.run( 'close_server( instance4 )' )
-        dds.wait_for_devices( context, only_sw_devices, n=0. )
+        rs.wait_for_devices( context, rs.only_sw_devices, n=0. )
     #
     #############################################################################################
 

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
 #test:retries:gha 2
@@ -10,15 +10,13 @@ log.nested = 'C  '
 import d435i
 import d405
 import d455
-import dds
+import librs as rs
 
-import pyrealsense2 as rs
 if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
 context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'device-properties-client' }} )
-only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
 
 
 import os.path
@@ -31,7 +29,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D435i" ):
         remote.run( 'instance = broadcast_device( d435i, d435i.device_info )' )
-        dev = dds.wait_for_devices( context, only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d435i.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d435i.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d435i.device_info.topic_root )
@@ -62,7 +60,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D405" ):
         remote.run( 'instance = broadcast_device( d405, d405.device_info )' )
-        dev = dds.wait_for_devices( context, only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d405.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d405.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d405.device_info.topic_root )
@@ -80,7 +78,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D455" ):
         remote.run( 'instance = broadcast_device( d455, d455.device_info )' )
-        dev = dds.wait_for_devices( context, only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d455.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d455.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d455.device_info.topic_root )

--- a/unit-tests/dds/test-librs-extrinsics.py
+++ b/unit-tests/dds/test-librs-extrinsics.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
 #test:retries:gha 2
@@ -7,8 +7,7 @@
 from rspy import log, test
 log.nested = 'C  '
 
-import dds
-import pyrealsense2 as rs
+import librs as rs
 if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
@@ -28,7 +27,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     try:
         remote.run( 'instance = broadcast_device( d435i, d435i.device_info )' )
         n_devs = 0
-        for dev in dds.wait_for_devices( context, only_sw_devices ):
+        for dev in rs.wait_for_devices( context, only_sw_devices ):
             n_devs += 1
         test.check_equal( n_devs, 1 )
 

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -1,19 +1,17 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
 #test:retries:gha 2
 
 from rspy import log, test
-import pyrealsense2 as rs
-import dds
+import librs as rs
 
 if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 log.nested = 'C  '
 
 context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'test-formats-conversion' }} )
-only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any)
 
 import os.path
 cwd = os.path.dirname(os.path.realpath(__file__))
@@ -25,10 +23,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test setup", on_fail=test.ABORT ):
         remote.run( 'create_server()' )
-        n_devs = 0
-        for dev in dds.wait_for_devices( context, only_sw_devices ):
-            n_devs += 1
-        test.check_equal( n_devs, 1 )
+        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
         sensors = {sensor.get_info( rs.camera_info.name ) : sensor for sensor in dev.query_sensors()}
     #
     #############################################################################################

--- a/unit-tests/dds/test-librs-options.py
+++ b/unit-tests/dds/test-librs-options.py
@@ -40,17 +40,15 @@ with test.remote.fork( nested_indent=None ) as remote:
     ###############################################################################################################
     # The client is LibRS
     #
-    import pyrealsense2 as rs
+    import librs as rs
     if log.is_debug_on():
         rs.log_to_console( rs.log_severity.debug )
-    from dds import wait_for_devices
 
     with test.closure( 'Initialize librealsense context', on_fail=test.ABORT ):
         context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'client' }} )
-        only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any)
 
     with test.closure( 'Find the server', on_fail=test.ABORT ):
-        dev = wait_for_devices( context, only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
         for s in dev.query_sensors():
             break
         options = test.info( "supported options", s.get_supported_options() )

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
 #test:retries:gha 2
@@ -137,13 +137,11 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #############################################################################################
     #
     with test.closure( "Initialize librs device", on_fail=test.ABORT ):
-        import pyrealsense2 as rs
+        import librs as rs
         if log.is_debug_on():
             rs.log_to_console( rs.log_severity.debug )
-        from dds import wait_for_devices
         context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'librs' }} )
-        only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
-        device = wait_for_devices( context, only_sw_devices, n=1. )
+        device = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
         sensors = device.sensors
         test.check_equal( len(sensors), 1, on_fail=test.RAISE )
         sensor = sensors[0]

--- a/unit-tests/dds/test-participant.py
+++ b/unit-tests/dds/test-participant.py
@@ -1,46 +1,79 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
+#test:retries:gha 2
 
-import pyrealdds as client
 from rspy import log, test
+import pyrealdds as dds
 
+with test.remote.fork( nested_indent='  S' ) as remote:
+    if remote is None:  # we're the fork
+        dds.debug( log.is_debug_on(), log.nested )
 
-import dds
-client.debug( log.is_debug_on(), 'C  ' )
-log.nested = 'C  '
+        def start_participant():
+            global participant
+            participant = dds.participant()
+            test.check( not participant )
 
+            participant.init( 123, 'participant-server' )
 
-#############################################################################################
-#
-test.start( "Checking we can detect another participant..." )
+            test.check( participant )
+            test.check( participant.is_valid() )
 
-server_added = False
-def on_participant_added( guid, name ):
-    global server_added
-    if name == 'test-participant-server':
-        server_added = True
-server_removed = False
-def on_participant_removed( guid, name ):
-    global server_removed
-    if name == 'test-participant-server':
-        server_removed = True
+        def stop_participant():
+            global participant
+            del participant
 
-participant = client.participant()
-participant.init( 123, "test-participant-client" )
-listener = participant.create_listener()
-listener.on_participant_added( on_participant_added )
-listener.on_participant_removed( on_participant_removed )
+        raise StopIteration()  # the remote is now interactive
 
-dds.run_server( 'participant-server.py', nested_indent="  S" )
+    ###############################################################################################################
+    # The client
+    #
 
-test.check( server_added )
-test.check( server_removed )
+    import threading
 
-listener = None
-participant = None
-test.finish()
-#
-#############################################################################################
-test.print_results_and_exit()
+    dds.debug( log.is_debug_on(), 'C  ' )
+    log.nested = 'C  '
+
+    with test.closure( 'setup client' ):
+
+        server_added = False
+        participants_changed = threading.Event()
+        def on_participant_added( guid, name ):
+            global server_added
+            if name == 'participant-server':
+                server_added = True
+                participants_changed.set()
+        server_removed = False
+        def on_participant_removed( guid, name ):
+            global server_removed
+            if name == 'participant-server':
+                server_removed = True
+                participants_changed.set()
+
+        participant = dds.participant()
+        participant.init( 123, 'participant-client' )
+
+        listener = participant.create_listener()
+        listener.on_participant_added( on_participant_added )
+        listener.on_participant_removed( on_participant_removed )
+
+    with test.closure( 'We can see a new participant' ):
+        test.check_false( server_added )
+        participants_changed.clear()
+        remote.run( 'start_participant()' )
+        test.check( participants_changed.wait( 3 ) )
+        test.check( server_added )
+
+    with test.closure( 'And its removal' ):
+        test.check_false( server_removed )
+        participants_changed.clear()
+        remote.run( 'stop_participant()' )
+        test.check( participants_changed.wait( 3 ) )
+        test.check( server_removed )
+
+    listener = None
+    participant = None
+
+test.print_results()

--- a/unit-tests/dds/test-query-option.py
+++ b/unit-tests/dds/test-query-option.py
@@ -48,7 +48,6 @@ with test.remote.fork( nested_indent=None ) as remote:
     ###############################################################################################################
     # The client is a device from which we send controls
     #
-    from dds import wait_for_devices
 
     with test.closure( 'Start the client participant' ):
         participant = dds.participant()


### PR DESCRIPTION
The D400 has all resolutions predefined on camera and retrieved via `RECPARAMSGET`. But sometimes we want a single 'nominal' resolution intrinsics (focal length, principal point) that gets scaled to all other resolutions dynamically.

- dds intrinsics serialize as an object now; fixed member names; added JSON serialization of float3
- providing only a single resolution in the intrinsics set will now make it scalable (in libRS)
- add unit-test

Also:
- fix many D400 color/IR profiles that, under the adapter (where the format conversion isn't full), were missing tags
- [fix 5e distortion model; add d500_calibration_distortion enum](d58fcf14e1e50a0d3dd2becfea6d40c83bd1cd96)

Tracked on [RSDEV-1868]