### PR TITLE
FastDDS v2.11.2 -> 2.10.4 (LTS)

### DIFF
--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -16,7 +16,11 @@ function(get_fastdds)
     FetchContent_Declare(
       fastdds
       GIT_REPOSITORY https://github.com/eProsima/Fast-DDS.git
-      GIT_TAG        v2.11.2
+      # 2.10.x is eProsima's last LTS version that still supports U20
+      # 2.10.4 has specific modifications based on support provided, but it has some incompatibility
+      # with the way we clone (which works with v2.11+), so they made a fix and tagged it for us:
+      # Once they have 2.10.5 we should move to it
+      GIT_TAG        v2.10.4-realsense
       GIT_SUBMODULES ""     # Submodules will be cloned as part of the FastDDS cmake configure stage
       GIT_SHALLOW ON        # No history needed
       SOURCE_DIR ${CMAKE_BINARY_DIR}/third-party/fastdds


### PR DESCRIPTION
v2.10.x is eProsima's last LTS version that still supports U20.
We were on v2.11.2, which is already out of support, so any fixes eProsima made for us cannot be on this branch.
Specifically, [v2.10.4](https://github.com/eProsima/Fast-DDS/releases/tag/v2.10.4) includes two of the fixes we asked for:
> **Feature 3**: New max_message_size property to limit output datagrams size ([#4807](https://github.com/eProsima/Fast-DDS/pull/4807))
> **Bug fix 31**: Fix on_sample_lost notification on best-effort readers for fragmented samples ([#4606](https://github.com/eProsima/Fast-DDS/pull/4606))

There was a problem when I went to v2.10.4 with the CMake files:
```
CMake Error in build/third-party/fastdds/src/cpp/CMakeLists.txt:
  export called with target "fastrtps" which requires target "fastcdr" that
  is not in any export set.

CMake Error in build/third-party/fastdds/src/cpp/CMakeLists.txt:
  export called with target "fastrtps" which requires target
  "foonathan_memory" that is not in any export set.
```
After investigating, it seems v2.11+ made changes in their CMake that were correct and compatible with our code, so when we went back to v2.10 they lost those and our compilation failed. I reported this and so they gave us a special tag that includes these, to be included in v2.10.5 at a later date. For now, we use this special tag.
