### PR TITLE
fix 'cannot bind non-const lvalue reference' error in lrs-device-controller

### DIFF
--- a/tools/dds/dds-adapter/lrs-device-controller.cpp
+++ b/tools/dds/dds-adapter/lrs-device-controller.cpp
@@ -738,7 +738,7 @@ lrs_device_controller::lrs_device_controller( rs2::device dev, std::shared_ptr< 
                         image.set_timestamp( timestamp );
                         auto data = static_cast< const uint8_t * >( f.get_data() );
                         image.raw().data().assign( data, data + f.get_data_size() );
-                        video->publish_image( std::move( image ) );
+                        video->publish_image( image );
 
                         publish_frame_metadata( f, timestamp );
                     } );


### PR DESCRIPTION
Fix error on debian generation which wasn't caught by GHA:
```
[2024-10-08T23:37:17.066Z] /jenkins/workspace/LRS_SDK_CI_Debian/src/tools/dds/dds-adapter/lrs-device-controller.cpp:741:56: error: cannot bind non-const lvalue reference of type 'realdds::topics::image_msg&' to an rvalue of type 'std::remove_reference<realdds::topics::image_msg&>::type' {aka 'realdds::topics::image_msg'}
```

Move semantics no longer needed, so removed...

Build:
https://rsjenkins.iil.intel.com/job/LRS_release_flow_pipeline/7545