### PR TITLE
fix #13185 & #13192: move inline bool operator to json.h

### DIFF
--- a/third-party/rsutils/include/rsutils/json-fwd.h
+++ b/third-party/rsutils/include/rsutils/json-fwd.h
@@ -39,13 +39,7 @@ class json_base
 
 public:
     inline bool exists() const;
-    // WARNING: this "overrides" the implicit operator<T> that the *derived* class defines that does implicit casting!
-    // I.e., if
-    //      bool b = j;
-    // used the implicit conversion ('bool b = j.get< bool >();') before, now it will do:
-    //      bool b = j.exists();
-    // In general, it is preferable to NEVER use implicit value conversions and instead stick to the .get<T>() syntax.
-    operator bool() const { return exists(); }
+    inline operator bool() const;
 
     template< class T > inline T default_value( T const & default_value ) const;
 

--- a/third-party/rsutils/include/rsutils/json.h
+++ b/third-party/rsutils/include/rsutils/json.h
@@ -186,6 +186,19 @@ inline bool json_base::exists() const
     return _ref().exists();
 }
 
+
+// WARNING: this "overrides" the implicit operator<T> that the *derived* class defines that does implicit casting!
+// I.e., if
+//      bool b = j;
+// used the implicit conversion ('bool b = j.get< bool >();') before, now it will do:
+//      bool b = j.exists();
+// In general, it is preferable to NEVER use implicit value conversions and instead stick to the .get<T>() syntax.
+inline json_base::operator bool() const
+{
+    return exists();
+}
+
+
 // Get the JSON as a value, or a default if not there (throws if wrong type)
 template< class T >
 inline T json_base::default_value( T const & default_value ) const

--- a/unit-tests/py/rspy/repo.py
+++ b/unit-tests/py/rspy/repo.py
@@ -39,10 +39,10 @@ def find_pyrs():
         return None
     from rspy import file
     if platform.system() == 'Linux':
-        for so in file.find( build, '(^|/)pyrealsense2.*\.so$' ):
+        for so in file.find( build, r'(^|/)pyrealsense2.*\.so$' ):
             return os.path.join( build, so )
     else:
-        for pyd in file.find( build, '(^|/)pyrealsense2.*\.pyd$' ):
+        for pyd in file.find( build, r'(^|/)pyrealsense2.*\.pyd$' ):
             return os.path.join( build, pyd )
 
 

--- a/unit-tests/unit-test-config.py
+++ b/unit-tests/unit-test-config.py
@@ -94,11 +94,11 @@ def add_slash_before_spaces(links):
     Because spaces in links can't been read properly from cmake files.
     """
     if links and type(links) is str:
-        return links.replace(' ', '\ ')
+        return links.replace( ' ', r'\ ' )
     if links and type(links) is list:
         # Build list comprehension of strings with backslash before spaces in case the link.
         # We can get a ${var} so, when we get this we return as is
-        return [link.replace(' ', '\ ') if link[0] != '$' else link for link in links]
+        return [link.replace( ' ', r'\ ' ) if link[0] != '$' else link for link in links]
     else:
         raise TypeError
 
@@ -209,7 +209,7 @@ def process_cpp( dir, builddir ):
     if regex:
         pattern = re.compile( regex )
     log.d( 'looking for C++ files in:', dir )
-    for f in file.find( dir, '(^|/)test-.*\.cpp$' ):
+    for f in file.find( dir, r'(^|/)test-.*\.cpp$' ):
         testdir = os.path.splitext( f )[0]                          # "log/internal/test-all"  <-  "log/internal/test-all.cpp"
         testparent = os.path.dirname(testdir)                       # "log/internal"
         # We need the project name unique: keep the path but make it nicer:
@@ -257,7 +257,7 @@ def process_cpp( dir, builddir ):
             static = False
             custom_main = False
             dependencies = 'realsense2'
-            for cmake_directive in file.grep( '^//#cmake:\s*', dir + '/' + f ):
+            for cmake_directive in file.grep( r'^//#cmake:\s*', dir + '/' + f ):
                 m = cmake_directive['match']
                 index = cmake_directive['index']
                 cmd, *rest = cmake_directive['line'][m.end():].split()
@@ -281,17 +281,17 @@ def process_cpp( dir, builddir ):
                                 includes = find_includes( abs_file, includes, dependencies )
                 elif cmd == 'static!':
                     if len(rest):
-                        log.e( f + '+' + str(index) + ': unexpected arguments past \'' + cmd + '\'' )
+                        log.e( f"{f}+{index}: unexpected arguments past '{cmd}'" )
                     elif shared:
-                        log.e( f + '+' + str(index) + ': \'' + cmd + '\' mutually exclusive with \'shared!\'' )
+                        log.e( f"{f}+{index}: '{cmd}' mutually exclusive with 'shared!'" )
                     else:
                         log.d( 'static!' )
                         static = True
                 elif cmd == 'shared!':
                     if len(rest):
-                        log.e( f + '+' + str(index) + ': unexpected arguments past \'' + cmd + '\'' )
+                        log.e( f"{f}+{index}: unexpected arguments past '{cmd}'" )
                     elif static:
-                        log.e( f + '+' + str(index) + ': \'' + cmd + '\' mutually exclusive with \'static!\'' )
+                        log.e( f"{f}+{index}: '{cmd}' mutually exclusive with 'static!'" )
                     else:
                         log.d( 'shared!' )
                         shared = True
@@ -300,7 +300,7 @@ def process_cpp( dir, builddir ):
                 elif cmd == 'dependencies':
                     dependencies = ' '.join( rest )
                 else:
-                    log.e( f + '+' + str(index) + ': unknown cmd \'' + cmd + '\' (should be \'add-file\', \'static!\', or \'shared!\')' )
+                    log.e( f"{f}+{index}: unknown cmd '{cmd}' (should be 'add-file', 'static!', or 'shared!')" )
 
             # Add any includes specified in the .cpp that we can find
             includes = find_includes( dir + '/' + f, includes, dependencies )


### PR DESCRIPTION
PR #13192 caused warnings under Linux:
```
In file included from /home/jenkins/workspace/LRS_linux_compile_lib_ci/src/core/option-interface.h:8,
                 from /home/jenkins/workspace/LRS_linux_compile_lib_ci/src/option.h:5,
                 from /home/jenkins/workspace/LRS_linux_compile_lib_ci/src/source.cpp:6:
/home/jenkins/workspace/LRS_linux_compile_lib_ci/third-party/rsutils/include/rsutils/json-fwd.h:41:17: warning: inline function 'bool rsutils::json_base::exists() const' used but never defined
   41 |     inline bool exists() const;
      |                 ^~~~~~
```
Moved inline `operator bool()` to `json.h`.

Fixed additional Python `SyntaxWarning: invalid escape sequence '\ '` warnings for backslash usage with invalid following character.

