### PR TITLE
fix PR #13185: json bool operator now same as json_ref

### DIFF
--- a/common/rs-config.cpp
+++ b/common/rs-config.cpp
@@ -90,7 +90,8 @@ config_file::config_file( std::string const & filename )
 {
     try
     {
-        if( auto j = rsutils::json_config::load_from_file( filename ) )
+        auto j = rsutils::json_config::load_from_file( filename );
+        if( j.exists() )
             _j = std::move( j );
     }
     catch(...)

--- a/third-party/rsutils/include/rsutils/json-fwd.h
+++ b/third-party/rsutils/include/rsutils/json-fwd.h
@@ -39,6 +39,13 @@ class json_base
 
 public:
     inline bool exists() const;
+    // WARNING: this "overrides" the implicit operator<T> that the *derived* class defines that does implicit casting!
+    // I.e., if
+    //      bool b = j;
+    // used the implicit conversion ('bool b = j.get< bool >();') before, now it will do:
+    //      bool b = j.exists();
+    // In general, it is preferable to NEVER use implicit value conversions and instead stick to the .get<T>() syntax.
+    operator bool() const { return exists(); }
 
     template< class T > inline T default_value( T const & default_value ) const;
 
@@ -54,7 +61,6 @@ public:
 
     // Recursively patches with contents of 'overrides', which must be a JSON object
     void override( json_ref overrides, std::string const & what = {} );
-
 };
 
 


### PR DESCRIPTION
Innocent-looking code like this (from PR #13185):
```
if( auto j = rsutils::json_config::load_from_file( filename ) )
    _j = std::move( j );
```
does an implicit bool conversion.

This is implemented in `json_ref` as `exists()` while the default json implementation uses an implicit templated conversion. The logic is different.

We decided to align the operator bool logic so they both behave the same: both check for existence rather than doing a conversion. It is preferable to never use implicit conversions!


