### PR TITLE
rs-dds-config

### DIFF
--- a/include/librealsense2/hpp/rs_device.hpp
+++ b/include/librealsense2/hpp/rs_device.hpp
@@ -1049,8 +1049,8 @@ namespace rs2
             rs2_error* e = nullptr;
             auto buffer = rs2_build_debug_protocol_command(_dev.get(), opcode, param1, param2, param3, param4,
                 (void*)data.data(), (uint32_t)data.size(), &e);
-            std::shared_ptr<const rs2_raw_data_buffer> list(buffer, rs2_delete_raw_data);
             error::handle(e);
+            std::shared_ptr< const rs2_raw_data_buffer > list( buffer, rs2_delete_raw_data );
 
             auto size = rs2_get_raw_data_size(list.get(), &e);
             error::handle(e);

--- a/src/platform/uvc-option.h
+++ b/src/platform/uvc-option.h
@@ -85,7 +85,7 @@ public:
                 T t;
                 if( ! dev.get_xu( _xu, _id, reinterpret_cast< uint8_t * >( &t ), sizeof( T ) ) )
                     throw invalid_value_exception( rsutils::string::from()
-                                                   << "get_xu(id=" << std::to_string( _id ) << ") failed!"
+                                                   << "get_xu(id=" << _id << ") failed!"
                                                    << " Last Error: " << strerror( errno ) );
                 if (_parsing_modifier)
                     return _parsing_modifier(t);

--- a/third-party/realdds/doc/control.md
+++ b/third-party/realdds/doc/control.md
@@ -247,7 +247,18 @@ A device can run the flow when in recovery mode or during normal operation:
 
 Starts the DFU process.
 
-The device will subscribe to a `dfu` topic under the topic root (accepting a `blob` message, reliable). Enough memory should be allocated to make sure we're ready to receive the image before a reply is sent.
+The device will subscribe to a `dfu` topic under the topic root (accepting a `blob` message, reliable).
+
+```JSON
+{
+    "id": "dfu-start",
+    "size": 2097152,
+    "crc": 65358876
+}
+```
+
+- A `size` will be communicated to ensure enough memory is allocated and we're ready to receive the image
+- The `crc` is needed to verify the image is intact
 
 A reply should indicate the image is ready to be received.
 
