### PR TITLE
Add step to change directory

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -73,6 +73,7 @@ if not the SDK will use a timer polling approach which is less sensitive for dev
 
 2. Run Intel Realsense permissions script from _librealsense2_ root directory:
    ```sh
+   cd librealsense
    ./scripts/setup_udev_rules.sh
    ```
    Notice: You can always remove permissions by running: `./scripts/setup_udev_rules.sh --uninstall`


### PR DESCRIPTION
This adds a step to explicitly change the directory after installing librealsense, to bring this in line with the same change on https://dev.intelrealsense.com/docs/compiling-librealsense-for-linux-ubuntu-guide