### PR TITLE
calibration-changed behavior under dds for thermal compensation

### DIFF
--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -394,6 +394,24 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
         !strcmp(get_info(RS2_CAMERA_INFO_PRODUCT_LINE).c_str(), "D500"))
         set_auto_calibration_capability(std::make_shared<d500_auto_calibrated>(
             std::make_shared<d500_debug_protocol_calibration_engine>(this)));
+            
+    _calibration_changed_subscription = _dds_dev->on_calibration_changed(
+        [this]( std::shared_ptr< const realdds::dds_stream > const & stream )
+        {
+            auto it = _stream_name_to_profiles.find( stream->name() );
+            if( it == _stream_name_to_profiles.end() )
+                throw std::runtime_error( rsutils::string::from() << "no such stream?!" );
+
+            if( auto video_stream = std::dynamic_pointer_cast< const realdds::dds_video_stream >( stream ) )
+            {
+                for( auto & profile : it->second )
+                    set_video_profile_intrinsics( profile, video_stream );
+            }
+            else
+            {
+                throw std::runtime_error( rsutils::string::from() << "non-video stream calibrations not supported" );
+            }
+        } );
 }
 
 
@@ -412,7 +430,7 @@ int dds_device_proxy::get_index_from_stream_name( const std::string & name ) con
 }
 
 
