### PR TITLE
pyrealdds.image_msg.data as a memoryview; fps.py --save-frames

### DIFF
--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -625,7 +625,7 @@ PYBIND11_MODULE(NAME, m) {
         .def_static( "create_topic", &image_msg::create_topic )
         .def_property(
             "data",
-            []( image_msg const & self ) { return self.raw().data(); },
+            []( image_msg const & self ) { return py::memoryview::from_memory( self.raw().data().data(), self.raw().data().size() ); },
             []( image_msg & self, std::vector< uint8_t > bytes ) { self.raw().data( std::move( bytes ) ); } )
         .def_property( "width", &image_msg::width, &image_msg::set_width )
         .def_property( "height", &image_msg::height, &image_msg::set_height )

--- a/third-party/realdds/scripts/fps.py
+++ b/third-party/realdds/scripts/fps.py
@@ -6,6 +6,7 @@ args = ArgumentParser()
 args.add_argument( '--debug', action='store_true', help='enable debug mode' )
 args.add_argument( '--quiet', action='store_true', help='No output; just the minimum FPS as a number' )
 args.add_argument( '--debug-frames', action='store_true', help='Output frame signatures as we get them' )
+args.add_argument( '--save-frames', action='store_true', help='Save each image data on disk, as <stream-name>_<frame-number>' )
 args.add_argument( '--device', metavar='<path>', required=True, help='the topic root for the device' )
 def time_arg(x):
     t = int(x)
@@ -97,6 +98,10 @@ def on_image( stream, image, sample ):
     global n_stream_frames, capturing
     if capturing:
         n_stream_frames[stream.name()] += 1
+        if args.save_frames:
+            filename = f'{stream.name().lower()}_{image.frame_id or n_stream_frames[stream.name()]}'
+            with open( filename, 'wb' ) as f:
+                f.write( image.data )
 
 fps = args.fps
 width = args.res[0]


### PR DESCRIPTION
Add `--save-frames` flag in `fps.py`.

Changed the `pyrealdds.topics.image.data()` call to return a memoryview so data is not copied and can be treated as a `bytearray`.