### PR TITLE
Force shallow clone of json 3-rd party

### DIFF
--- a/CMake/json-download.cmake.in
+++ b/CMake/json-download.cmake.in
@@ -5,15 +5,16 @@ include(ExternalProject)
 ExternalProject_Add(
     nlohmann_json
     PREFIX .
-    GIT_REPOSITORY "https://github.com/nlohmann/json.git"
-    GIT_TAG        v3.11.3
-    GIT_CONFIG     advice.detachedHead=false  # otherwise we'll get "You are in 'detached HEAD' state..."
-    SOURCE_DIR     "${CMAKE_BINARY_DIR}/third-party/json"
-    GIT_SHALLOW    1        # No history needed (requires cmake 3.6)
+    
+    # We do not use 'GIT_REPOSITORY' as it doesn't support a shallow clone of a specific commit,
+    # this make the clone step very long, so we clone by ourselves
+    DOWNLOAD_COMMAND   git clone -c advice.detachedHead=false --branch v3.11.3 https://github.com/nlohmann/json.git --depth 1 json
+    DOWNLOAD_DIR       ${CMAKE_BINARY_DIR}/third-party/
+    
     # Override default steps with no action, we just want the clone step.
+    UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     )
-
 

--- a/CMake/json-download.cmake.in
+++ b/CMake/json-download.cmake.in
@@ -7,9 +7,10 @@ ExternalProject_Add(
     PREFIX .
     
     # We do not use 'GIT_REPOSITORY' as it doesn't support a shallow clone of a specific commit,
-    # this make the clone step very long, so we clone by ourselves
+    # this make the clone step very long, so we clone by ourselves (See https://gitlab.kitware.com/cmake/cmake/-/issues/17770).
+    # Adding detachedHead=false to avoid warnings like: "You are in 'detached HEAD' state..."
     DOWNLOAD_COMMAND   git clone -c advice.detachedHead=false --branch v3.11.3 https://github.com/nlohmann/json.git --depth 1 json
-    DOWNLOAD_DIR       ${CMAKE_BINARY_DIR}/third-party/
+    DOWNLOAD_DIR       "${CMAKE_BINARY_DIR}/third-party/"
     
     # Override default steps with no action, we just want the clone step.
     UPDATE_COMMAND ""


### PR DESCRIPTION
CMake ignore the shallow clone, json history is huge (185 [MB] when the repo itself is ~7 [MB]) and take much time to download.
Jenkins fail on that many times on timeout.
This fix it.

Before:
![image](https://github.com/IntelRealSense/librealsense/assets/64067618/82710a45-6ac0-4178-b7bb-bda3fe753fc6)
![image](https://github.com/IntelRealSense/librealsense/assets/64067618/8fe0f66b-ffee-467f-9b92-84caaf5107db)


After:
![image](https://github.com/IntelRealSense/librealsense/assets/64067618/fa8bdd6a-aa77-4565-ba13-73e9cab3f46c)
![image](https://github.com/IntelRealSense/librealsense/assets/64067618/4932f911-1580-4020-9240-c99bc25c1f06)


Also notified json on GH
https://github.com/nlohmann/json/issues/4370