### PR TITLE
rs2_get_video_stream_intrinsics no longer reports errors if not intrinsics available

### DIFF
--- a/src/api.h
+++ b/src/api.h
@@ -403,6 +403,18 @@ return __p.invoke(func);\
 
 #define BEGIN_API_CALL try
 #define NOEXCEPT_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); rs2_error* e; librealsense::translate_exception(__FUNCTION__, ss.str(), &e); LOG_WARNING(rs2_get_error_message(e)); rs2_free_error(e); return R; }
+// If you want to avoid any errors being reported because an exception an expected API behavior:
+#define EXPECTED_EXCEPTION( E, R, ... )                                                                                \
+    catch( E const & e )                                                                                               \
+    {                                                                                                                  \
+        if( error )                                                                                                    \
+        {                                                                                                              \
+            std::ostringstream ss;                                                                                     \
+            librealsense::stream_args( ss, #__VA_ARGS__, __VA_ARGS__ );                                                \
+            *error = new rs2_error{ e.what(), __FUNCTION__, ss.str(), RS2_EXCEPTION_TYPE_COUNT };                      \
+        }                                                                                                              \
+        return R;                                                                                                      \
+    }
 #define HANDLE_EXCEPTIONS_AND_RETURN(R, ...) catch(...) { std::ostringstream ss; librealsense::stream_args(ss, #__VA_ARGS__, __VA_ARGS__); librealsense::translate_exception(__FUNCTION__, ss.str(), error); return R; }
 #define NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(R) catch(...) { librealsense::translate_exception(__FUNCTION__, "", error); return R; }
 #define NOARGS_HANDLE_EXCEPTIONS_AND_RETURN_VOID() catch(...) { librealsense::translate_exception(__FUNCTION__, "", error); }

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -464,17 +464,41 @@ void rs2_delete_stream_profiles_list(rs2_stream_profile_list* list) BEGIN_API_CA
 }
 NOEXCEPT_RETURN(, list)
 
-void rs2_get_video_stream_intrinsics(const rs2_stream_profile* from, rs2_intrinsics* intr, rs2_error** error) BEGIN_API_CALL
+
+std::ostream & operator<<( std::ostream & os, rs2_stream_profile const & p )
 {
-    VALIDATE_NOT_NULL(from);
+    if( ! p.profile )
+    {
+        os << "NULL";
+    }
+    else
+    {
+        os << "[ " << librealsense::get_abbr_string( p.profile->get_stream_type() );
+        os << " " << librealsense::get_string( p.profile->get_format() );
+        os << " " << p.profile->get_stream_index();
+        if( auto vsp = As< video_stream_profile, stream_profile_interface >( p.profile ) )
+        {
+            os << " " << vsp->get_width();
+            os << "x" << vsp->get_height();
+        }
+        os << " @ " << p.profile->get_framerate();
+        os << " ]";
+    }
+    return os;
+}
+
+
+void rs2_get_video_stream_intrinsics(const rs2_stream_profile* profile, rs2_intrinsics* intr, rs2_error** error) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( profile );
     VALIDATE_NOT_NULL(intr);
 
-    auto vid = VALIDATE_INTERFACE(from->profile, librealsense::video_stream_profile_interface);
+    auto vid = VALIDATE_INTERFACE( profile->profile, librealsense::video_stream_profile_interface);
 
     *intr = vid->get_intrinsics();
 }
-EXPECTED_EXCEPTION( not_implemented_exception, , from, intr )  // only accepted way of checking if profile has intrinsics
-HANDLE_EXCEPTIONS_AND_RETURN( , from, intr )
+EXPECTED_EXCEPTION( not_implemented_exception, , profile, output_arg( intr ) )  // only accepted way of checking if profile has intrinsics
+HANDLE_EXCEPTIONS_AND_RETURN(, profile, output_arg( intr ) )
 
 // librealsense wrapper around a C function
 class calibration_change_callback : public rs2_calibration_change_callback

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -473,6 +473,7 @@ void rs2_get_video_stream_intrinsics(const rs2_stream_profile* from, rs2_intrins
 
     *intr = vid->get_intrinsics();
 }
+EXPECTED_EXCEPTION( not_implemented_exception, , from, intr )  // only accepted way of checking if profile has intrinsics
 HANDLE_EXCEPTIONS_AND_RETURN( , from, intr )
 
 // librealsense wrapper around a C function


### PR DESCRIPTION
As of v2.55, we report errors (`LOG_ERROR`) if API calls fail.

`rs-enumerate-devices -c` goes through all profiles and tries to get their intrinsics using `rs2_get_video_stream_intrinsics`.
Some profiles have none, and so a `not_implemented_exception` is triggered, and thus causes error log messages that now come out.
Since this function has no return value, an error is the only valid way of reporting that no intrinsics exist. Adding a return value and not throwing is a change in behavior, which I didn't want to make. We can also add a new API, remove the errors completely, or change them to debug...

Instead, I marked a `not_implemented_exception` as an "expected exception" in the code so it behaves the same but without an error.

See below: I also improved the errors given:
- `rs2_stream_profile` arguments will actually show the profile
- added `output_arg( ... )` syntax, so an error would show them as `(out)`

Reported by CDE.
Tracked on [LRS-1130]
