### PR TITLE
DFU for D457 recovery device

### DIFF
--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2017 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2017-2024 Intel Corporation. All Rights Reserved.
 
 #ifndef LIBREALSENSE_RS2_DEVICE_HPP
 #define LIBREALSENSE_RS2_DEVICE_HPP
@@ -60,6 +60,8 @@ namespace rs2
             {
                 std::string pid = get_info( RS2_CAMERA_INFO_PRODUCT_ID );
                 if( pid == "ABCD" ) // Specific for D457
+                    return "GMSL";
+                if( pid == "BBCD" ) // Specific for D457 Recovery DFU
                     return "GMSL";
                 return pid;  // for DDS devices, this will be "DDS"
             }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,8 @@ target_sources(${LRS_TARGET}
         "${CMAKE_CURRENT_LIST_DIR}/platform/hid-data.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/hid-device.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/hid-device-info.h"
+        "${CMAKE_CURRENT_LIST_DIR}/platform/mipi-device.h"
+        "${CMAKE_CURRENT_LIST_DIR}/platform/mipi-device-info.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/playback-device-info.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/platform-utils.h"
         "${CMAKE_CURRENT_LIST_DIR}/platform/platform-utils.cpp"

--- a/src/backend-device-factory.cpp
+++ b/src/backend-device-factory.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-2024 Intel Corporation. All Rights Reserved.
 
 #include "backend-device-factory.h"
 #include "context.h"
@@ -181,6 +181,7 @@ std::vector< std::shared_ptr< device_info > > backend_device_factory::query_devi
     auto backend = _device_watcher->get_backend();
     platform::backend_device_group group( backend->query_uvc_devices(),
                                           backend->query_usb_devices(),
+                                          backend->query_mipi_devices(),
                                           backend->query_hid_devices() );
     auto devices = create_devices_from_group( group, requested_mask );
     return { devices.begin(), devices.end() };
@@ -211,6 +212,13 @@ backend_device_factory::create_devices_from_group( platform::backend_device_grou
         {
             auto recovery_devices
                 = fw_update_info::pick_recovery_devices( ctx, devices.usb_devices, mask );
+            std::copy( begin( recovery_devices ), end( recovery_devices ), std::back_inserter( list ) );
+        }
+
+        // Supported mipi recovery devices
+        {
+            auto recovery_devices
+                = fw_update_info::pick_recovery_devices( ctx, devices.mipi_devices, mask );
             std::copy( begin( recovery_devices ), end( recovery_devices ), std::back_inserter( list ) );
         }
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -1,10 +1,11 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2015-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
 #include "platform/uvc-device-info.h"
 #include "platform/hid-device-info.h"
+#include "platform/mipi-device-info.h"
 #include "platform/stream-profile.h"
 #include "platform/frame-object.h"
 
@@ -27,6 +28,7 @@ namespace librealsense
         class device_watcher;
         class hid_device;
         class uvc_device;
+        class mipi_device;
         class command_transfer;
 
 
@@ -41,6 +43,8 @@ namespace librealsense
 
             virtual std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const = 0;
             virtual std::vector<hid_device_info> query_hid_devices() const = 0;
+
+            virtual std::vector<mipi_device_info> query_mipi_devices() const = 0;
 
             virtual std::shared_ptr<device_watcher> create_device_watcher() const = 0;
 

--- a/src/ds/d400/d400-fw-update-device.cpp
+++ b/src/ds/d400/d400-fw-update-device.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
 
 #include "d400-fw-update-device.h"
 #include "d400-private.h"
@@ -18,6 +18,16 @@ ds_d400_update_device::ds_d400_update_device(
         _serial_number = parse_serial_number(_serial_number_buffer);
     }
 
+    ds_d400_update_device::ds_d400_update_device(
+    std::shared_ptr< const device_info > const & dev_info,
+    std::shared_ptr< platform::mipi_device > const & mipi_device )
+    : update_device( dev_info, mipi_device, "D400" )
+    {
+        auto info = mipi_device->get_info();
+        _name = ds::rs400_sku_names.find(info.pid) != ds::rs400_sku_names.end() ? ds::rs400_sku_names.at(info.pid) : "unknown";
+        _serial_number = info.serial_number;
+    }
+
 
     bool ds_d400_update_device::check_fw_compatibility(const std::vector<uint8_t>& image) const
     {
@@ -27,7 +37,12 @@ ds_d400_update_device::ds_d400_update_device(
                 rsutils::string::from() << "Unsupported firmware binary image provided - " << image.size() << " bytes" );
 
         std::string fw_version = ds::extract_firmware_version_string(image);
-        auto it = ds::d400_device_to_fw_min_version.find(_usb_device->get_info().pid);
+        uint16_t pid;
+        if (_usb_device != nullptr )
+            pid = _usb_device->get_info().pid;
+        else if (_mipi_device != nullptr )
+            pid = _mipi_device->get_info().pid;
+            auto it = ds::d400_device_to_fw_min_version.find(pid);
         if (it == ds::d400_device_to_fw_min_version.end())
             throw librealsense::invalid_value_exception(
                 rsutils::string::from() << "Min and Max firmware versions have not been defined for this device: "

--- a/src/ds/d400/d400-fw-update-device.h
+++ b/src/ds/d400/d400-fw-update-device.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -12,6 +12,8 @@ namespace librealsense
     public:
         ds_d400_update_device( std::shared_ptr< const device_info > const &,
                                std::shared_ptr< platform::usb_device > const & usb_device );
+        ds_d400_update_device( std::shared_ptr< const device_info > const &,
+                               std::shared_ptr< platform::mipi_device > const & mipi_device );
         virtual ~ds_d400_update_device() = default;
 
         virtual bool check_fw_compatibility(const std::vector<uint8_t>& image) const override;

--- a/src/ds/d400/d400-private.h
+++ b/src/ds/d400/d400-private.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2015-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -37,6 +37,7 @@ namespace librealsense
         const uint16_t RS405_PID = 0x0B5B; // D405
         const uint16_t RS455_PID = 0x0B5C; // D455
         const uint16_t RS457_PID = 0xabcd; // D457
+        const uint16_t RS457_RECOVERY_PID = 0xbbcd; // D457 DFU Recovery
 
         // d400 Devices supported by the current version
         static const std::set<std::uint16_t> rs400_sku_pid = {
@@ -124,6 +125,7 @@ namespace librealsense
             { RS405_PID,            "Intel RealSense D405" },
             { RS455_PID,            "Intel RealSense D455" },
             { RS457_PID,            "Intel RealSense D457" },
+            { RS457_RECOVERY_PID,   "Intel RealSense D457 Recovery"},
         };
 
         static std::map<uint16_t, std::string> d400_device_to_fw_min_version = {
@@ -150,7 +152,8 @@ namespace librealsense
             {RS416_RGB_PID, "5.8.15.0" },
             {RS405_PID, "5.12.11.8" },
             {RS455_PID, "5.13.0.50" },
-            {RS457_PID, "5.13.1.1" }
+            {RS457_PID, "5.13.1.1" },
+            {RS457_RECOVERY_PID, "5.13.1.1" }
         };
 
         std::vector<platform::uvc_device_info> filter_d400_device_by_capability(

--- a/src/fw-update/fw-update-device.h
+++ b/src/fw-update/fw-update-device.h
@@ -5,6 +5,7 @@
 #include <src/core/device-interface.h>
 #include "fw-update-device-interface.h"
 #include "usb/usb-device.h"
+#include "platform/mipi-device.h"
 
 namespace librealsense
 {
@@ -19,7 +20,7 @@ namespace librealsense
         RS2_DFU_STATUS_VERIFY = 0x07,       // Programmed memory failed verification.
         RS2_DFU_STATUS_ADDRESS = 0x08,      // Cannot program memory due to received address that is out of range.
         RS2_DFU_STATUS_NOTDONE = 0x09,      // Received DFU_DNLOAD with wLength = 0, but device does    not think it has all of the data yet.
-        RS2_DFU_STATUS_FIRMWARE = 0x0A,     // Device’s firmware is corrupt.It cannot return to run - time    (non - DFU) operations.
+        RS2_DFU_STATUS_FIRMWARE = 0x0A,     // Deviceï¿½s firmware is corrupt.It cannot return to run - time    (non - DFU) operations.
         RS2_DFU_STATUS_VENDOR = 0x0B,       // iString indicates a vendor - specific RS2_DFU_STATUS_or.
         RS2_DFU_STATUS_USBR = 0x0C,         // Device detected unexpected USB reset signaling.
         RS2_DFU_STATUS_POR = 0x0D,          // Device detected unexpected power on reset.
@@ -102,10 +103,15 @@ namespace librealsense
         update_device( std::shared_ptr< const device_info > const &,
                        std::shared_ptr< platform::usb_device > const & usb_device,
                        const std::string & _product_line );
+
+        update_device( std::shared_ptr< const device_info > const &,
+                       std::shared_ptr< platform::mipi_device > const & mipi_device,
+                       const std::string & _product_line );
+
         virtual ~update_device();
 
         virtual void update(const void* fw_image, int fw_image_size, rs2_update_progress_callback_sptr = nullptr) const override;
-        
+
         virtual sensor_interface& get_sensor(size_t i) override;
 
         virtual const sensor_interface& get_sensor(size_t i) const override;
@@ -143,6 +149,8 @@ namespace librealsense
         virtual void enable_recording(std::function<void(const info_interface&)> recording_function) override;
 
     protected:
+        void update_usb(const void* fw_image, int fw_image_size, rs2_update_progress_callback_sptr = nullptr) const;
+        void update_mipi(const void* fw_image, int fw_image_size, rs2_update_progress_callback_sptr = nullptr) const;
         rs2_dfu_state get_dfu_state(std::shared_ptr<platform::usb_messenger> messenger) const;
         void detach(std::shared_ptr<platform::usb_messenger> messenger) const;
         bool wait_for_state(std::shared_ptr<platform::usb_messenger> messenger, const rs2_dfu_state state, size_t timeout = 1000) const;
@@ -160,6 +168,7 @@ namespace librealsense
         const int FW_UPDATE_INTERFACE_NUMBER = 0;
         const std::shared_ptr< const device_info > _dev_info;
         const platform::rs_usb_device _usb_device;
+        const platform::rs_mipi_device _mipi_device;
         std::vector<uint8_t> _serial_number_buffer;
         std::string _highest_fw_version;
         std::string _last_fw_version;

--- a/src/fw-update/fw-update-factory.cpp
+++ b/src/fw-update/fw-update-factory.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
 
 #include "fw-update-factory.h"
 #include "fw-update-device.h"
@@ -42,25 +42,57 @@ namespace librealsense
         return list;
     }
 
+    std::vector< std::shared_ptr< fw_update_info > > fw_update_info::pick_recovery_devices(
+        std::shared_ptr< context > ctx, const std::vector< platform::mipi_device_info > & mipi_devices, int mask )
+    {
+        std::vector< std::shared_ptr< fw_update_info > > list;
+        for (auto&& mipi : mipi_devices)
+        {
+            list.push_back(std::make_shared<fw_update_info>(ctx, mipi));
+        }
+        return list;
+    }
+
 
     std::shared_ptr<device_interface> fw_update_info::create_device()
     {
         auto devices = platform::usb_enumerator::query_devices_info();
-        auto const & dfu_id = get_group().usb_devices.front().id;
-        for (auto&& info : devices)
-        {
-            if( info.id == dfu_id )
+        auto & dfu_id = get_group().usb_devices.front().id;
+
+        auto const & mipi_id = get_group().mipi_devices.front().id;
+
+        if (&dfu_id != nullptr) {
+            for (auto&& info : devices)
             {
-                auto usb = platform::usb_enumerator::create_usb_device(info);
-                if (!usb)
+                if( info.id == dfu_id )
+                {
+                    auto usb = platform::usb_enumerator::create_usb_device(info);
+                    if (!usb)
+                        continue;
+                    switch( info.pid )
+                    {
+                    case ds::RS_D400_RECOVERY_PID:
+                    case ds::RS_D400_USB2_RECOVERY_PID:
+                        return std::make_shared< ds_d400_update_device >( shared_from_this(), usb );
+                    case ds::D555E_RECOVERY_PID:
+                        return std::make_shared< ds_d500_update_device >( shared_from_this(), usb );
+                    default:
+                        // Do nothing
+                        break;
+                    }
+                }
+            }
+        }
+        else {
+            for (auto&& info: get_group().mipi_devices)
+            {
+                auto mipi = platform::mipi_device::create_mipi_device(info);
+                if (!mipi)
                     continue;
                 switch( info.pid )
                 {
-                case ds::RS_D400_RECOVERY_PID:
-                case ds::RS_D400_USB2_RECOVERY_PID:
-                    return std::make_shared< ds_d400_update_device >( shared_from_this(), usb );
-                case ds::D555E_RECOVERY_PID:
-                    return std::make_shared< ds_d500_update_device >( shared_from_this(), usb );
+                case 0xbbcd:
+                    return std::make_shared< ds_d400_update_device >( shared_from_this(), mipi );
                 default:
                     // Do nothing
                     break;
@@ -70,4 +102,5 @@ namespace librealsense
         throw std::runtime_error( rsutils::string::from()
                                   << "Failed to create FW update device, device id: " << dfu_id );
     }
+
 }

--- a/src/fw-update/fw-update-factory.h
+++ b/src/fw-update/fw-update-factory.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2019-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -19,7 +19,13 @@ namespace librealsense
         static std::vector< std::shared_ptr< fw_update_info > > pick_recovery_devices(
             std::shared_ptr< context > ctx, const std::vector< platform::usb_device_info > & usb_devices, int mask );
 
+        static std::vector< std::shared_ptr< fw_update_info > > pick_recovery_devices(
+            std::shared_ptr< context > ctx, const std::vector< platform::mipi_device_info > & mipi_devices, int mask );
+
         explicit fw_update_info(std::shared_ptr<context> ctx, platform::usb_device_info const & dfu)
+            : platform_device_info( ctx, { { dfu } } ) {}
+
+        explicit fw_update_info(std::shared_ptr<context> ctx, platform::mipi_device_info const & dfu)
             : platform_device_info( ctx, { { dfu } } ) {}
 
         std::string get_address() const override { return "recovery:" + super::get_address(); }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -948,10 +948,11 @@ namespace librealsense
             std::vector<std::string> dfu_device_paths = get_mipi_dfu_paths();
 
             for (const auto& dfu_device_path: dfu_device_paths) {
-                int vfd = open(dfu_device_path.c_str(), O_RDONLY | O_NONBLOCK);
+                auto mipi_dfu_chardev = "/dev/" + dfu_device_path;
+                int vfd = open(mipi_dfu_chardev.c_str(), O_RDONLY | O_NONBLOCK);
                 if (vfd >= 0) {
                     // Use legacy DFU device node used in firmware_update_manager
-                    info.dfu_device_path = dfu_device_path;
+                    info.dfu_device_path = mipi_dfu_chardev;
                     ::close(vfd); // file exists, close file and continue to assign it
                     break;
                 }

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2015-2024 Intel Corporation. All Rights Reserved.
 
 #include "backend-v4l2.h"
 #include <src/platform/command-transfer.h>
@@ -696,6 +696,64 @@ namespace librealsense
             return video_paths;
         }
 
+        std::vector<std::string> v4l_uvc_device::get_mipi_dfu_paths()
+        {
+            std::vector<std::string> dfu_paths;
+            static const std::regex dfu_dev_pattern("./d4xx-dfu.");
+            // Enumerate all d4xx dfu devices present on the system
+            DIR * dir = opendir("/sys/class/d4xx-class");
+            if(!dir)
+            {
+                LOG_INFO("Cannot access /sys/class/d4xx-class");
+                return dfu_paths;
+            }
+            while (dirent * entry = readdir(dir))
+            {
+                std::string name = entry->d_name;
+                if(name == "." || name == "..") continue;
+                std::string path = "/sys/class/d4xx-class/" + name;
+                std::string real_path{};
+                char buff[PATH_MAX] = {0};
+                if (realpath(path.c_str(), buff) != nullptr)
+                {
+                    real_path = std::string(buff);
+                    if (real_path.find("virtual") == std::string::npos)
+                        continue;
+                    if (!std::regex_search(real_path, dfu_dev_pattern))
+                    {
+                        continue;
+                    }
+                    //                    if (get_devname_from_video_path(real_path, name))
+                    std::ifstream uevent_file(real_path + "/uevent");
+                    if (!uevent_file)
+                    {
+                        LOG_ERROR("Cannot access " + real_path + "/uevent");
+                        continue;
+                    }
+                    std::string uevent_line, devname;
+                    while (std::getline(uevent_file, uevent_line) && (devname.empty()))
+                    {
+                        if (uevent_line.find("DEVNAME=") != std::string::npos)
+                        {
+                            devname = uevent_line.substr(uevent_line.find_last_of('=') + 1);
+                        }
+                    }
+                    uevent_file.close();
+                    if (devname.empty())
+                    {
+                        LOG_ERROR("No DEVNAME found for " + real_path);
+                        continue;
+                    }
+                    if ( std::find(dfu_paths.begin(), dfu_paths.end(), devname) == dfu_paths.end() )
+                    {
+                        dfu_paths.push_back(devname);
+                    }
+                }
+            }
+            closedir(dir);
+            return dfu_paths;
+        }
+
         bool v4l_uvc_device::is_usb_path_valid(const std::string& usb_video_path, const std::string& dev_name,
                                                std::string& busnum, std::string& devnum, std::string& devpath)
         {
@@ -887,7 +945,8 @@ namespace librealsense
             // Note - jetson can use only bus_info, as card is different for each sensor and metadata node.
             info.unique_id = bus_info + "-" + std::to_string(cam_id); // use bus_info as per camera unique id for mipi
             // Get DFU node for MIPI camera
-            std::array<std::string, 2> dfu_device_paths = {"/dev/d4xx-dfu504", "/dev/d4xx-dfu-30-0010"};
+            std::vector<std::string> dfu_device_paths = get_mipi_dfu_paths();
+
             for (const auto& dfu_device_path: dfu_device_paths) {
                 int vfd = open(dfu_device_path.c_str(), O_RDONLY | O_NONBLOCK);
                 if (vfd >= 0) {
@@ -909,11 +968,64 @@ namespace librealsense
             return std::regex_search(video_path, uvc_pattern);
         }
 
+        void v4l_mipi_device::foreach_mipi_device(
+                std::function<void(const mipi_device_info&,
+                                   const std::string&)> action)
+        {
+            typedef std::pair<mipi_device_info,std::string> node_info;
+            std::vector<node_info> mipi_devices;
+
+            std::vector<std::string> mipi_dfu_paths = get_mipi_dfu_paths();
+            for(auto it = mipi_dfu_paths.begin(); mipi_dfu_paths.size() && it != mipi_dfu_paths.end(); ++it)
+            {
+                auto mipi_dfu_path = "/dev/" + *it;
+                std::string dfu_ver;
+                for (int retry = 10; retry; retry--) {
+                    std::ifstream fw_path_in_device(mipi_dfu_path);
+                    std::getline(fw_path_in_device, dfu_ver);
+                    if (dfu_ver.size()) {
+                        fw_path_in_device.close();
+                        break;
+                    }
+                    fw_path_in_device.close();
+                }
+                // look for "recovery" string, if no - skip.
+                if (dfu_ver.find("recovery") == std::string::npos)
+                    continue;
+                mipi_device_info info{};
+                info.pid = 0xbbcd;
+                info.vid = 0x8086;
+                info.id = *it;
+                info.device_path = mipi_dfu_path;
+                info.unique_id = *it;
+                info.dfu_device_path = mipi_dfu_path;
+                // The expected string is  "DFU info:  recovery:  209443110028"
+                std::string delimiter = ":";
+                dfu_ver.erase(0, dfu_ver.find(delimiter) + delimiter.length());
+                dfu_ver.erase(0, dfu_ver.find(delimiter) + delimiter.length());
+                // Trim leading whitespace
+                dfu_ver.erase(0, dfu_ver.find_first_not_of(' '));
+                info.serial_number = dfu_ver;
+                mipi_devices.emplace_back(info, *it);
+            }
+            try
+            {
+                // Dispatch registration for enumerated MIPI Recovery devices
+                for (auto&& dev : mipi_devices)
+                    action(dev.first, dev.second);
+            }
+            catch(const std::exception & e)
+            {
+                LOG_ERROR("Registration of MIPI recovery device failed: " << e.what());
+            }
+        }
+
         void v4l_uvc_device::foreach_uvc_device(
                 std::function<void(const uvc_device_info&,
                                    const std::string&)> action)
         {
             std::vector<std::string> video_paths = get_video_paths();
+            std::vector<std::string> mipi_dfu_paths = get_mipi_dfu_paths();
             typedef std::pair<uvc_device_info,std::string> node_info;
             std::vector<node_info> uvc_nodes,uvc_devices;
             std::vector<node_info> mipi_rs_enum_nodes;
@@ -2769,6 +2881,7 @@ namespace librealsense
         std::vector<uvc_device_info> v4l_backend::query_uvc_devices() const
         {
             std::vector<uvc_device_info> uvc_nodes;
+
             v4l_uvc_device::foreach_uvc_device(
             [&uvc_nodes](const uvc_device_info& i, const std::string&)
             {
@@ -2792,6 +2905,18 @@ namespace librealsense
             return device_infos;
         }
 
+        std::vector<mipi_device_info> v4l_backend::query_mipi_devices() const
+        {
+            std::vector<mipi_device_info> mipi_nodes;
+
+            v4l_mipi_device::foreach_mipi_device(
+            [&mipi_nodes](const mipi_device_info& i, const std::string&)
+            {
+                mipi_nodes.push_back(i);
+            });
+
+            return mipi_nodes;
+        }
         std::shared_ptr<hid_device> v4l_backend::create_hid_device(hid_device_info info) const
         {
             return std::make_shared<v4l_hid_device>(info);

--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2015-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -318,6 +318,7 @@ namespace librealsense
                                        const std::string&)> action);
 
             static std::vector<std::string> get_video_paths();
+            static std::vector<std::string> get_mipi_dfu_paths();
 
             static bool is_usb_path_valid(const std::string& usb_video_path, const std::string &dev_name,
                                           std::string &busnum, std::string &devnum, std::string &devpath);
@@ -473,6 +474,19 @@ namespace librealsense
         {
         public:
             v4l_mipi_device(const uvc_device_info& info, bool use_memory_map = true);
+            v4l_mipi_device(const mipi_device_info& info, bool use_memory_map = true);
+
+            static void foreach_mipi_device(
+                    std::function<void(const mipi_device_info&,
+                                       const std::string&)> action);
+
+            static std::vector<std::string> get_video_paths();
+
+            static mipi_device_info get_info_from_mipi_device_path(
+                    const std::string& video_path, const std::string& name);
+
+            static void get_mipi_device_info(const std::string& dev_name,
+                                             std::string& bus_info, std::string& card);
 
             virtual ~v4l_mipi_device();
 
@@ -500,6 +514,8 @@ namespace librealsense
 
             std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const override;
             std::vector<hid_device_info> query_hid_devices() const override;
+
+            std::vector<mipi_device_info> query_mipi_devices() const override;
 
             std::shared_ptr<device_watcher> create_device_watcher() const override;
         };

--- a/src/mf/mf-backend.cpp
+++ b/src/mf/mf-backend.cpp
@@ -176,6 +176,11 @@ namespace librealsense
             return devices;
         }
 
+        std::vector<mipi_device_info> wmf_backend::query_mipi_devices() const
+        {
+            return std::vector<mipi_device_info>();
+        }
+
         class win_event_device_watcher : public device_watcher
         {
         public:

--- a/src/mf/mf-backend.h
+++ b/src/mf/mf-backend.h
@@ -25,6 +25,9 @@ namespace librealsense
 
             std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const override;
             std::vector<hid_device_info> query_hid_devices() const override;
+
+            std::vector<mipi_device_info> query_mipi_devices() const override;
+
             std::shared_ptr<device_watcher> create_device_watcher() const override;
             std::string get_device_serial(uint16_t device_vid, uint16_t device_pid, const std::string& device_uid) const override;
 

--- a/src/platform/backend-device-group.h
+++ b/src/platform/backend-device-group.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -8,6 +8,7 @@
 
 #include "hid-device-info.h"
 #include "uvc-device-info.h"
+#include "mipi-device-info.h"
 
 #include <memory>
 #include <functional>
@@ -60,6 +61,22 @@ struct backend_device_group
     {
     }
 
+    backend_device_group( const std::vector< uvc_device_info > & uvc_devices,
+                          const std::vector< usb_device_info > & usb_devices,
+                          const std::vector< mipi_device_info > & mipi_devices,
+                          const std::vector< hid_device_info > & hid_devices )
+        : uvc_devices( uvc_devices )
+        , usb_devices( usb_devices )
+        , mipi_devices( mipi_devices )
+        , hid_devices( hid_devices )
+    {
+    }
+
+    backend_device_group( const std::vector< mipi_device_info > & mipi_devices )
+        : mipi_devices( mipi_devices )
+    {
+    }
+
     backend_device_group( const std::vector< usb_device_info > & usb_devices )
         : usb_devices( usb_devices )
     {
@@ -74,6 +91,7 @@ struct backend_device_group
 
     std::vector< uvc_device_info > uvc_devices;
     std::vector< usb_device_info > usb_devices;
+    std::vector< mipi_device_info > mipi_devices;
     std::vector< hid_device_info > hid_devices;
 
     bool operator==( const backend_device_group & other ) const
@@ -95,6 +113,13 @@ struct backend_device_group
         for( auto usb : usb_devices )
         {
             s += usb;
+            s += "\n\n";
+        }
+
+        s += mipi_devices.size() > 0 ? "mipi devices:\n" : "";
+        for( auto mipi : mipi_devices )
+        {
+            s += mipi;
             s += "\n\n";
         }
 
@@ -123,6 +148,12 @@ struct backend_device_group
         {
             if( std::find( second_data.usb_devices.begin(), second_data.usb_devices.end(), usb )
                 == second_data.usb_devices.end() )
+                return false;
+        }
+        for( auto & mipi : mipi_devices )
+        {
+            if( std::find( second_data.mipi_devices.begin(), second_data.mipi_devices.end(), mipi )
+                == second_data.mipi_devices.end() )
                 return false;
         }
         for( auto & hid : hid_devices )

--- a/src/platform/mipi-device-info.h
+++ b/src/platform/mipi-device-info.h
@@ -1,0 +1,42 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <sstream>
+#include <memory>
+
+
+namespace librealsense {
+namespace platform {
+
+
+struct mipi_device_info
+{
+    std::string id;
+    uint16_t vid;
+    uint16_t pid;
+    std::string unique_id;
+    std::string device_path;
+    std::string dfu_device_path;
+    std::string serial_number;
+
+    operator std::string()
+    {
+        std::ostringstream s;
+        s << "id- " << id << "\nvid- " << std::hex << vid << "\npid- " << std::hex << pid << "\nunique_id- "
+          << unique_id << "\npath- " << device_path;
+
+        return s.str();
+    }
+};
+
+
+inline bool operator==( const mipi_device_info & a, const mipi_device_info & b )
+{
+    return ( a.id == b.id ) && ( a.vid == b.vid ) && ( a.pid == b.pid ) && ( a.unique_id == b.unique_id )
+        && ( a.device_path == b.device_path );
+}
+
+}  // namespace platform
+}  // namespace librealsense

--- a/src/platform/mipi-device.h
+++ b/src/platform/mipi-device.h
@@ -1,0 +1,32 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#pragma once
+
+#include <sstream>
+#include <memory>
+#include "mipi-device-info.h"
+
+namespace librealsense {
+namespace platform {
+
+class mipi_device;
+typedef std::shared_ptr<mipi_device> rs_mipi_device;
+
+class mipi_device
+{
+public:
+    mipi_device(const mipi_device_info& info) : _info(info) {}
+    virtual ~mipi_device() = default;
+    static rs_mipi_device create_mipi_device(const mipi_device_info& info)
+    {
+        return std::make_shared<mipi_device>(info);
+    }
+    const mipi_device_info get_info() const { return _info; };
+private:
+    const mipi_device_info _info;
+};
+
+
+}  // namespace platform
+}  // namespace librealsense

--- a/src/platform/platform-device-info.h
+++ b/src/platform/platform-device-info.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -39,6 +39,8 @@ public:
             return _group.uvc_devices.front().device_path;
         if( ! _group.usb_devices.empty() )
             return _group.usb_devices.front().id;
+        if( ! _group.mipi_devices.empty() )
+            return _group.mipi_devices.front().id;
         throw std::runtime_error( "non-standard platform-device-info" );
     }
 

--- a/src/platform/platform-utils.h
+++ b/src/platform/platform-utils.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-2024 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
@@ -15,6 +15,7 @@ namespace platform {
 struct uvc_device_info;
 struct hid_device_info;
 struct usb_device_info;
+struct mipi_device_info;
 
 
 // Helper functions for device list manipulation:

--- a/src/rsusb-backend/rsusb-backend.cpp
+++ b/src/rsusb-backend/rsusb-backend.cpp
@@ -64,5 +64,10 @@ namespace librealsense
         {
             return query_hid_devices_info();
         }
+
+        std::vector<mipi_device_info> rs_backend::query_mipi_devices() const
+        {
+            return std::vector<mipi_device_info>();
+        }
     }
 }

--- a/src/rsusb-backend/rsusb-backend.h
+++ b/src/rsusb-backend/rsusb-backend.h
@@ -27,6 +27,7 @@ namespace librealsense
             // Not supported
             std::shared_ptr<hid_device> create_hid_device(hid_device_info info) const override;
             std::vector<hid_device_info> query_hid_devices() const override;
+            std::vector<mipi_device_info> query_mipi_devices() const override;
         };
     }
 }

--- a/tools/fw-update/rs-fw-update.cpp
+++ b/tools/fw-update/rs-fw-update.cpp
@@ -340,6 +340,7 @@ try
         try
         {
             update_serial_number = recovery_device.get_info( RS2_CAMERA_INFO_FIRMWARE_UPDATE_ID );
+            bool d457_recovery_device = strcmp( recovery_device.get_info( RS2_CAMERA_INFO_PRODUCT_ID ), "BBCD" ) == 0;
             volatile bool recovery_device_found = false;
             ctx.set_devices_changed_callback( [&]( rs2::event_information & info ) {
                 for( auto && d : info.get_new_devices() )
@@ -362,6 +363,7 @@ try
             print_device_info( recovery_device );
             update( recovery_device, fw_image );
             std::cout << "Waiting for new device..." << std::endl;
+            if (!d457_recovery_device)
             {
                 std::unique_lock< std::mutex > lk( mutex );
                 if( ! recovery_device_found
@@ -374,6 +376,12 @@ try
                 }
             }
             std::cout << std::endl << "Recovery done" << std::endl;
+            if (d457_recovery_device)
+            {
+                std::cout << std::endl << "For GMSL device please reload d4xx driver:" << std::endl;
+                std::cout << "sudo rmmod d4xx && sudo modprobe d4xx" << std::endl;
+                std::cout << "or reboot the system" << std::endl;
+            }
             return EXIT_SUCCESS;
         }
         catch (...)


### PR DESCRIPTION
Tracked-by: [RSDSO-19297] - [D457]: LRS applications cannot recognized cameras in recovery mode
Viewer:
![image](https://github.com/IntelRealSense/librealsense/assets/64067618/9d080731-4944-4bf0-b146-9cc7167be729)

rs-fw-update:
![image](https://github.com/IntelRealSense/librealsense/assets/64067618/1e3d9151-718c-4579-980a-800d44101a67)
