### PR TITLE
Handle Accel correctly in D500

### DIFF
--- a/src/backend-device.h
+++ b/src/backend-device.h
@@ -31,8 +31,8 @@ public:
     uint16_t get_pid() const { return _pid; }
     std::shared_ptr< platform::backend > get_backend();
 
-    // Some FW versions use 16 bit accel values and some use 32 bit for higher accuracy.
-    virtual bool is_accel_high_accuracy() const { return false; }
+    // Some FW versions use 16 bit imu register values and some use 32 bit for higher accuracy.
+    virtual bool is_imu_high_accuracy() const { return false; }
     // Gyro scale factor (raw to physical) can be different between product lines and FW versions.
     virtual double get_gyro_default_scale() const { return 0.1; }
 

--- a/src/backend-device.h
+++ b/src/backend-device.h
@@ -31,7 +31,10 @@ public:
     uint16_t get_pid() const { return _pid; }
     std::shared_ptr< platform::backend > get_backend();
 
-    virtual bool is_gyro_high_sensitivity() const { return false; }
+    // Some FW versions use 16 bit accel values and some use 32 bit for higher accuracy.
+    virtual bool is_accel_high_accuracy() const { return false; }
+    // Gyro scale factor (raw to physical) can be different between product lines and FW versions.
+    virtual double get_gyro_default_scale() const { return 0.1; }
 
 protected:
     uint16_t _pid = 0;

--- a/src/ds/d400/d400-motion.cpp
+++ b/src/ds/d400/d400-motion.cpp
@@ -94,11 +94,10 @@ namespace librealsense
     }
 
 
-    std::shared_ptr<synthetic_sensor> d400_motion::create_hid_device(std::shared_ptr<context> ctx,
-                                                                const std::vector<platform::hid_device_info>& all_hid_infos,
-                                                                const firmware_version& camera_fw_version)
+    std::shared_ptr<synthetic_sensor> d400_motion::create_hid_device( std::shared_ptr<context> ctx,
+                                                                      const std::vector<platform::hid_device_info>& all_hid_infos )
     {
-        return _ds_motion_common->create_hid_device(ctx, all_hid_infos, camera_fw_version, _tf_keeper);
+        return _ds_motion_common->create_hid_device( ctx, all_hid_infos, _tf_keeper );
     }
 
     d400_motion_base::d400_motion_base( std::shared_ptr< const d400_info > const & dev_info )
@@ -125,7 +124,7 @@ namespace librealsense
         initialize_fisheye_sensor( dev_info->get_context(), dev_info->get_group() );
 
         // Try to add HID endpoint
-        auto hid_ep = create_hid_device(dev_info->get_context(), dev_info->get_group().hid_devices, _fw_version);
+        auto hid_ep = create_hid_device( dev_info->get_context(), dev_info->get_group().hid_devices );
         if (hid_ep)
         {
             _motion_module_device_idx = static_cast<uint8_t>(add_sensor(hid_ep));
@@ -149,6 +148,19 @@ namespace librealsense
     {
         auto raw_sensor = get_motion_sensor().get_raw_sensor();
         return std::dynamic_pointer_cast< hid_sensor >( raw_sensor );
+    }
+
+    bool d400_motion::is_accel_high_accuracy() const
+    {
+        // D400 FW 5.16 and above use 32 bits in the struct, instead of 16.
+        return _fw_version >= firmware_version( 5, 16, 0, 0 );
+    }
+
+    double d400_motion::get_gyro_default_scale() const
+    {
+        // FW scale in the HID feature report was 10 up to 5.16, changed to 1000 to support gyro sensitivity option.
+        // D400 FW performs conversion from raw to physical, we get [deg/sec] values.
+        return _fw_version >= firmware_version( 5, 16, 0, 0 ) ? 0.0001 : 0.1;
     }
 
     d400_motion_uvc::d400_motion_uvc( std::shared_ptr< const d400_info > const & dev_info )

--- a/src/ds/d400/d400-motion.cpp
+++ b/src/ds/d400/d400-motion.cpp
@@ -80,14 +80,13 @@ namespace librealsense
         }
         catch (...) {}
 
