### PR TITLE
LibCI - Recycle device on retry

### DIFF
--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -561,7 +561,6 @@ def finish( on_fail=LOG ):
         log.i("Test passed")
     test_in_progress = None
 
-
 def print_separator():
     """
     For use only in-between test-cases, this will separate them in some visual way so as

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -441,13 +441,13 @@ def test_wrapper( test, configuration=None, repetition=1, sns=None ):
     global n_tests
     n_tests += 1
     for retry in range( test.config.retries + 1 ):
-        if test_wrapper_( test, configuration, repetition, retry, sns ) and log.n_errors() == 0:
+        if test_wrapper_( test, configuration, repetition, retry, sns ):
             return True
         log._n_errors -= 1
         if no_reset:
             time.sleep(1)  # small pause between tries
         elif retry < test.config.retries:
-            log.d("retry", retry + 1, "out of", test.config.retries)
+            log.w("retry", retry + 1, "out of", test.config.retries)
             devices.enable_only(serial_numbers, recycle=True)
 
     log._n_errors += 1

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -421,6 +421,8 @@ def test_wrapper_( test, configuration=None, repetition=1, retry=0, sns=None ):
     if rslog:
         opts.add( '--rslog' )
     try:
+        if repetition > 0:
+            log.d("repeat #", repetition + 1)
         test.run_test( configuration = configuration, log_path = log_path, opts = opts )
     except FileNotFoundError as e:
         log.e( log.red + test.name + log.reset + ':', str( e ) + configuration_str( configuration, repetition, prefix=' ' ) )
@@ -560,8 +562,6 @@ try:
                 test_ok = True
                 for repetition in range(repeat):
                     test_ok = test_wrapper( test, repetition = repetition ) and test_ok
-                    if repetition + 1 < repeat:
-                        log.d("repeating #", repetition + 1)
                 if not test_ok:
                     failed_tests.append( test )
                 continue
@@ -585,8 +585,6 @@ try:
                         log.w( log.red + test.name + log.reset + ': ' + str( e ) )
                     else:
                         test_ok = test_wrapper( test, configuration, repetition, sns=serial_numbers ) and test_ok
-                        if repetition + 1 < repeat:
-                            log.d("repeating #", repetition + 1)
                     finally:
                         log.debug_unindent()
             if not test_ok:


### PR DESCRIPTION
When a test fails and retry it doesn't reset the device so normally it fails again.
This PR make sure the device is resetting before each try 

+ also add some helpful prints