### PR TITLE
adjust dds dfu timeout based on image size

### DIFF
--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -11,6 +11,7 @@
 #include <realdds/dds-trinsics.h>
 #include <realdds/dds-participant.h>
 #include <realdds/dds-topic-writer.h>
+#include <realdds/dds-utilities.h>
 
 #include <realdds/topics/device-info-msg.h>
 #include <realdds/topics/flexible-msg.h>
@@ -594,7 +595,7 @@ bool dds_device_proxy::check_fw_compatibility( const std::vector< uint8_t > & im
             { realdds::topics::control::dfu_start::key::crc, crc },
         };
         json reply;
-        _dds_dev->send_control( dfu_start, &reply );
+        _dds_dev->send_control( dfu_start, &reply );  // throws on error
 
         // Set up a reply handler that will get the "dfu-ready" message
         std::mutex mutex;
@@ -622,9 +623,20 @@ bool dds_device_proxy::check_fw_compatibility( const std::vector< uint8_t > & im
         writer->run( wqos );
         if( ! writer->wait_for_readers( { 3, 0 } ) )
             throw std::runtime_error( "timeout waiting for DFU subscriber" );
+        LOG_DEBUG( "transmitting image: " << image.size() << " bytes; crc= " << crc );
         auto blob = realdds::topics::blob_msg( std::vector< uint8_t >( image ) );
         blob.write_to( *writer );
-        if( ! writer->wait_for_acks( { 3, 0 } ) )
+
+        double timeout = 5.;  // seconds
+        if( auto controller
+            = _dds_dev->participant()->find_flow_controller( wqos.publish_mode().flow_controller_name ) )
+        {
+            // Timeout depends on how much data we need to send, because of the flow controller
+            auto const seconds_to_send = realdds::estimate_seconds_to_send( blob.data().size(), *controller );
+            timeout += seconds_to_send * 2;  // *2 in case of resend etc.
+            LOG_DEBUG( "expecting ~" << rsutils::string::from( seconds_to_send, 2 ) << " seconds for image to get sent; timeout= " << rsutils::string::from( timeout, 2 ) );
+        }
+        if( ! writer->wait_for_acks( timeout ) )
             throw std::runtime_error( "timeout waiting for DFU image ack" );
 
         // Wait for a reply
@@ -639,8 +651,7 @@ bool dds_device_proxy::check_fw_compatibility( const std::vector< uint8_t > & im
     }
     catch( std::exception const & e )
     {
-        //LOG_ERROR( "DFU start failed: " << e.what() );
-        throw std::runtime_error( rsutils::string::from() << "failed to check image compatibility: " << e.what() );
+        throw invalid_value_exception( e.what() );
     }
 
     return true;

--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -115,6 +115,10 @@ public:
     //
     rsutils::string::slice name() const;
 
+    // Given a flow-controller name, look it up in the participant QoS and return its object
+    //
+    std::shared_ptr< const eprosima::fastdds::rtps::FlowControllerDescriptor > find_flow_controller( char const * name ) const;
+
     // Utility to create a custom GUID, to help
     //
     dds_guid create_guid();

--- a/third-party/realdds/include/realdds/dds-utilities.h
+++ b/third-party/realdds/include/realdds/dds-utilities.h
@@ -8,6 +8,16 @@
 #include <rsutils/easylogging/easyloggingpp.h>
 #include <rsutils/string/slice.h>
 
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+struct FlowControllerDescriptor;
+}  // namespace rtps
+}  // namespace fastdds
+}  // namespace eprosima
+
+
 // FastDDS, in most case, is using two error conventions:
 // 1. ReturnCode_t api_call(...)   -> return ReturnCode_t != RETCODE_OK
 // 2. <class_name> * api_call(...) -> return nullptr
@@ -28,6 +38,10 @@ inline std::string get_dds_error( T * address )
 
 // Given a topic-root, return a debug name to use for debug
 rsutils::string::slice device_name_from_root( std::string const & topic_root );
+
+
+// Calculate approximately how long it will take to send X bytes to the destination, given specific flow control.
+double estimate_seconds_to_send( size_t, eprosima::fastdds::rtps::FlowControllerDescriptor const & );
 
 
 }  // namespace realdds

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -300,6 +300,18 @@ rsutils::string::slice dds_participant::name() const
 }
 
 
