### PR TITLE
don't start backend if device-mask specifies sw-only

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -59,11 +59,14 @@ namespace librealsense {
 
     void context::create_factories( std::shared_ptr< context > const & sptr )
     {
-        _factories.push_back( std::make_shared< backend_device_factory >(
-            sptr,
-            [this]( std::vector< std::shared_ptr< device_info > > const & removed,
-                    std::vector< std::shared_ptr< device_info > > const & added )
-            { invoke_devices_changed_callbacks( removed, added ); } ) );
+        if( 0 == ( get_device_mask() & RS2_PRODUCT_LINE_SW_ONLY ) )
+        {
+            _factories.push_back( std::make_shared< backend_device_factory >(
+                sptr,
+                [this]( std::vector< std::shared_ptr< device_info > > const & removed,
+                        std::vector< std::shared_ptr< device_info > > const & added )
+                { invoke_devices_changed_callbacks( removed, added ); } ) );
+        }
 
 #ifdef BUILD_WITH_DDS
         _factories.push_back( std::make_shared< rsdds_device_factory >(

--- a/unit-tests/dds/librs.py
+++ b/unit-tests/dds/librs.py
@@ -20,7 +20,7 @@ def _device_change_callback( info ):
     _devices_updated.set()
 
 
-def wait_for_devices( context, mask, n=1, timeout=3, throw=None ):
+def wait_for_devices( context, mask=product_line.any, n=1, timeout=3, throw=None ):
     """
     Since DDS devices may take time to be recognized and then initialized, we try over time:
 

--- a/unit-tests/dds/test-librs-connections.py
+++ b/unit-tests/dds/test-librs-connections.py
@@ -27,18 +27,25 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         remote.run( 'instance2 = broadcast_device( d405, d405.device_info )' )
 
         # Create context after remote device is ready to test discovery on start-up
-        context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'librs' }} )
+        context = rs.context( {
+            'dds': {
+                'enabled': True,
+                'domain': 123,
+                'participant': 'librs'
+                },
+            'device-mask': rs.only_sw_devices
+            } )
         # The DDS devices take time to be recognized and we just created the context; we
         # should not see them yet!
         #test.check( len( context.query_devices( rs.only_sw_devices )) != 2 )
         # Wait for them
-        rs.wait_for_devices( context, rs.only_sw_devices, n=2. )
+        rs.wait_for_devices( context, n=2. )
     #
     #############################################################################################
     #
     with test.closure( "Start a third", on_fail=test.ABORT ):
         remote.run( 'instance3 = broadcast_device( d455, d455.device_info )' )
-        rs.wait_for_devices( context, rs.only_sw_devices, n=3. )
+        rs.wait_for_devices( context, n=3. )
     #
     #############################################################################################
     #
@@ -46,33 +53,33 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
         rs._devices_updated.clear()
         remote.run( 'close_server( instance )' )
         remote.run( 'instance = None', timeout=1 )
-        rs.wait_for_devices( context, rs.only_sw_devices, n=2. )
+        rs.wait_for_devices( context, n=2. )
     #
     #############################################################################################
     #
     with test.closure( "Add a fourth", on_fail=test.ABORT ):
         remote.run( 'instance4 = broadcast_device( d435i, d435i.device_info )' )
-        rs.wait_for_devices( context, rs.only_sw_devices, n=3. )
+        rs.wait_for_devices( context, n=3. )
     #
     #############################################################################################
     #
     with test.closure( "Close the second", on_fail=test.ABORT ):
         remote.run( 'close_server( instance2 )' )
         remote.run( 'instance2 = None', timeout=1 )
-        rs.wait_for_devices( context, rs.only_sw_devices, n=2. )
+        rs.wait_for_devices( context, n=2. )
     #
     #############################################################################################
     #
     with test.closure( "Close the third", on_fail=test.ABORT ):
         remote.run( 'close_server( instance3 )' )
         remote.run( 'instance2 = None', timeout=1 )
-        rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
+        rs.wait_for_devices( context, n=1. )
     #
     #############################################################################################
     #
     with test.closure( "Close the last", on_fail=test.ABORT ):
         remote.run( 'close_server( instance4 )' )
-        rs.wait_for_devices( context, rs.only_sw_devices, n=0. )
+        rs.wait_for_devices( context, n=0. )
     #
     #############################################################################################
 

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -16,7 +16,14 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'device-properties-client' }} )
+context = rs.context( {
+    'dds': {
+        'enabled': True,
+        'domain': 123,
+        'participant': 'device-properties-client'
+       },
+    'device-mask': rs.only_sw_devices
+    } )
 
 
 import os.path
@@ -29,7 +36,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D435i" ):
         remote.run( 'instance = broadcast_device( d435i, d435i.device_info )' )
-        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d435i.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d435i.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d435i.device_info.topic_root )
@@ -60,7 +67,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D405" ):
         remote.run( 'instance = broadcast_device( d405, d405.device_info )' )
-        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d405.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d405.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d405.device_info.topic_root )
@@ -78,7 +85,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test D455" ):
         remote.run( 'instance = broadcast_device( d455, d455.device_info )' )
-        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, n=1. )
         test.check_equal( dev.get_info( rs.camera_info.name ), d455.device_info.name )
         test.check_equal( dev.get_info( rs.camera_info.serial_number ), d455.device_info.serial )
         test.check_equal( dev.get_info( rs.camera_info.physical_port ), d455.device_info.topic_root )

--- a/unit-tests/dds/test-librs-extrinsics.py
+++ b/unit-tests/dds/test-librs-extrinsics.py
@@ -12,8 +12,13 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 from time import sleep
 
-context = rs.context( { 'dds': { 'enabled': True, 'domain': 123 }} )
-only_sw_devices = int(rs.product_line.sw_only) | int(rs.product_line.any_intel)
+context = rs.context( {
+    'dds': {
+        'enabled': True,
+        'domain': 123
+       },
+    'device-mask': rs.only_sw_devices
+    } )
 
 import os.path
 cwd = os.path.dirname(os.path.realpath(__file__))
@@ -27,7 +32,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     try:
         remote.run( 'instance = broadcast_device( d435i, d435i.device_info )' )
         n_devs = 0
-        for dev in rs.wait_for_devices( context, only_sw_devices ):
+        for dev in rs.wait_for_devices( context ):
             n_devs += 1
         test.check_equal( n_devs, 1 )
 

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -11,7 +11,14 @@ if log.is_debug_on():
     rs.log_to_console( rs.log_severity.debug )
 log.nested = 'C  '
 
-context = rs.context( { 'dds': { 'enabled': True, 'domain': 123, 'participant': 'test-formats-conversion' }} )
+context = rs.context( {
+    'dds': {
+        'enabled': True,
+        'domain': 123,
+        'participant': 'test-formats-conversion'
+        },
+    'device-mask': rs.only_sw_devices
+    } )
 
 import os.path
 cwd = os.path.dirname(os.path.realpath(__file__))
@@ -23,7 +30,7 @@ with test.remote( remote_script, nested_indent="  S" ) as remote:
     #
     with test.closure( "Test setup", on_fail=test.ABORT ):
         remote.run( 'create_server()' )
-        dev = rs.wait_for_devices( context, rs.only_sw_devices, n=1. )
+        dev = rs.wait_for_devices( context, n=1. )
         sensors = {sensor.get_info( rs.camera_info.name ) : sensor for sensor in dev.query_sensors()}
     #
     #############################################################################################


### PR DESCRIPTION
If user specifies only SW devices should be found by a context, there's no need to start the regular USB device factory (including its device watcher).

Update the DDS tests to use the `device-mask` in the context to simplify.