-        // For FW >=5.16 the scale factor changed to 0.0001 to support higher resolution (diff between two adjacent samples)
-        double gyro_scale_factor = _fw_version >= firmware_version( 5, 16, 0, 0 ) ? 0.0001 : 0.1 ;
-
+        double gyro_scale_factor = get_gyro_default_scale();
+        bool high_accuracy = is_imu_high_accuracy();
         motion_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL}, {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
             [&, mm_correct_opt, gyro_scale_factor]()
-            { return std::make_shared< motion_to_accel_gyro >( _mm_calib, mm_correct_opt, gyro_scale_factor );
+            { return std::make_shared< motion_to_accel_gyro >( _mm_calib, mm_correct_opt, gyro_scale_factor, high_accuracy );
         });
 
         return motion_ep;
@@ -150,7 +149,7 @@ namespace librealsense
         return std::dynamic_pointer_cast< hid_sensor >( raw_sensor );
     }
 
-    bool d400_motion::is_accel_high_accuracy() const
+    bool d400_motion::is_imu_high_accuracy() const
     {
         // D400 FW 5.16 and above use 32 bits in the struct, instead of 16.
         return _fw_version >= firmware_version( 5, 16, 0, 0 );

--- a/src/ds/d400/d400-motion.h
+++ b/src/ds/d400/d400-motion.h
@@ -49,7 +49,7 @@ namespace librealsense
         ds_motion_sensor & get_motion_sensor();
         std::shared_ptr<hid_sensor > get_raw_motion_sensor();
 
-        bool is_accel_high_accuracy() const override;
+        bool is_imu_high_accuracy() const override;
         double get_gyro_default_scale() const override;
 
     protected:

--- a/src/ds/d400/d400-motion.h
+++ b/src/ds/d400/d400-motion.h
@@ -44,11 +44,13 @@ namespace librealsense
     public:
         d400_motion( std::shared_ptr< const d400_info > const & dev_info );
 
-        std::shared_ptr<synthetic_sensor> create_hid_device(std::shared_ptr<context> ctx,
-            const std::vector<platform::hid_device_info>& all_hid_infos,
-            const firmware_version& camera_fw_version);
+        std::shared_ptr<synthetic_sensor> create_hid_device( std::shared_ptr<context> ctx,
+                                                             const std::vector<platform::hid_device_info>& all_hid_infos );
         ds_motion_sensor & get_motion_sensor();
         std::shared_ptr<hid_sensor > get_raw_motion_sensor();
+
+        bool is_accel_high_accuracy() const override;
+        double get_gyro_default_scale() const override;
 
     protected:
         friend class ds_motion_common;

--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -30,16 +30,16 @@ namespace librealsense
         return _ds_motion_common->get_motion_intrinsics(stream);
     }
 
-    bool d500_motion::is_gyro_high_sensitivity() const
+    double d500_motion::get_gyro_default_scale() const
     {
-        return false;
+        // D500 devices output physical data in 0.1 [deg/sec] units.
+        return 0.1;
     }
 
-    std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device(std::shared_ptr<context> ctx,
-                                                                const std::vector<platform::hid_device_info>& all_hid_infos,
-                                                                const firmware_version& camera_fw_version)
+    std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device( std::shared_ptr<context> ctx,
+                                                                      const std::vector<platform::hid_device_info>& all_hid_infos )
     {
-        return _ds_motion_common->create_hid_device(ctx, all_hid_infos, camera_fw_version, _tf_keeper);
+        return _ds_motion_common->create_hid_device( ctx, all_hid_infos, _tf_keeper );
     }
 
     d500_motion::d500_motion( std::shared_ptr< const d500_info > const & dev_info )
@@ -57,7 +57,7 @@ namespace librealsense
         initialize_fisheye_sensor( dev_info->get_context(), dev_info->get_group() );
 
         // Try to add HID endpoint
