### PR TITLE
make our own json dump available in Python

### DIFF
--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -142,6 +142,19 @@ PYBIND11_MODULE(NAME, m) {
            py::arg( "nested-string" ) = "",
            py::arg( "logger" ) = LIBREALSENSE_ELPP_ID );
 
+    m.def(
+        "json_dump",  // pretty print, using our own output; also available in pyrsutils - here for convenience
+        []( rsutils::json const & j, size_t indent )
+        {
+            std::ostringstream os;
+            if( indent )
+                os << std::setw( indent );
+            os << j;
+            return os.str();
+        },
+        py::arg( "json" ),
+        py::arg( "indent" ) = 4 );
+
     using realdds::dds_guid;
     py::class_< dds_guid >( m, "guid" )
         .def( py::init<>() )

--- a/third-party/realdds/scripts/topic-sink.py
+++ b/third-party/realdds/scripts/topic-sink.py
@@ -125,7 +125,7 @@ def on_flexible_available( reader ):
             if not s:
                 s = json.dumps( j )  # without indent
         else:
-            s = json.dumps( j, indent=4 )
+            s = dds.json_dump( j, indent=4 )
         i( f'{timestamp()} {sample} {s}', )
         got_something = True
 for topic_path in args.flexible_be or []:

--- a/third-party/rsutils/py/pyrsutils.cpp
+++ b/third-party/rsutils/py/pyrsutils.cpp
@@ -44,6 +44,18 @@ PYBIND11_MODULE(NAME, m) {
         { return rsutils::string::shorten_json_string( j.dump(), max_length ).to_string(); },
         py::arg( "json" ),
         py::arg( "max-length" ) = 96 );
+    m.def(
+        "json_dump",  // pretty print, using our own output
+        []( rsutils::json const & j, size_t indent )
+        {
+            std::ostringstream os;
+            if( indent )
+                os << std::setw( indent );
+            os << j;
+            return os.str();
+        },
+        py::arg( "json" ),
+        py::arg( "indent" ) = 4 );
     m.def( "executable_path", &rsutils::os::executable_path );
     m.def( "executable_name", &rsutils::os::executable_name, py::arg( "with_extension" ) = false );
 


### PR DESCRIPTION
Simplified output in topic-sink really helps.
`json_dump` now available from both pyrsutils and pyrealdds (people don't always have pyrsutils).