### PR TITLE
Validate option setting for calibrations

### DIFF
--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -132,6 +132,9 @@ namespace rs2
         if( it != _sub->options_metadata.end() )  // Option supported
         {
             it->second.set_option( RS2_OPTION_EMITTER_ENABLED, value, ignored_error_message );
+            if( it->second.value_as_float() != value )
+                throw std::runtime_error( rsutils::string::from()
+                                          << "Failed to set laser " << ( value == off_value ? "off" : "on" ) );
         }
     }
 
@@ -143,6 +146,9 @@ namespace rs2
         if( it != _sub->options_metadata.end() )  // Option supported
         {
             it->second.set_option( RS2_OPTION_THERMAL_COMPENSATION, value, ignored_error_message );
+            if( it->second.value_as_float() != value )
+                throw std::runtime_error( rsutils::string::from()
+                                          << "Failed to set laser " << ( value == off_value ? "off" : "on" ) );
         }
     }
 

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -486,7 +486,7 @@ bool option_model::draw_slider( notifications_model & model,
             {
                 buff_str = convert_float_str( buff_str, 0.01f );
                 memset( buff, 0, TEXT_BUFF_SIZE );
-                strcpy( buff, buff_str.c_str() );
+                strncpy( buff, buff_str.c_str(), TEXT_BUFF_SIZE - 1 );
             }
             edit_value = buff;
         }


### PR DESCRIPTION
We saw one time that running FL calibration laser have stayed on even though we sent a command to turn it off.
Added getting actual value after setting and terminating the calibration if not set properly.

Also fix a small Coverity issue - limit copy to string size + keep last byte as terminating null.
