### PR TITLE
Add uvcvideo version update patch

### DIFF
--- a/scripts/patch-realsense-ubuntu-lts-hwe.sh
+++ b/scripts/patch-realsense-ubuntu-lts-hwe.sh
@@ -177,6 +177,7 @@ then
 		# Patching kernel for RealSense devices
 		echo -e "\e[32mApplying patches for \e[36m${ubuntu_codename}-${kernel_branch}\e[32m line\e[0m"
 		echo -e "\e[32mApplying realsense-uvc patch\e[0m"
+		patch -p1 < ../scripts/realsense-uvc-driver-version.patch 
 		patch -p1 < ../scripts/realsense-camera-formats-${ubuntu_codename}-${kernel_branch}.patch || patch -p1 < ../scripts/realsense-camera-formats-${ubuntu_codename}-master.patch
 		if [ ${skip_md_patch} -eq 0 ]; then
 			echo -e "\e[32mApplying realsense-metadata patch\e[0m"

--- a/scripts/realsense-uvc-driver-version.patch
+++ b/scripts/realsense-uvc-driver-version.patch
@@ -1,0 +1,27 @@
+From 327de73504d2d5ac897d86fe15c3aceaeb051da8 Mon Sep 17 00:00:00 2001
+From: Nir <nir.azkiel@intel.com>
+Date: Tue, 7 May 2024 23:02:47 +0300
+Subject: [PATCH] make realsense uvcvideo driver version unique
+
+---
+ drivers/media/usb/uvc/uvcvideo.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
+index 6fb0a78b1..b35431ae1 100644
+--- a/drivers/media/usb/uvc/uvcvideo.h
++++ b/drivers/media/usb/uvc/uvcvideo.h
+@@ -44,8 +44,8 @@
+ /* ------------------------------------------------------------------------
+  * Driver specific constants.
+  */
+-
+-#define DRIVER_VERSION		"1.1.1"
++#define DRIVER_VERSION_SUFFIX "realsense-patch"
++#define DRIVER_VERSION		"1.1.1-" DRIVER_VERSION_SUFFIX
+ 
+ /* Number of isochronous URBs. */
+ #define UVC_URBS		5
+-- 
+2.34.1
+

--- a/scripts/realsense-uvc-driver-version.patch
+++ b/scripts/realsense-uvc-driver-version.patch
@@ -1,21 +1,20 @@
-From 327de73504d2d5ac897d86fe15c3aceaeb051da8 Mon Sep 17 00:00:00 2001
+From fddfc8b3055abe1ccb3d03eacbe8028043d81257 Mon Sep 17 00:00:00 2001
 From: Nir <nir.azkiel@intel.com>
-Date: Tue, 7 May 2024 23:02:47 +0300
-Subject: [PATCH] make realsense uvcvideo driver version unique
+Date: Thu, 9 May 2024 21:21:31 +0300
+Subject: [PATCH] add uvcvideo version update patch
 
 ---
- drivers/media/usb/uvc/uvcvideo.h | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ drivers/media/usb/uvc/uvcvideo.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/media/usb/uvc/uvcvideo.h b/drivers/media/usb/uvc/uvcvideo.h
-index 6fb0a78b1..b35431ae1 100644
+index 6fb0a78b1..d522b0f10 100644
 --- a/drivers/media/usb/uvc/uvcvideo.h
 +++ b/drivers/media/usb/uvc/uvcvideo.h
-@@ -44,8 +44,8 @@
- /* ------------------------------------------------------------------------
+@@ -45,7 +45,8 @@
   * Driver specific constants.
   */
--
+ 
 -#define DRIVER_VERSION		"1.1.1"
 +#define DRIVER_VERSION_SUFFIX "realsense-patch"
 +#define DRIVER_VERSION		"1.1.1-" DRIVER_VERSION_SUFFIX


### PR DESCRIPTION
We wish to distinguish between a native uvc driver and a realsense manual patched uvc driver
This patch will add a "realsense-patch" suffix to the uvcvideo driver

![image](https://github.com/IntelRealSense/librealsense/assets/64067618/ef36abca-676f-4b40-95d8-84236ad5a8af)

Tracked on [LRS-1098]