### PR TITLE
Adding OCC and Tare calibration flows to D555

### DIFF
--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -111,7 +111,7 @@ namespace rs2
     }
 
     d500_autocalib_notification_model::d500_autocalib_notification_model(std::string name, 
-        std::shared_ptr<d500_on_chip_calib_manager> manager, bool exp)
+        std::shared_ptr<process_manager> manager, bool exp)
         : process_notification_model(manager)
     {
         enable_expand = false;

--- a/common/d500-on-chip-calib.h
+++ b/common/d500-on-chip-calib.h
@@ -85,7 +85,7 @@ namespace rs2
             RS2_CALIB_STATE_ABORT_CALLED
         };
 
-        d500_autocalib_notification_model(std::string name, std::shared_ptr<d500_on_chip_calib_manager> manager, bool expaned);
+        d500_autocalib_notification_model(std::string name, std::shared_ptr<process_manager> manager, bool expaned);
 
         d500_on_chip_calib_manager& get_manager() { return *std::dynamic_pointer_cast<d500_on_chip_calib_manager>(update_manager); }
         void draw_content(ux_window& win, int x, int y, float t, std::string& error_message) override;

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -3366,6 +3366,7 @@ namespace rs2
                         std::shared_ptr< process_notification_model > n;
                         if( is_d555 )
                         {
+                            // D555 OHM is same as D455, using D400 calibration algorithms.
                             manager = std::make_shared< on_chip_calib_manager >( viewer, sub, *this, dev );
                             n = std::make_shared< autocalib_notification_model >( "", manager, false );
                         }

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -3130,7 +3130,7 @@ namespace rs2
         }
     }
 
-    autocalib_notification_model::autocalib_notification_model(std::string name, std::shared_ptr<on_chip_calib_manager> manager, bool exp)
+    autocalib_notification_model::autocalib_notification_model(std::string name, std::shared_ptr<process_manager> manager, bool exp)
         : process_notification_model(manager)
     {
         enable_expand = false;

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -199,7 +199,7 @@ namespace rs2
             RS2_CALIB_STATE_FL_PLUS_INPUT,        // Collect input parameters for focal length plus calib
         };
 
-        autocalib_notification_model(std::string name, std::shared_ptr<on_chip_calib_manager> manager, bool expaned);
+        autocalib_notification_model(std::string name, std::shared_ptr<process_manager> manager, bool expaned);
 
         on_chip_calib_manager& get_manager() { return *std::dynamic_pointer_cast<on_chip_calib_manager>(update_manager); }
 

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -390,11 +390,19 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
     }
     set_matcher_type( matcher );
 
