### PR TITLE
Reverse order of sensor open in pipeline API

### DIFF
--- a/src/pipeline/resolver.h
+++ b/src/pipeline/resolver.h
@@ -136,9 +136,10 @@ namespace librealsense
 
                 void open()
                 {
-                    for (auto && kvp : _dev_to_profiles) {
-                        auto&& sub = _results.at(kvp.first);
-                        sub->open(kvp.second);
+                    std::map<int, stream_profiles>::reverse_iterator it;
+                    for (it = _dev_to_profiles.rbegin(); it != _dev_to_profiles.rend(); it++) {
+                        auto&& sub = _results.at(it->first);
+                        sub->open(it->second);
                     }
                 }
 

--- a/src/pipeline/resolver.h
+++ b/src/pipeline/resolver.h
@@ -136,10 +136,17 @@ namespace librealsense
 
                 void open()
                 {
-                    std::map<int, stream_profiles>::reverse_iterator it;
-                    for (it = _dev_to_profiles.rbegin(); it != _dev_to_profiles.rend(); it++) {
-                        auto&& sub = _results.at(it->first);
-                        sub->open(it->second);
+                    // Camera has a limitation such that opening the color sensor after the
+                    // depth sensor may cause the depth sensor a reset. 
+                    // This artifact may cause unexpected behavior when we ask to stop the sensor in parallel or control it
+                    // while it is doing a reset. 
+                    // As a workaround for pipeline API usage, we use the assumption that depth sensor is first in the map if it is added to the configuration,
+                    // When we reverse iterate it, the depth sensor opening will be last This should not affect other stream
+                    // which are capable of being opened decoupled from other sensors
+                    for( auto it = _dev_to_profiles.rbegin(); it != _dev_to_profiles.rend(); it++ )
+                    {
+                        auto && sub = _results.at( it->first );
+                        sub->open( it->second );
                     }
                 }
 

--- a/unit-tests/live/frames/test-pipeline-start-stop.py
+++ b/unit-tests/live/frames/test-pipeline-start-stop.py
@@ -1,6 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2023-2024 Intel Corporation. All Rights Reserved.
 
+# test:donotrun:!nightly
 # Currently, we exclude D457 as it's failing
 # test:device each(D400*) !D457
 
@@ -10,7 +11,7 @@ from rspy import test, log
 import time
 
 # Run multiple start stop of all streams and verify we get a frame for each once
-ITERATIONS_COUNT = 2
+ITERATIONS_COUNT = 50
 
 dev = test.find_first_device_or_exit()
 


### PR DESCRIPTION
The camera misbehaves when opening color sensor after depth sensor and it can reset the depth sensor on this case.
We know that if the depth sensor is configured, it will be the first sensor to open.
Here I used a reverse-iterator to open the sensors in reversed order, this way we know if we have depth sensor configures, it will be the last sensor to open.