### PR TITLE
align to width and height -1 to prevent SSEGV accessing out of range buffer

### DIFF
--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -4145,9 +4145,9 @@ bool is_pixel_in_line(const float curr[2], const float start[2], const float end
 void adjust_2D_point_to_boundary(float p[2], int width, int height)
 {
     if (p[0] < 0) p[0] = 0;
-    if (p[0] > width) p[0] = (float)width;
+    if (p[0] >= width) p[0] = (float)width - 1;
     if (p[1] < 0) p[1] = 0;
-    if (p[1] > height) p[1] = (float)height;
+    if (p[1] >= height) p[1] = (float)height - 1;
 }
 
 


### PR DESCRIPTION
align to width and height -1 to prevent SSEGV accessing out of range index on frame buffer 