### PR TITLE
reduce lease duration to 3sec and announcement period to 1.5

### DIFF
--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -192,7 +192,8 @@ dds_participant::qos::qos( std::string const & participant_name )
     name( participant_name );
 
     // Indicates for how much time should a remote DomainParticipant consider the local DomainParticipant to be alive.
-    wire_protocol().builtin.discovery_config.leaseDuration = { 10, 0 };  // [sec,nsec]
+    wire_protocol().builtin.discovery_config.leaseDuration = realdds::dds_time( 3.0 );  // seconds
+    wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod = realdds::dds_time( 1.5 );
 
     // Disable shared memory, use only UDP
     // Disabling because sometimes, after improper destruction (e.g. stopping debug) the shared memory is not opened

--- a/third-party/realdds/src/dds-serialization.cpp
+++ b/third-party/realdds/src/dds-serialization.cpp
@@ -425,7 +425,8 @@ std::ostream & operator<<( std::ostream & os, DiscoverySettings const & qos )
     //bool use_SIMPLE_EndpointDiscoveryProtocol = true;
     //bool use_STATIC_EndpointDiscoveryProtocol = false;
     os << dump_field_as( qos, leaseDuration, json );
-    //Duration_t leaseDuration_announcementperiod = { 3, 0 };
+    os << field::separator << "announcement-period" << field::value << json( qos.leaseDuration_announcementperiod )
+       << field_changed( qos, leaseDuration_announcementperiod, _def );
     //InitialAnnouncementConfig initial_announcements;
     //SimpleEDPAttributes m_simpleEDP;
     //PDPFactory m_PDPfactory{};
@@ -695,8 +696,10 @@ void override_participant_qos_from_json( eprosima::fastdds::dds::DomainParticipa
 {
     if( ! j.is_object() )
         return;
-    j.nested( "participant-id" ).get_ex( qos.wire_protocol().participant_id );
-    j.nested( "lease-duration" ).get_ex( qos.wire_protocol().builtin.discovery_config.leaseDuration );
+    auto & wp = qos.wire_protocol();
+    j.nested( "participant-id" ).get_ex( wp.participant_id );
+    j.nested( "lease-duration" ).get_ex( wp.builtin.discovery_config.leaseDuration );  // must be > announcement period!
+    j.nested( "announcement-period" ).get_ex( wp.builtin.discovery_config.leaseDuration_announcementperiod );
 
     j.nested( "use-builtin-transports" ).get_ex( qos.transport().use_builtin_transports );
     if( auto udp_j = j.nested( "udp" ) )


### PR DESCRIPTION
Lease duration (how long before the camera recognizes librealsense is gone) of 10 seconds seemed too long.
It also affects how the camera behaves: if it thinks the host is still alive, it will expect it to ACK device-info/handshake messages!

This makes the `announcement-period` customizable, and reduces the defaults to a lease of 3 seconds with announcement every 1.5.