### PR TITLE
Update minimal CMake version 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 
-# Xenial requires 3.5, Bionic 3.10...
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 set( LRS_TARGET realsense2 )
 project( ${LRS_TARGET} LANGUAGES CXX C )

--- a/common/fw/CMakeLists.txt
+++ b/common/fw/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-cmake_minimum_required(VERSION 3.1.3)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(fw)
 

--- a/examples/C/color/CMakeLists.txt
+++ b/examples/C/color/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamples-Color)
 

--- a/examples/C/depth/CMakeLists.txt
+++ b/examples/C/depth/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 20192024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamples-Depth)
 

--- a/examples/C/distance/CMakeLists.txt
+++ b/examples/C/distance/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamples-Distance)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 # Save the command line compile commands in the build output
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)

--- a/examples/align-advanced/CMakeLists.txt
+++ b/examples/align-advanced/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesAlignAdvanced)
 

--- a/examples/align-gl/CMakeLists.txt
+++ b/examples/align-gl/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2024 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesAlignGl )
 

--- a/examples/align/CMakeLists.txt
+++ b/examples/align/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesAlign)
 

--- a/examples/callback/CMakeLists.txt
+++ b/examples/callback/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(rs-callback)
 

--- a/examples/capture/CMakeLists.txt
+++ b/examples/capture/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesCapture)
 

--- a/examples/cmake/CMakeLists.txt
+++ b/examples/cmake/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(hello_librealsense2)
 

--- a/examples/cmake/readme.md
+++ b/examples/cmake/readme.md
@@ -15,7 +15,7 @@ Install the SDK or build it from source  ([Linux](https://github.com/IntelRealSe
 
 Set minimum required CMake version
 ```
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 ```
 
 Name the project, in this sample the project name will be also the executable name

--- a/examples/gl/CMakeLists.txt
+++ b/examples/gl/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesGL)
 

--- a/examples/hdr/CMakeLists.txt
+++ b/examples/hdr/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2020 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2020-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesHdr)
 

--- a/examples/hello-realsense/CMakeLists.txt
+++ b/examples/hello-realsense/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesHelloRealSense)
 

--- a/examples/measure/CMakeLists.txt
+++ b/examples/measure/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesMeasure)
 

--- a/examples/motion/CMakeLists.txt
+++ b/examples/motion/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesMotion)
 

--- a/examples/multicam/CMakeLists.txt
+++ b/examples/multicam/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesMulticam)
 

--- a/examples/pointcloud/CMakeLists.txt
+++ b/examples/pointcloud/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesPointcloud)
 

--- a/examples/post-processing/CMakeLists.txt
+++ b/examples/post-processing/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesPost-Processing)
 

--- a/examples/record-playback/CMakeLists.txt
+++ b/examples/record-playback/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesRecord-Playback)
 

--- a/examples/save-to-disk/CMakeLists.txt
+++ b/examples/save-to-disk/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesSaveToDisk)
 

--- a/examples/sensor-control/CMakeLists.txt
+++ b/examples/sensor-control/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesSensorControl)
 

--- a/examples/software-device/CMakeLists.txt
+++ b/examples/software-device/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesSoftwareDevice)
 

--- a/src/gl/CMakeLists.txt
+++ b/src/gl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
 
