### PR TITLE
Non-float option fixes

### DIFF
--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -215,12 +215,13 @@ std::vector< const char * > option_model::get_combo_labels( int * p_selected ) c
 
         switch( value->type )
         {
-        case RS2_OPTION_TYPE_FLOAT:
-            if( std::fabs( i - value->as_float ) < 0.001f )
-                selected = counter;
-            break;
         case RS2_OPTION_TYPE_STRING:
             if( 0 == strcmp( label, value->as_string ) )
+                selected = counter;
+            break;
+
+        default:
+            if( std::fabs( i - value_as_float() ) < 0.001f )
                 selected = counter;
             break;
         }
@@ -284,6 +285,48 @@ bool option_model::draw_combobox( notifications_model & model,
     return item_clicked;
 }
 
+
+float option_model::value_as_float() const
+{
+    switch( value->type )
+    {
+    case RS2_OPTION_TYPE_FLOAT:
+        return value->as_float;
+        break;
+
+    case RS2_OPTION_TYPE_INTEGER:
+    case RS2_OPTION_TYPE_BOOLEAN:
+        return float( value->as_integer );
+        break;
+    }
+    return 0.f;
+}
+
+
+std::string option_model::value_as_string() const
+{
+    switch( value->type )
+    {
+    case RS2_OPTION_TYPE_FLOAT:
+        if( is_all_integers() )
+            return rsutils::string::from() << (int) value->as_float;
+        else
+            return rsutils::string::from() << value->as_float;
+        break;
+
+    case RS2_OPTION_TYPE_INTEGER:
+    case RS2_OPTION_TYPE_BOOLEAN:
+        return rsutils::string::from() << value->as_integer;
+        break;
+
+    case RS2_OPTION_TYPE_STRING:
+        return value->as_string;
+        break;
+    }
+    return {};
+}
+
+
 bool option_model::draw_slider( notifications_model & model,
                                 std::string & error_message,
                                 const char * description,
@@ -320,10 +363,7 @@ bool option_model::draw_slider( notifications_model & model,
             ImGui::PushStyleColor( ImGuiCol_Button, { 1.f, 1.f, 1.f, 0.f } );
             if( ImGui::Button( edit_id.c_str(), { 20, 20 } ) )
             {
-                if( is_all_integers() )
-                    edit_value = rsutils::string::from() << (int)value->as_float;
-                else
-                    edit_value = rsutils::string::from() << value->as_float;
+                edit_value = value_as_string();
                 edit_mode = true;
             }
             if( ImGui::IsItemHovered() )
@@ -358,18 +398,17 @@ bool option_model::draw_slider( notifications_model & model,
         if( read_only )
         {
             ImVec2 vec{ 0, 20 };
-            std::string text = ( value->as_float == (int)value->as_float ) ? std::to_string( (int)value->as_float )
-                                                                           : std::to_string( value->as_float );
+            std::string text = value_as_string();
             if( range.min != range.max )
             {
-                ImGui::ProgressBar( ( value->as_float / ( range.max - range.min ) ), vec, text.c_str() );
+                ImGui::ProgressBar( ( value_as_float() / ( range.max - range.min ) ), vec, text.c_str() );
             }
             else  // constant value options
             {
                 auto c = ImGui::ColorConvertU32ToFloat4( ImGui::GetColorU32( ImGuiCol_FrameBg ) );
                 ImGui::PushStyleColor( ImGuiCol_FrameBgActive, c );
                 ImGui::PushStyleColor( ImGuiCol_FrameBgHovered, c );
-                float dummy = std::floor( value->as_float );
+                float dummy = std::floor( value_as_float() );
                 if( ImGui::DragFloat( id.c_str(), &dummy, 1, 0, 0, text.c_str() ) )
                 {
                     // Changing the depth units not on advanced mode is not allowed,
@@ -438,7 +477,7 @@ bool option_model::draw_slider( notifications_model & model,
                     {
                         if (invalidate_flag)
                             *invalidate_flag = true;
-                        model.add_log(rsutils::string::from() << "Setting " << opt << " to " << value->as_float);
+                        model.add_log( rsutils::string::from() << "Setting " << opt << " to " << value_as_string() );
                     }
                 }
                 edit_mode = false;
@@ -454,13 +493,14 @@ bool option_model::draw_slider( notifications_model & model,
         else if( is_all_integers() )
         {
             // runs when changing a value with slider and not the textbox
-            auto int_value = static_cast< int >( value->as_float );
+            auto int_value = static_cast< int >( value_as_float() );
 
             if( ImGui::SliderIntWithSteps( id.c_str(),
                                            &int_value,
                                            static_cast< int >( range.min ),
                                            static_cast< int >( range.max ),
-                                           static_cast< int >( range.step ) ) )
+                                           static_cast< int >( range.step ),
+                                           "%.0f" ) )  // integers don't have any precision
             {
                 // TODO: Round to step?
                 slider_clicked = slider_selected( opt,
@@ -478,7 +518,7 @@ bool option_model::draw_slider( notifications_model & model,
         }
         else
         {
-            float tmp_value = value->as_float;
+            float tmp_value = value_as_float();
             float temp_value_displayed = tmp_value;
             float min_range_displayed = range.min;
             float max_range_displayed = range.max;
@@ -554,7 +594,8 @@ bool option_model::draw_checkbox( notifications_model & model,
 {
     bool checkbox_was_clicked = false;
 
-    auto bool_value = value->as_float > 0.0f;
+    bool bool_value = value_as_float() > 0.f;
+
     if( ImGui::Checkbox( label.c_str(), &bool_value ) )
     {
         checkbox_was_clicked = true;

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -24,6 +24,8 @@ namespace rs2
             std::string& error_message, notifications_model& model );
 
         std::vector< const char * > get_combo_labels( int * p_selected = nullptr ) const;
+        std::string value_as_string() const;
+        float value_as_float() const;
 
         rs2_option opt;
         option_range range;

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -103,19 +103,19 @@ namespace rs2
     bool restore_processing_block(const char* name,
         std::shared_ptr<rs2::processing_block> pb, bool enable)
     {
-        for (auto opt : pb->get_supported_options())
+        for( auto opt : pb->get_supported_option_values() )
         {
             std::string key = name;
             key += ".";
-            key += pb->get_option_name(opt);
+            key += pb->get_option_name( opt->id );
             if (config_file::instance().contains(key.c_str()))
             {
                 float val = config_file::instance().get(key.c_str());
                 try
                 {
-                    auto range = pb->get_option_range(opt);
+                    auto range = pb->get_option_range( opt->id );
                     if (val >= range.min && val <= range.max)
-                        pb->set_option(opt, val);
+                        pb->set_option( opt->id, val );
                 }
                 catch (...)
                 {
@@ -1678,7 +1678,7 @@ namespace rs2
                 if (next == RS2_OPTION_ENABLE_AUTO_EXPOSURE)
                 {
                     auto old_ae_enabled = auto_exposure_enabled;
-                    auto_exposure_enabled = opt_md.value->as_float > 0;
+                    auto_exposure_enabled = opt_md.value_as_float() > 0;
 
                     if (!old_ae_enabled && auto_exposure_enabled)
                     {
@@ -1702,11 +1702,11 @@ namespace rs2
 
                 if (next == RS2_OPTION_DEPTH_UNITS)
                 {
-                    opt_md.dev->depth_units = opt_md.value->as_float;
+                    opt_md.dev->depth_units = opt_md.value_as_float();
                 }
 
                 if (next == RS2_OPTION_STEREO_BASELINE)
-                    opt_md.dev->stereo_baseline = opt_md.value->as_float;
+                    opt_md.dev->stereo_baseline = opt_md.value_as_float();
             }
 
             next_option++;

--- a/src/core/options-watcher.cpp
+++ b/src/core/options-watcher.cpp
@@ -131,7 +131,7 @@ options_watcher::options_and_values options_watcher::update_options()
         {
             json curr_val;
             if( opt.second.sptr->is_enabled() )
-                curr_val = opt.second.sptr->query();
+                curr_val = opt.second.sptr->get_value();
 
             if( ! opt.second.p_last_known_value || *opt.second.p_last_known_value != curr_val )
             {


### PR DESCRIPTION
- `options_watcher` was using the old `query()` to update values but this turned all the options into floats; instead, it now uses `get_value()`
- non-float options were displaying as zeroes; fixed
- integer sliders were showing decimal points; fixed
