### PR TITLE
Install pyrealsense2 .so and __init__.py

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -168,6 +168,15 @@ install(TARGETS pybackend2 pyrealsense2
 )
 
 target_include_directories(pybackend2 PRIVATE ../../src)
+
+else() # not BUILD_LEGACY_PYBACKEND
+
+install(TARGETS pyrealsense2
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${PYTHON_INSTALL_DIR}
+    ARCHIVE DESTINATION ${PYTHON_INSTALL_DIR}
+)
+
 endif()  # BUILD_LEGACY_PYBACKEND
 
 write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/pyrealsense2ConfigVersion.cmake"
@@ -190,6 +199,10 @@ install(FILES "${CMAKE_BINARY_DIR}/wrappers/python/pyrealsense2Config.cmake"
 
 install(FILES "${CMAKE_BINARY_DIR}/wrappers/python/pyrealsense2ConfigVersion.cmake"
     DESTINATION ${CMAKECONFIG_PY_INSTALL_DIR}
+)
+
+install(FILES pyrealsense2/__init__.py
+    DESTINATION ${PYTHON_INSTALL_DIR}
 )
 
 target_include_directories(pyrealsense2 PRIVATE ../../src)


### PR DESCRIPTION
Fix for python bindings, issue https://github.com/IntelRealSense/librealsense/issues/13080 , where pyrealsense2 is not installed when built from source.
Added:
 - install rule for libraries
 - install rule for \_\_init__.py which was necessary for python to find the module

The first was added in an else statement because the installation is done when pybackend2 is used

At `make install`, you now see these extra lines:
```
-- Installing: /usr/lib/python3/dist-packages/pyrealsense2/pyrealsense2.cpython-310-aarch64-linux-gnu.so.2.56.0
-- Installing: /usr/lib/python3/dist-packages/pyrealsense2/pyrealsense2.cpython-310-aarch64-linux-gnu.so.2.56
-- Set runtime path of "/usr/lib/python3/dist-packages/pyrealsense2/pyrealsense2.cpython-310-aarch64-linux-gnu.so.2.56.0" to ""
-- Installing: /usr/lib/python3/dist-packages/pyrealsense2/pyrealsense2.cpython-310-aarch64-linux-gnu.so
...
-- Up-to-date: /usr/lib/python3/dist-packages/pyrealsense2/__init__.py
```


Other related issues: 

https://github.com/IntelRealSense/librealsense/issues/10635
https://github.com/IntelRealSense/librealsense/issues/6449
https://github.com/IntelRealSense/librealsense/issues/6964#issuecomment-707501049
https://github.com/IntelRealSense/librealsense/issues/12894
https://github.com/IntelRealSense/librealsense/issues/3062
and more...