-cmake_minimum_required(VERSION 2.8.9...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 project(realsense2-gl)
 

--- a/third-party/glfw/CMakeLists.txt
+++ b/third-party/glfw/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(GLFW C)
 

--- a/third-party/realdds/py/CMakeLists.txt
+++ b/third-party/realdds/py/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2022-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 project( pyrealdds )
 
 set( PYREALDDS_FILES

--- a/third-party/realsense-file/CMakeLists.txt
+++ b/third-party/realsense-file/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 project(realsense-file)
 

--- a/third-party/realsense-file/rosbag/config.cmake
+++ b/third-party/realsense-file/rosbag/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 include(${CMAKE_CURRENT_LIST_DIR}/console_bridge/config.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/rosbag_storage/config.cmake)

--- a/third-party/realsense-file/rosbag/console_bridge/config.cmake
+++ b/third-party/realsense-file/rosbag/console_bridge/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 set(HEADER_FILES_CONSOLE_BRIDGE
         ${CMAKE_CURRENT_LIST_DIR}/include/console_bridge/console.h

--- a/third-party/realsense-file/rosbag/cpp_common/config.cmake
+++ b/third-party/realsense-file/rosbag/cpp_common/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 set(HEADER_FILES_CPP_COMMON
         ${CMAKE_CURRENT_LIST_DIR}/include/ros/cpp_common_decl.h

--- a/third-party/realsense-file/rosbag/rosbag_storage/config.cmake
+++ b/third-party/realsense-file/rosbag/rosbag_storage/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 set(HEADER_FILES_CPP_COMMON
         ${CMAKE_CURRENT_LIST_DIR}/include/ros/cpp_common_decl.h

--- a/third-party/realsense-file/rosbag/roscpp_serialization/config.cmake
+++ b/third-party/realsense-file/rosbag/roscpp_serialization/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 set(HEADER_FILES_ROSCPP_SERIALIZATION
   ${CMAKE_CURRENT_LIST_DIR}/include/ros/roscpp_serialization_macros.h

--- a/third-party/realsense-file/rosbag/roscpp_traits/config.cmake
+++ b/third-party/realsense-file/rosbag/roscpp_traits/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 set(HEADER_FILES_ROSCPP_TRAITS
   ${CMAKE_CURRENT_LIST_DIR}/include/ros/builtin_message_traits.h

--- a/third-party/realsense-file/rosbag/roslz4/config.cmake
+++ b/third-party/realsense-file/rosbag/roslz4/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 set(HEADER_FILES_ROSLZ4
         ${CMAKE_CURRENT_LIST_DIR}/include/roslz4/lz4s.h

--- a/third-party/realsense-file/rosbag/rostime/config.cmake
+++ b/third-party/realsense-file/rosbag/rostime/config.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3...3.20.5)
+cmake_minimum_required(VERSION 3.8)
 
 set(HEADER_FILES_ROSTIME
   ${CMAKE_CURRENT_LIST_DIR}/include/ros/duration.h

--- a/third-party/rsutils/py/CMakeLists.txt
+++ b/third-party/rsutils/py/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2022-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 project( pyrsutils )
 
 set( DEPENDENCIES rsutils )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 # Save the command line compile commands in the build output
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)

--- a/tools/benchmark/CMakeLists.txt
+++ b/tools/benchmark/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsBenchmark)
 

--- a/tools/convert/CMakeLists.txt
+++ b/tools/convert/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsConvert)
 set(RS_TARGET rs-convert)

--- a/tools/data-collect/CMakeLists.txt
+++ b/tools/data-collect/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsDataCollect)
 

--- a/tools/dds/dds-adapter/CMakeLists.txt
+++ b/tools/dds/dds-adapter/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2023 Intel Corporation. All Rights Reserved.
-cmake_minimum_required( VERSION 3.1.0 )
+# Copyright(c) 2023-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required( VERSION 3.8 )
 project( rs-dds-adapter )
 
 set(TOOL_FILES

--- a/tools/depth-quality/CMakeLists.txt
+++ b/tools/depth-quality/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project( rs-depth-quality )
 

--- a/tools/embed/CMakeLists.txt
+++ b/tools/embed/CMakeLists.txt
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2021-2024 Intel Corporation. All Rights Reserved.
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsEmbed)
 

--- a/tools/enumerate-devices/CMakeLists.txt
+++ b/tools/enumerate-devices/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesEnumerateDevices)
 

--- a/tools/fw-logger/CMakeLists.txt
+++ b/tools/fw-logger/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsFirmwareLogger)
 

--- a/tools/fw-update/CMakeLists.txt
+++ b/tools/fw-update/CMakeLists.txt
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(rs-fw-update)
 

--- a/tools/realsense-viewer/CMakeLists.txt
+++ b/tools/realsense-viewer/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(realsense-viewer)
 

--- a/tools/recorder/CMakeLists.txt
+++ b/tools/recorder/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsRecorder)
 

--- a/tools/rosbag-inspector/CMakeLists.txt
+++ b/tools/rosbag-inspector/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-# ubuntu 16.04 LTS cmake version 3.5.1
-cmake_minimum_required(VERSION 2.8.3...3.20.5)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsRosbagInspector)
 

--- a/tools/terminal/CMakeLists.txt
+++ b/tools/terminal/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseToolsTerminal)
 include_directories(

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)

