### PR TITLE
Enable dds flow controller

### DIFF
--- a/third-party/realdds/scripts/topic-send.py
+++ b/third-party/realdds/scripts/topic-send.py
@@ -68,7 +68,7 @@ if args.blob:
         sys.exit( 1 )
     writer = dds.topic_writer( dds.message.blob.create_topic( participant, topic_path ))
     wqos = dds.topic_writer.qos()  # reliable
-    #writer.override_qos_from_json( wqos, { 'publish-mode': { 'flow-control': 'blob' } } )
+    writer.override_qos_from_json( wqos, { 'publish-mode': { 'flow-control': 'blob' } } )
     writer.run( wqos )
     if not writer.wait_for_readers( dds.time( 2. ) ):
         e( 'Timeout waiting for readers' )

--- a/third-party/realdds/scripts/topic-sink.py
+++ b/third-party/realdds/scripts/topic-sink.py
@@ -22,7 +22,7 @@ def time_arg(x):
         raise ValueError( f'--time should be >=0' )
     return t
 args.add_argument( '--wait', metavar='<seconds>', type=time_arg, default=5., help='seconds to wait for writers (default 5; 0=disable)' )
-args.add_argument( '--time', metavar='<seconds>', type=time_arg, default=5., help='runtime before stopping, in seconds (default 0=forever)' )
+args.add_argument( '--time', metavar='<seconds>', type=time_arg, help='runtime before stopping, in seconds (default 0=forever)' )
 args.add_argument( '--not-ready', action='store_true', help='start output immediately, without waiting for all topics' )
 args = args.parse_args()
 

--- a/third-party/realdds/src/dds-serialization.cpp
+++ b/third-party/realdds/src/dds-serialization.cpp
@@ -398,7 +398,8 @@ std::ostream & operator<<( std::ostream & os, WriterProxyData const & info )
         os << /*field::separator << "durability" << field::group() <<*/ info.m_qos.m_durability;
     if( ! ( info.m_qos.m_liveliness == eprosima::fastdds::dds::LivelinessQosPolicy() ) )
         os << field::separator << "liveliness" << field::value << info.m_qos.m_liveliness;
-    if( info.m_qos.m_publishMode.flow_controller_name )
+    if( info.m_qos.m_publishMode.flow_controller_name
+        && info.m_qos.m_publishMode.flow_controller_name != eprosima::fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT )
         os << field::separator << "flow-controller" << field::value << "'"
            << info.m_qos.m_publishMode.flow_controller_name << "'";
     return os;


### PR DESCRIPTION
Following #12924, this actually enables:
- 1470 max write packet size
- 256*1470 every 100ms "dfu" flow controller now defined and used in DFU
- updated scripts/topic-send.py to use a similar flow and adjust the ACK timeout based on the file size

Also:
- remove topic-sink --time default (was 5), so it waits forever
- do not show the default FastDDS flow controller "FastDDSFlowControllerDefault" in operator<<