### PR TITLE
Explicitly include `<chrono>`

### DIFF
--- a/src/platform/uvc-device.h
+++ b/src/platform/uvc-device.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <chrono>
 #include <thread>
 #include <algorithm>  // find
 


### PR DESCRIPTION
I work on Microsoft Visual C++, where we regularly build popular open-source projects, including yours, with development builds of our compiler and libraries to detect and prevent shipping regressions that would affect you. This also allows us to provide advance notice of breaking changes, which is the case here.

I just merged https://github.com/microsoft/STL/pull/5105, which revealed a conformance issue in librealsense.

Compiler error with this STL change:
```
C:\gitP\IntelRealSense\librealsense\src\backend.cpp(56,88): error C2039: 'system_clock': is not a member of 'std::chrono'
```

Affected code:
https://github.com/IntelRealSense/librealsense/blob/a75366ff9e40e765993b15ad6f18b45200616a73/src/backend.cpp#L56

`src/backend.cpp` includes `platform/uvc-device.h` which includes `<thread>`:
https://github.com/IntelRealSense/librealsense/blob/a75366ff9e40e765993b15ad6f18b45200616a73/src/backend.cpp#L19
https://github.com/IntelRealSense/librealsense/blob/a75366ff9e40e765993b15ad6f18b45200616a73/src/platform/uvc-device.h#L18

This was assuming that including `<thread>` makes the `chrono::system_clock` type available, which is not guaranteed by the Standard. You must explicitly include `<chrono>`.

`platform/uvc-device.h` itself uses `chrono::milliseconds`:
https://github.com/IntelRealSense/librealsense/blob/a75366ff9e40e765993b15ad6f18b45200616a73/src/platform/uvc-device.h#L194

While MSVC's STL still has `<thread>` dragging in `chrono::milliseconds`, this is also not guaranteed by the Standard. Therefore, the proper change is to include `<chrono>` in `platform/uvc-device.h`.