### PR TITLE
Fix json clone for a build directory that contain spaces

### DIFF
--- a/CMake/json-download.cmake.in
+++ b/CMake/json-download.cmake.in
@@ -13,7 +13,7 @@ ExternalProject_Add(
     # Once we have a minimal version support of cmake 3.17, we can switch the command to rm -rF
     DOWNLOAD_COMMAND   "${CMAKE_COMMAND}" -E  remove_directory  "${CMAKE_BINARY_DIR}/third-party/json"
              COMMAND   git clone -c advice.detachedHead=false --branch v3.11.3 https://github.com/nlohmann/json.git --depth 1 json
-    DOWNLOAD_DIR       ${CMAKE_BINARY_DIR}/third-party/
+    DOWNLOAD_DIR       "${CMAKE_BINARY_DIR}/third-party/"
     
     # Override default steps with no action, we just want the clone step.
     UPDATE_COMMAND ""


### PR DESCRIPTION
When the build directory contains spaces like `\lrs dev\` json clone on cmake would fail on illegal path.
This fixes it.