-        auto hid_ep = create_hid_device(dev_info->get_context(), dev_info->get_group().hid_devices, _fw_version);
+        auto hid_ep = create_hid_device( dev_info->get_context(), dev_info->get_group().hid_devices );
         if (hid_ep)
         {
             _motion_module_device_idx = static_cast<uint8_t>(add_sensor(hid_ep));

--- a/src/ds/d500/d500-motion.h
+++ b/src/ds/d500/d500-motion.h
@@ -11,15 +11,14 @@ namespace librealsense
     class d500_motion : public virtual d500_device
     {
     public:
-        std::shared_ptr<synthetic_sensor> create_hid_device(std::shared_ptr<context> ctx,
-                                                      const std::vector<platform::hid_device_info>& all_hid_infos,
-                                                      const firmware_version& camera_fw_version);
+        std::shared_ptr<synthetic_sensor> create_hid_device( std::shared_ptr<context> ctx,
+                                                             const std::vector<platform::hid_device_info>& all_hid_infos );
 
         d500_motion( std::shared_ptr< const d500_info > const & );
 
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
 
-        bool is_gyro_high_sensitivity() const override;
+        double get_gyro_default_scale() const override;
 
     protected:
         friend class ds_motion_common;

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -445,18 +445,15 @@ namespace librealsense
 
     }
 
-    std::shared_ptr<synthetic_sensor> ds_motion_common::create_hid_device(std::shared_ptr<context> ctx, 
-        const std::vector<platform::hid_device_info>& all_hid_infos, 
-        const firmware_version& camera_fw_version,
-        std::shared_ptr<time_diff_keeper> tf_keeper)
+    std::shared_ptr<synthetic_sensor> ds_motion_common::create_hid_device( std::shared_ptr<context> ctx, 
+                                                                           const std::vector<platform::hid_device_info>& all_hid_infos, 
+                                                                           std::shared_ptr<time_diff_keeper> tf_keeper )
     {
         if (all_hid_infos.empty())
         {
             LOG_WARNING("No HID info provided, IMU is disabled");
             return nullptr;
         }
-
-        static const char* custom_sensor_fw_ver = "5.6.0.0";
 
         std::unique_ptr<frame_timestamp_reader> iio_hid_ts_reader(new iio_hid_timestamp_reader());
         std::unique_ptr<frame_timestamp_reader> custom_hid_ts_reader(new ds_custom_hid_timestamp_reader());
@@ -479,8 +476,8 @@ namespace librealsense
 
         auto raw_hid_ep = std::make_shared< hid_sensor >(
             _owner->get_backend()->create_hid_device( all_hid_infos.front() ),
-            std::unique_ptr< frame_timestamp_reader >(
-                new global_timestamp_reader( std::move( iio_hid_ts_reader ), tf_keeper, enable_global_time_option ) ),
+            std::unique_ptr< frame_timestamp_reader >( new global_timestamp_reader( std::move( iio_hid_ts_reader ),
+                                                                                    tf_keeper, enable_global_time_option ) ),
             std::unique_ptr< frame_timestamp_reader >( new global_timestamp_reader( std::move( custom_hid_ts_reader ),
                                                                                     tf_keeper,
                                                                                     enable_global_time_option ) ),
@@ -507,7 +504,7 @@ namespace librealsense
         }
         catch (...) {}
 
-        bool high_accuracy =  _fw_version >= firmware_version( 5, 16, 0, 0 );    
+        bool high_accuracy = _owner->is_accel_high_accuracy();    
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
@@ -515,9 +512,7 @@ namespace librealsense
             { return std::make_shared< acceleration_transform >( _mm_calib, mm_correct_opt, high_accuracy );
             });
 
-        //TODO this FW version is relevant for d400 devices. Need to change for propre d500 devices support.
-        bool high_sensitivity = _owner->is_gyro_high_sensitivity();
-        double gyro_scale_factor = high_sensitivity ? 0.003814697265625 : ( _fw_version >= firmware_version( 5, 16, 0, 0 ) ? 0.0001: 0.1 );    
+        double gyro_scale_factor = _owner->get_gyro_default_scale();
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },

--- a/src/ds/ds-motion-common.cpp
+++ b/src/ds/ds-motion-common.cpp
@@ -504,7 +504,7 @@ namespace librealsense
         }
         catch (...) {}
 
