### PR TITLE
update for Android Studio 2024.2.1

### DIFF
--- a/wrappers/android/build.gradle
+++ b/wrappers/android/build.gradle
@@ -8,8 +8,8 @@ plugins {
      * see Applying external plugins with same version to subprojects.
      */
 
-    id 'com.android.application' version '8.0.1' apply false
-    id 'com.android.library' version '8.0.1' apply false
+    id 'com.android.application' version '8.1.4' apply false
+    id 'com.android.library' version '8.1.4' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
 }
 

--- a/wrappers/android/librealsense/src/androidTest/java/com/intel/realsense/librealsense/ExampleInstrumentedTest.java
+++ b/wrappers/android/librealsense/src/androidTest/java/com/intel/realsense/librealsense/ExampleInstrumentedTest.java
@@ -19,7 +19,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() {
         // RsContext of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = InstrumentationRegistry.getInstrumentation().getContext();
 
         assertEquals("com.intel.realsense.librealsense", appContext.getPackageName());
     }


### PR DESCRIPTION
Upgrade AGP (Android Gradle Plugin) to 8.1 from 8.0 for Android Studio 2024.2.1.
update the code of androidTest for build error.

The AGP can be upgraded from the menu "Tools -> AGP Upgrade Assistant..." in Android Studio.