### PR TITLE
Fix settings in rs2_create_context

### DIFF
--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -271,7 +271,7 @@ rs2_context* rs2_create_context(int api_version, rs2_error** error) BEGIN_API_CA
 {
     verify_version_compatibility(api_version);
 
-    json settings;
+    json settings = json::object();
     return new rs2_context{ context::make( settings ) };
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, api_version)


### PR DESCRIPTION
C examples weren't working, but really it was `rs2_create_context` due to null JSON settings used internally.
The C++ API worked fine.

Tracked on [LRS-1078]