+std::shared_ptr< const eprosima::fastdds::rtps::FlowControllerDescriptor >
+dds_participant::find_flow_controller( char const * name ) const
+{
+    for( auto & controller : get()->get_qos().flow_controllers() )
+    {
+        if( ! strcmp( name, controller->name ) )
+            return controller;
+    }
+    return {};
+}
+
+
 std::string dds_participant::print( dds_guid const & guid_to_print ) const
 {
     return rsutils::string::from( realdds::print_guid( guid_to_print, guid() ) );

--- a/third-party/realdds/src/dds-serialization.cpp
+++ b/third-party/realdds/src/dds-serialization.cpp
@@ -633,17 +633,15 @@ void override_publish_mode_qos_from_json( eprosima::fastdds::dds::PublishModeQos
         }
         else if( j_name.is_string() )
         {
-            auto & controller_name = j_name.string_ref();
-            for( auto & controller : participant.get()->get_qos().flow_controllers() )
+            if( auto controller = participant.find_flow_controller( j_name.string_ref().c_str() ) )
             {
-                if( ! strcmp( controller_name.c_str(), controller->name ) )
-                {
-                    qos.kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
-                    qos.flow_controller_name = controller->name;
-                    return;
-                }
+                qos.kind = eprosima::fastdds::dds::ASYNCHRONOUS_PUBLISH_MODE;
+                qos.flow_controller_name = controller->name;
             }
-            DDS_THROW( runtime_error, "invalid flow-control name in publish-mode; got " << j_name );
+            else
+            {
+                DDS_THROW( runtime_error, "invalid flow-control name in publish-mode; got " << j_name );
+            }
         }
         else
             DDS_THROW( runtime_error, "flow-control must be a name; got " << j_name );

--- a/third-party/realdds/src/dds-utilities.cpp
+++ b/third-party/realdds/src/dds-utilities.cpp
@@ -1,9 +1,12 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #include <realdds/dds-utilities.h>
 #include <realdds/dds-log-consumer.h>
 #include <realdds/topics/dds-topic-names.h>
+
+#include <fastdds/rtps/flowcontrol/FlowControllerDescriptor.hpp>
+
 
 namespace realdds {
 
@@ -58,6 +61,17 @@ void log_consumer::Consume( const eprosima::fastdds::dds::Log::Entry & e )
         LOG_DDS_ENTRY( e, Info, e.message );
         break;
     }
+}
+
+
+// Calculate approximately how long it will take to send X bytes to the destination, given specific flow control. The
+// flow control will slow down the send and do it asynchronously: any write() call will return immediately rather than
+// wait until the send is complete, so the caller will have to manually wait if an ack or reply is expected!
+//
+double estimate_seconds_to_send( size_t size, eprosima::fastdds::rtps::FlowControllerDescriptor const & controller )
+{
+    auto seconds_to_send = size * controller.period_ms / ( 1000. * controller.max_bytes_per_period );
+    return seconds_to_send;
 }
 
 

--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -1324,7 +1324,7 @@ bool lrs_device_controller::on_dfu_start( rsutils::json const & control, rsutils
                     }
                     catch( std::exception const & e )
                     {
-                        j[realdds::topics::reply::key::status] = "check-fw-compat";
+                        j[realdds::topics::reply::key::status] = "error";
                         j[realdds::topics::reply::key::explanation] = e.what();
                         LOG_ERROR( dfu->debug_name() << "DFU image check failed: " << e.what() << "; exiting DFU state" );
                         dfu->reset();

--- a/unit-tests/dds/test-device-discovery.py
+++ b/unit-tests/dds/test-device-discovery.py
@@ -290,7 +290,7 @@ with test.remote.fork( nested_indent='  S' ) as remote:
     with test.closure( "Check new content" ):
         test.check_throws( lambda:
             d2.query_option_value( d2option ),
-            RuntimeError, r'''["query-option" error] device option 'Backlight Compensation' not found''' )
+            RuntimeError, r'''["query-option"] device option 'Backlight Compensation' not found''' )
         if test.check_equal( len(d2.streams()), 1 ):
             stream = d2.streams()[0]
             test.check_equal( stream.name(), 's2' )

--- a/unit-tests/dds/test-query-option.py
+++ b/unit-tests/dds/test-query-option.py
@@ -75,7 +75,7 @@ with test.remote.fork( nested_indent=None ) as remote:
                 'option-name': 'custom option'
             }, True ),  # Wait for reply
             RuntimeError,
-            '["query-option" error] \'s1\' option \'custom option\' not found' )
+            '["query-option"] \'s1\' option \'custom option\' not found' )
 
     with test.closure( 'Query all options in a stream' ):
         reply = device.send_control( {


### PR DESCRIPTION
The timeout was fixed before, but needs to be adjusted based on the image size: the flow controller is asynchronous so any write() calls return immediately. The time estimate is calculated in a utility function.

Tracked on [RSDEV-2328]