### PR TITLE
Jammy compilation fix with log macro changes

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -413,6 +413,47 @@ jobs:
   
 
   #--------------------------------------------------------------------------------
+  U22_SH_Py_DDS_CI:  # Ubuntu 2022, Shared, Python, DDS, LibCI without executables
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v3
+          
+    - name: Prebuild
+      shell: bash
+      run: |
+        sudo apt-get update;
+        sudo apt-get install -qq build-essential xorg-dev libgl1-mesa-dev libglu1-mesa-dev libglew-dev libglm-dev;
+        sudo apt-get install -qq libusb-1.0-0-dev;
+        sudo apt-get install -qq libgtk-3-dev;
+        sudo apt-get install libglfw3-dev libglfw3;
+        python3 -m pip install numpy
+
+    - name: Check_API
+      shell: bash
+      run: |
+        cd scripts
+        ./api_check.sh
+        ./pr_check.sh
+        cd ..  
+        mkdir build
+
+    - name: Build
+      shell: bash
+      run: | 
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=${{env.LRS_RUN_CONFIG}} -DBUILD_SHARED_LIBS=true -DBUILD_EXAMPLES=false -DBUILD_TOOLS=false -DBUILD_UNIT_TESTS=false -DCHECK_FOR_UPDATES=false -DBUILD_WITH_DDS=true -DBUILD_PYTHON_BINDINGS=true -DPYTHON_EXECUTABLE=$(which python3)
+        cmake --build . -- -j4
+
+    - name: LibCI
+      # Note: we specifically disable BUILD_UNIT_TESTS so the executable C++ unit-tests won't run
+      # This is to save time as DDS already lengthens the build...
+      shell: bash
+      run: |
+        python3 unit-tests/run-unit-tests.py --no-color --debug --stdout --not-live --context "dds linux" --tag dds
+  
+
+  #--------------------------------------------------------------------------------
   U22_SH_RSUSB_LiveTest:  # Ubuntu 2022, Shared, Legacy live-tests
     runs-on: ubuntu-22.04
     timeout-minutes: 60

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -3101,24 +3101,24 @@ void rs2_log(rs2_log_severity severity, const char * message, rs2_error ** error
     switch (severity)
     {
     case RS2_LOG_SEVERITY_DEBUG:
-        LOG_DEBUG(message);
+        LOG_DEBUG_STR(message);
         break;
     case RS2_LOG_SEVERITY_INFO:
-        LOG_INFO(message);
+        LOG_INFO_STR(message);
         break;
     case RS2_LOG_SEVERITY_WARN:
-        LOG_WARNING(message);
+        LOG_WARNING_STR(message);
         break;
     case RS2_LOG_SEVERITY_ERROR:
-        LOG_ERROR(message);
+        LOG_ERROR_STR(message);
         break;
     case RS2_LOG_SEVERITY_FATAL:
-        LOG_FATAL(message);
+        LOG_FATAL_STR(message);
         break;
     case RS2_LOG_SEVERITY_NONE:
         break;
     default:
-        LOG_INFO(message);
+        LOG_INFO_STR(message);
     }
 }
 HANDLE_EXCEPTIONS_AND_RETURN(, severity, message)

--- a/third-party/realdds/include/realdds/dds-exceptions.h
+++ b/third-party/realdds/include/realdds/dds-exceptions.h
@@ -1,11 +1,9 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
-
+// Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <stdexcept>
-#include <rsutils/string/from.h>
 
 
 // E.g.:
@@ -14,8 +12,11 @@
 #define DDS_THROW( ERR_TYPE, WHAT )                                                                                    \
     do                                                                                                                 \
     {                                                                                                                  \
-        LOG_ERROR( "throwing: " << WHAT );                                                                             \
-        throw realdds::dds_##ERR_TYPE( rsutils::string::from() << WHAT );                                              \
+        std::ostringstream os__;                                                                                       \
+        os__ << WHAT;                                                                                                  \
+        auto log_message__ = os__.str();                                                                               \
+        LOG_ERROR_STR( "throwing: " << log_message__ );                                                                \
+        throw realdds::dds_##ERR_TYPE( std::move( log_message__ ) );                                                   \
     }                                                                                                                  \
     while( 0 )
 
