### PR TITLE
Cherry Pick PR #12799 l4t: uvc patch fix localversion

### DIFF
--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -140,7 +140,7 @@ if [ "4.4" = "$PATCHES_REV" ]; then
 	sed -i '/CONFIG_HID_SENSOR_GYRO_3D/c\CONFIG_HID_SENSOR_GYRO_3D=m' .config
 	sed -i '/CONFIG_HID_SENSOR_IIO_COMMON/c\CONFIG_HID_SENSOR_IIO_COMMON=m\nCONFIG_HID_SENSOR_IIO_TRIGGER=m' .config
 fi
-make ARCH=arm64 prepare modules_prepare  -j$(($(nproc)-1))
+make ARCH=arm64 prepare modules_prepare LOCALVERSION='' -j$(($(nproc)-1))
 
 #Remove previously applied patches
 git reset --hard


### PR DESCRIPTION
w/o setting an empty `localversion`, the make script was concatenating a `#` to the new kernel name, and this caused the script to miss the required kernel name.
This hack fix it 