### PR TITLE
unit-tests: check hwmc error codes

### DIFF
--- a/unit-tests/live/debug_protocol/test-hwmc-errors.py
+++ b/unit-tests/live/debug_protocol/test-hwmc-errors.py
@@ -1,0 +1,109 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+
+# test:device D400*
+
+import pyrealsense2 as rs
+from rspy import devices, log, test, file, repo
+
+
+#############################################################################################
+# Help Functions
+#############################################################################################
+
+def convert_bytes_string_to_decimal_list(command):
+    command_input = []  # array of uint_8t
+
+    # Parsing the command to array of unsigned integers(size should be < 8bits)
+    # threw out spaces
+    command = command.lower()
+    command = command.split()
+
+    for byte in command:
+        command_input.append(int('0x' + byte, 0))
+
+    return command_input
+
+
+def send_hardware_monitor_command(device, command):
+    raw_result = rs.debug_protocol(device).send_and_receive_raw_data(command)
+    status = raw_result[:4]
+    result = raw_result[4:]
+    return status, result
+
+
+#############################################################################################
+# Tests
+#############################################################################################
+
+test.start("Init")
+try:
+    ctx = rs.context()
+    dev = ctx.query_devices()[0]
+except:
+    test.unexpected_exception()
+test.finish()
+
+#############################################################################################
+
+test.start("WRONGCOMMAND")
+try:
+    hwmc_opcode_as_int = 0xee
+    hwmc_opcode_as_string = "ff ff ff ff"  # little endian
+
+    raw_command = rs.debug_protocol(dev).build_command(hwmc_opcode_as_int)
+    status, new_scenario_result = send_hardware_monitor_command(dev, raw_command)
+
+    # expected status in case of success of "send_hardware_monitor_command" is the same as opcode
+    # we expect erro code instead of opcode
+    expected_status = convert_bytes_string_to_decimal_list(hwmc_opcode_as_string)
+    test.check_equal_lists(status, expected_status)
+
+except:
+    test.unexpected_exception()
+test.finish()
+
+#############################################################################################
+
+test.start("GETSUBPRESETID")
+try:
+    hwmc_opcode_as_int = 0x7d
+    # ERR_NoDataToReturn = -21 = 0xeb
+    hwmc_opcode_as_string = "eb ff ff ff"  # little endian
+
+    raw_command = rs.debug_protocol(dev).build_command(hwmc_opcode_as_int)
+    status, new_scenario_result = send_hardware_monitor_command(dev, raw_command)
+
+    # expected status in case of success of "send_hardware_monitor_command" is the same as opcode
+    # we expect erro code instead of opcode
+    expected_status = convert_bytes_string_to_decimal_list(hwmc_opcode_as_string)
+    test.check_equal_lists(status, expected_status)
+
+except:
+    test.unexpected_exception()
+test.finish()
+
+#############################################################################################
+
+test.start("SPWM")
+try:
+    hwmc_opcode_as_int = 0x1a
+    # ERR_WrongParameter = -6 = 0xfa
+    hwmc_opcode_as_string = "fa ff ff ff"  # little endian
+
+    raw_command = rs.debug_protocol(dev).build_command(hwmc_opcode_as_int)
+    raw_command[9] = 2
+    status, new_scenario_result = send_hardware_monitor_command(dev, raw_command)
+
+    # expected status in case of success of "send_hardware_monitor_command" is the same as opcode
+    # we expect erro code instead of opcode
+    expected_status = convert_bytes_string_to_decimal_list(hwmc_opcode_as_string)
+    test.check_equal_lists(status, expected_status)
+
+except:
+    test.unexpected_exception()
+test.finish()
+
+#############################################################################################
+
+test.print_results_and_exit()

--- a/unit-tests/live/debug_protocol/test-hwmc-errors.py
+++ b/unit-tests/live/debug_protocol/test-hwmc-errors.py
@@ -46,16 +46,16 @@ test.finish()
 
 #############################################################################################
 
-test.start("WRONGCOMMAND")
+test.start("WRONG COMMAND")
 try:
     hwmc_opcode_as_int = 0xee
     hwmc_opcode_as_string = "ff ff ff ff"  # little endian
 
     raw_command = rs.debug_protocol(dev).build_command(hwmc_opcode_as_int)
-    status, new_scenario_result = send_hardware_monitor_command(dev, raw_command)
+    status, result = send_hardware_monitor_command(dev, raw_command)
 
     # expected status in case of success of "send_hardware_monitor_command" is the same as opcode
-    # we expect erro code instead of opcode
+    # we expect error code instead of opcode
     expected_status = convert_bytes_string_to_decimal_list(hwmc_opcode_as_string)
     test.check_equal_lists(status, expected_status)
 
@@ -65,17 +65,17 @@ test.finish()
 
 #############################################################################################
 
-test.start("GETSUBPRESETID")
+test.start("GETSUBPRESETID - No Data to Return")
 try:
     hwmc_opcode_as_int = 0x7d
     # ERR_NoDataToReturn = -21 = 0xeb
     hwmc_opcode_as_string = "eb ff ff ff"  # little endian
 
     raw_command = rs.debug_protocol(dev).build_command(hwmc_opcode_as_int)
-    status, new_scenario_result = send_hardware_monitor_command(dev, raw_command)
+    status, result = send_hardware_monitor_command(dev, raw_command)
 
     # expected status in case of success of "send_hardware_monitor_command" is the same as opcode
-    # we expect erro code instead of opcode
+    # we expect error code instead of opcode
     expected_status = convert_bytes_string_to_decimal_list(hwmc_opcode_as_string)
     test.check_equal_lists(status, expected_status)
 
@@ -85,7 +85,7 @@ test.finish()
 
 #############################################################################################
 
-test.start("SPWM")
+test.start("Set PWM - Wrong Parameter")
 try:
     hwmc_opcode_as_int = 0x1a
     # ERR_WrongParameter = -6 = 0xfa
@@ -93,10 +93,10 @@ try:
 
     raw_command = rs.debug_protocol(dev).build_command(hwmc_opcode_as_int)
     raw_command[9] = 2
-    status, new_scenario_result = send_hardware_monitor_command(dev, raw_command)
+    status, result = send_hardware_monitor_command(dev, raw_command)
 
     # expected status in case of success of "send_hardware_monitor_command" is the same as opcode
-    # we expect erro code instead of opcode
+    # we expect error code instead of opcode
     expected_status = convert_bytes_string_to_decimal_list(hwmc_opcode_as_string)
     test.check_equal_lists(status, expected_status)
 

--- a/unit-tests/live/debug_protocol/test-hwmc-errors.py
+++ b/unit-tests/live/debug_protocol/test-hwmc-errors.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 # test:device D400*
 


### PR DESCRIPTION
Verify error codes returned by hwmc bad commands.

This test relevant to D457 MIPI driver version.

Expected: d4xx driver versions

above 1.0.1.22 - pass

below 1.0.1.22 - fail

Tracked-by: LRS-1065

<!--
    Pull requests should go to the development branch:
    https://github.com/IntelRealSense/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/IntelRealSense/librealsense/blob/master/CONTRIBUTING.md
-->
