### PR TITLE
Fix termination issue cause by PR # 13614

### DIFF
--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -360,7 +360,7 @@ namespace librealsense
             if (_use_memory_map)
             {
                if(munmap(_start, _original_length) < 0)
-                   throw linux_backend_exception("munmap");
+                   LOG_DEBUG_V4L("munmap failed on buffer Dtor");
             }
             else
             {


### PR DESCRIPTION
PR #13614 fixed a missing throw but activated an exception thrown on DTor which is not allowed and will cause the application termination.
This PR remove the throw and ignore the return value since we are in a Dtor case