@@ -268,14 +279,6 @@ Errors can look like this:
 }
 ```
 If status is not `OK`, then the device is expected to go back to the pre-DFU state and the process needs to start over.
-
-On success, the device may send back a `"crc": <crc32-value>` or `"size": <number-of-bytes>`, to help debug, or any other relevant content:
-```JSON
-{
-    "id": "dfu-ready",
-    "crc": <value>
-}
-```
 
 The `dfu` subscription can be removed at this time.
 

--- a/third-party/realdds/include/realdds/dds-option.h
+++ b/third-party/realdds/include/realdds/dds-option.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <rsutils/json.h>
-#include <rsutils/string/ip-address.h>
+#include <rsutils/type/ip-address.h>
 
 #include <string>
 #include <vector>
@@ -194,7 +194,7 @@ class dds_ip_option : public dds_string_option
     using super = dds_string_option;
 
 public:
-    using ip_address = rsutils::string::ip_address;
+    using ip_address = rsutils::type::ip_address;
 
     char const * value_type() const override { return "ip-address"; }
 

--- a/third-party/realdds/include/realdds/dds-time.h
+++ b/third-party/realdds/include/realdds/dds-time.h
@@ -59,7 +59,29 @@ inline long double time_to_double( eprosima::fastrtps::rtps::Time_t const & t )
 }
 
 
-std::string time_to_string( dds_time const & t );
+struct time_to_string
+{
+    int32_t _seconds;
+    uint32_t _nanosec;
+
+    time_to_string( dds_time const & t )
+        : _seconds( t.seconds )
+        , _nanosec( t.nanosec )
+    {}
+
+    time_to_string( eprosima::fastrtps::rtps::Time_t const & t )
+        : _seconds( t.seconds() )
+        , _nanosec( t.nanosec() )
+    {}
+
+    time_to_string( int32_t seconds, uint32_t nanoseconds )
+        : _seconds( seconds )
+        , _nanosec( nanoseconds )
+    {}
+};
+
+
+std::ostream & operator<<( std::ostream &, time_to_string const & );
 
 
 // Easy way to format DDS time to a legible string, in milliseconds

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -178,7 +178,7 @@ PYBIND11_MODULE(NAME, m) {
         .def_static( "from_ns", []( dds_nsec ns ) { return realdds::time_from( ns ); } )
         .def_static( "from_double", []( long double d ) { return realdds::dds_time( d ); } )
         .def( "to_double", py::overload_cast< dds_time const & >( &realdds::time_to_double ) )
-        .def( "__repr__", &realdds::time_to_string )
+        .def( "__repr__", []( dds_time const & self ) -> std::string { return rsutils::string::from( realdds::time_to_string( self ) ); } )
         .def( pybind11::self == pybind11::self )
         .def( pybind11::self != pybind11::self );
 
@@ -503,7 +503,17 @@ PYBIND11_MODULE(NAME, m) {
         .def( py::init<>() )
         .def( "identity", []( dds_sample const & self ) { return self.sample_identity; } )
         .def( "source_timestamp", []( dds_sample const & self ) { return self.source_timestamp.to_ns(); } )
-        .def( "reception_timestamp", []( dds_sample const & self ) { return self.reception_timestamp.to_ns(); } );
+        .def( "reception_timestamp", []( dds_sample const & self ) { return self.reception_timestamp.to_ns(); } )
+        .def( "__repr__",
+              []( dds_sample const & self )
+              {
+                  std::ostringstream os;
+                  os << "<sample #" << self.sample_identity.sequence_number();
+                  os << " @ " << realdds::time_to_string( self.reception_timestamp );
+                  os << " from " << realdds::print_guid( self.sample_identity.writer_guid() );
+                  os << ">";
+                  return os.str();
+              } );
 
 
     py::class_< flexible_msg >( message, "flexible" )

--- a/third-party/realdds/scripts/topic-sink.py
+++ b/third-party/realdds/scripts/topic-sink.py
@@ -24,6 +24,7 @@ def time_arg(x):
 args.add_argument( '--wait', metavar='<seconds>', type=time_arg, default=5., help='seconds to wait for writers (default 5; 0=disable)' )
 args.add_argument( '--time', metavar='<seconds>', type=time_arg, help='runtime before stopping, in seconds (default 0=forever)' )
 args.add_argument( '--not-ready', action='store_true', help='start output immediately, without waiting for all topics' )
+args.add_argument( '--field', metavar='<name>', help='name to extract from the flexible JSON (or whole JSON is printed, indented)' )
 args = args.parse_args()
 
 if args.quiet:
@@ -118,7 +119,14 @@ def on_flexible_available( reader ):
             if not got_something:
                 raise RuntimeError( "expected message not received!" )
             break
-        i( f'{timestamp()} {sample} {json.dumps( msg.json_data(), indent=4 )}', )
+        j = msg.json_data()
+        if args.field:
+            s = j.get( args.field )
+            if not s:
+                s = json.dumps( j )  # without indent
+        else:
+            s = json.dumps( j, indent=4 )
+        i( f'{timestamp()} {sample} {s}', )
         got_something = True
 for topic_path in args.flexible_be or []:
     reader = dds.topic_reader( dds.message.flexible.create_topic( participant, topic_path ))

--- a/third-party/realdds/scripts/topic-sink.py
+++ b/third-party/realdds/scripts/topic-sink.py
@@ -43,6 +43,10 @@ if not args.flexible and not args.flexible_be and not args.blob and not args.ima
 
 import pyrealdds as dds
 import time
+from datetime import datetime
+
+def timestamp():
+   return datetime.now().time()
 
 dds.debug( args.debug )
 
@@ -66,7 +70,7 @@ def on_blob_available( reader ):
             if not got_something:
                 raise RuntimeError( "expected message not received!" )
             break
-        i( f'{msg}', )
+        i( f'{timestamp()} {msg}', )
         got_something = True
 for topic_path in args.blob or []:
     reader = dds.topic_reader( dds.message.blob.create_topic( participant, topic_path ))
@@ -90,7 +94,7 @@ def on_image_available( reader ):
             if not got_something:
                 raise RuntimeError( "expected message not received!" )
             break
-        i( f'{msg}', )
+        i( f'{timestamp()} {msg}', )
         got_something = True
 for topic_path in args.image or []:
     reader = dds.topic_reader( dds.message.image.create_topic( participant, topic_path ))
@@ -114,7 +118,7 @@ def on_flexible_available( reader ):
             if not got_something:
                 raise RuntimeError( "expected message not received!" )
             break
-        i( f'{json.dumps( msg.json_data(), indent=4 )}', )
+        i( f'{timestamp()} {sample} {json.dumps( msg.json_data(), indent=4 )}', )
         got_something = True
 for topic_path in args.flexible_be or []:
     reader = dds.topic_reader( dds.message.flexible.create_topic( participant, topic_path ))

--- a/third-party/realdds/src/dds-option.cpp
+++ b/third-party/realdds/src/dds-option.cpp
@@ -585,7 +585,7 @@ json dds_enum_option::to_json() const
 }
 
 
-/*static*/ rsutils::string::ip_address dds_ip_option::check_ip( json const & value )
+/*static*/ dds_ip_option::ip_address dds_ip_option::check_ip( json const & value )
 {
     ip_address ip( value.string_ref() );
     if( ip.is_valid() )

--- a/third-party/realdds/src/dds-time.cpp
+++ b/third-party/realdds/src/dds-time.cpp
@@ -8,19 +8,23 @@
 namespace realdds {
 
 
-std::string time_to_string( dds_time const & t )
+std::ostream & operator<<( std::ostream & os, time_to_string const & t )
 {
-    if( t == eprosima::fastrtps::c_TimeInvalid )
-        return std::string( "INVALID", 7 );
-    std::string nsec = std::to_string( t.nanosec );
-    if( t.nanosec )
-    {
-        // DDS spec 2.3.2: "the nanosec field must verify 0 <= nanosec < 1000000000"
-        nsec.insert( 0, 9 - nsec.length(), '0' );  // will throw if more than 9 digits!
-        while( nsec.length() > 1 && nsec.back() == '0' )
-            nsec.pop_back();
-    }
-    return std::to_string( t.seconds ) + '.' + nsec;
+    if( t._seconds == eprosima::fastrtps::c_TimeInvalid.seconds
+        && t._nanosec == eprosima::fastrtps::c_TimeInvalid.nanosec )
+        return os << "INVALID";
+
+    os << t._seconds << '.';
+
+    if( ! t._nanosec )
+        return os << '0';
+
+    std::string nsec = std::to_string( t._nanosec );
+    // DDS spec 2.3.2: "the nanosec field must verify 0 <= nanosec < 1000000000"
+    nsec.insert( 0, 9 - nsec.length(), '0' );  // will throw if more than 9 digits!
+    while( nsec.length() > 1 && nsec.back() == '0' )
+        nsec.pop_back();
+    return os << nsec;
 }
 
 

--- a/third-party/rsutils/include/rsutils/exceptions.h
+++ b/third-party/rsutils/include/rsutils/exceptions.h
@@ -1,0 +1,15 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+#pragma once
+
+
+namespace rsutils {
+
+
+// Enum that can be used to make code more verbose:
+//     ip_address( "blah", throw_if_not_valid );
+//
+enum _throw_if_not_valid { throw_if_not_valid };
+
+
+}

--- a/third-party/rsutils/include/rsutils/string/ip-address.h
+++ b/third-party/rsutils/include/rsutils/string/ip-address.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <rsutils/json-fwd.h>
+#include <rsutils/exceptions.h>
 
 #include <string>
 #include <iosfwd>
@@ -19,33 +20,50 @@ namespace string {
 //
 class ip_address
 {
-    std::string _str;
+    uint8_t _b[4];
 
 public:
-    ip_address() = default;
+    ip_address() : _b{ 0 } {}
+    ip_address( uint8_t b1, uint8_t b2, uint8_t b3, uint8_t b4 ) : _b{ b1, b2, b3, b4 } {}
+    ip_address( uint8_t const b[4] ) : _b{ b[0], b[1], b[2], b[3] } {}
     ip_address( ip_address const & ) = default;
-    ip_address( ip_address && ) = default;
-    explicit ip_address( std::string );
+
+    explicit ip_address( std::string const & ) noexcept;
+    explicit ip_address( std::string const &, _throw_if_not_valid );
 
     ip_address & operator=( ip_address const & ) = default;
-    ip_address & operator=( ip_address && ) = default;
 
-    bool is_valid() const { return ! empty(); }
+    bool is_valid() const { return _b[0] || _b[1] || _b[2] || _b[3]; }
 
-    bool empty() const { return _str.empty(); }
-    void clear() { _str.clear(); }
+    bool empty() const { return ! _b[0] && ! _b[1] && ! _b[2] && ! _b[3]; }
+    void clear() { _b[0] = _b[1] = _b[2] = _b[3] = 0; }
 
-    std::string to_string() const { return _str; }
+    std::string to_string() const;
+
+    bool operator==( ip_address const & other ) const
+    {
+        return _b[0] == other._b[0] && _b[1] == other._b[1] && _b[2] == other._b[2] && _b[3] == other._b[3];
+    }
+    bool operator!=( ip_address const & other ) const
+    {
+        return _b[0] != other._b[0] || _b[1] != other._b[1] || _b[2] != other._b[2] || _b[3] != other._b[3];
+    }
+
+    void get_components( uint8_t & b0, uint8_t & b1, uint8_t & b2, uint8_t & b3 ) const
+    {
+        b0 = _b[0];
+        b1 = _b[1];
+        b2 = _b[2];
+        b3 = _b[3];
+    }
+    void get_components( uint8_t b[4] ) const { get_components( b[0], b[1], b[2], b[3] ); }
 
 private:
     friend std::ostream & operator<<( std::ostream &, ip_address const & );
 };
 
 
-inline std::ostream & operator<<( std::ostream & os, ip_address const & ip )
-{
-    return operator<<( os, ip._str );
-}
+std::ostream & operator<<( std::ostream &, ip_address const & );
 
 
 // Allow j["key"] = ip_address( "1.2.3.4" );

--- a/third-party/rsutils/include/rsutils/type/ip-address.h
+++ b/third-party/rsutils/include/rsutils/type/ip-address.h
@@ -10,7 +10,7 @@
 
 
 namespace rsutils {
-namespace string {
+namespace type {
 
 
 // An IP address, version 4.
@@ -73,5 +73,5 @@ void from_json( rsutils::json const &, ip_address & );
 // See https://github.com/nlohmann/json#arbitrary-types-conversions
 
 
-}  // namespace string
+}  // namespace type
 }  // namespace rsutils

--- a/third-party/rsutils/src/ip-address.cpp
+++ b/third-party/rsutils/src/ip-address.cpp
@@ -1,7 +1,7 @@
 // License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
-#include <rsutils/string/ip-address.h>
+#include <rsutils/type/ip-address.h>
 #include <rsutils/string/from.h>
 
 #include <rsutils/json.h>
@@ -9,7 +9,7 @@ using rsutils::json;
 
 
 namespace rsutils {
-namespace string {
+namespace type {
 
 
 static bool parse_ip_part( char const *& pch, uint8_t & out_byte ) noexcept
@@ -97,5 +97,5 @@ void from_json( json const & j, ip_address & ip )
 }
 
 
-}  // namespace string
+}  // namespace type
 }  // namespace rsutils

--- a/third-party/rsutils/src/ip-address.cpp
+++ b/third-party/rsutils/src/ip-address.cpp
@@ -2,6 +2,7 @@
 // Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #include <rsutils/string/ip-address.h>
+#include <rsutils/string/from.h>
 
 #include <rsutils/json.h>
 using rsutils::json;
@@ -11,16 +12,16 @@ namespace rsutils {
 namespace string {
 
 
-static int parse_ip_part( char const *& pch )
+static bool parse_ip_part( char const *& pch, uint8_t & out_byte ) noexcept
 {
     // Parse part of the IP address, and return it
-    // Return -1 on failure
+    // Return false on failure
     // On success, pch should be on the character after the number:
     //        192.168.11.55
     //      in^  ^out
 
     if( *pch < '0' || *pch > '9' )
-        return -1;  // At least one digit
+        return false;  // At least one digit
     
     int part = 0;
     do
@@ -28,35 +29,52 @@ static int parse_ip_part( char const *& pch )
         part *= 10;
         part += *pch - '0';
         if( part > 255 )
-            return -1;  // Must be <= 255
+            return false;  // Must be <= 255
         ++pch;
     }
     while( *pch >= '0' && *pch <= '9' );
 
-    return part;
+    out_byte = (uint8_t)part;
+    return true;
 }
 
 
-ip_address::ip_address( std::string str )
+ip_address::ip_address( std::string const & str ) noexcept
+    : ip_address()
 {
     char const * pch = str.c_str();
-    if( parse_ip_part( pch ) < 0 )
-        return;
-    if( *pch++ != '.' )
-        return;
-    if( parse_ip_part( pch ) < 0 )
-        return;
-    if( *pch++ != '.' )
-        return;
-    if( parse_ip_part( pch ) < 0 )
-        return;
-    if( *pch++ != '.' )
-        return;
-    if( parse_ip_part( pch ) < 0 )
-        return;
-    if( *pch )
-        return;
-    _str = std::move( str );
+    uint8_t b0, b1, b2, b3;
+    if( parse_ip_part( pch, b0 ) && *pch == '.' && parse_ip_part( ++pch, b1 ) && *pch == '.'
+        && parse_ip_part( ++pch, b2 ) && *pch == '.' && parse_ip_part( ++pch, b3 ) && ! *pch )
+    {
+        _b[0] = b0;
+        _b[1] = b1;
+        _b[2] = b2;
+        _b[3] = b3;
+    }
+}
+
+
+ip_address::ip_address( std::string const & str, _throw_if_not_valid )
+    : ip_address( str )
+{
+    if( ! is_valid() )
+        throw std::invalid_argument( "invalid IP address: " + str );
+}
+
+
+std::ostream & operator<<( std::ostream & os, ip_address const & ip )
+{
+    os << +ip._b[0] << '.';
+    os << +ip._b[1] << '.';
+    os << +ip._b[2] << '.';
+    return os << +ip._b[3];
+}
+
+
+std::string ip_address::to_string() const
+{
+    return rsutils::string::from( *this );
 }
 
 

--- a/tools/dds/CMakeLists.txt
+++ b/tools/dds/CMakeLists.txt
@@ -3,4 +3,5 @@
 
 add_subdirectory(dds-sniffer)
 add_subdirectory(dds-adapter)
+add_subdirectory(dds-config)
 

--- a/tools/dds/dds-adapter/rs-dds-adapter.cpp
+++ b/tools/dds/dds-adapter/rs-dds-adapter.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #include <realdds/dds-device-server.h>
 #include <realdds/dds-stream-server.h>
@@ -113,7 +113,7 @@ int main( int argc, char * argv[] )
 try
 {
     dds_domain_id domain = -1;  // from settings; default to 0
-    CmdLine cmd( "librealsense rs-dds-adapter tool, use CTRL + C to stop..", ' ' );
+    CmdLine cmd( "librealsense rs-dds-adapter tool, use CTRL + C to stop..", ' ', RS2_API_FULL_VERSION_STR );
     ValueArg< dds_domain_id > domain_arg( "d",
                                           "domain",
                                           "Select domain ID to publish on",

--- a/tools/dds/dds-config/CMakeLists.txt
+++ b/tools/dds/dds-config/CMakeLists.txt
@@ -1,0 +1,27 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+cmake_minimum_required( VERSION 3.1.0 )
+project( rs-dds-config )
+
+add_executable( ${PROJECT_NAME} )
+
+file( GLOB_RECURSE RS_DDS_CONFIG_SOURCE_FILES
+    LIST_DIRECTORIES false
+    RELATIVE ${PROJECT_SOURCE_DIR}
+    "${CMAKE_CURRENT_LIST_DIR}/*"
+    )
+target_sources( ${PROJECT_NAME} PRIVATE ${RS_DDS_CONFIG_SOURCE_FILES} )
+
+target_link_libraries( ${PROJECT_NAME} PRIVATE realdds realsense2 tclap )
+
+set_target_properties (${PROJECT_NAME} PROPERTIES
+    FOLDER Tools/dds
+    CXX_STANDARD 14
+    )
+
+install( TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+using_easyloggingpp( ${PROJECT_NAME} SHARED )
+

--- a/tools/dds/dds-config/eth-config-header.h
+++ b/tools/dds/dds-config/eth-config-header.h
@@ -1,0 +1,18 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include <cstdint>
+
+
+#pragma pack( push, 1 )
+
+// The header structure for eth config
+struct eth_config_header
+{
+    uint16_t version;
+    uint16_t size;  // without header
+    uint32_t crc;   // without header
+};
+
+#pragma pack( pop )

--- a/tools/dds/dds-config/eth-config-v3.h
+++ b/tools/dds/dds-config/eth-config-v3.h
@@ -1,0 +1,36 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include "eth-config-header.h"
+
+
+#pragma pack( push, 1 )
+
+// The structure data for eth config info, version 3
+// See table definition in HWMC v0.53 spec
+struct eth_config_v3
+{
+    eth_config_header header;
+    uint32_t link_check_timeout;  // The threshold to wait eth link(ms).
+    uint8_t config_ip[4];         // static IP
+    uint8_t config_netmask[4];    // static netmask
+    uint8_t config_gateway[4];    // static gateway
+    uint8_t actual_ip[4];         // actual IP when dhcp is ON, read-only
+    uint8_t actual_netmask[4];    // actual netmask when dhcp is ON, read-only
+    uint8_t actual_gateway[4];    // actual gateway when dhcp is ON, read-only
+    uint32_t link_speed;          // Mbps read-only
+    uint32_t mtu;                 // read-only
+    uint8_t dhcp_on;              // 0=off
+    uint8_t dhcp_timeout;         // The threshold to wait valid ip when DHCP is on(s).
+    uint8_t domain_id;            // dds domain id
+    uint8_t link_priority;        // device link priority. 0-USB_ONLY, 1-ETH_ONLY, 2-ETH_FIRST, 3 USB_FIRST
+    uint8_t mac_address[6];       // read-only
+    uint8_t reserved[2];          // needed to make size divisible by 4
+};
+
+#pragma pack( pop )
+
+
+static_assert( sizeof( eth_config_v3 ) % 4 == 0, "eth config v3 struct size must be divisible by 4" );
+

--- a/tools/dds/dds-config/eth-config.cpp
+++ b/tools/dds/dds-config/eth-config.cpp
@@ -1,0 +1,141 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#include "eth-config.h"
+#include "eth-config-v3.h"
+
+#include <rsutils/number/crc32.h>
+#include <rsutils/string/hexdump.h>
+#include <rsutils/string/from.h>
+
+
+std::ostream & operator<<( std::ostream & os, link_priority p )
+{
+    if( static_cast< uint8_t >( p ) & static_cast< uint8_t >( link_priority::_dynamic_bit ) )
+    {
+        os << "dynamic-";
+        p = static_cast< link_priority >( static_cast< uint8_t >( p )
+                                          & ~static_cast< uint8_t >( link_priority::_dynamic_bit ) );
+    }
+    switch( p )
+    {
+    case link_priority::usb_only:
+        os << "usb-only";
+        break;
+    case link_priority::usb_first:
+        os << "usb-first";
+        break;
+    case link_priority::eth_only:
+        os << "eth-only";
+        break;
+    case link_priority::eth_first:
+        os << "eth-first";
+        break;
+    default:
+        os << "UNKNOWN-" << (int) p;
+        break;
+    }
+    return os;
+}
+
+
+std::ostream & operator<<( std::ostream & os, ip_3 const & ip3 )
+{
+    os << ip3.ip;
+    if( ip3.netmask.is_valid() )
+        os << " & " << ip3.netmask;
+    if( ip3.gateway.is_valid() )
+        os << " / " << ip3.gateway;
+    return os;
+}
+
+
+eth_config::eth_config( eth_config_v3 const & v3 )
+    : header( v3.header )
+    , mac_address( rsutils::string::from( rsutils::string::hexdump( v3.mac_address, sizeof( v3.mac_address ) )
+                                              .format( "{01}:{01}:{01}:{01}:{01}:{01}" ) ) )
+    , configured{ v3.config_ip, v3.config_netmask, v3.config_gateway }
+    , actual{ v3.actual_ip, v3.actual_netmask, v3.actual_gateway }
+    , dds{ v3.domain_id }
+    , link{ v3.mtu, v3.link_speed, v3.link_check_timeout, link_priority( v3.link_priority ) }
+    , dhcp{ v3.dhcp_on != 0, v3.dhcp_timeout }
+{
+}
+
+
+eth_config::eth_config( std::vector< uint8_t > const & hwm_response )
+{
+    auto header = reinterpret_cast< eth_config_header const * >( hwm_response.data() );
+    if( hwm_response.size() < sizeof( *header ) )
+        throw std::runtime_error( rsutils::string::from()
+                                  << "HWM response size (" << hwm_response.size() << ") does not fit header (size "
+                                  << sizeof( *header ) << ")" );
+
+    if( hwm_response.size() != sizeof( *header ) + header->size )
+        throw std::runtime_error( rsutils::string::from()
+                                  << "HWM response size (" << hwm_response.size() << ") does not fit header ("
+                                  << sizeof( *header ) << ") + header size (" << header->size << ")" );
+
+    auto const crc = rsutils::number::calc_crc32( hwm_response.data() + sizeof( *header ), header->size );
+    if( header->crc != crc )
+        throw std::runtime_error( rsutils::string::from()
+                                  << "Eth config table CRC (" << header->crc << ") does not match response " << crc );
+
+    switch( header->version )
+    {
+    case 3: {
+        if( header->size != sizeof( eth_config_v3 ) - sizeof( *header ) )
+            throw std::runtime_error( rsutils::string::from()
+                                      << "invalid Eth config table v3 size (" << header->size << "); expecting "
+                                      << sizeof( eth_config_v3 ) << "-" << sizeof( *header ) );
+        auto config = reinterpret_cast< eth_config_v3 const * >( hwm_response.data() );
+        *this = *config;
+        break;
+    }
+
+    default:
+        throw std::runtime_error( rsutils::string::from()
+                                  << "unrecognized Eth config table version " << header->version );
+    }
+}
+
+
+bool eth_config::operator==( eth_config const & other ) const noexcept
+{
+    // Only compare those items that are configurable
+    return configured.ip == other.configured.ip && configured.netmask == other.configured.netmask
+        && configured.gateway == other.configured.gateway && dds.domain_id == other.dds.domain_id
+        && dhcp.on == other.dhcp.on && link.priority == other.link.priority && link.timeout == other.link.timeout;
+}
+
+
+bool eth_config::operator!=( eth_config const & other ) const noexcept
+{
+    // Only compare those items that are configurable
+    return configured.ip != other.configured.ip || configured.netmask != other.configured.netmask
+        || configured.gateway != other.configured.gateway || dds.domain_id != other.dds.domain_id
+        || dhcp.on != other.dhcp.on || link.priority != other.link.priority || link.timeout != other.link.timeout;
+}
+
+
+std::vector< uint8_t > eth_config::build_command() const
+{
+    std::vector< uint8_t > data;
+    data.resize( sizeof( eth_config_v3 ) );
+    eth_config_v3 & cfg = *reinterpret_cast< eth_config_v3 * >( data.data() );
+    configured.ip.get_components( cfg.config_ip );
+    configured.netmask.get_components( cfg.config_netmask );
+    configured.gateway.get_components( cfg.config_gateway );
+    cfg.dhcp_on = dhcp.on;
+    cfg.dhcp_timeout = dhcp.timeout;
+    cfg.domain_id = dds.domain_id;
+    cfg.link_check_timeout = link.timeout;
+    cfg.link_priority = (uint8_t)link.priority;
+
+    cfg.mtu = 9000;  // R/O, but must be set to this value
+
+    cfg.header.version = 3;
+    cfg.header.size = sizeof( cfg ) - sizeof( cfg.header );
+    cfg.header.crc = rsutils::number::calc_crc32( data.data() + sizeof( cfg.header ), cfg.header.size );
+    return data;
+}

--- a/tools/dds/dds-config/eth-config.h
+++ b/tools/dds/dds-config/eth-config.h
@@ -1,0 +1,72 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+#pragma once
+
+#include "eth-config-header.h"
+
+#include <rsutils/type/ip-address.h>
+
+
+enum class link_priority : uint8_t
+{
+    usb_only = 0,
+    eth_only = 1,
+    eth_first = 2,
+    usb_first = 3,
+
+    _dynamic_bit = 0x10,
+    dynamic_eth_first = eth_first | _dynamic_bit,
+    dynamic_usb_first = usb_first | _dynamic_bit
+};
+std::ostream & operator<<( std::ostream & os, link_priority );
+
+
+struct ip_3
+{
+    rsutils::type::ip_address ip;
+    rsutils::type::ip_address netmask;
+    rsutils::type::ip_address gateway;
+
+    operator bool() const { return ip.is_valid(); }
+
+    bool operator==( ip_3 const & other ) const { return ip == other.ip && netmask == other.netmask && gateway == other.gateway; }
+    bool operator!=( ip_3 const & other ) const { return ip != other.ip || netmask != other.netmask || gateway != other.gateway; }
+};
+std::ostream & operator<<( std::ostream &, ip_3 const & );
+
+
+struct eth_config_v3;
+
+
+struct eth_config
+{
+    eth_config_header header;
+    std::string mac_address;
+    ip_3 configured;
+    ip_3 actual;
+    struct
+    {
+        int domain_id;  // dds domain id
+    } dds;
+    struct
+    {
+        unsigned mtu;      // bytes per packet
+        unsigned speed;    // Mbps read-only; 0 if link is off
+        unsigned timeout;  // The threshold to wait eth link(ms)
+        link_priority priority;
+    } link;
+    struct
+    {
+        bool on;
+        int timeout;  // The threshold to wait valid ip when DHCP is on(s)
+    } dhcp;
+
+    eth_config() {}
+    explicit eth_config( std::vector< uint8_t > const & hwm_response_without_code );
+    eth_config( eth_config_v3 const & );
+
+    bool operator==( eth_config const & ) const noexcept;
+    bool operator!=( eth_config const & ) const noexcept;
+
+    std::vector< uint8_t > build_command() const;
+};

--- a/tools/dds/dds-config/rs-dds-config.cpp
+++ b/tools/dds/dds-config/rs-dds-config.cpp
@@ -1,0 +1,387 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2024 Intel Corporation. All Rights Reserved.
+
+#include <librealsense2/rs.hpp>
+
+#include "eth-config.h"
+
+#include <tclap/CmdLine.h>
+#include <tclap/ValueArg.h>
+
+#include <rsutils/os/special-folder.h>
+#include <rsutils/json.h>
+#include <rsutils/json-config.h>
+#include <rsutils/string/hexdump.h>
+#include <rsutils/string/from.h>
+
+#include <iostream>
+#include <thread>
+#include <set>
+
+using namespace TCLAP;
+using rsutils::json;
+using rsutils::type::ip_address;
+
+
+static json load_settings( json const & local_settings )
+{
+    // Load the realsense configuration file settings
+    std::string const filename = rsutils::os::get_special_folder( rsutils::os::special_folder::app_data ) + RS2_CONFIG_FILENAME;
+    auto config = rsutils::json_config::load_from_file( filename );
+
+    // Take just the 'context' part
+    config = rsutils::json_config::load_settings( config, "context", "config-file" );
+
+    // Patch the given local settings into the configuration
+    config.override( local_settings, "local settings" );
+
+    return config;
+}
+
+
+uint32_t const GET_ETH_CONFIG = 0xBB;
+uint32_t const SET_ETH_CONFIG = 0xBA;
+char const * const HWM_FMT = "{4} {04}({4i},{4i},{4i},{4i}) {repeat:}{1}{:}";
+
+
+#define LOG_DEBUG( ... )                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        std::ostringstream os__;                                                                                       \
+        os__ << __VA_ARGS__;                                                                                           \
+        rs2_log( RS2_LOG_SEVERITY_DEBUG, os__.str().c_str(), nullptr );                                                \
+    }                                                                                                                  \
+    while( false )
+bool g_quiet = false;
+#define INFO( ... )                                                                                                    \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if( ! g_quiet )                                                                                                \
+            std::cout << "-I- " << __VA_ARGS__ << std::endl;                                                           \
+    }                                                                                                                  \
+    while( false )
+
+
+struct indent
+{
+    int _spaces;
+    indent( int spaces ) : _spaces( spaces ) {}
+};
+std::ostream & operator<<( std::ostream & os, indent const & ind )
+{
+    for( int i = ind._spaces; i; --i )
+        os << ' ';
+    return os;
+}
+
+
+template< class T >
+struct _output_field
+{
+    char const * const _name;
+    T const & _current;
+    T const & _requested;
+};
+template< class T >
+std::ostream & operator<<( std::ostream & os, _output_field< T > const & f )
+{
+    os << f._name << ": " << f._current;
+    if( f._requested != f._current )
+        os << " --> " << f._requested;
+    return os;
+}
+template< class T >
+_output_field< T > setting( const char * name, T const & current )
+{
+    return { name, current, current };
+}
+template< class T >
+_output_field< T > setting( const char * name, T const & current, T const & requested )
+{
+    return { name, current, requested };
+}
+
+
+eth_config get_eth_config( rs2::debug_protocol hwm, bool golden )
+{
+    if( ! hwm )
+        throw std::runtime_error( "no debug_protocol available" );
+    auto cmd = hwm.build_command( GET_ETH_CONFIG, golden ? 0 : 1 );  // 0=golden; 1=actual
+    LOG_DEBUG( "cmd: " << rsutils::string::hexdump( cmd.data(), cmd.size() ).format( HWM_FMT ) );
+    auto data = hwm.send_and_receive_raw_data( cmd );
+    int32_t const & code = *reinterpret_cast<int32_t const *>(data.data());
+    if( data.size() < sizeof( code ) )
+        throw std::runtime_error( rsutils::string::from()
+                                  << "bad response " << rsutils::string::hexdump( data.data(), data.size() ) );
+    if( code != GET_ETH_CONFIG )
+        throw std::runtime_error( rsutils::string::from() << "bad response " << code );
+    LOG_DEBUG( "response: " << rsutils::string::hexdump( data.data(), data.size() ).format( "{4} {repeat:}{1}{:}" ) );
+    data.erase( data.begin(), data.begin() + sizeof( code ) );
+
+    return eth_config( data );
+}
+
+
+bool find_device( rs2::context const & ctx,
+                  rs2::device & device,
+                  eth_config & config,
+                  ValueArg< std::string > & sn_arg,
+                  bool const golden,
+                  std::set< std::string > & devices_looked_at )
+{
+    auto device_list = ctx.query_devices();
+    auto const n_devices = device_list.size();
+    for( uint32_t i = 0; i < n_devices; ++i )
+    {
+        auto possible_device = device_list[i];
+        try
+        {
+            std::string sn = possible_device.get_info( RS2_CAMERA_INFO_SERIAL_NUMBER );
+            if( sn_arg.isSet() && sn != sn_arg.getValue() )
+                continue;
+            if( ! devices_looked_at.insert( sn ).second )
+                continue;  // insert failed: device was already looked at
+            LOG_DEBUG( "trying " << possible_device.get_description() );
+            config = get_eth_config( possible_device, golden );
+            if( device )
+                throw std::runtime_error( "More than one device is available; please use --serial-number" );
+            device = possible_device;
+        }
+        catch( std::exception const & e )
+        {
+            LOG_DEBUG( "failed! " << e.what() );
+        }
+    }
+    return device;
+}
+
+
+int main( int argc, char * argv[] )
+try
+{
+    CmdLine cmd( "librealsense rs-dds-config tool", ' ', RS2_API_FULL_VERSION_STR );
+    SwitchArg debug_arg( "", "debug", "Enable debug (-D-) output; by default only errors (-E-) are shown" );
+    SwitchArg quiet_arg( "", "quiet", "Suppress regular informational (-I-) messages" );
+    SwitchArg no_reset_arg( "", "no-reset", "Do not hardware reset after changes are made" );
+    SwitchArg golden_arg( "", "golden", "Show R/O golden values vs. current; mutually exclusive with any changes" );
+    SwitchArg factory_reset_arg( "", "factory-reset", "Reset settings back to the --golden values" );
+    ValueArg< std::string > sn_arg( "", "serial-number",
+                                    "Device serial-number to use, if more than one device is available",
+                                    false, "", "S/N" );
+    ValueArg< std::string > ip_arg( "", "ip",
+                                    "Device static IP address to use when DHCP is off",
+                                    false, "", "1.2.3.4" );
+    ValueArg< std::string > mask_arg( "", "mask",
+                                    "Device static IP network mask to use when DHCP is off",
+                                    false, "", "1.2.3.4" );
+    ValueArg< std::string > gateway_arg( "", "gateway",
+                                      "Device static IP network mask to use when DHCP is off",
+                                      false, "", "1.2.3.4" );
+    ValueArg< std::string > dhcp_arg( "", "dhcp",
+                                      "DHCP dynamic IP discovery 'on' or 'off'",
+                                      false, "on", "on/off" );
+    ValueArg< uint32_t > dhcp_timeout_arg( "", "dhcp-timout",
+                                           "Seconds before DHCP times out and falls back to a static IP",
+                                           false, 30, "seconds" );
+    ValueArg< uint32_t > link_timeout_arg( "", "link-timout",
+                                           "Milliseconds before --eth-first link times out and falls back to USB",
+                                           false, 4000, "milliseconds" );
+    ValueArg< uint8_t > domain_id_arg( "", "domain-id",
+                                       "DDS Domain ID to use (default is 0)",
+                                       false, 0, "0-232" );
+    SwitchArg usb_first_arg( "", "usb-first", "Prioritize USB before Ethernet" );
+    SwitchArg eth_first_arg( "", "eth-first", "Prioritize Ethernet and fall back to USB after link timeout" );
+    SwitchArg dynamic_priority_arg( "", "dynamic-priority", "Dynamically prioritize the last-working connection method (the default)" );
+
+    // In reverse order to how they will be listed
+    cmd.add( no_reset_arg );
+    cmd.add( domain_id_arg );
+    cmd.add( gateway_arg );
+    cmd.add( mask_arg );
+    cmd.add( ip_arg );
+    cmd.add( dhcp_timeout_arg );
+    cmd.add( dhcp_arg );
+    cmd.add( link_timeout_arg );
+    cmd.add( dynamic_priority_arg );
+    cmd.add( eth_first_arg );
+    cmd.add( usb_first_arg );
+    cmd.add( factory_reset_arg );
+    cmd.add( golden_arg );
+    cmd.add( sn_arg );
+    cmd.add( quiet_arg );
+    cmd.add( debug_arg );
+    cmd.parse( argc, argv );
+
+    g_quiet = quiet_arg.isSet();
+    bool const golden = golden_arg.isSet();
+
+    rs2::log_to_console( debug_arg.isSet() ? RS2_LOG_SEVERITY_DEBUG : RS2_LOG_SEVERITY_ERROR );
+
+    // Create a RealSense context and look for a device
+    json settings = load_settings( json::object() );
+    rs2::context ctx( settings.dump() );
+
+    rs2::device device;
+    eth_config current;
+    std::set< std::string > devices_looked_at;
+    if( ! find_device( ctx, device, current, sn_arg, golden, devices_looked_at ) )
+    {
+        auto dds_enabled = settings.nested( "dds", "enabled", &json::is_boolean );
+        if( ! dds_enabled || dds_enabled.get< bool >() )
+        {
+            LOG_DEBUG( "Waiting for ETH devices..." );
+            int tries = 5;
+            while( tries-- > 0 )
+            {
+                std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
+                if( find_device( ctx, device, current, sn_arg, golden, devices_looked_at ) )
+                    break;
+            }
+        }
+        if( ! device )
+        {
+            if( sn_arg.isSet() )
+                throw std::runtime_error( "Device not found or does not support Eth" );
+
+            throw std::runtime_error( "No device found supporting Eth" );
+        }
+    }
+    INFO( "Device: " << device.get_description() );
+
+    eth_config requested( current );
+    if( golden || factory_reset_arg.isSet() )
+    {
+        if( ip_arg.isSet() || mask_arg.isSet() || usb_first_arg.isSet() || eth_first_arg.isSet()
+            || dynamic_priority_arg.isSet() || link_timeout_arg.isSet() || dhcp_arg.isSet() || dhcp_timeout_arg.isSet()
+            || golden == factory_reset_arg.isSet() )
+        {
+            throw std::runtime_error( "Cannot change any settings with --golden" );
+        }
+        if( factory_reset_arg.isSet() )
+        {
+            LOG_DEBUG( "getting golden:" );
+            requested = get_eth_config( device, true );  // golden
+        }
+        else
+        {
+            // Current is the golden values; show them vs the actual values in requested
+            // No actual changes will be made
+            LOG_DEBUG( "getting current:" );
+            requested = get_eth_config( device, false );  // not golden
+        }
+    }
+    else
+    {
+        if( ip_arg.isSet() )
+            requested.configured.ip = ip_address( ip_arg.getValue(), rsutils::throw_if_not_valid );
+        if( mask_arg.isSet() )
+            requested.configured.netmask = ip_address( ip_arg.getValue(), rsutils::throw_if_not_valid );
+        if( gateway_arg.isSet() )
+            requested.configured.gateway = ip_address( ip_arg.getValue(), rsutils::throw_if_not_valid );
+        if( usb_first_arg.isSet() + eth_first_arg.isSet() + dynamic_priority_arg.isSet() > 1 )
+            throw std::invalid_argument( "--usb-first, --eth-first, and --dynamic-priority are mutually exclusive" );
+        if( usb_first_arg.isSet() )
+            requested.link.priority = link_priority::usb_first;
+        else if( eth_first_arg.isSet() )
+            requested.link.priority = link_priority::eth_first;
+        else if( dynamic_priority_arg.isSet() )
+            requested.link.priority  // Enable eth-first if we have a link
+                = current.link.speed ? link_priority::dynamic_eth_first : link_priority::dynamic_usb_first;
+        if( link_timeout_arg.isSet() )
+            requested.link.timeout = link_timeout_arg.getValue();
+        if( dhcp_arg.isSet() )
+        {
+            if( dhcp_arg.getValue() == "on" )
+                requested.dhcp.on = true;
+            else if( dhcp_arg.getValue() == "off" )
+                requested.dhcp.on = false;
+            else
+                throw std::invalid_argument( "--dhcp can be 'on' or 'off'; got " + dhcp_arg.getValue() );
+        }
+        if( dhcp_timeout_arg.isSet() )
+            requested.dhcp.timeout = dhcp_timeout_arg.getValue();
+        if( domain_id_arg.isSet() )
+        {
+            if( domain_id_arg.getValue() > 232 )
+                throw std::invalid_argument( "--domain-id must be 0-232" );
+            requested.dds.domain_id = domain_id_arg.getValue();
+        }
+    }
+
+    if( ! g_quiet )
+    {
+        INFO( indent( 4 ) << setting( "MAC address", current.mac_address ) );
+        INFO( indent( 4 ) << setting( "configured", current.configured, requested.configured ) );
+        if( ! golden && current.actual && current.actual != current.configured )
+            INFO( indent( 4 ) << setting( "actual    ", current.actual ) );
+
+        {
+            INFO( indent( 4 ) << "DDS:" );
+            INFO( indent( 8 ) << setting( "domain ID", current.dds.domain_id, requested.dds.domain_id ) );
+        }
+        {
+            if( golden )
+            {
+                INFO( indent( 4 ) << "link:" );
+            }
+            else
+            {
+                if( current.link.speed )
+                    INFO( indent( 4 ) << setting( "link", current.link.speed ) << " Mbps" );
+                else
+                    INFO( indent( 4 ) << setting( "link", "OFF" ) );
+            }
+            INFO( indent( 8 ) << setting( "MTU, bytes", current.link.mtu ) );
+            INFO( indent( 8 ) << setting( "timeout, ms", current.link.timeout, requested.link.timeout ) );
+            INFO( indent( 8 ) << setting( "priority", current.link.priority, requested.link.priority ) );
+        }
+        {
+            std::string current_dhcp( current.dhcp.on ? "ON" : "OFF" );
+            std::string requested_dhcp( requested.dhcp.on ? "ON" : "OFF" );
+            INFO( indent( 4 ) << setting( "DHCP", current_dhcp, requested_dhcp ) );
+            INFO( indent( 8 ) << setting( "timeout, sec", current.dhcp.timeout, requested.dhcp.timeout ) );
+        }
+    }
+
+    if( golden )
+    {
+        LOG_DEBUG( "no changes requested with --golden" );
+    }
+    else if( requested == current )
+    {
+        LOG_DEBUG( "nothing to do" );
+    }
+    else
+    {
+        rs2::debug_protocol hwm( device );
+        auto cmd = hwm.build_command( SET_ETH_CONFIG, 0, 0, 0, 0, requested.build_command() );
+        LOG_DEBUG( "cmd: " << rsutils::string::hexdump( cmd.data(), cmd.size() ).format( HWM_FMT ) );
+        auto data = hwm.send_and_receive_raw_data( cmd );
+        int32_t const & code = *reinterpret_cast< int32_t const * >( data.data() );
+        if( data.size() != sizeof( code ) )
+            throw std::runtime_error( rsutils::string::from()
+                                      << "Failed to change: bad response size " << data.size() << ' '
+                                      << rsutils::string::hexdump( data.data(), data.size() ) );
+        if( code != SET_ETH_CONFIG )
+            throw std::runtime_error( rsutils::string::from() << "Failed to change: bad response " << code );
+        INFO( "Successfully changed" );
+        if( ! no_reset_arg.isSet() )
+        {
+            INFO( "Resetting device..." );
+            device.hardware_reset();
+        }
+    }
+
+    return EXIT_SUCCESS;
+}
+catch( const rs2::error & e )
+{
+    std::cerr << "-F- RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args()
+              << "):\n    " << e.what() << std::endl;
+    return EXIT_FAILURE;
+}
+catch( const std::exception & e )
+{
+    std::cerr << "-F- " << e.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/unit-tests/dds/test-option-value.py
+++ b/unit-tests/dds/test-option-value.py
@@ -130,7 +130,10 @@ with test.closure( 'IP address' ):
     test.check_throws( lambda:
         dds.option.from_json( ['ip', '', 'desc', ['IPv4']] ),
         RuntimeError, 'not an IP address: ""' )
-    dds.option.from_json( ['ip', '0.0.0.0', 'desc', ['IPv4']] )
+    test.check_throws( lambda:  # 0.0.0.0 is used to denote an "invalid" IP
+        dds.option.from_json( ['ip', '0.0.0.0', 'desc', ['IPv4']] ),
+        RuntimeError, 'not an IP address: "0.0.0.0"' )
+    dds.option.from_json( ['ip', '0.0.0.1', 'desc', ['IPv4']] )
     dds.option.from_json( ['ip', '255.255.255.255', 'desc', ['IPv4']] )
     test.check_throws( lambda:
         dds.option.from_json( ['ip', '255.255.255.256', 'desc', ['IPv4']] ),


### PR DESCRIPTION
Add command-line utility to get/set eth config:
```
> rs-dds-config.exe
-I- Device: ...
-I-     MAC address: 98:4f:ee:18:9e:69
-I-     configured: 192.168.11.55 & 255.255.255.0 / 192.168.11.1
-I-     DDS:
-I-         domain ID: 0
-I-     link: 1000 Mbps
-I-         MTU, bytes: 9000
-I-         timeout, ms: 4000
-I-         priority: eth-first
-I-     DHCP: OFF
-I-         timeout, sec: 30
```
* By default, show the current config
* Can show the default "golden" config with `--golden`, which also shows the diffs between golden and current with `-->`
* Can change any of the settings using the various command-line switches
* Restarts the camera if changes are made
* Finds software devices, too, so can configure over USB or Eth

This is most of the basic functionality - not everything was tested but most should be ready.

Tracked on [RSDEV-1998]