-    if (supports_info(RS2_CAMERA_INFO_PRODUCT_LINE) && 
-        !strcmp(get_info(RS2_CAMERA_INFO_PRODUCT_LINE).c_str(), "D500"))
+    if( supports_info( RS2_CAMERA_INFO_PRODUCT_LINE )
+        && ! strcmp( get_info( RS2_CAMERA_INFO_PRODUCT_LINE ).c_str(), "D500" ) )
+    {
+        // Find depth sensor to pass into d500_auto_calibrated object
+        sensor_base * depth_sensor = nullptr;
+        for( auto & sensor : sensor_name_to_info )
+            if( sensor.second.type == RS2_STREAM_DEPTH )
+                depth_sensor = sensor.second.proxy.get();
+
         set_auto_calibration_capability( std::make_shared< d500_auto_calibrated >(
-            std::make_shared< d500_debug_protocol_calibration_engine >( this ), this ) );
-            
+            std::make_shared< d500_debug_protocol_calibration_engine >( this ), this, depth_sensor ) );
+    }
+
     _calibration_changed_subscription = _dds_dev->on_calibration_changed(
         [this]( std::shared_ptr< const realdds::dds_stream > const & stream )
         {

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -392,8 +392,8 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
 
     if (supports_info(RS2_CAMERA_INFO_PRODUCT_LINE) && 
         !strcmp(get_info(RS2_CAMERA_INFO_PRODUCT_LINE).c_str(), "D500"))
-        set_auto_calibration_capability(std::make_shared<d500_auto_calibrated>(
-            std::make_shared<d500_debug_protocol_calibration_engine>(this)));
+        set_auto_calibration_capability( std::make_shared< d500_auto_calibrated >(
+            std::make_shared< d500_debug_protocol_calibration_engine >( this ), this ) );
             
     _calibration_changed_subscription = _dds_dev->on_calibration_changed(
         [this]( std::shared_ptr< const realdds::dds_stream > const & stream )

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -5,6 +5,7 @@
 #include "json_loader.hpp"
 #include "ds/d400/d400-color.h"
 #include "ds/d500/d500-color.h"
+#include "ds/d500/d500-private.h"
 
 #include <src/ds/features/amplitude-factor-feature.h>
 #include <src/ds/features/remove-ir-pattern-feature.h>
@@ -117,6 +118,7 @@ namespace librealsense
                 break;
             case ds::RS455_PID:
             case ds::RS457_PID:
+            case ds::D555_PID:
                 default_450_mid_low_res(p);
                 switch (res)
                 {

--- a/src/ds/d400/d400-auto-calibration.cpp
+++ b/src/ds/d400/d400-auto-calibration.cpp
@@ -47,13 +47,6 @@ namespace librealsense
         uint16_t tableSize;  // 512 bytes
     };
 
-    struct DscResultBuffer
-    {
-        uint16_t paramSize;
-        uint16_t status;
-        float healthCheck;
-        uint16_t tableSize;
-    };
 #pragma pack(pop)
 
     enum class host_assistance_type

--- a/src/ds/d400/d400-auto-calibration.h
+++ b/src/ds/d400/d400-auto-calibration.h
@@ -5,27 +5,11 @@
 
 #include "auto-calibrated-device.h"
 #include "../../core/advanced_mode.h"
+#include <src/ds/ds-calib-common.h>
 
 
 namespace librealsense
 {
-#pragma pack(push, 1)
-#pragma pack(1)
-    struct DirectSearchCalibrationResult
-    {
-        uint16_t status;      // DscStatus
-        uint16_t stepCount;
-        uint16_t stepSize; // 1/1000 of a pixel
-        uint32_t pixelCountThreshold; // minimum number of pixels in
-                                      // selected bin
-        uint16_t minDepth;  // Depth range for FWHM
-        uint16_t maxDepth;
-        uint32_t rightPy;   // 1/1000000 of normalized unit
-        float healthCheck;
-        float rightRotation[9]; // Right rotation
-    };
-#pragma pack(pop)
-
     class auto_calibrated : public auto_calibrated_interface
     {
         enum class auto_calib_action
@@ -69,11 +53,8 @@ namespace librealsense
         void handle_calibration_error(int status) const;
         std::map<std::string, int> parse_json(std::string json);
         std::shared_ptr< ds_advanced_mode_base> change_preset();
-        void check_params(int speed, int scan_parameter, int data_sampling) const;
         void check_tare_params(int speed, int scan_parameter, int data_sampling, int average_step_count, int step_count, int accuracy);
-        void check_focal_length_params(int step_count, int fy_scan_range, int keep_new_value_after_sucessful_scan, int interrrupt_data_samling, int adjust_both_sides, int fl_scan_location, int fy_scan_direction, int white_wall_mode) const;
         void check_one_button_params(int speed, int keep_new_value_after_sucessful_scan, int data_sampling, int adjust_both_sides, int fl_scan_location, int fy_scan_direction, int white_wall_mode) const;
-        void get_target_rect_info(rs2_frame_queue* frames, float rect_sides[4], float& fx, float& fy, int progress, rs2_update_progress_callback_sptr progress_callback);
         void undistort(uint8_t* img, const rs2_intrinsics& intrin, int roi_ws, int roi_hs, int roi_we, int roi_he);
         void change_preset_and_stay();
         void restore_preset();
@@ -83,7 +64,7 @@ namespace librealsense
         void fill_missing_data(uint16_t data[256], int size);
         void remove_outliers(uint16_t data[256], int size);
         void collect_depth_frame_sum(const rs2_frame* f);
-        DirectSearchCalibrationResult get_calibration_status(int timeout_ms, std::function<void(const int count)> progress_func, bool wait_for_final_results = true);
+        ds_calib_common::dsc_check_status_result get_calibration_status( int timeout_ms, std::function< void( const int count ) > progress_func, bool wait_for_final_results = true );
 
         std::vector<uint8_t> _curr_calibration;
         std::shared_ptr<hw_monitor> _hw_monitor;

--- a/src/ds/d400/d400-auto-calibration.h
+++ b/src/ds/d400/d400-auto-calibration.h
@@ -51,9 +51,7 @@ namespace librealsense
         std::vector<uint8_t> get_calibration_results(float* const health = nullptr) const;
         std::vector<uint8_t> get_PyRxFL_calibration_results(float* const health = nullptr, float* health_fl = nullptr) const;
         void handle_calibration_error(int status) const;
-        std::map<std::string, int> parse_json(std::string json);
         std::shared_ptr< ds_advanced_mode_base> change_preset();
-        void check_tare_params(int speed, int scan_parameter, int data_sampling, int average_step_count, int step_count, int accuracy);
         void check_one_button_params(int speed, int keep_new_value_after_sucessful_scan, int data_sampling, int adjust_both_sides, int fl_scan_location, int fy_scan_direction, int white_wall_mode) const;
         void undistort(uint8_t* img, const rs2_intrinsics& intrin, int roi_ws, int roi_hs, int roi_we, int roi_he);
         void change_preset_and_stay();

--- a/src/ds/d500/d500-auto-calibration.h
+++ b/src/ds/d500/d500-auto-calibration.h
@@ -5,15 +5,19 @@
 
 #include <src/auto-calibrated-device.h>
 #include <src/calibration-engine-interface.h>  // should remain for members _mode, _state, _result
+#include <src/ds/ds-calib-common.h>
 
 
 namespace librealsense
 {
+    class debug_interface;
     class d500_debug_protocol_calibration_engine;
+
     class d500_auto_calibrated : public auto_calibrated_interface
     {
     public:
-        d500_auto_calibrated(std::shared_ptr<d500_debug_protocol_calibration_engine> calib_engine);
+        d500_auto_calibrated( std::shared_ptr< d500_debug_protocol_calibration_engine > calib_engine,
+                              debug_interface * debug_dev );
         void write_calibration() const override;
         std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json, float* const health, rs2_update_progress_callback_sptr progress_callback) override;
         std::vector<uint8_t> run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, float* const health, rs2_update_progress_callback_sptr progress_callback) override;
@@ -35,11 +39,20 @@ namespace librealsense
         void get_mode_from_json(const std::string& json);
         std::vector<uint8_t> update_calibration_status(int timeout_ms, rs2_update_progress_callback_sptr progress_callback);
         std::vector<uint8_t> update_abort_status();
+        std::vector< uint8_t > run_triggered_calibration( int timeout_ms, std::string json,
+                                                          rs2_update_progress_callback_sptr progress_callback );
+        std::vector< uint8_t > run_occ( int timeout_ms, std::string json, float * const health,
+                                        rs2_update_progress_callback_sptr progress_callback );
+        ds_calib_common::dsc_check_status_result get_calibration_status( int timeout_ms,
+                                                            std::function< void( const int count ) > progress_func,
+                                                            bool wait_for_final_results = true ) const;
+        std::vector< uint8_t > get_calibration_results( float * const health = nullptr ) const;
 
         mutable std::vector< uint8_t > _curr_calibration;
         std::shared_ptr<d500_debug_protocol_calibration_engine> _calib_engine;
         calibration_mode _mode;
         calibration_state _state;
         calibration_result _result;
+        debug_interface * _debug_dev;
     };
 }

--- a/src/ds/d500/d500-auto-calibration.h
+++ b/src/ds/d500/d500-auto-calibration.h
@@ -12,12 +12,15 @@ namespace librealsense
 {
     class debug_interface;
     class d500_debug_protocol_calibration_engine;
+    class ds_advanced_mode_base;
+    class sensor_base;
 
     class d500_auto_calibrated : public auto_calibrated_interface
     {
     public:
         d500_auto_calibrated( std::shared_ptr< d500_debug_protocol_calibration_engine > calib_engine,
-                              debug_interface * debug_dev );
+                              debug_interface * debug_dev,
+                              sensor_base * ds = nullptr );
         void write_calibration() const override;
         std::vector<uint8_t> run_on_chip_calibration(int timeout_ms, std::string json, float* const health, rs2_update_progress_callback_sptr progress_callback) override;
         std::vector<uint8_t> run_tare_calibration(int timeout_ms, float ground_truth_mm, std::string json, float* const health, rs2_update_progress_callback_sptr progress_callback) override;
@@ -33,6 +36,7 @@ namespace librealsense
             float target_width, float target_height, rs2_update_progress_callback_sptr progress_callback) override;
         std::string get_calibration_config() const override;
         void set_calibration_config(const std::string& calibration_config_json_str) const override;
+        void set_depth_sensor( sensor_base * ds ) { _depth_sensor = ds; }
 
     private:
         void check_preconditions_and_set_state();
@@ -47,12 +51,14 @@ namespace librealsense
                                                             std::function< void( const int count ) > progress_func,
                                                             bool wait_for_final_results = true ) const;
         std::vector< uint8_t > get_calibration_results( float * const health = nullptr ) const;
+        std::shared_ptr< option > change_preset();
 
         mutable std::vector< uint8_t > _curr_calibration;
         std::shared_ptr<d500_debug_protocol_calibration_engine> _calib_engine;
         calibration_mode _mode;
         calibration_state _state;
         calibration_result _result;
+        sensor_base * _depth_sensor;
         debug_interface * _debug_dev;
     };
 }

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -369,7 +369,7 @@ namespace librealsense
 
     d500_device::d500_device( std::shared_ptr< const d500_info > const & dev_info )
         : backend_device(dev_info), global_time_interface(),
