### PR TITLE
fix 'format not a string literal' warning

### DIFF
--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -1279,7 +1279,7 @@ namespace rs2
                 auto rc = ImGui::GetCursorPos();
                 ImGui::SetCursorPos( { rc.x + 12, rc.y + 4 } );
                 ImGui::PushStyleColor( ImGuiCol_Text, from_rgba( 255, 255, 255, 255, true ) );
-                ImGui::Text( title );
+                ImGui::Text( "%s", title );
                 ImGui::PopStyleColor( 1 );
                 ImGui::SetCursorPos( { rc.x, rc.y + line_h } );
                 total_h += line_h;


### PR DESCRIPTION
PR #13041 introduced a line:
```
ImGui::Text( title );
```
Which is entirely valid and yet generates a warning:
```
warning: format not a string literal and no format arguments [-Wformat-security]
```

This fixes it.
