### PR TITLE
scripts: patch: support for d421 windows metadata

### DIFF
--- a/scripts/realsense_metadata_win10.ps1
+++ b/scripts/realsense_metadata_win10.ps1
@@ -78,7 +78,8 @@ $MultiPinDevices =
     "USB\VID_8086&PID_0B5C&MI_00",# D455
     "USB\VID_8086&PID_0B64&MI_00",# L515
     "USB\VID_8086&PID_0B68&MI_00",# L535
-    "USB\VID_8086&PID_0B56&MI_00" # D555e
+    "USB\VID_8086&PID_0B56&MI_00",# D555e
+    "USB\VID_8086&PID_1155&MI_00" # D421
 
 #Inhibit system warnings and erros, such as permissions or missing values
 $ErrorActionPreference = "silentlycontinue"


### PR DESCRIPTION
Track-by: RSDEV-2233

Add D421 PID to Udev-rules manual script and manual patches for MD support

