### PR TITLE
add motion_frame::get_combined_motion_data() for DDS Motion streams

### DIFF
--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -903,13 +903,23 @@ namespace rs2
             error::handle(e);
         }
         /**
-        * Retrieve the motion data from IMU sensor
-        * \return rs2_vector - 3D vector in Euclidean coordinate space.
-        */
+         * Retrieve the motion data for frames with RS2_FORMAT_MOTION_XYZ32F, RS2_STREAM_GYRO or RS2_STREAM_ACCEL.
+         * For RS2_STREAM_MOTION and RS2_FORMAT_COMBINED_MOTION, use get_combined_motion_data().
+         * \return rs2_vector - 3D vector in Euclidean coordinate space.
+         */
         rs2_vector get_motion_data() const
         {
             auto data = reinterpret_cast<const float*>(get_data());
             return rs2_vector{ data[0], data[1], data[2] };
+        }
+        /**
+         * Retrieve the combined motion data for frames with RS2_FORMAT_COMBINED_MOTION and RS2_STREAM_MOTION.
+         * For RS2_FORMAT_MOTION_XYZ32F and RS2_STREAM_GYRO or RS2_STREAM_ACCEL, use get_motion_data().
+         * \return rs2_combined_motion - including linear acceleration and angular velocity.
+         */
+        rs2_combined_motion get_combined_motion_data() const
+        {
+            return *reinterpret_cast< rs2_combined_motion const * >( get_data() );
         }
     };
 

--- a/unit-tests/py/rspy/test.py
+++ b/unit-tests/py/rspy/test.py
@@ -199,6 +199,7 @@ def check_passed():
     :return: always False (so you can 'return check_failed()'
     """
     _count_check()
+    print_info( error = False )
     reset_info()
     return True
 
@@ -498,13 +499,13 @@ def reset_info(persistent = False):
         test_info = new_info
 
 
-def print_info():
+def print_info( error = True ):
     global test_info
     if not test_info: # No information is stored
         return
-    #log.out("Printing information")
+    logger = error and log.out or log.d
     for name, information in test_info.items():
-        log.out( f"        {name} : {information.value}" )
+        logger( f"        {name} : {information.value}" )
     reset_info()
 
 

--- a/wrappers/python/c_files.cpp
+++ b/wrappers/python/c_files.cpp
@@ -132,6 +132,40 @@ void init_c_files(py::module &m) {
             return ss.str();
         });
 
+    py::class_< rs2_combined_motion > combined_motion( m, "combined_motion", "IMU combined GYRO & ACCEL data" );
+    combined_motion.def( py::init<>() )
+        .def_property(
+            "angular_velocity",
+            []( rs2_combined_motion const & self )
+            {
+                return rs2_vector{ (float)self.angular_velocity.x,
+                                   (float)self.angular_velocity.y,
+                                   (float)self.angular_velocity.z };
+            },
+            []( rs2_combined_motion & self, rs2_vector const & v ) {
+                self.angular_velocity = { v.x, v.y, v.z };
+            } )
+        .def_property(
+            "linear_acceleration",
+            []( rs2_combined_motion const & self )
+            {
+                return rs2_vector{ (float)self.linear_acceleration.x,
+                                   (float)self.linear_acceleration.y,
+                                   (float)self.linear_acceleration.z };
+            },
+            []( rs2_combined_motion & self, rs2_vector const & v ) {
+                self.linear_acceleration = { v.x, v.y, v.z };
+            } )
+        .def( "__repr__",
+              []( const rs2_combined_motion & self )
+              {
+                  std::ostringstream ss;
+                  ss << "gyro[" << self.angular_velocity.x << "," << self.angular_velocity.y << ","
+                      << self.angular_velocity.z << "] accel[" << self.linear_acceleration.x << ","
+                      << self.linear_acceleration.y << "," << self.linear_acceleration.z << "]";
+                  return ss.str();
+              } );
+
     py::class_<rs2_pose> pose(m, "pose"); // No docstring in C++
     pose.def(py::init<>())
         .def_readwrite("translation", &rs2_pose::translation, "X, Y, Z values of translation, in meters (relative to initial position)")

--- a/wrappers/python/pyrs_frame.cpp
+++ b/wrappers/python/pyrs_frame.cpp
@@ -285,7 +285,8 @@ void init_frame(py::module &m) {
 
     py::class_<rs2::motion_frame, rs2::frame> motion_frame(m, "motion_frame", "Extends the frame class with additional motion related attributes and functions");
     motion_frame.def(py::init<rs2::frame>())
-        .def("get_motion_data", &rs2::motion_frame::get_motion_data, "Retrieve the motion data from IMU sensor.")
+        .def("get_motion_data", &rs2::motion_frame::get_motion_data, "Retrieve motion data from a GYRO/ACCEL sensor")
+        .def("get_combined_motion_data", &rs2::motion_frame::get_combined_motion_data, "Retrieve motion data from a MOTION sensor")
         .def_property_readonly("motion_data", &rs2::motion_frame::get_motion_data, "Motion data from IMU sensor. Identical to calling get_motion_data.");
 
     py::class_<rs2::pose_frame, rs2::frame> pose_frame(m, "pose_frame", "Extends the frame class with additional pose related attributes and functions.");


### PR DESCRIPTION
No API existed to get the combined motion data.
The previous API in `rs2::motion_frame` is `get_motion_data()` returning `rs2_vector` which ASSUMES the data type. This should be used with `RS2_FORMAT_MOTION_XYZ32F`.
I did the same: added `get_combined_motion_data()` returning `rs2_combined_motion`. This should be used with `RS2_FORMAT_COMBINED_MOTION`.
I.e., it is up to the user to call the right one.

Added Python API.

Tracked on [RSDEV-2243]