### PR TITLE
add NO_TLS for FastDDS builds to disable SSL linkage

### DIFF
--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -33,6 +33,8 @@ function(get_fastdds)
     set(SQLITE3_SUPPORT OFF CACHE INTERNAL "" FORCE)
     #set(ENABLE_OLD_LOG_MACROS OFF CACHE INTERNAL "" FORCE)  doesn't work
     set(FASTDDS_STATISTICS OFF CACHE INTERNAL "" FORCE)
+    # Enforce NO_TLS to disable SSL: if OpenSSL is found, it will be linked to, and we don't want it!
+    set(NO_TLS ON CACHE INTERNAL "" FORCE)
 
     # Set special values for FastDDS sub directory
     set(BUILD_SHARED_LIBS OFF)


### PR DESCRIPTION
Even with `SECURITY` set to OFF, if FastDDS detects OpenSSL then it tries to link with `libssl`. Our build machines have OpenSSL and are compiled on non-Jammy machines, so this results in a dependency on `libssl1.1` which is deprecated with Jammy so librealsense cannot be loaded.

eProsima indicates the proper way to disable this is to set `NO_TLS` to `ON`.

Tracked on [RSDEV-2112]