### PR TITLE
Viewer displays options in the order reported by librealsense

### DIFF
--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2620,11 +2620,11 @@ namespace rs2
 
                         std::vector<rs2_option> so_ordered;
 
-                        for (auto const & id_model : supported_options)
+                        for( auto const id_model : sub->supported_options )
                         {
-                            auto it = find( color_options.begin(), color_options.end(), id_model.first );
+                            auto it = find( color_options.begin(), color_options.end(), id_model );
                             if (it == color_options.end())
-                                so_ordered.push_back( id_model.first );
+                                so_ordered.push_back( id_model );
                         }
 
                         std::for_each( color_options.begin(),

--- a/src/core/options-container.cpp
+++ b/src/core/options-container.cpp
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2023 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #include "options-container.h"
 #include "enum-helpers.h"
@@ -12,8 +12,8 @@ namespace librealsense {
 
 const option & options_container::get_option( rs2_option id ) const
 {
-    auto it = _options.find( id );
-    if( it == _options.end() )
+    auto it = _options_by_id.find( id );
+    if( it == _options_by_id.end() )
     {
         throw invalid_value_exception( rsutils::string::from()
                                        << "option '" << get_option_name( id ) << "' not supported" );
@@ -27,17 +27,47 @@ void options_container::update( std::shared_ptr< extension_snapshot > ext )
     auto ctr = As< options_container >( ext );
     if( ! ctr )
         return;
-    for( auto && opt : ctr->_options )
+    for( auto id : ctr->_ordered_options )
     {
-        _options[opt.first] = opt.second;
+        auto & opt = _options_by_id[id];
+        if( ! opt )
+            _ordered_options.push_back( id );
+        opt = ctr->_options_by_id[id];
     }
+}
+
+
+void options_container::register_option( rs2_option id, std::shared_ptr< option > option )
+{
+    auto & opt = _options_by_id[id];
+    if( ! opt )
+        _ordered_options.push_back( id );
+    opt = option;
+    _recording_function( *this );
+}
+
+
+void options_container::unregister_option( rs2_option id )
+{
+    for( auto it = _ordered_options.begin(); it != _ordered_options.end(); ++it )
+    {
+        if( *it == id )
+        {
+            _ordered_options.erase( it );
+            break;
+        }
+    }
+    _options_by_id.erase( id );
 }
 
 
 std::vector< rs2_option > options_container::get_supported_options() const
 {
+    // Return options ordered by their ID values! This means custom options will be first!
+    // Kept for backwards compatibility with existing devices; software sensors will return the _ordered_options
+
     std::vector< rs2_option > options;
-    for( auto option : _options )
+    for( auto option : _options_by_id )
         options.push_back( option.first );
 
     return options;

--- a/src/software-sensor.cpp
+++ b/src/software-sensor.cpp
@@ -395,4 +395,12 @@ void software_sensor::add_processing_block( std::shared_ptr< processing_block_in
 }
 
 
+std::vector< rs2_option > software_sensor::get_supported_options() const
+{
+    // Override the default options_container behavior: software sensors return the options in the same order they were
+    // registered!
+    return _ordered_options;
+}
+
+
 }  // namespace librealsense

--- a/src/software-sensor.h
+++ b/src/software-sensor.h
@@ -53,6 +53,10 @@ public:
     void set_metadata( rs2_frame_metadata_value key, rs2_metadata_type value );
     void erase_metadata( rs2_frame_metadata_value key );
 
+    // options_container
+public:
+    std::vector< rs2_option > get_supported_options() const override;
+
 protected:
     frame_interface * allocate_new_frame( rs2_extension, stream_profile_interface *, frame_additional_data && );
     frame_interface * allocate_new_video_frame( video_stream_profile_interface *, int stride, int bpp, frame_additional_data && );


### PR DESCRIPTION
SW devices now give options in the same order they were registered.
I.e., DDS devices will follow the order provided by the camera.
