### PR TITLE
Identify D555 by name and some minor changes

### DIFF
--- a/common/d500-on-chip-calib.cpp
+++ b/common/d500-on-chip-calib.cpp
@@ -88,7 +88,8 @@ namespace rs2
             auto depth_sensor = _sub->s->as <rs2::depth_sensor>();
 
             // disabling the depth visual preset change for D555 - not needed
-            if (get_device_pid() != "0B56" && get_device_pid() != "DDS")
+            std::string dev_name = _dev.supports( RS2_CAMERA_INFO_NAME ) ? _dev.get_info( RS2_CAMERA_INFO_NAME ) : "";
+            if( dev_name.find( "D555" ) == std::string::npos )
             {
                 // set depth preset as default preset
                 set_option_if_needed<rs2::depth_sensor>(depth_sensor, RS2_OPTION_VISUAL_PRESET, 1);

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -3351,10 +3351,10 @@ namespace rs2
             {
                 bool is_d555 = false;
 
-                if( dev.supports( RS2_CAMERA_INFO_PRODUCT_ID ) )
+                if( dev.supports( RS2_CAMERA_INFO_NAME ) )
                 {
-                    auto pid_str = std::string( dev.get_info( RS2_CAMERA_INFO_PRODUCT_ID ) );
-                    if( pid_str == "0B56" || pid_str == "DDS" )
+                    auto dev_name = std::string( dev.get_info( RS2_CAMERA_INFO_NAME ) );
+                    if( dev_name.find( "D555" ) != std::string::npos )
                         is_d555 = true;
                 }
 

--- a/src/dds/rsdds-device-factory.cpp
+++ b/src/dds/rsdds-device-factory.cpp
@@ -51,8 +51,15 @@ public:
         _device_watcher->on_device_added(
             [this]( std::shared_ptr< realdds::dds_device > const & dev )
             {
-                dev->wait_until_ready();  // make sure handshake is complete
-                _callbacks.raise( dev, true );
+                try
+                {
+                    dev->wait_until_ready();  // make sure handshake is complete, might throw
+                    _callbacks.raise( dev, true );
+                }
+                catch (std::runtime_error e)
+                {
+                    LOG_ERROR( "Discovered DDS device failed to be ready within timeout" << e.what() );
+                }
             } );
 
         _device_watcher->on_device_removed( [this]( std::shared_ptr< realdds::dds_device > const & dev )

--- a/src/ds/d500/d500-auto-calibration.cpp
+++ b/src/ds/d500/d500-auto-calibration.cpp
@@ -95,8 +95,8 @@ namespace librealsense
     {
         bool is_d555 = false;
         auto dev = As< device >( _debug_dev );
-        std::string pid_str = dev ? dev->get_info( RS2_CAMERA_INFO_PRODUCT_ID ) : "";
-        if( pid_str == "0B56" || pid_str == "DDS" )
+        std::string dev_name = dev ? dev->get_info( RS2_CAMERA_INFO_NAME ) : "";
+        if( dev_name.find( "D555" ) != std::string::npos )
             is_d555 = true;
 
         if( is_d555 )

--- a/tools/enumerate-devices/rs-enumerate-devices.cpp
+++ b/tools/enumerate-devices/rs-enumerate-devices.cpp
@@ -393,7 +393,7 @@ int main(int argc, char** argv) try
     if( !device_count )
     {
         cout << "No device detected. Is it plugged in?\n";
-        return EXIT_SUCCESS;
+        return EXIT_FAILURE;
     }
 
     if (short_view || compact_view)


### PR DESCRIPTION
- `rs-enumerate-devices` returns failure if no devices found, helps when running in scripts
- SDK does not throw on DDS device initialization timeout, e.g when debugging initialization viewer does not crash.
- Use D555 name not PID to identify, "DDS" PID may be assigned to more products in the future