### PR TITLE
Power on UVC sensors after creation to speed initialization

### DIFF
--- a/src/ds/d400/d400-device.cpp
+++ b/src/ds/d400/d400-device.cpp
@@ -493,6 +493,9 @@ namespace librealsense
 
         auto depth_ep = std::make_shared<d400_depth_sensor>(this, raw_depth_ep);
 
+        // Many commands need power during initialization phase, no point turning it on and off again for each.
+        raw_depth_ep->power_for_duration( std::chrono::milliseconds( 1000 ) );
+
         depth_ep->register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, filter_by_mi(all_device_infos, 0).front().device_path);
 
         depth_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -345,6 +345,9 @@ namespace librealsense
 
         auto depth_ep = std::make_shared<d500_depth_sensor>(this, raw_depth_ep);
 
+        // Many commands need power during initialization phase, no point turning it on and off again for each.
+        raw_depth_ep->power_for_duration( std::chrono::milliseconds( 1000 ) );
+
         depth_ep->register_info(RS2_CAMERA_INFO_PHYSICAL_PORT, filter_by_mi(all_device_infos, 0).front().device_path);
 
         depth_ep->register_option(RS2_OPTION_GLOBAL_TIME_ENABLED, enable_global_time_option);

--- a/src/uvc-sensor.h
+++ b/src/uvc-sensor.h
@@ -43,6 +43,20 @@ public:
         return action( *_device );
     }
 
+    
+    void power_for_duration( std::chrono::steady_clock::duration timeout = std::chrono::milliseconds( 500 ) )
+    {
+        acquire_power();
+        std::weak_ptr< uvc_sensor > weak = std::dynamic_pointer_cast< uvc_sensor >( shared_from_this() );
+        std::thread release_power_thread( [weak, timeout]()
+        {
+            std::this_thread::sleep_for( timeout );
+            if( auto strong = weak.lock() )
+                strong->release_power();
+        } );
+        release_power_thread.detach();
+    }
+
 protected:
     stream_profiles init_stream_profiles() override;
     void verify_supported_requests( const stream_profiles & requests ) const;


### PR DESCRIPTION
At initialization phase there are many HWM and other commands that need the sensor to be in powered on (D0) state.
Keeping it on for a short time instead of turning it on and off (D3) can speed up the initialization.

Testing with a D500 device it reduced pipeline time to first frame by an average of 90 milliseconds.