### PR TITLE
Fix DDS stream tagging

### DIFF
--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -556,9 +556,9 @@ void dds_device_proxy::tag_default_profile_of_stream(
         // Superset = picked up in pipeline with enable_all_stream() config
         // We want color and depth to be default, and add infrared as superset
         int tag = PROFILE_TAG_SUPERSET;
-        if( stream->type_string() == "color" || stream->type_string() == "depth" )
+        if( strcmp( stream->type_string(), "color" ) == 0 || strcmp( stream->type_string(), "depth" ) == 0 )
             tag |= PROFILE_TAG_DEFAULT;
-        else if( stream->type_string() != "infrared" || profile->get_stream_index() >= 2 )
+        else if( strcmp( stream->type_string(), "ir" ) != 0 || profile->get_stream_index() >= 2 )
             return;  // leave untagged
         profile->tag_profile( tag );
     }


### PR DESCRIPTION
Tracked on [RSDEV-2861]

Stream type string was changed on a previous PR but not updated here. Also using `strcmp` to compare `char*` strings, not `==` as the operator compares pointers and might not work as expected.