### PR TITLE
DDS metadata: add ToA, backend, actual FPS, raw-frame-size

### DIFF
--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include "sid_index.h"
@@ -8,6 +8,7 @@
 #include <src/proc/formats-converter.h>
 #include <src/core/options-watcher.h>
 
+#include <realdds/dds-defines.h>
 #include <realdds/dds-metadata-syncer.h>
 
 #include <rsutils/json-fwd.h>
@@ -54,6 +55,7 @@ protected:
     {
         syncer_type syncer;
         std::atomic< unsigned long long > last_frame_number{ 0 };
+        std::atomic< rs2_time_t > last_timestamp;
     };
 
 private:
@@ -99,10 +101,12 @@ protected:
     std::shared_ptr< realdds::dds_motion_stream_profile >
     find_profile( sid_index sidx, realdds::dds_motion_stream_profile const & profile ) const;
 
-    void handle_video_data( realdds::topics::image_msg && dds_frame,
+    void handle_video_data( realdds::topics::image_msg &&,
+                            realdds::dds_sample &&,
                             const std::shared_ptr< stream_profile_interface > &,
                             streaming_impl & streaming );
     void handle_motion_data( realdds::topics::imu_msg &&,
+                             realdds::dds_sample &&,
                              const std::shared_ptr< stream_profile_interface > &,
                              streaming_impl & );
     void handle_new_metadata( std::string const & stream_name,

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -69,10 +69,12 @@ namespace librealsense
     class md_array_parser : public md_attribute_parser_base
     {
         rs2_frame_metadata_value _key;
+        std::shared_ptr< md_attribute_parser_base > _fallback;
 
     public:
-        md_array_parser( rs2_frame_metadata_value key )
+        md_array_parser( rs2_frame_metadata_value key, std::shared_ptr< md_attribute_parser_base > fallback = {} )
             : _key( key )
+            , _fallback( std::move( fallback ) )
         {
         }
 
@@ -81,7 +83,7 @@ namespace librealsense
             auto pmd = reinterpret_cast< metadata_array_value const * >( frm.additional_data.metadata_blob.data() );
             metadata_array_value const & value = pmd[_key];
             if( ! value.is_valid )
-                return false;
+                return _fallback ? _fallback->find( frm, p_value ) : false;
             if( p_value )
                 *p_value = value.value;
             return true;

--- a/src/metadata-parser.h
+++ b/src/metadata-parser.h
@@ -95,17 +95,6 @@ namespace librealsense
      *  e.g change auto_exposure enum to boolean, change units from nano->ms,etc'*/
     typedef std::function<rs2_metadata_type(const rs2_metadata_type& param)> attrib_modifyer;
 
-    class md_time_of_arrival_parser : public md_attribute_parser_base
-    {
-    public:
-        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
-        {
-            if( p_value )
-                *p_value = (rs2_metadata_type)frm.get_frame_system_time();
-            return true;
-        }
-    };
-
     /**\brief The metadata parser class directly access the metadata attribute in the blob received from HW.
     *   Given the metadata-nested construct, and the c++ lack of pointers
     *   to the inner struct, we pre-calculate and store the attribute offset internally
@@ -275,7 +264,7 @@ namespace librealsense
     {
     public:
         md_additional_parser(Attribute St::* attribute_name) :
-            _md_attribute(attribute_name) {};
+            _md_attribute(attribute_name) {}
 
         bool find( const frame & frm, rs2_metadata_type * p_value ) const override
         {
@@ -297,6 +286,45 @@ namespace librealsense
     {
         std::shared_ptr<md_additional_parser<St, Attribute>> parser(new md_additional_parser<St, Attribute>(attribute));
         return parser;
+    }
+
+    /**
+     * provide attributes generated and stored internally by the library, unless set to a specific (default?)
+     * value
+     */
+    template< class St, class Attribute >
+    class md_additional_parser_unless : public md_additional_parser< St, Attribute >
+    {
+        using super = md_additional_parser< St, Attribute >;
+
+        Attribute _unless;  // value for which we return "not found"
+
+    public:
+        md_additional_parser_unless( Attribute St::*attribute_name, Attribute unless )
+            : super( attribute_name )
+            , _unless( unless )
+        {
+        }
+
+        bool find( const frame & frm, rs2_metadata_type * p_value ) const override
+        {
+            rs2_metadata_type value;
+            if( ! super::find( frm, &value ) )
+                return false;
+            if( value == _unless )
+                return false;
+            if( p_value )
+                *p_value = value;
+            return true;
+        }
+    };
+
+    /**\brief A utility function to create additional_data parser*/
+    template< class St, class Attribute >
+    std::shared_ptr< md_attribute_parser_base > make_additional_data_parser_unless( Attribute St::*attribute,
+                                                                                    Attribute unless )
+    {
+        return std::make_shared< md_additional_parser_unless< St, Attribute > >( attribute, unless );
     }
 
     /**\brief Optical timestamp for RS4xx devices is calculated internally*/

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -73,7 +73,8 @@ void log_callback_end( uint32_t fps,
     {
         register_option(RS2_OPTION_FRAMES_QUEUE_SIZE, _source.get_published_size_option());
 
-        register_metadata(RS2_FRAME_METADATA_TIME_OF_ARRIVAL, std::make_shared<librealsense::md_time_of_arrival_parser>());
+        register_metadata( RS2_FRAME_METADATA_TIME_OF_ARRIVAL,
+                           make_additional_data_parser_unless( &frame_additional_data::system_time, rs2_time_t( 0 ) ) );
 
         register_info(RS2_CAMERA_INFO_NAME, name);
     }

--- a/src/software-sensor.cpp
+++ b/src/software-sensor.cpp
@@ -29,13 +29,13 @@ static std::shared_ptr< metadata_parser_map > create_software_metadata_parser_ma
         switch( key )
         {
         case RS2_FRAME_METADATA_TIME_OF_ARRIVAL:
-            fallback = std::make_shared< librealsense::md_time_of_arrival_parser >();
+            fallback = make_additional_data_parser_unless( &frame_additional_data::system_time, rs2_time_t( 0 ) );
             break;
         case RS2_FRAME_METADATA_BACKEND_TIMESTAMP:
-            fallback = make_additional_data_parser( &frame_additional_data::backend_timestamp );
+            fallback = make_additional_data_parser_unless( &frame_additional_data::backend_timestamp, rs2_time_t(0) );
             break;
         case RS2_FRAME_METADATA_RAW_FRAME_SIZE:
-            fallback = make_additional_data_parser( &frame_additional_data::raw_size );
+            fallback = make_additional_data_parser_unless( &frame_additional_data::raw_size, uint32_t(0) );
             break;
         case RS2_FRAME_METADATA_ACTUAL_FPS:
             fallback = std::make_shared< ds_md_attribute_actual_fps >();

--- a/src/software-sensor.cpp
+++ b/src/software-sensor.cpp
@@ -25,7 +25,23 @@ static std::shared_ptr< metadata_parser_map > create_software_metadata_parser_ma
     for( int i = 0; i < static_cast< int >( rs2_frame_metadata_value::RS2_FRAME_METADATA_COUNT ); ++i )
     {
         auto key = static_cast< rs2_frame_metadata_value >( i );
-        md_parser_map->emplace( key, std::make_shared< md_array_parser >( key ) );
+        std::shared_ptr< md_attribute_parser_base > fallback;
+        switch( key )
+        {
+        case RS2_FRAME_METADATA_TIME_OF_ARRIVAL:
+            fallback = std::make_shared< librealsense::md_time_of_arrival_parser >();
+            break;
+        case RS2_FRAME_METADATA_BACKEND_TIMESTAMP:
+            fallback = make_additional_data_parser( &frame_additional_data::backend_timestamp );
+            break;
+        case RS2_FRAME_METADATA_RAW_FRAME_SIZE:
+            fallback = make_additional_data_parser( &frame_additional_data::raw_size );
+            break;
+        case RS2_FRAME_METADATA_ACTUAL_FPS:
+            fallback = std::make_shared< ds_md_attribute_actual_fps >();
+            break;
+        }
+        md_parser_map->emplace( key, std::make_shared< md_array_parser >( key, fallback ) );
     }
     return md_parser_map;
 }

--- a/third-party/realdds/include/realdds/dds-defines.h
+++ b/third-party/realdds/include/realdds/dds-defines.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -18,7 +18,13 @@ namespace types {
     class DynamicType_ptr;
 }  // namespace types
 }  // namespace fastrtps
+namespace fastdds {
+namespace dds {
+    struct SampleInfo;
+}  // namespace dds
+}  // namespace fastdds
 }  // namespace eprosima
+
 
 namespace realdds {
 
@@ -30,6 +36,7 @@ using dds_guid_prefix = eprosima::fastrtps::rtps::GuidPrefix_t;
 using dds_entity_id = eprosima::fastrtps::rtps::EntityId_t;
 typedef int dds_domain_id;
 typedef uint64_t dds_sequence_number;  // sample_identity.sequence_number()
+using dds_sample = eprosima::fastdds::dds::SampleInfo;
 
 
 }  // namespace realdds

--- a/third-party/realdds/include/realdds/dds-device-server.h
+++ b/third-party/realdds/include/realdds/dds-device-server.h
@@ -18,15 +18,6 @@
 #include <functional>
 
 
-namespace eprosima {
-namespace fastdds {
-namespace dds {
-struct SampleInfo;
-}  // namespace dds
-}  // namespace fastdds
-}  // namespace eprosima
-
-
 namespace realdds {
 
 

--- a/third-party/realdds/include/realdds/dds-sample.h
+++ b/third-party/realdds/include/realdds/dds-sample.h
@@ -1,0 +1,5 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <fastdds/dds/subscriber/SampleInfo.hpp>

--- a/third-party/realdds/include/realdds/dds-stream.h
+++ b/third-party/realdds/include/realdds/dds-stream.h
@@ -67,7 +67,7 @@ public:
 
     void open( std::string const & topic_name, std::shared_ptr< dds_subscriber > const & ) override;
 
-    typedef std::function< void( topics::image_msg && f ) > on_data_available_callback;
+    typedef std::function< void( topics::image_msg &&, dds_sample && ) > on_data_available_callback;
     void on_data_available( on_data_available_callback cb ) { _on_data_available = cb; }
 
     void set_intrinsics( const std::set< video_intrinsics > & intrinsics ) { _intrinsics = intrinsics; }
@@ -132,7 +132,7 @@ public:
 
     void open( std::string const & topic_name, std::shared_ptr< dds_subscriber > const & ) override;
 
-    typedef std::function< void( topics::imu_msg && f ) > on_data_available_callback;
+    typedef std::function< void( topics::imu_msg &&, dds_sample && ) > on_data_available_callback;
     void on_data_available( on_data_available_callback cb ) { _on_data_available = cb; }
 
     void set_accel_intrinsics( const motion_intrinsics & intrinsics ) { _accel_intrinsics = intrinsics; }

--- a/third-party/realdds/include/realdds/dds-time.h
+++ b/third-party/realdds/include/realdds/dds-time.h
@@ -50,6 +50,15 @@ inline long double time_to_double( dds_time const & t )
 }
 
 
+inline long double time_to_double( eprosima::fastrtps::rtps::Time_t const & t )
+{
+    long double sec = t.seconds();
+    long double nsec = t.nanosec();
+    nsec /= 1000000000ULL;
+    return sec + nsec;
+}
+
+
 std::string time_to_string( dds_time const & t );
 
 

--- a/third-party/realdds/include/realdds/topics/blob-msg.h
+++ b/third-party/realdds/include/realdds/topics/blob-msg.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include "blob/blob.h"
@@ -8,15 +8,6 @@
 #include <string>
 #include <memory>
 #include <vector>
-
-
-namespace eprosima {
-namespace fastdds {
-namespace dds {
-struct SampleInfo;
-}
-}  // namespace fastdds
-}  // namespace eprosima
 
 
 namespace udds {
@@ -63,7 +54,7 @@ public:
     //
     static bool take_next( dds_topic_reader &,
                            blob_msg * output,
-                           eprosima::fastdds::dds::SampleInfo * optional_info = nullptr );
+                           dds_sample * optional_sample = nullptr );
 
     // Returns some unique (to the writer) identifier for the sample that was sent, or 0 if unsuccessful
     dds_sequence_number write_to( dds_topic_writer & ) const;

--- a/third-party/realdds/include/realdds/topics/flexible-msg.h
+++ b/third-party/realdds/include/realdds/topics/flexible-msg.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include "flexible/flexible.h"
@@ -9,15 +9,6 @@
 #include <string>
 #include <memory>
 #include <vector>
-
-
-namespace eprosima {
-namespace fastdds {
-namespace dds {
-struct SampleInfo;
-}
-}  // namespace fastdds
-}  // namespace eprosima
 
 
 namespace realdds {
@@ -69,7 +60,7 @@ public:
     //
     static bool take_next( dds_topic_reader &,
                            flexible_msg * output,
-                           eprosima::fastdds::dds::SampleInfo * optional_info = nullptr );
+                           dds_sample * optional_sample = nullptr );
 
     // WARNING: this moves the message content!
     raw::flexible to_raw() &&;

--- a/third-party/realdds/include/realdds/topics/image-msg.h
+++ b/third-party/realdds/include/realdds/topics/image-msg.h
@@ -1,8 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
+// Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 #pragma once
-
 
 #include <realdds/dds-defines.h>
 #include <fastdds/rtps/common/Time_t.h>
@@ -12,20 +10,13 @@
 #include <vector>
 
 
-namespace eprosima {
-namespace fastdds {
-namespace dds {
-struct SampleInfo;
-}
-}  // namespace fastdds
-}  // namespace eprosima
-
 namespace sensor_msgs {
 namespace msg {
 class ImagePubSubType;
 class Image;
 }  // namespace msg
 }  // namespace sensor_msgs
+
 
 namespace realdds {
 
@@ -71,7 +62,7 @@ public:
     //TODO - add an API for a function that loans the data and enables the user to free it later.
     static bool take_next( dds_topic_reader &,
                            image_msg * output,
-                           eprosima::fastdds::dds::SampleInfo * optional_info = nullptr );
+                           dds_sample * optional_sample = nullptr );
 
     std::vector< uint8_t > raw_data;
     int width = -1;

--- a/third-party/realdds/include/realdds/topics/imu-msg.h
+++ b/third-party/realdds/include/realdds/topics/imu-msg.h
@@ -1,8 +1,6 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-
+// Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 #pragma once
-
 
 #include <realdds/dds-defines.h>
 #include <fastdds/rtps/common/Time_t.h>
@@ -13,14 +11,6 @@
 #include <memory>
 #include <vector>
 
-
-namespace eprosima {
-namespace fastdds {
-namespace dds {
-struct SampleInfo;
-}
-}  // namespace fastdds
-}  // namespace eprosima
 
 namespace sensor_msgs {
 namespace msg {
@@ -94,7 +84,7 @@ public:
     // Note - copies the data.
     static bool take_next( dds_topic_reader &,
                            imu_msg * output,
-                           eprosima::fastdds::dds::SampleInfo * optional_info = nullptr );
+                           dds_sample * optional_sample = nullptr );
 
     void write_to( dds_topic_writer & );
 

--- a/third-party/realdds/scripts/fps.py
+++ b/third-party/realdds/scripts/fps.py
@@ -62,13 +62,13 @@ except:
     sys.exit(1)
 
 n_depth = 0
-def on_depth_image( stream, image ):
+def on_depth_image( stream, image, sample ):
     #d( f'----> depth {image}')
     global n_depth
     n_depth += 1
 
 n_color = 0
-def on_color_image( stream, image ):
+def on_color_image( stream, image, sample ):
     #d( f'----> color {image}')
     global n_color
     n_color += 1
@@ -93,11 +93,12 @@ for stream in device.streams():
     stream.start_streaming()
 
 # Wait until we have at least one frame from each
-tries = 3
+tries = 5
 while tries > 0:
     if n_depth > 0  and  n_color > 0:
         break
     time.sleep( 1 )
+    tries -= 1
 else:
     raise RuntimeError( 'timed out waiting for frames to arrive' )
 n_depth = n_color = 0

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -134,11 +134,11 @@ std::string dds_device::impl::debug_name() const
 }
 
 
-void dds_device::impl::on_notification( json && j, eprosima::fastdds::dds::SampleInfo const & notification_sample )
+void dds_device::impl::on_notification( json && j, dds_sample const & notification_sample )
 {
     typedef std::map< std::string,
                       void ( dds_device::impl::* )( json const &,
-                                                    eprosima::fastdds::dds::SampleInfo const & ) >
+                                                    dds_sample const & ) >
         notification_handlers;
     static notification_handlers const _notification_handlers{
         { topics::reply::set_option::id, &dds_device::impl::on_set_option },
@@ -214,7 +214,7 @@ void dds_device::impl::on_notification( json && j, eprosima::fastdds::dds::Sampl
 }
 
 
-void dds_device::impl::on_set_option( json const & j, eprosima::fastdds::dds::SampleInfo const & )
+void dds_device::impl::on_set_option( json const & j, dds_sample const & )
 {
     if( ! is_ready() )
         return;
@@ -263,7 +263,7 @@ void dds_device::impl::on_set_option( json const & j, eprosima::fastdds::dds::Sa
 }
 
 
-void dds_device::impl::on_query_options( json const & j, eprosima::fastdds::dds::SampleInfo const & )
+void dds_device::impl::on_query_options( json const & j, dds_sample const & )
 {
     if( ! is_ready() )
         return;
@@ -330,13 +330,13 @@ void dds_device::impl::on_query_options( json const & j, eprosima::fastdds::dds:
 }
 
 
-void dds_device::impl::on_known_notification( json const & j, eprosima::fastdds::dds::SampleInfo const & )
+void dds_device::impl::on_known_notification( json const & j, dds_sample const & )
 {
     // This is a known notification, but we don't want to do anything for it
 }
 
 
-void dds_device::impl::on_log( json const & j, eprosima::fastdds::dds::SampleInfo const & )
+void dds_device::impl::on_log( json const & j, dds_sample const & )
 {
     // This is the notification for "log"  (see docs/notifications.md#Logging)
     //     - `entries` is an array containing 1 or more log entries
@@ -495,7 +495,7 @@ void dds_device::impl::create_notifications_reader()
         [&]()
         {
             topics::flexible_msg notification;
-            eprosima::fastdds::dds::SampleInfo sample;
+            dds_sample sample;
             while( topics::flexible_msg::take_next( *_notifications_reader, &notification, &sample ) )
             {
                 if( ! notification.is_valid() )
@@ -561,7 +561,7 @@ void dds_device::impl::create_control_writer()
 }
 
 
-void dds_device::impl::on_device_header( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_device_header( json const & j, dds_sample const & sample )
 {
     if( _state != state_t::ONLINE )
         return;
@@ -592,7 +592,7 @@ void dds_device::impl::on_device_header( json const & j, eprosima::fastdds::dds:
 }
 
 
-void dds_device::impl::on_device_options( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_device_options( json const & j, dds_sample const & sample )
 {
     if( _state != state_t::WAIT_FOR_DEVICE_OPTIONS )
         return;
@@ -615,7 +615,7 @@ void dds_device::impl::on_device_options( json const & j, eprosima::fastdds::dds
 }
 
 
-void dds_device::impl::on_stream_header( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_stream_header( json const & j, dds_sample const & sample )
 {
     if( _state != state_t::WAIT_FOR_STREAM_HEADER )
         return;
@@ -676,7 +676,7 @@ void dds_device::impl::on_stream_header( json const & j, eprosima::fastdds::dds:
 }
 
 
-void dds_device::impl::on_stream_options( json const & j, eprosima::fastdds::dds::SampleInfo const & sample )
+void dds_device::impl::on_stream_options( json const & j, dds_sample const & sample )
 {
     if( _state != state_t::WAIT_FOR_STREAM_OPTIONS )
         return;

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -121,16 +121,16 @@ private:
     void create_control_writer();
 
     // notification handlers
-    void on_set_option( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_query_options( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_known_notification( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_log( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_device_header( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_device_options( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_stream_header( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
-    void on_stream_options( rsutils::json const &, eprosima::fastdds::dds::SampleInfo const & );
+    void on_set_option( rsutils::json const &, dds_sample const & );
+    void on_query_options( rsutils::json const &, dds_sample const & );
+    void on_known_notification( rsutils::json const &, dds_sample const & );
+    void on_log( rsutils::json const &, dds_sample const & );
+    void on_device_header( rsutils::json const &, dds_sample const & );
+    void on_device_options( rsutils::json const &, dds_sample const & );
+    void on_stream_header( rsutils::json const &, dds_sample const & );
+    void on_stream_options( rsutils::json const &, dds_sample const & );
 
-    void on_notification( rsutils::json &&, eprosima::fastdds::dds::SampleInfo const & );
+    void on_notification( rsutils::json &&, dds_sample const & );
 
     on_metadata_available_signal _on_metadata_available;
     on_device_log_signal _on_device_log;

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -19,8 +19,7 @@
 #include <realdds/dds-topic-writer.h>
 #include <realdds/dds-option.h>
 #include <realdds/dds-guid.h>
-
-#include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <realdds/dds-sample.h>
 
 #include <rsutils/string/shorten-json-string.h>
 #include <rsutils/json.h>
@@ -310,7 +309,7 @@ bool dds_device_server::has_metadata_readers() const
 struct dds_device_server::control_sample
 {
     rsutils::json const json;
-    eprosima::fastdds::dds::SampleInfo const sample;
+    dds_sample const sample;
 };
 
 
@@ -326,14 +325,14 @@ void dds_device_server::on_control_message_received()
     };
 
     topics::flexible_msg data;
-    eprosima::fastdds::dds::SampleInfo info;
-    while( topics::flexible_msg::take_next( *_control_reader, &data, &info ) )
+    dds_sample sample;
+    while( topics::flexible_msg::take_next( *_control_reader, &data, &sample ) )
     {
         if( ! data.is_valid() )
             continue;
 
         _control_dispatcher.invoke(
-            [control = control_sample{ data.json_data(), info }, this]( dispatcher::cancellable_timer )
+            [control = control_sample{ data.json_data(), sample }, this]( dispatcher::cancellable_timer )
             {
                 auto sample_j = json::array( {
                     rsutils::string::from( realdds::print_raw_guid( control.sample.sample_identity.writer_guid() ) ),

--- a/third-party/realdds/src/dds-device-watcher.cpp
+++ b/third-party/realdds/src/dds-device-watcher.cpp
@@ -30,8 +30,8 @@ dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const
         [this]()
         {
             topics::flexible_msg msg;
-            eprosima::fastdds::dds::SampleInfo info;
-            while( topics::flexible_msg::take_next( *_device_info_topic, &msg, &info ) )
+            dds_sample sample;
+            while( topics::flexible_msg::take_next( *_device_info_topic, &msg, &sample ) )
             {
                 if( ! msg.is_valid() )
                     continue;
@@ -39,7 +39,7 @@ dds_device_watcher::dds_device_watcher( std::shared_ptr< dds_participant > const
                 // NOTE: the GUID we get here is the writer on the device-info, used nowhere again in the system, which
                 // can therefore be confusing. It is not the "server GUID" that's stored in the device!
                 dds_guid guid;
-                eprosima::fastrtps::rtps::iHandle2GUID( guid, info.publication_handle );
+                eprosima::fastrtps::rtps::iHandle2GUID( guid, sample.publication_handle );
 
                 auto const j = msg.json_data();
 

--- a/third-party/realdds/src/dds-stream.cpp
+++ b/third-party/realdds/src/dds-stream.cpp
@@ -10,10 +10,9 @@
 #include <realdds/topics/imu-msg.h>
 #include <realdds/topics/flexible-msg.h>
 #include <realdds/dds-exceptions.h>
+#include <realdds/dds-sample.h>
 
 #include <rsutils/json.h>
-
-#include <fastdds/dds/subscriber/SampleInfo.hpp>
 
 
 namespace realdds {
@@ -92,14 +91,14 @@ void dds_stream::start_streaming()
 void dds_video_stream::handle_data()
 {
     topics::image_msg frame;
-    eprosima::fastdds::dds::SampleInfo info;
-    while( _reader && topics::image_msg::take_next( *_reader, &frame, &info ) )
+    dds_sample sample;
+    while( _reader && topics::image_msg::take_next( *_reader, &frame, &sample ) )
     {
         if( ! frame.is_valid() )
             continue;
 
         if( is_streaming() && _on_data_available )
-            _on_data_available( std::move( frame ) );
+            _on_data_available( std::move( frame ), std::move( sample ) );
     }
 }
 
@@ -107,11 +106,11 @@ void dds_video_stream::handle_data()
 void dds_motion_stream::handle_data()
 {
     topics::imu_msg imu;
-    eprosima::fastdds::dds::SampleInfo info;
-    while( _reader && topics::imu_msg::take_next( *_reader, &imu, &info ) )
+    dds_sample sample;
+    while( _reader && topics::imu_msg::take_next( *_reader, &imu, &sample ) )
     {
         if( is_streaming() && _on_data_available )
-            _on_data_available( std::move( imu ) );
+            _on_data_available( std::move( imu ), std::move( sample ) );
     }
 }
 

--- a/third-party/realdds/src/topics/blob-msg.cpp
+++ b/third-party/realdds/src/topics/blob-msg.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #include <realdds/topics/blob-msg.h>
 #include <realdds/topics/blob/blobPubSubTypes.h>
@@ -28,7 +28,7 @@ blob_msg::create_topic( std::shared_ptr< dds_participant > const & participant, 
 
 
 /*static*/ bool
-blob_msg::take_next( dds_topic_reader & reader, blob_msg * output, eprosima::fastdds::dds::SampleInfo * info )
+blob_msg::take_next( dds_topic_reader & reader, blob_msg * output, dds_sample * info )
 {
     eprosima::fastdds::dds::SampleInfo info_;
     if( ! info )

--- a/third-party/realdds/src/topics/flexible-msg.cpp
+++ b/third-party/realdds/src/topics/flexible-msg.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #include <realdds/topics/flexible-msg.h>
 #include <realdds/topics/flexible/flexiblePubSubTypes.h>
@@ -69,13 +69,13 @@ flexible_msg::create_topic( std::shared_ptr< dds_participant > const & participa
 
 
 /*static*/ bool
-flexible_msg::take_next( dds_topic_reader & reader, flexible_msg * output, eprosima::fastdds::dds::SampleInfo * info )
+flexible_msg::take_next( dds_topic_reader & reader, flexible_msg * output, dds_sample * sample )
 {
     raw::flexible raw_data;
-    eprosima::fastdds::dds::SampleInfo info_;
-    if( ! info )
-        info = &info_;  // use the local copy if the user hasn't provided their own
-    auto status = reader->take_next_sample( &raw_data, info );
+    dds_sample sample_;
+    if( ! sample )
+        sample = &sample_;  // use the local copy if the user hasn't provided their own
+    auto status = reader->take_next_sample( &raw_data, sample );
     if( status == ReturnCode_t::RETCODE_OK )
     {
         // We have data
@@ -84,7 +84,7 @@ flexible_msg::take_next( dds_topic_reader & reader, flexible_msg * output, epros
             // Only samples for which valid_data is true should be accessed
             // valid_data indicates that the instance is still ALIVE and the `take` return an
             // updated sample
-            if( ! info->valid_data )
+            if( ! sample->valid_data )
                 output->invalidate();
             else
                 *output = std::move( raw_data );

--- a/third-party/realdds/src/topics/image-msg.cpp
+++ b/third-party/realdds/src/topics/image-msg.cpp
@@ -47,13 +47,13 @@ image_msg::create_topic( std::shared_ptr< dds_participant > const & participant,
 
 
 /*static*/ bool
-image_msg::take_next( dds_topic_reader & reader, image_msg * output, eprosima::fastdds::dds::SampleInfo * info )
+image_msg::take_next( dds_topic_reader & reader, image_msg * output, dds_sample * sample )
 {
     sensor_msgs::msg::Image raw_data;
-    eprosima::fastdds::dds::SampleInfo info_;
-    if ( !info )
-        info = &info_;  // use the local copy if the user hasn't provided their own
-    auto status = reader->take_next_sample( &raw_data, info );
+    dds_sample sample_;
+    if( ! sample )
+        sample = &sample_;  // use the local copy if the user hasn't provided their own
+    auto status = reader->take_next_sample( &raw_data, sample );
     if ( status == ReturnCode_t::RETCODE_OK )
     {
         // We have data
@@ -62,7 +62,7 @@ image_msg::take_next( dds_topic_reader & reader, image_msg * output, eprosima::f
             // Only samples for which valid_data is true should be accessed
             // valid_data indicates that the instance is still ALIVE and the `take` return an
             // updated sample
-            if ( !info->valid_data )
+            if( ! sample->valid_data )
                 output->invalidate();
             else
                 *output = std::move( raw_data ); //TODO - optimize copy, use dds loans

--- a/third-party/realdds/src/topics/imu-msg.cpp
+++ b/third-party/realdds/src/topics/imu-msg.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #include <realdds/topics/ros2/ros2imu.h>
 #include <realdds/topics/imu-msg.h>
@@ -57,13 +57,13 @@ imu_msg::create_topic( std::shared_ptr< dds_participant > const & participant, c
 
 
 /*static*/ bool
-imu_msg::take_next( dds_topic_reader & reader, imu_msg * output, eprosima::fastdds::dds::SampleInfo * info )
+imu_msg::take_next( dds_topic_reader & reader, imu_msg * output, dds_sample * sample )
 {
     sensor_msgs::msg::Imu raw_data;
-    eprosima::fastdds::dds::SampleInfo info_;
-    if( ! info )
-        info = &info_;  // use the local copy if the user hasn't provided their own
-    auto status = reader->take_next_sample( &raw_data, info );
+    dds_sample sample_;
+    if( ! sample )
+        sample = &sample_;  // use the local copy if the user hasn't provided their own
+    auto status = reader->take_next_sample( &raw_data, sample );
     if( status == ReturnCode_t::RETCODE_OK )
     {
         // We have data
@@ -72,7 +72,7 @@ imu_msg::take_next( dds_topic_reader & reader, imu_msg * output, eprosima::fastd
             // Only samples for which valid_data is true should be accessed
             // valid_data indicates that the instance is still ALIVE and the `take` return an
             // updated sample
-            if( ! info->valid_data )
+            if( ! sample->valid_data )
                 output->invalidate();
             else
                 *output = std::move( raw_data );  // TODO - optimize copy, use dds loans

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -17,8 +17,7 @@
 #include <realdds/dds-topic-reader-thread.h>
 #include <realdds/dds-participant.h>
 #include <realdds/dds-guid.h>
-
-#include <fastdds/dds/subscriber/SampleInfo.hpp>
+#include <realdds/dds-sample.h>
 
 #include <rsutils/number/crc32.h>
 #include <rsutils/easylogging/easyloggingpp.h>
@@ -1267,7 +1266,7 @@ bool lrs_device_controller::on_dfu_start( rsutils::json const & control, rsutils
         [weak_dfu = std::weak_ptr< dfu_support >( _dfu )]
         {
             topics::blob_msg blob;
-            eprosima::fastdds::dds::SampleInfo sample;
+            realdds::dds_sample sample;
             while( auto dfu = weak_dfu.lock() )
             {
                 if( ! topics::blob_msg::take_next( *dfu->reader, &blob, &sample ) )

--- a/tools/dds/dds-sniffer/rs-dds-sniffer.cpp
+++ b/tools/dds/dds-sniffer/rs-dds-sniffer.cpp
@@ -396,10 +396,10 @@ void dds_sniffer::dds_reader_listener::on_data_available( DataReader * reader )
     if( dit != _datas.end() )
     {
         DynamicData_ptr data = dit->second;
-        SampleInfo info;
-        if( DDS_API_CALL( reader->take_next_sample( data.get(), &info ) ) == ReturnCode_t::RETCODE_OK )
+        realdds::dds_sample sample;
+        if( DDS_API_CALL( reader->take_next_sample( data.get(), &sample ) ) == ReturnCode_t::RETCODE_OK )
         {
-            if( info.valid_data )
+            if( sample.valid_data )
             {
                 DynamicDataHelper::print( data );
             }

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -89,8 +89,8 @@ with test.remote.fork( nested_indent='  S' ) as remote:
     import threading
     image_received = threading.Event()
     image_content = []
-    def on_image_available( stream, image ):
-        log.d( f'----> image {image}')
+    def on_image_available( stream, image, sample ):
+        log.d( f'----> image {image} {sample}')
         image_content.append( image )
         image_received.set()
 

--- a/unit-tests/sw-dev/test-metadata.py
+++ b/unit-tests/sw-dev/test-metadata.py
@@ -24,8 +24,14 @@ try:
         # Publish a frame
         f = sensor.publish( depth.frame() )
 
+        # Some metadata may be automatically added, even for software sensors
+        expected = set()
         for md in frame_metadata_values():
-            test.check_false( f.supports_frame_metadata( md ))
+            test.info( 'metadata', md )
+            if md in expected:
+                test.check( f.supports_frame_metadata( md ))
+            else:
+                test.check_false( f.supports_frame_metadata( md ))
 except:
     test.unexpected_exception()
 test.finish()

--- a/unit-tests/syncer/sw.py
+++ b/unit-tests/syncer/sw.py
@@ -203,6 +203,7 @@ def generate_depth_frame( frame_number, timestamp, next_expected=None ):
         depth_sensor.set_metadata( rs.frame_metadata_value.actual_fps, actual_fps )
         log.d( "-->", depth_frame, "with actual FPS", actual_fps )
     else:
+        depth_sensor.set_metadata( rs.frame_metadata_value.actual_fps, 0 )  # force to not use
         log.d( "-->", depth_frame )
     depth_sensor.on_video_frame( depth_frame )
 
@@ -228,6 +229,7 @@ def generate_color_frame( frame_number, timestamp, next_expected=None ):
         color_sensor.set_metadata( rs.frame_metadata_value.actual_fps, actual_fps )
         log.d( "-->", color_frame, "with actual FPS", actual_fps )
     else:
+        color_sensor.set_metadata( rs.frame_metadata_value.actual_fps, 0 )  # force to not use
         log.d( "-->", color_frame )
     color_sensor.on_video_frame( color_frame )
 


### PR DESCRIPTION
- adds `dds_sample` definition in dds-defines.h
- adds another variant of `time_to_double`
- add dds_sample to stream `on_data_available` callbacks
- add optional fallback parser to `md_array_parser`
- add the "missing" metadata to all software sensors (not just DDS sensors)
- fix DDS frame creation to add missing fields

NOTE:
- this means that software frames will have an 'actual_fps' now, whereas before they did not
- the syncer uses actual-fps
- the syncer tests failed, so I made them manually set the actual fps to 0, thereby forcing it to "not be available"
- this can be considered a change of behavior, though I know of no use of actual-fps outside of the syncer, and IMO the new behavior is desired (as it is with DDS) if the SW parameters are set correctly

Tracked on [RSDEV-1937]