### PR TITLE
Improve query_devices time on high device count systems

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1205,7 +1205,10 @@ namespace librealsense
         }
 
         v4l_uvc_device::v4l_uvc_device(const uvc_device_info& info, bool use_memory_map)
-            : _name(""), _info(),
+            : _name(info.id), 
+              _device_path(info.device_path),
+              _device_usb_spec(info.conn_spec),
+              _info(info),
               _is_capturing(false),
               _is_alive(true),
               _is_started(false),
@@ -1217,19 +1220,6 @@ namespace librealsense
               _buf_dispatch(use_memory_map),
               _frame_drop_monitor(DEFAULT_KPI_FRAME_DROPS_PERCENTAGE)
         {
-            foreach_uvc_device([&info, this](const uvc_device_info& i, const std::string& name)
-            {
-                if (i == info)
-                {
-                    _name = name;
-                    _info = i;
-                    _device_path = i.device_path;
-                    _device_usb_spec = i.conn_spec;
-                }
-            });
-            if (_name == "")
-                throw linux_backend_exception("device is no longer connected!");
-
             _named_mtx = std::unique_ptr<named_mutex>(new named_mutex(_name, 5000));
         }
 


### PR DESCRIPTION
During the `v4l_uvc_device` constructor it would call `foreach_uvc_device` in order to check if the constructed device is still connected.

It is very inefficient to search all devices to do find if 1 device is within the list.
This problem is them squared by the number of devices.

In this pr I have removed the check all together, as it is unlikely a newly found device would not be connected.

For the curious, I followed the source of why `foreach_uvc_device` is slow on high device count systems (>24).
It appears `get_dev_capabilities` tends too take up to 100ms on several `open(/dev/videoXXX)` calls, causing the total time of `foreach_uvc_device` to balloon out to ~3s.

Another note is that `udev_device_watcher` also lists devices on creation. Since this is a singleton its only called once. But it may be more efficient to use this cache for `query_devices` instead of calling direct to the source `/dev/videoXXX`, although potentially less accurate.