-void dds_device_proxy::set_profile_intrinsics( std::shared_ptr< stream_profile_interface > & profile,
+void dds_device_proxy::set_profile_intrinsics( std::shared_ptr< stream_profile_interface > const & profile,
                                                const std::shared_ptr< realdds::dds_stream > & stream ) const
 {
     if( auto video_stream = std::dynamic_pointer_cast< realdds::dds_video_stream >( stream ) )
@@ -426,8 +444,8 @@ void dds_device_proxy::set_profile_intrinsics( std::shared_ptr< stream_profile_i
 }
 
 
-void dds_device_proxy::set_video_profile_intrinsics( std::shared_ptr< stream_profile_interface > profile,
-                                                     std::shared_ptr< realdds::dds_video_stream > stream ) const
+void dds_device_proxy::set_video_profile_intrinsics( std::shared_ptr< stream_profile_interface > const & profile,
+                                                     std::shared_ptr< const realdds::dds_video_stream > const & stream ) const
 {
     auto vsp = std::dynamic_pointer_cast< video_stream_profile >( profile );
     int const w = vsp->get_width();
@@ -437,8 +455,8 @@ void dds_device_proxy::set_video_profile_intrinsics( std::shared_ptr< stream_pro
     if( 1 == stream_intrinsics.size() )
     {
         // A single set of intrinsics will get scaled to any profile resolution
-        vsp->set_intrinsics( [intrinsics = *stream_intrinsics.begin(), w, h]()
-                             { return to_rs2_intrinsics( intrinsics.scaled_to( w, h ) ); } );
+        auto intr = stream_intrinsics.begin()->scaled_to( w, h );
+        vsp->set_intrinsics( [intr = to_rs2_intrinsics( intr )]() { return intr; } );
     }
     else
     {

--- a/src/dds/rs-dds-device-proxy.h
+++ b/src/dds/rs-dds-device-proxy.h
@@ -8,6 +8,8 @@
 #include "sid_index.h"
 #include "rsdds-serializable.h"
 #include <src/auto-calibrated-proxy.h>
+
+#include <rsutils/json-fwd.h>
 #include <memory>
 #include <vector>
 
@@ -48,14 +50,15 @@ class dds_device_proxy
     std::map< std::string, std::vector< std::shared_ptr< stream_profile_interface > > > _stream_name_to_profiles;
     std::map< std::string, std::shared_ptr< librealsense::stream > > _stream_name_to_librs_stream;
     std::map< std::string, std::shared_ptr< dds_sensor_proxy > > _stream_name_to_owning_sensor;
-
+    
+    rsutils::subscription _calibration_changed_subscription;
     rsutils::subscription _metadata_subscription;
 
     int get_index_from_stream_name( const std::string & name ) const;
-    void set_profile_intrinsics( std::shared_ptr< stream_profile_interface > & profile,
+    void set_profile_intrinsics( std::shared_ptr< stream_profile_interface > const & profile,
                                  const std::shared_ptr< realdds::dds_stream > & stream ) const;
-    void set_video_profile_intrinsics( std::shared_ptr< stream_profile_interface > profile,
-                                       std::shared_ptr< realdds::dds_video_stream > stream ) const;
+    void set_video_profile_intrinsics( std::shared_ptr< stream_profile_interface > const & profile,
+                                       std::shared_ptr< const realdds::dds_video_stream > const & stream ) const;
     void set_motion_profile_intrinsics( std::shared_ptr< stream_profile_interface > profile,
                                        std::shared_ptr< realdds::dds_motion_stream > stream ) const;
 

--- a/src/ds/ds-private.h
+++ b/src/ds/ds-private.h
@@ -318,6 +318,16 @@ namespace librealsense
                                                << "Calibration data invalid, buffer too small : expected "
                                                << sizeof( table_header ) << " , actual: " << raw_data.size() );
             }
+
+            // Make sure the table size does not exceed the actual data we have!
+            if( header->table_size + sizeof( table_header ) > raw_data.size() )
+            {
+                throw invalid_value_exception( rsutils::string::from()
+                                               << "Calibration table size does not fit inside reply: expected "
+                                               << ( raw_data.size() - sizeof( table_header ) ) << " but got "
+                                               << header->table_size );
+            }
+
             // verify the parsed table
             if (table->header.crc32 != rsutils::number::calc_crc32(raw_data.data() + sizeof(table_header), raw_data.size() - sizeof(table_header)))
             {

--- a/third-party/realdds/doc/notifications.md
+++ b/third-party/realdds/doc/notifications.md
@@ -90,3 +90,29 @@ Combining multiple log notifications can be done by packaging them together into
 Anybody can write to the notifications topic; but only a single participant is ever the real device - this is the participant from which the [device-info](discovery.md) was published.
 
 It is recommended that the device implementation on the Client ignore notifications that do not originate from this participant.
+
+
+# Notification Messages
+
+## `calibration-changed`
+
+Sent when clients need to be updated that internal camera calibration values have changed. Usually this can happen due to temperature fluctuations, especially while streaming.
+
+```JSON
+{
+    "id": "calibration-changed",
+    "Depth" : {
+        "intrinsics": {
+            "focal-length": [631.3428955078125,631.3428955078125]
+        }
+    },
+    "Infrared" : { ... },
+    "Infrared_2" : { ... }
+}
+```
+
+- Each stream for which calibration values change needs to be included by name
+- For each stream, the same format is used as by the [Initialization](initialization.md) message `stream-options`
+    - The intrinsics `width` and `height` are not expected to change
+
+The client is expected to take these new values into consideration when performing any calculations post-update.

--- a/third-party/realdds/include/realdds/dds-device.h
+++ b/third-party/realdds/include/realdds/dds-device.h
@@ -99,6 +99,9 @@ public:
     typedef std::function< void( std::string const & id, rsutils::json const & ) > on_notification_callback;
     rsutils::subscription on_notification( on_notification_callback && );
 
+    typedef std::function< void( std::shared_ptr< const dds_stream > const & ) > on_calibration_changed_callback;
+    rsutils::subscription on_calibration_changed( on_calibration_changed_callback && );
+
     // dds_discovery_sink
 protected:
     void on_discovery_lost() override;

--- a/third-party/realdds/include/realdds/dds-stream.h
+++ b/third-party/realdds/include/realdds/dds-stream.h
@@ -70,7 +70,7 @@ public:
     typedef std::function< void( topics::image_msg &&, dds_sample && ) > on_data_available_callback;
     void on_data_available( on_data_available_callback cb ) { _on_data_available = cb; }
 
-    void set_intrinsics( const std::set< video_intrinsics > & intrinsics ) { _intrinsics = intrinsics; }
+    void set_intrinsics( std::set< video_intrinsics > intrinsics ) { _intrinsics = std::move( intrinsics ); }
     const std::set< video_intrinsics > & get_intrinsics() const { return _intrinsics; }
 
 protected:

--- a/third-party/realdds/include/realdds/dds-trinsics.h
+++ b/third-party/realdds/include/realdds/dds-trinsics.h
@@ -51,6 +51,7 @@ struct video_intrinsics
     float2 principal_point = { 0, 0 };                 // Pixel offset from top-left edge
     float2 focal_length = { 0, 0 };                    // As a multiple of pixel width and height
     distortion_parameters distortion = { distortion_model::none, { 0 } };
+    bool force_symmetry = false;
 
     bool is_valid() const { return focal_length.x > 0 && focal_length.y > 0; }
 
@@ -63,7 +64,7 @@ struct video_intrinsics
     video_intrinsics scaled_to( int width, int height ) const;
 
     rsutils::json to_json() const;
-    static video_intrinsics from_json( rsutils::json const & j );
+    static video_intrinsics from_json( rsutils::json const & );
 };
 
 std::ostream & operator<<( std::ostream &, video_intrinsics const & );

--- a/third-party/realdds/include/realdds/dds-trinsics.h
+++ b/third-party/realdds/include/realdds/dds-trinsics.h
@@ -34,6 +34,15 @@ struct distortion_parameters
 {
     distortion_model model;
     std::array< float, 5 > coeffs;
+
+    bool operator==( distortion_parameters const & other ) const
+    {
+        return model == other.model && coeffs == other.coeffs;
+    }
+    bool operator!=( distortion_parameters const & other ) const
+    {
+        return model != other.model || coeffs != other.coeffs;
+    }
 };
 
 std::ostream & operator<<( std::ostream &, distortion_parameters const & );
@@ -60,6 +69,13 @@ struct video_intrinsics
         // Arrange the intrinsics in order of increasing resolution (width then height)
         return width < rhs.width || ( width == rhs.width && height < rhs.height );
     }
+    bool operator==( video_intrinsics const & other ) const
+    {
+        return width == other.width && height == other.height && principal_point == other.principal_point
+            && focal_length == other.focal_length && distortion == other.distortion
+            && force_symmetry == other.force_symmetry;
+    }
+    bool operator!=( video_intrinsics const & other ) const { return ! operator==( other ); }
 
     video_intrinsics scaled_to( int width, int height ) const;
 
@@ -83,6 +99,12 @@ struct motion_intrinsics
 
     rsutils::json to_json() const;
     static motion_intrinsics from_json( rsutils::json const & j );
+
+    bool operator!=( motion_intrinsics const & other ) const
+    {
+        return data != other.data || noise_variances != other.noise_variances || bias_variances != other.bias_variances;
+    }
+    bool operator==( motion_intrinsics const & other ) const { return ! operator!=( other ); }
 };
 
 

--- a/third-party/realdds/include/realdds/dds-trinsics.h
+++ b/third-party/realdds/include/realdds/dds-trinsics.h
@@ -63,8 +63,11 @@ struct video_intrinsics
 
     video_intrinsics scaled_to( int width, int height ) const;
 
+    static distortion_parameters distortion_from_json( rsutils::json const & );
+
     rsutils::json to_json() const;
     static video_intrinsics from_json( rsutils::json const & );
+    void override_from_json( rsutils::json const & );
 };
 
 std::ostream & operator<<( std::ostream &, video_intrinsics const & );

--- a/third-party/realdds/include/realdds/topics/dds-topic-names.h
+++ b/third-party/realdds/include/realdds/topics/dds-topic-names.h
@@ -99,6 +99,15 @@ namespace notification {
             extern std::string const progress;
         }
     }
