### PR TITLE
Make json clone more robust

### DIFF
--- a/CMake/json-download.cmake.in
+++ b/CMake/json-download.cmake.in
@@ -9,8 +9,11 @@ ExternalProject_Add(
     # We do not use 'GIT_REPOSITORY' as it doesn't support a shallow clone of a specific commit,
     # this make the clone step very long, so we clone by ourselves (See https://gitlab.kitware.com/cmake/cmake/-/issues/17770).
     # Adding detachedHead=false to avoid warnings like: "You are in 'detached HEAD' state..."
-    DOWNLOAD_COMMAND   git clone -c advice.detachedHead=false --branch v3.11.3 https://github.com/nlohmann/json.git --depth 1 json
-    DOWNLOAD_DIR       "${CMAKE_BINARY_DIR}/third-party/"
+    # 'remove_directory' is working but cound as deprecated from cmake version 3.17, 
+    # Once we have a minimal version support of cmake 3.17, we can switch the command to rm -rF
+    DOWNLOAD_COMMAND   "${CMAKE_COMMAND}" -E  remove_directory  "${CMAKE_BINARY_DIR}/third-party/json"
+             COMMAND   git clone -c advice.detachedHead=false --branch v3.11.3 https://github.com/nlohmann/json.git --depth 1 json
+    DOWNLOAD_DIR       ${CMAKE_BINARY_DIR}/third-party/
     
     # Override default steps with no action, we just want the clone step.
     UPDATE_COMMAND ""
@@ -18,4 +21,5 @@ ExternalProject_Add(
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     )
-
+    
+   


### PR DESCRIPTION
We clone json third party with a custom command to enforce shallow clone.
This clone step has some corner cases like if the directory already exist the clone can fail.

Here we make sure we first delete the folder if exist and then clone a fresh version