-        bool high_accuracy = _owner->is_accel_high_accuracy();    
+        bool high_accuracy = _owner->is_imu_high_accuracy();    
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_ACCEL} },
@@ -516,8 +516,8 @@ namespace librealsense
         hid_ep->register_processing_block(
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
             { {RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO} },
-                                           [&, mm_correct_opt, gyro_scale_factor]() {
-                                               return std::make_shared< gyroscope_transform >( _mm_calib, mm_correct_opt, gyro_scale_factor );
+            [&, mm_correct_opt, gyro_scale_factor, high_accuracy]()
+            { return std::make_shared< gyroscope_transform >( _mm_calib, mm_correct_opt, gyro_scale_factor, high_accuracy );
             });
 
         return hid_ep;

--- a/src/ds/ds-motion-common.h
+++ b/src/ds/ds-motion-common.h
@@ -118,9 +118,9 @@ namespace librealsense
     {
     public:
         ds_motion_common( backend_device * owner,
-            firmware_version fw_version,
-            const ds::ds_caps& device_capabilities,
-            std::shared_ptr<hw_monitor> hwm);
+                          firmware_version fw_version,
+                          const ds::ds_caps& device_capabilities,
+                          std::shared_ptr<hw_monitor> hwm);
 
         rs2_motion_device_intrinsic get_motion_intrinsics(rs2_stream) const;
 
@@ -135,9 +135,8 @@ namespace librealsense
         void register_fisheye_metadata();
 
         std::shared_ptr<synthetic_sensor> create_hid_device(std::shared_ptr<context> ctx,
-            const std::vector<platform::hid_device_info>& all_hid_infos,
-            const firmware_version& camera_fw_version,
-            std::shared_ptr<time_diff_keeper> tf_keeper);
+                                                            const std::vector<platform::hid_device_info>& all_hid_infos,
+                                                            std::shared_ptr<time_diff_keeper> tf_keeper);
 
         void init_motion(bool is_infos_empty, const stream_interface& depth_stream);
 