-          d500_auto_calibrated(std::make_shared<d500_debug_protocol_calibration_engine>(this)),
+          d500_auto_calibrated(std::make_shared<d500_debug_protocol_calibration_engine>(this), this),
           _device_capabilities(ds::ds_caps::CAP_UNDEFINED),
           _depth_stream(new stream(RS2_STREAM_DEPTH)),
           _left_ir_stream(new stream(RS2_STREAM_INFRARED, 1)),

--- a/src/ds/d500/d500-device.cpp
+++ b/src/ds/d500/d500-device.cpp
@@ -438,6 +438,8 @@ namespace librealsense
         auto& depth_sensor = get_depth_sensor();
         auto raw_depth_sensor = get_raw_depth_sensor();
 
+        d500_auto_calibrated::set_depth_sensor( &depth_sensor );
+
         using namespace platform;
 
         std::string pid_hex_str, usb_type_str;

--- a/src/ds/ds-calib-common.cpp
+++ b/src/ds/ds-calib-common.cpp
@@ -64,29 +64,28 @@ namespace librealsense
                                                 int progress,
                                                 rs2_update_progress_callback_sptr progress_callback )
     {
-        fx = -1.0f;
-        std::vector< std::array< float, 4 > > rect_sides_arr;
-
         rs2_error * e = nullptr;
-        rs2_frame * f = nullptr;
-
         int queue_size = rs2_frame_queue_size( frames, &e );
         if( queue_size == 0 )
             throw std::runtime_error( "Extract target rectangle info - no frames in input queue!" );
 
-        int fc = 0;
-        while( ( fc++ < queue_size ) && rs2_poll_for_frame( frames, &f, &e ) )
+        int frame_counter = 0;
+        bool first_time = true;
+        rs2_frame * f = nullptr;
+        std::vector< std::array< float, 4 > > rect_sides_arr;
+        while( ( frame_counter++ < queue_size ) && rs2_poll_for_frame( frames, &f, &e ) )
         {
             rs2::frame ff( f );
             if( ff.get_data() )
             {
-                if( fx < 0.0f )
+                if( first_time )
                 {
                     auto p = ff.get_profile();
                     auto vsp = p.as< rs2::video_stream_profile >();
                     rs2_intrinsics intrin = vsp.get_intrinsics();
                     fx = intrin.fx;
                     fy = intrin.fy;
+                    first_time = false;
                 }
 
                 std::array< float, 4 > rec_sides_cur{};

--- a/src/ds/ds-calib-common.cpp
+++ b/src/ds/ds-calib-common.cpp
@@ -92,6 +92,25 @@ namespace librealsense
                                            << data_sampling << " is out of range (0 - 1)." );
     }
 
+    void ds_calib_common::check_tare_params( int speed, int scan_parameter, int data_sampling,
+                                             int average_step_count, int step_count, int accuracy )
+    {
+        check_params( speed, scan_parameter, data_sampling );
+
+        if( average_step_count < 1 || average_step_count > 30 )
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "Auto calibration failed! Given value of 'number of frames to average' "
+                                           << average_step_count << " is out of range (1 - 30)." );
+        if( step_count < 5 || step_count > 30 )
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "Auto calibration failed! Given value of 'max iteration steps' "
+                                           << step_count << " is out of range (5 - 30)." );
+        if( accuracy < ACCURACY_HIGH || accuracy > ACCURACY_LOW )
+            throw invalid_value_exception( rsutils::string::from()
+                                           << "Auto calibration failed! Given value of 'subpixel accuracy' " << accuracy
+                                           << " is out of range (0 - 3)." );
+    }
+
     void ds_calib_common::check_focal_length_params( int step_count,
                                                      int fy_scan_range,
                                                      int keep_new_value_after_sucessful_scan,

--- a/src/ds/ds-calib-common.h
+++ b/src/ds/ds-calib-common.h
@@ -5,11 +5,113 @@
 
 #include <librealsense2/hpp/rs_types.hpp>
 
+#include <map>
+
 namespace librealsense
 {
+    class auto_calibrated_interface;
+    class sensor_interface;
+
+    // RAII to handle auto-calibration with the thermal compensation disabled
+    class thermal_compensation_guard
+    {
+    public:
+        thermal_compensation_guard( auto_calibrated_interface * handle );
+        virtual ~thermal_compensation_guard();
+
+    protected:
+        bool restart_tl;
+        librealsense::sensor_interface* snr;
+
+    private:
+        // Disable copy/assignment ctors
+        thermal_compensation_guard( const thermal_compensation_guard & ) = delete;
+        thermal_compensation_guard & operator=( const thermal_compensation_guard & ) = delete;
+    };
+
     class ds_calib_common
     {
     public:
+        enum auto_calib_speed : uint8_t
+        {
+            SPEED_VERY_FAST  = 0,
+            SPEED_FAST       = 1,
+            SPEED_MEDIUM     = 2,
+            SPEED_SLOW       = 3,
+            SPEED_WHITE_WALL = 4
+        };
+
+        enum dsc_status : uint16_t
+        {
+            STATUS_SUCCESS             = 0,
+            STATUS_RESULT_NOT_READY    = 1, // Self calibration result is not ready yet
+            STATUS_FILL_FACTOR_TOO_LOW = 2, // There are too little textures in the scene
+            STATUS_EDGE_TOO_CLOSE      = 3, // Self calibration range is too small
+            STATUS_NOT_CONVERGE        = 4, // For tare calibration only
+            STATUS_BURN_SUCCESS        = 5,
+            STATUS_BURN_ERROR          = 6,
+            STATUS_NO_DEPTH_AVERAGE    = 7
+        };
+
+#pragma pack( push, 1 )
+        struct dsc_check_status_result
+        {
+            uint16_t status;
+            uint16_t stepCount;
+            uint16_t stepSize;            // 1/1000 of a pixel
+            uint32_t pixelCountThreshold; // minimum number of pixels in selected bin
+            uint16_t minDepth;            // Depth range for FWHM
+            uint16_t maxDepth;
+            uint32_t rightPy;             // 1/1000000 of normalized unit
+            float healthCheck;
+            float rightRotation[9];
+        };
+
+        struct dsc_result
+        {
+            uint16_t paramSize;
+            uint16_t status;
+            float healthCheck;
+            uint16_t tableSize;
+        };
+#pragma pack( pop )
+
+        enum data_sampling
+        {
+            POLLING   = 0,
+            INTERRUPT = 1
+        };
+
+        enum scan_parameter
+        {
+            PY_SCAN = 0,
+            RX_SCAN = 1
+        };
+
+        enum auto_calib_sub_cmd : uint8_t
+        {
+            PY_RX_CALIB_CHECK_STATUS       = 0X03,
+            INTERACTIVE_SCAN_CONTROL       = 0X05,
+            PY_RX_CALIB_BEGIN              = 0X08,
+            TARE_CALIB_BEGIN               = 0X0B,
+            TARE_CALIB_CHECK_STATUS        = 0X0C,
+            GET_CALIBRATION_RESULT         = 0X0D,
+            FOCAL_LENGTH_CALIB_BEGIN       = 0X11,
+            GET_FOCAL_LEGTH_CALIB_RESULT   = 0X12,
+            PY_RX_PLUS_FL_CALIB_BEGIN      = 0X13,
+            GET_PY_RX_PLUS_FL_CALIB_RESULT = 0X14,
+            SET_COEFFICIENTS               = 0X19
+        };
+
+        // Convert json to string-int pairs.
+        static std::map< std::string, int > parse_json( const std::string & json_content );
+
+        // If map contains requested key-value pair, update value.
+        static void update_value_if_exists( const std::map< std::string, int > & jsn, const std::string & key, int & value );
+
+        // Check validity of common parameters.
+        static void check_params( int speed, int scan_parameter, int data_sampling );
+
         // Checks validity of focal length caliration parameters. Throws on error.
         static void check_focal_length_params( int step_count,
                                                int fy_scan_range,
@@ -38,5 +140,7 @@ namespace librealsense
                                                          const float baseline,
                                                          float & ratio,
                                                          float & angle );
+
+        static void handle_calibration_error( int status );
     };
 }

--- a/src/ds/ds-calib-common.h
+++ b/src/ds/ds-calib-common.h
@@ -132,7 +132,7 @@ namespace librealsense
                 uint8_t step_count;
                 uint8_t accuracy;
                 uint8_t reserved;
-            };
+            } field;
 
             uint32_t as_uint32 = 0;
         };
@@ -144,7 +144,7 @@ namespace librealsense
                 uint8_t scan_parameter : 1;
                 uint8_t reserved : 2;
                 uint8_t data_sampling : 1;
-            };
+            } field;
 
             uint32_t as_uint32 = 0;
         };


### PR DESCRIPTION
Tracked on [RSDEV-2681]

Some code from D400 moved to common. D500 flows do not need interactive/host-assistance logic.