### PR TITLE
issue-13304: fix a potential out of bound access

### DIFF
--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -4179,9 +4179,9 @@ bool is_pixel_in_line(const float curr[2], const float start[2], const float end
 void adjust_2D_point_to_boundary(float p[2], int width, int height)
 {
     if (p[0] < 0) p[0] = 0;
-    if (p[0] >= width) p[0] = (float)width - 1;
+    if (p[0] > width) p[0] = (float)width - 1e-10; // to make sure int(p[0]) + int(p[1])* width stay within [data, data + width * height)
     if (p[1] < 0) p[1] = 0;
-    if (p[1] >= height) p[1] = (float)height - 1;
+    if (p[1] > height) p[1] = (float)height - 1e-10; // to make sure int(p[0]) + int(p[1])* width stay within [data, data + width * height)
 }
 
 


### PR DESCRIPTION
This is to fix the issue mentioned in #13304

adjust_2D_point_to_boundry should make sure the returned p[] is safe to be used as array access index inside rs2_project_color_pixel_to_depth_pixel.

The current code will cause an out of bound access when the size of the data array is exactly width * height and the passed in input happened to be mapped to y >= height (or when y == height - 1 but x == width).

