### PR TITLE
make dfu flow slower based on feedback

### DIFF
--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -116,8 +116,8 @@ rsdds_device_factory::rsdds_device_factory( std::shared_ptr< context > const & c
             // Max bytes to be sent to network per period; [1, 2147483647]; default=0 -> no limit.
             // -> We allow 256 buffers, each the size of the UDP max-message-size
             dfu_flow_control->max_bytes_per_period = 256 * 1470; // qos.transport().user_transports.front()->maxMessageSize;
-            // -> Every 100ms
-            dfu_flow_control->period_ms = 100;  // default=100
+            // -> Every 250ms
+            dfu_flow_control->period_ms = 250;  // default=100
             // Further override with settings from device/dfu
             realdds::override_flow_controller_from_json( *dfu_flow_control, dds_settings.nested( "device", "dfu" ) );
             qos.flow_controllers().push_back( dfu_flow_control );

--- a/third-party/realdds/scripts/topic-send.py
+++ b/third-party/realdds/scripts/topic-send.py
@@ -44,7 +44,7 @@ dds.debug( args.debug )
 
 max_sample_size = 1470                     # assuming ~1500 max packet size at destination IP stack
 flow_period_bytes = 256 * max_sample_size  # 256=quarter of number of buffers available at destination
-flow_period_ms = 100                       # how often to send
+flow_period_ms = 250                       # how often to send
 settings = {
     'flow-controllers': {
         'blob': {


### PR DESCRIPTION
Slow down DDS DFU transmission per Tianshu's request: every 100ms -> every 250ms.