### PR TITLE
LRS_LOG_LEVEL fix; enable log optimizations

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -300,7 +300,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with: 
         name: Log file - U22_ST_Py_EX_CfU_LiveTest
-        path: build/*.log
+        path: build/${{env.LRS_RUN_CONFIG}}/*.log
 
     - name: Provide correct exit status for job 
       shell: bash
@@ -503,7 +503,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Log file - U22_SH_RSUSB_LiveTest
-        path: build/*.log
+        path: build/${{env.LRS_BUILD_CONFIG}}/*.log
 
     - name: Provide correct exit status for job 
       shell: bash

--- a/third-party/rsutils/src/from.cpp
+++ b/third-party/rsutils/src/from.cpp
@@ -33,7 +33,7 @@ std::string from::datetime( tm const * time, char const * format )
     std::string buffer;
     if( time )
     {
-        buffer.reserve( 50 );
+        buffer.resize( 50 );
         size_t cch = strftime( const_cast< char * >( buffer.data() ), buffer.capacity(), format, time );
         // "Provided that the result string, including the terminating null byte, does not exceed max bytes, strftime()
         // returns the number of bytes (excluding the terminating null byte) placed in the array. If the length of the

--- a/unit-tests/log/test-vs-LOG-static.cpp
+++ b/unit-tests/log/test-vs-LOG-static.cpp
@@ -23,6 +23,11 @@
 using namespace librealsense;
 
 
+static void dummy_callback( rs2_log_severity, rs2_log_message const *, void * )
+{
+};
+
+
 TEST_CASE( "rs2_log vs LOG() - internal", "[log]" )
 {
     size_t n_callbacks = 0;
@@ -46,16 +51,30 @@ TEST_CASE( "rs2_log vs LOG() - internal", "[log]" )
 
     // LOG(XXX) should log to the default logger, which is NOT the librealsense logger
     LOG(INFO) << "Log message to default logger";
-    REQUIRE( n_callbacks == 1 );
+    CHECK( n_callbacks == 1 );
 
-    CLOG(INFO, LIBREALSENSE_ELPP_ID) << "Log message to \"librealsense\" logger";
-    REQUIRE( n_callbacks == 2 );
+    // The librealsense logging mechanism is still off, so we don't get any callbacks
+
+    CLOG( INFO, LIBREALSENSE_ELPP_ID ) << "Log message to \"librealsense\" logger";
+    CHECK( n_callbacks == 1 );
 
     LOG_INFO( "Log message using LOG_INFO()" );
-    REQUIRE( n_callbacks == 3 );
+    CHECK( n_callbacks == 1 );
+
+    REQUIRE_NOTHROW( rs2_log( RS2_LOG_SEVERITY_INFO, "Log message using rs2_log()", nullptr ) );
+    CHECK( n_callbacks == 1 );
+
+    // But once we turn it on...
+    rs2_log_to_callback( RS2_LOG_SEVERITY_INFO, &dummy_callback, nullptr, nullptr );
+
+    CLOG(INFO, LIBREALSENSE_ELPP_ID) << "Log message to \"librealsense\" logger";
+    CHECK( n_callbacks == 2 );
+
+    LOG_INFO( "Log message using LOG_INFO()" );
+    CHECK( n_callbacks == 3 );
 
     REQUIRE_NOTHROW( rs2_log( RS2_LOG_SEVERITY_INFO, "Log message using rs2_log()", nullptr ));
-    REQUIRE( n_callbacks == 4 );
+    CHECK( n_callbacks == 4 );
 
     // NOTE that all the above called the same callback!! Callbacks are not logger-specific!
 }


### PR DESCRIPTION
`LRS_LOG_LEVEL` wasn't creating log files because of a bug (since #11186, 8-Dec'22) leaving the log filename empty. Tracked on [LRS-1125].

Also, PR #12959 optimizations were actually not working: all the levels were still enabled even if to-console and to-file were off! This disables unused log levels and the optimization actually works.
