### PR TITLE
Update tests to use default profiles

### DIFF
--- a/unit-tests/live/frames/test-fps.py
+++ b/unit-tests/live/frames/test-fps.py
@@ -86,10 +86,10 @@ for i in range(len(tested_fps)):
                   and p.stream_type() == rs.stream.depth
                   and p.format() == rs.format.z16)
     except StopIteration:
-        print("Requested fps: {:.1f} [Hz], not supported".format(requested_fps))
+        log.i("Requested fps: {:.1f} [Hz], not supported".format(requested_fps))
     else:
         fps = measure_fps(ds, dp, time_to_test_fps[i])
-        print("Requested fps: {:.1f} [Hz], actual fps: {:.1f} [Hz]. Time to first frame {:.6f}".format(requested_fps, fps, first_frame_seconds))
+        log.i("Requested fps: {:.1f} [Hz], actual fps: {:.1f} [Hz]. Time to first frame {:.6f}".format(requested_fps, fps, first_frame_seconds))
         delta_Hz = requested_fps * 0.05 # Validation KPI is 5%
         test.check(fps <= (requested_fps + delta_Hz) and fps >= (requested_fps - delta_Hz))
 test.finish()
@@ -114,10 +114,10 @@ for i in range(len(tested_fps)):
                   and p.stream_type() == rs.stream.color
                   and p.format() == rs.format.rgb8)
     except StopIteration:
-        print("Requested fps: {:.1f} [Hz], not supported".format(requested_fps))
+        log.i("Requested fps: {:.1f} [Hz], not supported".format(requested_fps))
     else:
         fps = measure_fps(cs, cp, time_to_test_fps[i])
-        print("Requested fps: {:.1f} [Hz], actual fps: {:.1f} [Hz]. Time to first frame {:.6f}".format(requested_fps, fps, first_frame_seconds))
+        log.i("Requested fps: {:.1f} [Hz], actual fps: {:.1f} [Hz]. Time to first frame {:.6f}".format(requested_fps, fps, first_frame_seconds))
         delta_Hz = requested_fps * 0.05 # Validation KPI is 5%
         test.check(fps <= (requested_fps + delta_Hz) and fps >= (requested_fps - delta_Hz))
 

--- a/unit-tests/live/frames/test-t2ff-sensor.py
+++ b/unit-tests/live/frames/test-t2ff-sensor.py
@@ -58,7 +58,7 @@ print("Device creation time is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".form
 test.check(device_creation_time < max_time_for_device_creation)
 test.finish()
 
-
+product_line = dev.get_info(rs.camera_info.product_line)
 max_delay_for_depth_frame = 1
 max_delay_for_color_frame = 1
 

--- a/unit-tests/live/frames/test-t2ff-sensor.py
+++ b/unit-tests/live/frames/test-t2ff-sensor.py
@@ -59,13 +59,8 @@ test.check(device_creation_time < max_time_for_device_creation)
 test.finish()
 
 
-# Set maximum delay for first frame according to product line
-product_line = dev.get_info(rs.camera_info.product_line)
-if product_line == "D400":
-    max_delay_for_depth_frame = 1
-    max_delay_for_color_frame = 1
-else:
-    log.f( "This test support only D400 devices" )
+max_delay_for_depth_frame = 1
+max_delay_for_color_frame = 1
 
 
 ds = dev.first_depth_sensor()
@@ -74,12 +69,14 @@ cs = dev.first_color_sensor()
 dp = next(p for p in
           ds.profiles if p.fps() == 30
           and p.stream_type() == rs.stream.depth
-          and p.format() == rs.format.z16)
+          and p.format() == rs.format.z16
+          and p.is_default())
 
 cp = next(p for p in
           cs.profiles if p.fps() == 30
           and p.stream_type() == rs.stream.color
-          and p.format() == rs.format.rgb8)
+          and p.format() == rs.format.rgb8
+          and p.is_default())
 
 
 #####################################################################################################

--- a/unit-tests/live/options/test-timestamp-domain.py
+++ b/unit-tests/live/options/test-timestamp-domain.py
@@ -49,7 +49,7 @@ device = test.find_first_device_or_exit()
 depth_frame_queue = rs.frame_queue(queue_capacity, keep_frames=False)
 
 depth_sensor = device.first_depth_sensor()
-depth_profile = next(p for p in depth_sensor.profiles if p.stream_type() == rs.stream.depth)
+depth_profile = next(p for p in depth_sensor.profiles if p.stream_type() == rs.stream.depth and p.is_default())
 depth_sensor.open(depth_profile)
 depth_sensor.start(depth_frame_queue)
 
@@ -69,7 +69,7 @@ close_resources(depth_sensor)
 color_frame_queue = rs.frame_queue(queue_capacity, keep_frames=False)
 
 color_sensor = device.first_color_sensor()
-color_profile = next(p for p in color_sensor.profiles if p.stream_type() == rs.stream.color)
+color_profile = next(p for p in color_sensor.profiles if p.stream_type() == rs.stream.color and p.is_default())
 color_sensor.open(color_profile)
 color_sensor.start(color_frame_queue)
 


### PR DESCRIPTION
Since some profiles has restrictions on certain cameras, best to peek the default profile whenever it is possible