### PR TITLE
fix rs-fw-update wait for device to reconnect

### DIFF
--- a/tools/fw-update/rs-fw-update.cpp
+++ b/tools/fw-update/rs-fw-update.cpp
@@ -525,7 +525,7 @@ try
                     }
                 }
 
-                 update( new_fw_update_device, fw_image );
+                update( new_fw_update_device, fw_image );
 
                 done = true;
                 break;
@@ -546,6 +546,7 @@ try
 
     std::cout << std::endl << "Waiting for device to reconnect..." << std::endl;
     std::unique_lock<std::mutex> lk(mutex);
+    new_device = rs2::device();  // otherwise the wait will exit right away
     cv.wait_for(lk, std::chrono::seconds(WAIT_FOR_DEVICE_TIMEOUT), [&] { return !done || new_device; });
 
     if (done)


### PR DESCRIPTION
The last stage when running rs-fw-update is "Waiting for device to reconnect...".
I noticed this stage does not wait at all and exits right away.

Tracked on [RSDEV-2791]