### PR TITLE
Add new line for error comments in fw-update.cpp

### DIFF
--- a/tools/fw-update/rs-fw-update.cpp
+++ b/tools/fw-update/rs-fw-update.cpp
@@ -197,13 +197,13 @@ int write_fw_to_mipi_device( const rs2::device & dev, const std::vector< uint8_t
         printf( "    \r" ); // Delete progress, as it is not accurate, don't leave 85% when writing done
         if( ! fw_path_in_device.good() )
         {
-            std::cout << std::endl << "Firmware Update failed - write to device error";
+            std::cout << std::endl << "Firmware Update failed - write to device error" << std::endl;
             return EXIT_FAILURE;
         }
     }
     else 
     {
-        std::cout << std::endl << "Firmware Update failed - wrong path or permissions missing";
+        std::cout << std::endl << "Firmware Update failed - wrong path or permissions missing" << std::endl;
         return EXIT_FAILURE;
     }
     std::cout << std::endl << "Firmware update done" << std::endl;


### PR DESCRIPTION
Tracked on: [LRS-1043]
Append new line to error message,
Before:
![Before](https://github.com/IntelRealSense/librealsense/assets/169997184/8c4837f5-a672-4333-af1f-5b6f7b45a082)
After:
![After](https://github.com/IntelRealSense/librealsense/assets/169997184/14795ae0-2f6a-4170-993e-e594a50bd3d9)


