### PR TITLE
D500 IMU gyro use RAW values and scale inside the SDK

### DIFF
--- a/src/ds/d500/d500-motion.cpp
+++ b/src/ds/d500/d500-motion.cpp
@@ -32,8 +32,8 @@ namespace librealsense
 
     double d500_motion::get_gyro_default_scale() const
     {
-        // D500 devices output physical data in 0.1 [deg/sec] units.
-        return 0.1;
+        // D500 outputs raw 16 bit register value, dynamic range +/-125 [deg/sec] --> 250/65536=0.003814697265625 [deg/sec/LSB]
+        return 0.003814697265625;
     }
 
     std::shared_ptr<synthetic_sensor> d500_motion::create_hid_device( std::shared_ptr<context> ctx,


### PR DESCRIPTION
For increasing IMU Gyro sensitivity, FW will set the gyro to highest sensitivity and sent the raw data from the sensor w/o scaling it (since we have 16 bit for each field)
Scale will be done at the SDK according to Bosch ICD spec.