+    namespace calibration_changed {
+        extern std::string const id;
+        namespace key {
+            using stream_options::key::intrinsics;
+        }
+        namespace intrinsics {
+            using namespace stream_options::intrinsics;
+        }
+    }
 }
 
 namespace control {

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -967,6 +967,7 @@ PYBIND11_MODULE(NAME, m) {
         video_stream_client_base( m, "video_stream", stream_client_base );
     video_stream_client_base  //
         .def( "set_intrinsics", &dds_video_stream::set_intrinsics )
+        .def( "get_intrinsics", &dds_video_stream::get_intrinsics )
         .def( FN_FWD( dds_video_stream,
                       on_data_available,
                       ( dds_video_stream &, image_msg &&, dds_sample && ),

--- a/third-party/realdds/src/dds-device-impl.cpp
+++ b/third-party/realdds/src/dds-device-impl.cpp
@@ -149,6 +149,7 @@ void dds_device::impl::on_notification( json && j, dds_sample const & notificati
         { topics::notification::stream_header::id, &dds_device::impl::on_stream_header },
         { topics::notification::stream_options::id, &dds_device::impl::on_stream_options },
         { topics::notification::log::id, &dds_device::impl::on_log },
+        { topics::notification::calibration_changed::id, &dds_device::impl::on_calibration_changed },
     };
 
     auto const control = j.nested( topics::reply::key::control );
@@ -749,6 +750,60 @@ void dds_device::impl::on_stream_options( json const & j, dds_sample const & sam
         set_state( state_t::READY );
     else
         set_state( state_t::WAIT_FOR_STREAM_HEADER );
+}
+
+
+void dds_device::impl::on_calibration_changed( json const & j, dds_sample const & sample )
+{
+    for( auto const & name_stream : _streams )
+    {
+        auto & stream = name_stream.second;
+
+        auto j_int = j.nested( stream->name(), topics::notification::calibration_changed::key::intrinsics );
+        if( ! j_int )
+            continue;  // stream isn't updated
+
+        try
+        {
+            auto video_stream = std::dynamic_pointer_cast< dds_video_stream >( stream );
+            if( ! video_stream )
+                DDS_THROW( runtime_error, "not a video stream" );
+
+            auto const & old_intrinsics = video_stream->get_intrinsics();
+            std::set< video_intrinsics > new_intrinsics;
+            if( j_int.is_array() )
+            {
+                // Multiple resolutions are provided, likely from legacy devices from the adapter
+                if( j_int.size() != old_intrinsics.size() )
+                    DDS_THROW( runtime_error, "expecting " << old_intrinsics.size() << " intrinsics; got: " << j_int );
+                for( auto & ij : j_int )
+                {
+                    auto i = video_intrinsics::from_json( ij );
+                    auto it = old_intrinsics.find( i );  // uses width & height only
+                    if( it == old_intrinsics.end() )
+                        DDS_THROW( runtime_error, "intrinsics not found: " << ij );
+                    if( ! new_intrinsics.insert( std::move( i ) ).second )
+                        DDS_THROW( runtime_error, "width & height specified twice: " << ij );
+                }
+                LOG_DEBUG( "calibration-changed '" << stream->name() << "': changing " << j_int );
+            }
+            else
+            {
+                // Single intrinsics that will get scaled
+                auto i = *old_intrinsics.begin();
+                i.override_from_json( j_int );
+                LOG_DEBUG( "calibration-changed '" << stream->name() << "': changing " << j_int << " --> " << i );
+                new_intrinsics.insert( std::move( i ) );
+            }
+
+            video_stream->set_intrinsics( std::move( new_intrinsics ) );
+            _on_calibration_changed.raise( stream );
+        }
+        catch( std::exception const & e )
+        {
+            LOG_ERROR( "calibration-changed '" << stream->name() << "': " << e.what() );
+        }
+    }
 }
 
 

--- a/third-party/realdds/src/dds-device-impl.h
+++ b/third-party/realdds/src/dds-device-impl.h
@@ -109,6 +109,12 @@ public:
     {
         return _on_notification.subscribe( std::move( cb ) );
     }
+    using on_calibration_changed_signal = rsutils::signal< std::shared_ptr< const realdds::dds_stream > const & >;
+    using on_calibration_changed_callback = on_calibration_changed_signal::callback;
+    rsutils::subscription on_calibration_changed( on_calibration_changed_callback && cb )
+    {
+        return _on_calibration_changed.subscribe( std::move( cb ) );
+    }
 
 private:
     void create_notifications_reader();
@@ -124,12 +130,14 @@ private:
     void on_device_options( rsutils::json const &, dds_sample const & );
     void on_stream_header( rsutils::json const &, dds_sample const & );
     void on_stream_options( rsutils::json const &, dds_sample const & );
+    void on_calibration_changed( rsutils::json const &, dds_sample const & );
 
     void on_notification( rsutils::json &&, dds_sample const & );
 
     on_metadata_available_signal _on_metadata_available;
     on_device_log_signal _on_device_log;
     on_notification_signal _on_notification;
+    on_calibration_changed_signal _on_calibration_changed;
 };
 
 

--- a/third-party/realdds/src/dds-device.cpp
+++ b/third-party/realdds/src/dds-device.cpp
@@ -244,6 +244,11 @@ rsutils::subscription dds_device::on_notification( on_notification_callback && c
     return _impl->on_notification( std::move( cb ) );
 }
 
+rsutils::subscription dds_device::on_calibration_changed( on_calibration_changed_callback && cb )
+{
+    return _impl->on_calibration_changed( std::move( cb ) );
+}
+
 
 bool dds_device::check_reply( json const & reply, std::string * p_explanation )
 {

--- a/third-party/realdds/src/dds-trinsics.cpp
+++ b/third-party/realdds/src/dds-trinsics.cpp
@@ -49,7 +49,8 @@ std::ostream & operator<<( std::ostream & os, distortion_parameters const & p )
     case distortion_model::brown:
     case distortion_model::inverse_brown:
     case distortion_model::modified_brown:
-        os << ":" << p.coeffs[0] << ',' << p.coeffs[1] << ',' << p.coeffs[2] << ',' << p.coeffs[3] << ',' << p.coeffs[4];
+        os << "[" << p.coeffs[0] << ',' << p.coeffs[1] << ',' << p.coeffs[2] << ',' << p.coeffs[3] << ',' << p.coeffs[4]
+           << "]";
         break;
     }
     return os;
@@ -58,8 +59,13 @@ std::ostream & operator<<( std::ostream & os, distortion_parameters const & p )
 
 std::ostream & operator<<( std::ostream & os, video_intrinsics const & self )
 {
-    return os << self.width << 'x' << self.height << " pp[" << self.principal_point.x << ',' << self.principal_point.y
-              << "] fl[" << self.focal_length.x << ',' << self.focal_length.y << "] distortion[" << self.distortion << "]";
+    os << self.width << 'x' << self.height;
+    os << " pp[" << self.principal_point.x << ',' << self.principal_point.y << "]";
+    os << " fl[" << self.focal_length.x << ',' << self.focal_length.y << "]";
+    os << " " << self.distortion;
+    if( self.force_symmetry )
+        os << " force-symmetry";
+    return os;
 }
 
 
@@ -93,14 +99,17 @@ json video_intrinsics::to_json() const
     default:
         DDS_THROW( runtime_error, "unknown distortion model: " << int( distortion.model ) );
     }
+    if( force_symmetry )
+        j[topics::notification::stream_options::intrinsics::key::force_symmetry] = true;
     return j;
 }
 
-/* static  */ video_intrinsics video_intrinsics::from_json( json const & j )
+/* static */ video_intrinsics video_intrinsics::from_json( json const & j )
 {
     video_intrinsics ret;
     if( j.is_array() )
     {
+        // Legacy format; should be removed
         int index = 0;
 
         ret.width = j[index++].get< int >();
@@ -141,20 +150,24 @@ json video_intrinsics::to_json() const
     }
     else if( j.is_object() )
     {
+        using namespace topics::notification::stream_options::intrinsics;
+
         // The intrinsics are communicated in an object:
         //    - A `width` and `height` are for the native stream resolution, as 16 - bit integer values
         //    - A `principal-point` defined as `[<x>, <y>]` floating point values
         //    - A `focal-length`, also as `[<x>, <y>]` floats
-        j.nested( topics::notification::stream_options::intrinsics::key::width ).get_to( ret.width );
-        j.nested( topics::notification::stream_options::intrinsics::key::height ).get_to( ret.height );
-        j.nested( topics::notification::stream_options::intrinsics::key::principal_point ).get_to( ret.principal_point );
-        j.nested( topics::notification::stream_options::intrinsics::key::focal_length ).get_to( ret.focal_length );
+        j.nested( key::width ).get_to( ret.width );
+        j.nested( key::height ).get_to( ret.height );
+        j.nested( key::principal_point ).get_to( ret.principal_point );
+        j.nested( key::focal_length ).get_to( ret.focal_length );
+        //    - Symmetry affects how the intrinsics are scaled to different resolutions
+        ret.force_symmetry = j.nested( key::force_symmetry ).default_value( false );
         // A distortion model may be applied:
         //    - The `model` would specify which model is to be used, with the default of `brown`
         //    - The `coefficients` is an array of floating point values, the number and meaning which depend on the `model`
         //    - For `brown`, 5 points [k1, k2, p1, p2, k3] are needed
-        auto coeffs_j = j.nested( topics::notification::stream_options::intrinsics::key::coefficients );
-        auto model_j = j.nested( topics::notification::stream_options::intrinsics::key::model );
+        auto coeffs_j = j.nested( key::coefficients );
+        auto model_j = j.nested( key::model );
         switch( model_j.type() )
         {
         case json::value_t::discarded:
@@ -284,6 +297,9 @@ json extrinsics::to_json() const
 }
 
 
+// Scale video intrinsics at some nominal resolution to another.
+// The algo is the latest as implemented for D500 devices, and adapted from there.
+//
 video_intrinsics video_intrinsics::scaled_to( int const new_width, int const new_height ) const
 {
     if( ! width || ! height )
@@ -291,7 +307,6 @@ video_intrinsics video_intrinsics::scaled_to( int const new_width, int const new
 
     video_intrinsics scaled( *this );
 
-    bool const force_symmetry = false;  // TODO
     if( force_symmetry )
     {
         // Cropping the frame so that the principal point is at the middle

--- a/third-party/realdds/src/dds-trinsics.cpp
+++ b/third-party/realdds/src/dds-trinsics.cpp
@@ -160,66 +160,103 @@ json video_intrinsics::to_json() const
         j.nested( key::height ).get_to( ret.height );
         j.nested( key::principal_point ).get_to( ret.principal_point );
         j.nested( key::focal_length ).get_to( ret.focal_length );
+
         //    - Symmetry affects how the intrinsics are scaled to different resolutions
         ret.force_symmetry = j.nested( key::force_symmetry ).default_value( false );
-        // A distortion model may be applied:
-        //    - The `model` would specify which model is to be used, with the default of `brown`
-        //    - The `coefficients` is an array of floating point values, the number and meaning which depend on the `model`
-        //    - For `brown`, 5 points [k1, k2, p1, p2, k3] are needed
-        auto coeffs_j = j.nested( key::coefficients );
-        auto model_j = j.nested( key::model );
-        switch( model_j.type() )
-        {
-        case json::value_t::discarded:
-            if( coeffs_j.is_array() && coeffs_j.size() == 5 )
-                ret.distortion.model = distortion_model::brown;
-            else
-                ret.distortion.model = distortion_model::none;
-            break;
 
-        case json::value_t::string:
-            if( "brown" == model_j.string_ref() )
-                ret.distortion.model = distortion_model::brown;
-            else if( "none" == model_j.string_ref() )
-                ret.distortion.model = distortion_model::none;
-            else if( "inverse-brown" == model_j.string_ref() )
-                ret.distortion.model = distortion_model::inverse_brown;
-            else if( "modified-brown" == model_j.string_ref() )
-                ret.distortion.model = distortion_model::modified_brown;
-            else
-                DDS_THROW( runtime_error, "unknown distortion model: " << model_j );
-            break;
-
-        default:
-            DDS_THROW( runtime_error, "invalid distortion model: " << model_j );
-        }
-        switch( ret.distortion.model )
-        {
-        case distortion_model::none:
-            if( coeffs_j )
-                DDS_THROW( runtime_error, "distortion coefficients without a model" );
-            ret.distortion.coeffs = { 0 };
-            break;
-
-        case distortion_model::brown:
-        case distortion_model::inverse_brown:
-        case distortion_model::modified_brown:
-            if( ! coeffs_j.is_array() )
-                DDS_THROW( runtime_error, "invalid distortion coefficients: " << coeffs_j );
-            if( coeffs_j.size() != 5 )
-                DDS_THROW( runtime_error, "distortion coefficients expected [k1,k2,p1,p2,k3]: " << coeffs_j );
-            coeffs_j.get_to( ret.distortion.coeffs );
-            break;
-
-        default:
-            DDS_THROW( runtime_error, "invalid distortion model" );
-        }
+        // A distortion model default to none
+        ret.distortion = distortion_from_json( j );
     }
     else
         DDS_THROW( runtime_error, "unspected intrinsics json: " << j );
 
     return ret;
 }
+
+
+/*static */ distortion_parameters video_intrinsics::distortion_from_json( rsutils::json const & j )
+{
+    distortion_parameters result;
+    using namespace topics::notification::stream_options::intrinsics;
+
+    // A distortion model may be applied:
+    //    - The `model` would specify which model is to be used, with the default of `brown`
+    //    - The `coefficients` is an array of floating point values, the number and meaning which depend on the `model`
+    //    - For `brown`, 5 points [k1, k2, p1, p2, k3] are needed
+    auto coeffs_j = j.nested( key::coefficients );
+    auto model_j = j.nested( key::model );
+    switch( model_j.type() )
+    {
+    case json::value_t::discarded:
+        if( coeffs_j.is_array() && coeffs_j.size() == 5 )
+            result.model = distortion_model::brown;
+        else
+            result.model = distortion_model::none;
+        break;
+
+    case json::value_t::string:
+        if( "brown" == model_j.string_ref() )
+            result.model = distortion_model::brown;
+        else if( "none" == model_j.string_ref() )
+            result.model = distortion_model::none;
+        else if( "inverse-brown" == model_j.string_ref() )
+            result.model = distortion_model::inverse_brown;
+        else if( "modified-brown" == model_j.string_ref() )
+            result.model = distortion_model::modified_brown;
+        else
+            DDS_THROW( runtime_error, "unknown distortion model: " << model_j );
+        break;
+
+    default:
+        DDS_THROW( runtime_error, "invalid distortion model: " << model_j );
+    }
+    switch( result.model )
+    {
+    case distortion_model::none:
+        if( coeffs_j )
+            DDS_THROW( runtime_error, "distortion coefficients without a model" );
+        result.coeffs = { 0 };
+        break;
+
+    case distortion_model::brown:
+    case distortion_model::inverse_brown:
+    case distortion_model::modified_brown:
+        if( !coeffs_j.is_array() )
+            DDS_THROW( runtime_error, "invalid distortion coefficients: " << coeffs_j );
+        if( coeffs_j.size() != 5 )
+            DDS_THROW( runtime_error, "distortion coefficients expected [k1,k2,p1,p2,k3]: " << coeffs_j );
+        coeffs_j.get_to( result.coeffs );
+        break;
+
+    default:
+        DDS_THROW( runtime_error, "invalid distortion model" );
+    }
+
+    return result;
+}
+
+
+void video_intrinsics::override_from_json( json const & j )
+{
+    if( ! j.is_object() )
+        DDS_THROW( runtime_error, "cannot override intrinsics if not an object: " << j );
+
+    using namespace topics::notification::calibration_changed::intrinsics;
+
+    int w, h;
+    if( j.nested( key::width ).get_ex( w ) && w != width )
+        DDS_THROW( runtime_error, "intrinsics should not change width" );
+    if( j.nested( key::height ).get_ex( h ) && h != height )
+        DDS_THROW( runtime_error, "intrinsics should not change height" );
+
+    j.nested( key::principal_point ).get_ex( principal_point );
+    j.nested( key::focal_length ).get_ex( focal_length );
+    j.nested( key::force_symmetry ).get_ex( force_symmetry );
+
+    if( j.nested( key::coefficients ) || j.nested( key::model ) )
+        distortion = distortion_from_json( j );
+}
+
 
 json motion_intrinsics::to_json() const
 {

--- a/third-party/realdds/src/topics/dds-topic-names.cpp
+++ b/third-party/realdds/src/topics/dds-topic-names.cpp
@@ -81,6 +81,15 @@ namespace notification {
             std::string const progress( "progress", 8 );
         }
     }
+    namespace calibration_changed {
+        std::string const id( "calibration-changed", 19 );
+        //namespace key {
+        //    using stream_options::key::intrinsics;
+        //}
+        //namespace intrinsics {
+        //    using namespace stream_options::intrinsics;
+        //}
+    }
 }
 
 namespace control {

--- a/third-party/rsutils/include/rsutils/number/float3.h
+++ b/third-party/rsutils/include/rsutils/number/float3.h
@@ -33,6 +33,9 @@ struct float2
     }
     float length() const;
     float2 normalized() const;
+
+    bool operator==( float2 const & other ) const { return x == other.x && y == other.y; }
+    bool operator!=( float2 const & other ) const { return x != other.x || y != other.y; }
 };
 struct float3
 {

--- a/tools/dds/dds-adapter/lrs-device-controller.h
+++ b/tools/dds/dds-adapter/lrs-device-controller.h
@@ -39,6 +39,7 @@ public:
 
 private:
     std::vector< std::shared_ptr< realdds::dds_stream_server > > get_supported_streams();
+    bool update_stream_trinsics( rsutils::json * p_changes = nullptr );
 
     void publish_frame_metadata( const rs2::frame & f, realdds::dds_time const & );
 


### PR DESCRIPTION
- Intercept `calibration-changed` messages in DDS device and raise notification
- Intercept in device-proxy and update profile intrinsics
- The adapter now responds to calibration-changed events and communicates over DDS
    - Note this uses the "old" intrinsics format (array, one per resolution)
- Both "old" and "new" (one master resolution that is then scaled) are supported

Tracked on [RSDEV-2379]