@@ -26,15 +27,7 @@ namespace realdds {
 class dds_runtime_error : public std::runtime_error
 {
 public:
-    dds_runtime_error( std::string const& str )
-        : std::runtime_error( str )
-    {
-    }
-
-    dds_runtime_error( char const* lpsz )
-        : std::runtime_error( lpsz )
-    {
-    }
+    using std::runtime_error::runtime_error;
 };
 
 

--- a/third-party/realdds/src/dds-device-server.cpp
+++ b/third-party/realdds/src/dds-device-server.cpp
@@ -21,6 +21,7 @@
 #include <realdds/dds-guid.h>
 #include <realdds/dds-sample.h>
 
+#include <rsutils/string/from.h>
 #include <rsutils/string/shorten-json-string.h>
 #include <rsutils/json.h>
 using rsutils::json;

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -14,6 +14,7 @@
 #include <fastdds/dds/core/status/SubscriptionMatchedStatus.hpp>
 #include <fastdds/rtps/transport/UDPv4TransportDescriptor.h>
 
+#include <rsutils/string/from.h>
 #include <rsutils/string/slice.h>
 #include <rsutils/json.h>
 

--- a/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
+++ b/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
@@ -48,12 +48,13 @@
 
 #else //__ANDROID__  
 
-// Direct log to ELPP, without conversion to string first
+// Direct log to ELPP, without conversion to string first; use this as an optimization, if you have simple string output
+// 
 // We've seen cases where this fails in U22, causing weird effects with custom overloads/types (e.g., json)
 #define LIBRS_LOG_STR_( LEVEL, STR )                                                                                   \
     do                                                                                                                 \
     {                                                                                                                  \
-        auto logger__ = el::Loggers::getLogger( LIBREALSENSE_ELPP_ID );                                                \
+        auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
         if( logger__ && logger__->enabled( el::Level::LEVEL ) )                                                        \
         {                                                                                                              \
             el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )   \
@@ -67,7 +68,7 @@
 #define LIBRS_LOG_( LEVEL, ... )                                                                                       \
     do                                                                                                                 \
     {                                                                                                                  \
-        auto logger__ = el::Loggers::getLogger( LIBREALSENSE_ELPP_ID );                                                \
+        auto logger__ = el::Loggers::getLogger( rsutils::g_librealsense_elpp_id );                                     \
         if( logger__ && logger__->enabled( el::Level::LEVEL ) )                                                        \
         {                                                                                                              \
             std::ostringstream os__;                                                                                   \
@@ -92,6 +93,10 @@
 #define LOG_FATAL_STR(STR)    LIBRS_LOG_STR_( Fatal,    STR )
 
 namespace rsutils {
+
+
+// This is a caching of LIBREALSENSE_ELPP_ID in a string, as a performance optimization
+extern std::string const g_librealsense_elpp_id;
 
 
 // Configure the same logger as librealsense (by default), to disable/enable debug output

--- a/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
+++ b/third-party/rsutils/include/rsutils/easylogging/easyloggingpp.h
@@ -1,6 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2021 Intel Corporation. All Rights Reserved.
-
+// Copyright(c) 2021-4 Intel Corporation. All Rights Reserved.
 #pragma once
 
 // When including this file outside LibRealSense you also need to:
@@ -41,13 +40,56 @@
 #define LOG_DEBUG(...)   do { std::ostringstream ss; ss << __VA_ARGS__; __android_log_write( ANDROID_LOG_DEBUG, ANDROID_LOG_TAG, ss.str().c_str() ); } while(false)
 #endif
 
+#define LOG_DEBUG_STR(STR)    LOG_DEBUG( STR )
+#define LOG_INFO_STR(STR)     LOG_INFO( STR )
+#define LOG_WARNING_STR(STR)  LOG_WARNING( STR )
+#define LOG_ERROR_STR(STR)    LOG_ERROR( STR )
+#define LOG_FATAL_STR(STR)    LOG_FATAL( STR )
+
 #else //__ANDROID__  
 
-#define LOG_DEBUG(...)   do { CLOG(DEBUG   , LIBREALSENSE_ELPP_ID) << __VA_ARGS__; } while(false)
-#define LOG_INFO(...)    do { CLOG(INFO    , LIBREALSENSE_ELPP_ID) << __VA_ARGS__; } while(false)
-#define LOG_WARNING(...) do { CLOG(WARNING , LIBREALSENSE_ELPP_ID) << __VA_ARGS__; } while(false)
-#define LOG_ERROR(...)   do { CLOG(ERROR   , LIBREALSENSE_ELPP_ID) << __VA_ARGS__; } while(false)
-#define LOG_FATAL(...)   do { CLOG(FATAL   , LIBREALSENSE_ELPP_ID) << __VA_ARGS__; } while(false)
+// Direct log to ELPP, without conversion to string first
+// We've seen cases where this fails in U22, causing weird effects with custom overloads/types (e.g., json)
+#define LIBRS_LOG_STR_( LEVEL, STR )                                                                                   \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        auto logger__ = el::Loggers::getLogger( LIBREALSENSE_ELPP_ID );                                                \
+        if( logger__ && logger__->enabled( el::Level::LEVEL ) )                                                        \
+        {                                                                                                              \
+            el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )   \
+                    .construct( logger__ )                                                                             \
+                << STR;                                                                                                \
+        }                                                                                                              \
+    }                                                                                                                  \
+    while( false )
+
+// Same, but first convert to string using usual mechanisms
+#define LIBRS_LOG_( LEVEL, ... )                                                                                       \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        auto logger__ = el::Loggers::getLogger( LIBREALSENSE_ELPP_ID );                                                \
+        if( logger__ && logger__->enabled( el::Level::LEVEL ) )                                                        \
+        {                                                                                                              \
+            std::ostringstream os__;                                                                                   \
+            os__ << __VA_ARGS__;                                                                                       \
+            el::base::Writer( el::Level::LEVEL, __FILE__, __LINE__, ELPP_FUNC, el::base::DispatchAction::NormalLog )   \
+                    .construct( logger__ )                                                                             \
+                << os__.str();                                                                                         \
+        }                                                                                                              \
+    }                                                                                                                  \
+    while( false )
+
+#define LOG_DEBUG(...)    LIBRS_LOG_( Debug,    __VA_ARGS__ )
+#define LOG_INFO(...)     LIBRS_LOG_( Info,     __VA_ARGS__ )
+#define LOG_WARNING(...)  LIBRS_LOG_( Warning,  __VA_ARGS__ )
+#define LOG_ERROR(...)    LIBRS_LOG_( Error,    __VA_ARGS__ )
+#define LOG_FATAL(...)    LIBRS_LOG_( Fatal,    __VA_ARGS__ )
+
+#define LOG_DEBUG_STR(STR)    LIBRS_LOG_STR_( Debug,    STR )
+#define LOG_INFO_STR(STR)     LIBRS_LOG_STR_( Info,     STR )
+#define LOG_WARNING_STR(STR)  LIBRS_LOG_STR_( Warning,  STR )
+#define LOG_ERROR_STR(STR)    LIBRS_LOG_STR_( Error,    STR )
+#define LOG_FATAL_STR(STR)    LIBRS_LOG_STR_( Fatal,    STR )
 
 namespace rsutils {
 
@@ -72,6 +114,12 @@ void configure_elpp_logger( bool enable_debug = false,
 #define LOG_WARNING(...) do { ; } while(false)
 #define LOG_ERROR(...)   do { ; } while(false)
 #define LOG_FATAL(...)   do { ; } while(false)
+
+#define LOG_DEBUG_STR(STR)    do { ; } while(false)
+#define LOG_INFO_STR(STR)     do { ; } while(false)
+#define LOG_WARNING_STR(STR)  do { ; } while(false)
+#define LOG_ERROR_STR(STR)    do { ; } while(false)
+#define LOG_FATAL_STR(STR)    do { ; } while(false)
 
 
 #endif // BUILD_EASYLOGGINGPP

--- a/third-party/rsutils/src/configure-elpp-logger.cpp
+++ b/third-party/rsutils/src/configure-elpp-logger.cpp
@@ -4,7 +4,11 @@
 #ifdef BUILD_EASYLOGGINGPP
 #include <rsutils/easylogging/easyloggingpp.h>
 
+
 namespace rsutils {
+
+
+std::string const g_librealsense_elpp_id( LIBREALSENSE_ELPP_ID );
 
 
 void configure_elpp_logger( bool enable_debug, std::string const & nested_indent, std::string const & logger_id )

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -698,7 +698,7 @@ if __name__ == '__main__':
 
     try:
         opts,args = getopt.getopt( sys.argv[1:], '',
-            longopts = [ 'help', 'recycle', 'all', 'none', 'list', 'port=', 'ports' ])
+            longopts = [ 'help', 'recycle', 'all', 'none', 'list', 'port=', 'PORT=', 'ports' ])
     except getopt.GetoptError as err:
         print( '-F-', err )   # something like "option -a not recognized"
         usage()
@@ -718,7 +718,7 @@ if __name__ == '__main__':
         for opt,arg in opts:
             if opt in ('--list'):
                 action = 'list'
-            elif opt in ('--port'):
+            elif opt in ('--port','--PORT'):
                 if not hub:
                     log.f( 'No hub available' )
                 all_ports = hub.all_ports()
@@ -726,7 +726,11 @@ if __name__ == '__main__':
                 ports = [int(port) for port in str_ports if port.isnumeric() and int(port) in all_ports]
                 if len(ports) != len(str_ports):
                     log.f( 'Invalid ports', str_ports )
-                hub.enable_ports( ports, disable_other_ports=False )
+                # With --port, leave other ports alone
+                # With --PORT, disable other ports
+                #       This would otherwise require --none, wait, --port)
+                #       Note that it does not recycle the port if it was already enabled
+                hub.enable_ports( ports, disable_other_ports=(opt == '--PORT') )
                 action = 'none'
             elif opt in ('--ports'):
                 printer = get_phys_port


### PR DESCRIPTION
Recent PR #12924 introduced issues with compilations in U22 Jammy. This was not caught in GHA (only happens with DDS):
- add a U22 GHA job

The error itself does not make sense. The offending code is `LOG_DEBUG( settings )` where `settings` is a `json` object. And the error complains of incomplete type `DataWriterQos`... What's even more confusing is that replacing with `ostringstream() << settings` no longer causes the error.
So that's the direction of this PR:
- redo the ELPP macros by wrapping the message building with `ostringstream` and only then sending to ELPP
    - this is a possible slight slowdown (if debug messages are on)
- check if the logger has the proper log level enabled before evaluating the message content (before it always evaluated message content, even if the log was off)
    - this is a performance boost (if debug messages are off), depending on the message content

