### PR TITLE
optimize rs2_get_options_list with bulk operation

### DIFF
--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -920,6 +920,9 @@ HANDLE_EXCEPTIONS_AND_RETURN( , options, option_value )
 rs2_options_list* rs2_get_options_list(const rs2_options* options, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(options);
+    rsutils::deferred bulk_op;
+    if( auto sensor = dynamic_cast<sensor_base *>(options->options) )
+        bulk_op = sensor->bulk_operation();
     auto rs2_list = new rs2_options_list;
     auto option_ids = options->options->get_supported_options();
     rs2_list->list.reserve( option_ids.size() );

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -260,6 +260,9 @@ namespace librealsense
         virtual void register_option_to_update( rs2_option id, std::shared_ptr< option > option );
         virtual void unregister_option_from_update( rs2_option id );
 
+        void prepare_for_bulk_operation() override { _raw_sensor->prepare_for_bulk_operation(); }
+        void finished_bulk_operation() override { _raw_sensor->finished_bulk_operation(); }
+
     private:
         void register_processing_block_options(const processing_block& pb);
         void unregister_processing_block_options(const processing_block& pb);

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -1,5 +1,5 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2015 Intel Corporation. All Rights Reserved.
+// Copyright(c) 2015-24 Intel Corporation. All Rights Reserved.
 #pragma once
 
 #include "core/sensor-interface.h"
@@ -13,6 +13,7 @@
 
 #include <rsutils/lazy.h>
 #include <rsutils/signal.h>
+#include <rsutils/deferred.h>
 
 #include <chrono>
 #include <memory>
@@ -88,6 +89,16 @@ namespace librealsense
         processing_blocks get_recommended_processing_blocks() const override
         {
             return {};
+        }
+
+        // Sometimes it is more efficient to prepare for large or repeating operations. Depending on the actual sensor
+        // type we might want to change power state or encapsulate small transactions into a large one.
+        virtual void prepare_for_bulk_operation() {}
+        virtual void finished_bulk_operation() {}
+        rsutils::deferred bulk_operation()
+        {
+            prepare_for_bulk_operation();
+            return rsutils::deferred( [this] { finished_bulk_operation(); } );
         }
 
         // recordable< recommended_proccesing_blocks_interface > is needed to record our recommended processing blocks
@@ -196,11 +207,6 @@ namespace librealsense
 
         std::shared_ptr< std::map< uint32_t, rs2_format > > & get_fourcc_to_rs2_format_map();
         std::shared_ptr< std::map< uint32_t, rs2_stream > > & get_fourcc_to_rs2_stream_map();
-
-        // Sometimes it is more efficient to prepare for large or repeating operations. Depending on the actual sensor
-        // type we might want to change power state or encapsulate small transactions into a large one.
-        virtual void prepare_for_bulk_operation() {}
-        virtual void finished_bulk_operation(){}
     };
 
     // A sensor pointer to another "raw sensor", usually UVC/HID


### PR DESCRIPTION
Before, a simple average `rs2_get_options_list()` on a D455 was ~350ms.
Now it's ~24.

Moved the `prepare_bulk_operation()` and `finish_bulk_operation()` functions into `sensor_base` so they can also be used on `synthetic_sensor` and forwarded to the raw sensor.

The actual `rs2_get_options_list` function now prepares and finishes the bulk-operation before/after doing its thing.