### PR TITLE
D500 - retry GET_GVD

### DIFF
--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -435,8 +435,15 @@ namespace librealsense
         bool advanced_mode = false;
         bool usb_modality = true;
         group_multiple_fw_calls(depth_sensor, [&]() {
+            
+            const int HW_NOT_READY_ERR_CODE = -3;
+            const std::set< int32_t > gvd_retry_errors{ HW_NOT_READY_ERR_CODE };
 
-            _hw_monitor->get_gvd(gvd_buff.size(), gvd_buff.data(), ds::fw_cmd::GVD);
+            _hw_monitor->get_gvd( gvd_buff.size(),
+                                  gvd_buff.data(),
+                                  ds::fw_cmd::GVD,
+                                  &gvd_retry_errors );
+
             get_gvd_details(gvd_buff, &gvd_parsed_fields);
             
             _device_capabilities = ds_caps::CAP_ACTIVE_PROJECTOR | ds_caps::CAP_RGB_SENSOR | ds_caps::CAP_IMU_SENSOR |

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -436,6 +436,13 @@ namespace librealsense
         bool usb_modality = true;
         group_multiple_fw_calls(depth_sensor, [&]() {
             
+            // D500 device can get enumerated before the whole HW in the camera is ready.
+            // Since GVD gather all information from all the HW, it might need some more time to finish all hand shakes.
+            // on this case it will return HW_NOT_READY error code.
+            // Note: D500 error codes list is different than D400.
+            //       This will need a redactor on hw_monitor class to except the error code list from outside.
+            //       Currently, we hard code the HW not ready error code
+
             const int HW_NOT_READY_ERR_CODE = -3;
             const std::set< int32_t > gvd_retry_errors{ HW_NOT_READY_ERR_CODE };
 

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -1,50 +1,27 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
-#include "uvc-sensor.h"
-#include <mutex>
 #include "platform/command-transfer.h"
+#include "uvc-sensor.h"
 #include <string>
 #include <algorithm>
 #include <vector>
+#include <set>
+#include <mutex>
 
 
 namespace librealsense
 {
-    const uint8_t   IV_COMMAND_FIRMWARE_UPDATE_MODE = 0x01;
-    const uint8_t   IV_COMMAND_GET_CALIBRATION_DATA = 0x02;
-    const uint8_t   IV_COMMAND_LASER_POWER          = 0x03;
-    const uint8_t   IV_COMMAND_DEPTH_ACCURACY       = 0x04;
-    const uint8_t   IV_COMMAND_ZUNIT                = 0x05;
-    const uint8_t   IV_COMMAND_LOW_CONFIDENCE_LEVEL = 0x06;
-    const uint8_t   IV_COMMAND_INTENSITY_IMAGE_TYPE = 0x07;
-    const uint8_t   IV_COMMAND_MOTION_VS_RANGE_TRADE= 0x08;
-    const uint8_t   IV_COMMAND_POWER_GEAR           = 0x09;
-    const uint8_t   IV_COMMAND_FILTER_OPTION        = 0x0A;
-    const uint8_t   IV_COMMAND_VERSION              = 0x0B;
-    const uint8_t   IV_COMMAND_CONFIDENCE_THRESHHOLD= 0x0C;
 
-    const uint8_t   IVCAM_MONITOR_INTERFACE         = 0x4;
-    const uint8_t   IVCAM_MONITOR_ENDPOINT_OUT      = 0x1;
-    const uint8_t   IVCAM_MONITOR_ENDPOINT_IN       = 0x81;
-    const uint8_t   IVCAM_MIN_SUPPORTED_VERSION     = 13;
-    const uint8_t   IVCAM_MONITOR_HEADER_SIZE       = (sizeof(uint32_t) * 6);
-    const uint8_t   NUM_OF_CALIBRATION_PARAMS       = 100;
-    const uint8_t   PARAMETERS2_BUFFER_SIZE          = 50;
-    const uint8_t   SIZE_OF_CALIB_HEADER_BYTES      = 4;
-    const uint8_t   NUM_OF_CALIBRATION_COEFFS       = 64;
-
-    const uint16_t  MAX_SIZE_OF_CALIB_PARAM_BYTES   = 800;
-    const uint16_t  SIZE_OF_CALIB_PARAM_BYTES       = 512;
-    const uint16_t  IVCAM_MONITOR_MAGIC_NUMBER      = 0xcdab;
-    const uint16_t  IVCAM_MONITOR_MAX_BUFFER_SIZE   = 1024;
-    const uint16_t  IVCAM_MONITOR_MUTEX_TIMEOUT     = 3000;
-    const uint16_t  HW_MONITOR_COMMAND_SIZE         = 1000;
-    const uint16_t  HW_MONITOR_BUFFER_SIZE          = 1024;
-    const uint16_t  HW_MONITOR_DATA_SIZE_OFFSET     = 1020;
-    const uint16_t  SIZE_OF_HW_MONITOR_HEADER       = 4;
+    const uint16_t  HW_MONITOR_MAGIC_NUMBER      = 0xcdab;
+    const uint16_t  HW_MONITOR_MAX_BUFFER_SIZE   = 1024;
+    const uint16_t  HW_MONITOR_MUTEX_TIMEOUT     = 3000;
+    const uint16_t  HW_MONITOR_COMMAND_SIZE      = 1000;
+    const uint16_t  HW_MONITOR_BUFFER_SIZE       = 1024;
+    const uint16_t  HW_MONITOR_DATA_SIZE_OFFSET  = 1020;
+    const uint16_t  SIZE_OF_HW_MONITOR_HEADER    = 4;
 
     class uvc_sensor;
 
@@ -318,7 +295,10 @@ namespace librealsense
             uint8_t const * data = nullptr,
             size_t dataLength = 0);
 
-        void get_gvd(size_t sz, unsigned char* gvd, uint8_t gvd_cmd) const;
+        void get_gvd( size_t sz,
+                      unsigned char * gvd,
+                      uint8_t gvd_cmd,
+                      const std::set< int32_t > * retry_error_codes = nullptr ) const;
 
         template<typename T>
         std::string get_firmware_version_string( const std::vector< uint8_t > & buff,

--- a/src/hw-monitor.h
+++ b/src/hw-monitor.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2015-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 


### PR DESCRIPTION
On D500 device, if the device is not ready after USB enumeration it will return NOT_READY error code to GET_GVD command.
This PR add retries when this happens on D500 devices

Note: also done some includes cleanup and renames
Tracked on [RSDEV-1826)]