### PR TITLE
Fix possible bug in D400 coefficient table handling

### DIFF
--- a/src/ds/ds-private.h
+++ b/src/ds/ds-private.h
@@ -271,6 +271,7 @@ namespace librealsense
             std::string to_string() const;
         };
 
+        // Note ds_rect_resolutions is used in struct d400_coefficients_table. Update with caution.
         enum ds_rect_resolutions : unsigned short
         {
             res_1920_1080,
@@ -290,8 +291,6 @@ namespace librealsense
             res_576_576,
             res_720_720,
             res_1152_1152,
-            // Internal scaled resolution of D405
-            res_770_480,
             max_ds_rect_resolutions
         };
 
@@ -565,7 +564,6 @@ namespace librealsense
             { res_576_576,{ 576, 576 } },
             { res_720_720,{ 720, 720 } },
             { res_1152_1152,{ 1152, 1152 } },
-            { res_770_480,{ 770, 480 } },
         };
 
         ds_rect_resolutions width_height_to_ds_rect_resolutions(uint32_t width, uint32_t height);


### PR DESCRIPTION
PR#13060 introduced a possible bug, changing size of d400 coefficient table structure.
This reverts the enum change from that PR.