### PR TITLE
C++ 17 fixes

### DIFF
--- a/src/fw-logs/fw-logs-formatting-options.cpp
+++ b/src/fw-logs/fw-logs-formatting-options.cpp
@@ -8,6 +8,7 @@
 #include <rsutils/string/from.h>
 
 #include <sstream>
+#include <stdint.h>
 
 namespace librealsense
 {

--- a/src/fw-logs/fw-logs-formatting-options.h
+++ b/src/fw-logs/fw-logs-formatting-options.h
@@ -13,6 +13,7 @@
 #include "../../common/android_helpers.h"
 #endif
 
+#include <stdint.h>
 
 namespace librealsense
 {


### PR DESCRIPTION
Fix missing C++17 headers in fw-logs-formatting-options

gcc-14
``` sh
[ 60%] Building CXX object CMakeFiles/realsense2.dir/src/firmware_logger_device.cpp.o
In file included from /home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.cpp:4:
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.h:31:42: error: ‘uint32_t’ has not been declared
   31 |             std::string get_thread_name( uint32_t thread_id ) const;
      |                                          ^~~~~~~~
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.h:32:42: error: ‘uint32_t’ has not been declared
   32 |             std::string get_module_name( uint32_t module_id ) const;
      |                                          ^~~~~~~~
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.cpp:42:21: error: no declaration matches ‘std::string librealsense::fw_logs::fw_logs_formatting_options::get_thread_name(uint32_t) const’
   42 |         std::string fw_logs_formatting_options::get_thread_name( uint32_t thread_id ) const
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.h:31:25: note: candidate is: ‘std::string librealsense::fw_logs::fw_logs_formatting_options::get_thread_name(int) const’
   31 |             std::string get_thread_name( uint32_t thread_id ) const;
      |                         ^~~~~~~~~~~~~~~
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.h:23:15: note: ‘class librealsense::fw_logs::fw_logs_formatting_options’ defined here
   23 |         class fw_logs_formatting_options
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.cpp:51:21: error: no declaration matches ‘std::string librealsense::fw_logs::fw_logs_formatting_options::get_module_name(uint32_t) const’
   51 |         std::string fw_logs_formatting_options::get_module_name( uint32_t module_id ) const
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.h:32:25: note: candidate is: ‘std::string librealsense::fw_logs::fw_logs_formatting_options::get_module_name(int) const’
   32 |             std::string get_module_name( uint32_t module_id ) const;
      |                         ^~~~~~~~~~~~~~~
/home/rurban/librealsense/src/fw-logs/fw-logs-formatting-options.h:23:15: note: ‘class librealsense::fw_logs::fw_logs_formatting_options’ defined here
   23 |         class fw_logs_formatting_options
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/realsense2.dir/build.make:1266: CMakeFiles/realsense2.dir/src/fw-logs/fw-logs-formatting-options.cpp.o] Error 1
```