--- a/src/proc/motion-transform.cpp
+++ b/src/proc/motion-transform.cpp
@@ -12,7 +12,7 @@
 
 namespace librealsense
 {
-    template<rs2_format FORMAT> void copy_hid_axes( uint8_t * const dest[], const uint8_t * source, double factor, bool high_accuracy, bool is_mipi)
+    void copy_hid_axes( uint8_t * const dest[], const uint8_t * source, double factor, bool high_accuracy, bool is_mipi)
     {
         using namespace librealsense;
 
@@ -52,17 +52,16 @@ namespace librealsense
 
     // The Accelerometer input format: signed int 16bit. data units 1LSB=0.001g;
     // Librealsense output format: floating point 32bit. units m/s^2,
-    template<rs2_format FORMAT> void unpack_accel_axes( uint8_t * const dest[], const uint8_t * source, int width, int height, int output_size, bool high_accuracy, bool is_mipi = false)
+    void unpack_accel_axes( uint8_t * const dest[], const uint8_t * source, int width, int height, int output_size, bool high_accuracy, bool is_mipi = false)
     {
         static constexpr float gravity = 9.80665f;          // Standard Gravitation Acceleration
         static constexpr double accelerator_transform_factor = 0.001*gravity;
 
-        copy_hid_axes< FORMAT >( dest, source, accelerator_transform_factor, high_accuracy, is_mipi );
+        copy_hid_axes( dest, source, accelerator_transform_factor, high_accuracy, is_mipi );
     }
 
     // The Gyro input format: signed int 16bit. data units depends on set sensitivity;
     // Librealsense output format: floating point 32bit. units rad/sec,
-    template< rs2_format FORMAT >
     void unpack_gyro_axes( uint8_t * const dest[], const uint8_t * source, int width, int height, int output_size,
                            double gyro_scale_factor = 0.1, bool is_mipi = false )
     {
@@ -70,7 +69,7 @@ namespace librealsense
         //high_accuracy=true (32 bit fields) when gyro_scale_factor=0.0001 for D400 FW version >= 5.16 
         //high_accuracy=false (16 bit fields) when gyro_scale_factor=0.1 for D400 FW version < 5.16 or 0.003814697265625 for D500
         bool high_accuracy = ( gyro_scale_factor == 0.0001 );
-        copy_hid_axes< FORMAT >( dest, source, gyro_transform_factor, high_accuracy, is_mipi );
+        copy_hid_axes( dest, source, gyro_transform_factor, high_accuracy, is_mipi );
     }
 
     motion_transform::motion_transform(rs2_format target_format, rs2_stream target_stream,
@@ -215,13 +214,12 @@ namespace librealsense
         {
             _target_stream = RS2_STREAM_ACCEL;
             bool high_accuracy = ( _gyro_scale_factor != 0.1 );
-            unpack_accel_axes< RS2_FORMAT_MOTION_XYZ32F >( dest, source, width, height, actual_size, high_accuracy, true );
+            unpack_accel_axes( dest, source, width, height, actual_size, high_accuracy, true );
         }
         else if (source[0] == 2)
         {
             _target_stream = RS2_STREAM_GYRO;
-            unpack_gyro_axes<RS2_FORMAT_MOTION_XYZ32F>( dest, source, width, height, actual_size,
-                                                       _gyro_scale_factor, true );
+            unpack_gyro_axes( dest, source, width, height, actual_size, _gyro_scale_factor, true );
         }
         else
         {
@@ -242,7 +240,7 @@ namespace librealsense
 
     void acceleration_transform::process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int output_size, int actual_size )
     {
-        unpack_accel_axes< RS2_FORMAT_MOTION_XYZ32F >( dest, source, width, height, actual_size, _high_accuracy );
+        unpack_accel_axes( dest, source, width, height, actual_size, _high_accuracy );
     }
 
     gyroscope_transform::gyroscope_transform( std::shared_ptr< mm_calib_handler > mm_calib,
@@ -261,12 +259,7 @@ namespace librealsense
 
     void gyroscope_transform::process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int output_size, int actual_size )
     {
-        unpack_gyro_axes< RS2_FORMAT_MOTION_XYZ32F >( dest,
-                                                      source,
-                                                      width,
-                                                      height,
-                                                      actual_size,
-                                                      _gyro_scale_factor );
+        unpack_gyro_axes( dest, source, width, height, actual_size, _gyro_scale_factor );
     }
 }
 

--- a/src/proc/motion-transform.cpp
+++ b/src/proc/motion-transform.cpp
@@ -34,8 +34,9 @@ namespace librealsense
         else
         {
             auto hid = (hid_data*)(source);
-            //since D400 FW version 5.16 the hid report struct changed to 32 bit for each paramater.
-            //To support older FW versions we convert the data to int16_t before casting to float as we only get valid data at the lower 16  bits.
+            // The backend puts the data in a struct with 32 bit fields. When accuracy is not high data is valid at the
+            // lower 16 bits only. We convert to int16_t before casting to float to avoid incorrect handling of negative
+            // values and overflows.
             if( ! high_accuracy )
             {
                 hid->x = static_cast< int16_t >( hid->x );
@@ -66,8 +67,8 @@ namespace librealsense
                            double gyro_scale_factor = 0.1, bool is_mipi = false )
     {
         const double gyro_transform_factor = deg2rad( gyro_scale_factor );
-        //high_accuracy=true when gyro_scale_factor=0.0001 for FW version >=5.16 
-        //high_accuracy=false when gyro_scale_factor=0.1 for FW version <5.16 or 0.003814697265625 for HKR
+        //high_accuracy=true (32 bit fields) when gyro_scale_factor=0.0001 for D400 FW version >= 5.16 
+        //high_accuracy=false (16 bit fields) when gyro_scale_factor=0.1 for D400 FW version < 5.16 or 0.003814697265625 for D500
         bool high_accuracy = ( gyro_scale_factor == 0.0001 );
         copy_hid_axes< FORMAT >( dest, source, gyro_transform_factor, high_accuracy, is_mipi );
     }

--- a/src/proc/motion-transform.h
+++ b/src/proc/motion-transform.h
@@ -10,6 +10,19 @@ namespace librealsense
     class mm_calib_handler;
     class functional_processing_block;
 
+    class imu_to_librs_converter
+    {
+    protected:
+        double _scale_factor = 1.;
+
+    public:
+        imu_to_librs_converter( double scale_factor ) : _scale_factor( scale_factor )
+        {
+        }
+
+        virtual void convert( uint8_t * const dest[], const uint8_t * source ) = 0;
+    };
+
     class motion_transform : public functional_processing_block
     {
     public:
@@ -33,62 +46,57 @@ namespace librealsense
         float3x3            _gyro_sensitivity;
         float3              _gyro_bias;
         float3x3            _imu2depth_cs_alignment_matrix;     // Transform and align raw IMU axis [x,y,z] to be consistent with the Depth frame CS
+        std::unique_ptr< imu_to_librs_converter > _converter;
     };
 
     class motion_to_accel_gyro : public motion_transform
     {
     public:
-        motion_to_accel_gyro( std::shared_ptr< mm_calib_handler > mm_calib = nullptr,
-                              std::shared_ptr< enable_motion_correction > mm_correct_opt = nullptr,
-                              double gyro_scale_factor = 0.1 );
+        motion_to_accel_gyro( std::shared_ptr< mm_calib_handler > mm_calib,
+                              std::shared_ptr< enable_motion_correction > mm_correct_opt,
+                              double gyro_scale_factor, bool high_accuracy );
 
     protected:
         motion_to_accel_gyro( const char * name,
                               std::shared_ptr< mm_calib_handler > mm_calib,
                               std::shared_ptr< enable_motion_correction > mm_correct_opt,
-                              double gyro_scale_factor );
+                              double gyro_scale_factor, bool high_accuracy );
         void configure_processing_callback();
-        void process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size ) override;
+        void process_function( uint8_t * const dest[], const uint8_t * source, int, int, int, int ) override;
         void correct_motion(float3* xyz) const;
 
         std::shared_ptr<stream_profile_interface> _source_stream_profile;
         std::shared_ptr<stream_profile_interface> _accel_gyro_target_profile;
-        double _gyro_scale_factor = 0.1;
     };
 
     class acceleration_transform : public motion_transform
     {
     public:
-        acceleration_transform( std::shared_ptr< mm_calib_handler > mm_calib = nullptr,
-                                std::shared_ptr< enable_motion_correction > mm_correct_opt = nullptr,
-                                bool high_accuracy = false );
+        acceleration_transform( std::shared_ptr< mm_calib_handler > mm_calib,
+                                std::shared_ptr< enable_motion_correction > mm_correct_opt,
+                                bool high_accuracy );
 
     protected:
         acceleration_transform( const char * name,
                                 std::shared_ptr< mm_calib_handler > mm_calib,
                                 std::shared_ptr< enable_motion_correction > mm_correct_opt,
                                 bool high_accuracy );
-        void process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size) override;
-        //To be refactored and change to accel_scale_factor once we implement sensitivity feature for the accel like the gyro
-        bool _high_accuracy = false;
-
+        void process_function( uint8_t * const dest[], const uint8_t * source, int, int, int, int) override;
     };
 
     class gyroscope_transform : public motion_transform
     {
     public:
-        gyroscope_transform( std::shared_ptr< mm_calib_handler > mm_calib = nullptr,
-                             std::shared_ptr< enable_motion_correction > mm_correct_opt = nullptr,
-                             double gyro_scale_factor = 0.1 );
+        gyroscope_transform( std::shared_ptr< mm_calib_handler > mm_calib,
+                             std::shared_ptr< enable_motion_correction > mm_correct_opt,
+                             double gyro_scale_factor, bool high_accuracy );
 
     protected:
         gyroscope_transform( const char * name,
                              std::shared_ptr< mm_calib_handler > mm_calib,
                              std::shared_ptr< enable_motion_correction > mm_correct_opt,
-                             double gyro_scale_factor );
+                             double gyro_scale_factor, bool high_accuracy );
                              
-        void process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size ) override;
-
-        double  _gyro_scale_factor = 0.1;
+        void process_function( uint8_t * const dest[], const uint8_t * source, int, int, int, int) override;
     };
 }


### PR DESCRIPTION
Tracked on [RSDEV-2127]

Moved accuracy and scale factor logic from common to device specific.
Also cleaned the code from unused template and parameters.

Tried to make motion-transform use cleaner code by using polymorphism instead of parameters and `if`s. 
The first commit is the logic change, afterwards is cleaning the code but keeping the logic.

Opening as draft until the accuracy will be tested in the lab.