### PR TITLE
fix abort in some cases with DDS

### DIFF
--- a/third-party/realdds/src/dds-network-adapter-watcher.cpp
+++ b/third-party/realdds/src/dds-network-adapter-watcher.cpp
@@ -60,7 +60,6 @@ public:
                                 if( new_ips.size() || old_ips.size() )
                                     callbacks.raise( new_ips, old_ips );
                             }
-                            _th.detach();  // so it's not joinable
                             LOG_DEBUG( "done waiting for IP changes" );
                         } );
                 }
@@ -72,8 +71,15 @@ public:
     ~network_adapter_watcher_singleton()
     {
         _adapter_watcher.reset();  // signal the thread to finish
-        if( _th.joinable() )
-            _th.join();
+        try
+        {
+            if (_th.joinable())
+                _th.join();
+        }
+        catch (std::exception& e)
+        {
+            LOG_DEBUG("Network adapter watcher termination failed: " << e.what());
+        }
     }
 
     void update_ips( ip_set * p_new_ips = nullptr, ip_set * p_old_ips = nullptr )


### PR DESCRIPTION
Fixed an issue where we randomly see an error where abort() is called after we finish using DDS (in the d'tor), added a try catch block due to the race condition there
Tracked on: [LRS-1212]