--- a/wrappers/CMakeLists.txt
+++ b/wrappers/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseWrappers)
 

--- a/wrappers/android/examples/native_example/app/CMakeLists.txt
+++ b/wrappers/android/examples/native_example/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.8)
 
 #################### librealsense dependencies begin ####################
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/main/cpp/include")

--- a/wrappers/android/librealsense/CMakeLists.txt
+++ b/wrappers/android/librealsense/CMakeLists.txt
@@ -2,7 +2,7 @@
 # documentation: https://d.android.com/studio/projects/add-native-code.html
 
 # Sets the minimum version of CMake required to build the native library.
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.8)
 
 include("../config.cmake")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LRS_ANDROID_ROOT_DIR}/build/jniLibs/${ANDROID_ABI})

--- a/wrappers/dlib/CMakeLists.txt
+++ b/wrappers/dlib/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseDlibSamples)
 

--- a/wrappers/dlib/face/CMakeLists.txt
+++ b/wrappers/dlib/face/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseDlibFaceExample)
 

--- a/wrappers/matlab/CMakeLists.txt
+++ b/wrappers/matlab/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseMatlabWrappers)
 

--- a/wrappers/opencv/CMakeLists.txt
+++ b/wrappers/opencv/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseCVExamples)
 

--- a/wrappers/opencv/depth-filter/CMakeLists.txt
+++ b/wrappers/opencv/depth-filter/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseDepthFilterExample)
 

--- a/wrappers/opencv/dnn/CMakeLists.txt
+++ b/wrappers/opencv/dnn/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseDNNExample)
 

--- a/wrappers/opencv/grabcuts/CMakeLists.txt
+++ b/wrappers/opencv/grabcuts/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseGrabCutsExample)
 

--- a/wrappers/opencv/imshow/CMakeLists.txt
+++ b/wrappers/opencv/imshow/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseImShowExample)
 

--- a/wrappers/opencv/kinfu/CMakeLists.txt
+++ b/wrappers/opencv/kinfu/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseKinfuExample)
 

--- a/wrappers/opencv/latency-tool/CMakeLists.txt
+++ b/wrappers/opencv/latency-tool/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseLatencyToolExample)
 

--- a/wrappers/opencv/rotate-pointcloud/CMakeLists.txt
+++ b/wrappers/opencv/rotate-pointcloud/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+=cmake_minimum_required(VERSION 3.8)
 
 project(rs-rotate-pc)
 

--- a/wrappers/openvino/CMakeLists.txt
+++ b/wrappers/openvino/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseOpenVINOSamples)
 

--- a/wrappers/openvino/dnn/CMakeLists.txt
+++ b/wrappers/openvino/dnn/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseVinoDnnExample)
 

--- a/wrappers/openvino/face/CMakeLists.txt
+++ b/wrappers/openvino/face/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSenseVinoFaceExample)
 

--- a/wrappers/pcl/CMakeLists.txt
+++ b/wrappers/pcl/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 if(NOT WIN32)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")

--- a/wrappers/pcl/pcl-color/CMakeLists.txt
+++ b/wrappers/pcl/pcl-color/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSensePCLColorExample)
 

--- a/wrappers/pcl/pcl/CMakeLists.txt
+++ b/wrappers/pcl/pcl/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealSensePCLExample)
 

--- a/wrappers/pointcloud/pointcloud-stitching/CMakeLists.txt
+++ b/wrappers/pointcloud/pointcloud-stitching/CMakeLists.txt
@@ -1,7 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2021 Intel Corporation. All Rights Reserved.
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+# Copyright(c) 2021-2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsenseExamplesPointcloudStitching)
 

--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsensePythonWrappers)
 

--- a/wrappers/python/docs/CMakeLists.txt
+++ b/wrappers/python/docs/CMakeLists.txt
@@ -1,5 +1,4 @@
-#  minimum required cmake version: 3.1.0
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.8)
 
 project(RealsensePythonDocs)
 


### PR DESCRIPTION
Avoid this warnings (many of it) and align LibRealSense to the real default build minimal CMake version

![image](https://github.com/IntelRealSense/librealsense/assets/64067618/96bd06d6-d0c9-4f2e-9e75-d90517cf2028)
