### PR TITLE
Fix FW logs bug.

### DIFF
--- a/src/firmware_logger_device.cpp
+++ b/src/firmware_logger_device.cpp
@@ -48,11 +48,11 @@ namespace librealsense
         {
             auto res = _hw_monitor->send( update_command );
             if( ! res.empty() )
-                HandleReceivedData( res );
+                handle_received_data( res );
         }
     }
 
-    void firmware_logger_device::HandleReceivedData( std::vector< uint8_t > & res )
+    void firmware_logger_device::handle_received_data( const std::vector< uint8_t > & res )
     {
         // Convert bytes to fw_logs_binary_data
         auto beginOfLogIterator = res.data();
@@ -180,7 +180,7 @@ namespace librealsense
         {
             auto res = _hw_monitor->send( start_command );
             if( !res.empty() )
-                HandleReceivedData( res );
+                handle_received_data( res );
         }
     }
 
@@ -196,7 +196,7 @@ namespace librealsense
         {
             auto res = _hw_monitor->send( stop_command );
             if( !res.empty() )
-                HandleReceivedData( res );
+                handle_received_data( res );
         }
     }
 

--- a/src/firmware_logger_device.h
+++ b/src/firmware_logger_device.h
@@ -49,7 +49,7 @@ namespace librealsense
 
     protected:
         void get_fw_logs_from_hw_monitor();
-        void HandleReceivedData( std::vector< uint8_t > & res );
+        void handle_received_data( const std::vector< uint8_t > & res );
         void get_flash_logs_from_hw_monitor();
         virtual command get_update_command();
         virtual size_t get_log_size( const uint8_t * buff ) const;

--- a/src/firmware_logger_device.h
+++ b/src/firmware_logger_device.h
@@ -49,6 +49,7 @@ namespace librealsense
 
     protected:
         void get_fw_logs_from_hw_monitor();
+        void HandleReceivedData( std::vector< uint8_t > & res );
         void get_flash_logs_from_hw_monitor();
         virtual command get_update_command();
         virtual size_t get_log_size( const uint8_t * buff ) const;


### PR DESCRIPTION
Did not parse messages returned for the "start" HWMC, only parsed for the "update" HWMC.

Also the viewer parse the XML repeatedly, changed to parse only once when starting.
