### PR TITLE
add heartbeat-period and default to half reply timeout

### DIFF
--- a/third-party/realdds/src/dds-topic-writer.cpp
+++ b/third-party/realdds/src/dds-topic-writer.cpp
@@ -92,6 +92,8 @@ void dds_topic_writer::override_qos_from_json( qos & wqos, rsutils::json const &
     // Default values should be set before we're called:
     // All we do here is override those - if specified!
     override_reliability_qos_from_json( wqos.reliability(), qos_settings.nested( "reliability" ) );
+    if( wqos.reliability().kind == eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS )
+        qos_settings.nested( "heartbeat-period" ).get_ex( wqos.reliable_writer_qos().times.heartbeatPeriod );
     override_durability_qos_from_json( wqos.durability(), qos_settings.nested( "durability" ) );
     override_history_qos_from_json( wqos.history(), qos_settings.nested( "history" ) );
     override_liveliness_qos_from_json( wqos.liveliness(), qos_settings.nested( "liveliness" ) );


### PR DESCRIPTION
We encountered rare cases where the camera seems to not receive a control sent from the host. Even worse, the control message (on a reliable topic) is asked to be resent.

Investigation showed that, on rare cases, it is possible for the control message to not be "announced" to remote participants in time. This announcement uses the heartbeat mechanism: if a heartbeat is not sent by our timeout (either on the host or on the camera), then we get an error get into a bad state.

We have a reply timeout of 2000ms (by default) for every control message. Digging into the QoS for the control writer, we found a way to control the heartbeat period, and saw that the default period is set to 3 seconds (3000ms). So it is possible for the timeout to fit within the heartbeat period: i.e., before a heartbeat is even sent out, we time out!

* Increase our timeout default to 2500ms
* Use a heartbeat period that's one half of our timeout
* Allow overriding the `control/heartbeat-period` value

Tracked on [RSDEV-2841]