### PR TITLE
Don't nullify on_frame_ready lambda

### DIFF
--- a/third-party/realdds/include/realdds/dds-metadata-syncer.h
+++ b/third-party/realdds/include/realdds/dds-metadata-syncer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <functional>
+#include <atomic>
 
 
 namespace realdds {
@@ -93,12 +94,17 @@ public:
         return frame_holder( frame, _on_frame_release );
     }
 
+    void start() { _started = true; }
+    void stop() { _started = false; }
+
 private:
     // Call these under lock:
     void search_for_match( std::unique_lock< std::mutex > & );
     bool handle_match( std::unique_lock< std::mutex > & );
     bool handle_frame_without_metadata( std::unique_lock< std::mutex > & );
     bool drop_metadata( std::unique_lock< std::mutex > & );
+
+    std::atomic< bool > _started;
 };
 
 

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -1211,6 +1211,12 @@ PYBIND11_MODULE(NAME, m) {
         dds_metadata_syncer()
         {
             on_frame_release( frame_releaser );
+            start();
+        }
+
+        ~dds_metadata_syncer()
+        {
+            stop();
         }
 
         void enqueue_frame( key_type key, frame_type const & img )

--- a/third-party/realdds/src/dds-metadata-syncer.cpp
+++ b/third-party/realdds/src/dds-metadata-syncer.cpp
@@ -112,7 +112,7 @@ bool dds_metadata_syncer::handle_match( std::unique_lock< std::mutex > & lock )
     _metadata_queue.pop_front();
     _frame_queue.pop_front();
 
-    if( _on_frame_ready )
+    if( _on_frame_ready && _started )
     {
         lock.unlock();
         _on_frame_ready( std::move( fh ), md );
@@ -132,7 +132,7 @@ bool dds_metadata_syncer::handle_frame_without_metadata( std::unique_lock< std::
     frame_holder fh = std::move( _frame_queue.front().second );
     _frame_queue.pop_front();
 
-    if( _on_frame_ready )
+    if( _on_frame_ready && _started )
     {
         lock.unlock();
         _on_frame_ready( std::move( fh ), metadata_type() );


### PR DESCRIPTION
Tracked on [RSDEV-3022]

We have experienced segmentation faults on Linux while running a start-stop loop test.
Root cause of the problem is handling frame callback in one thread, while stopping in another. Stop deleted the lambda expression calling the user callback, returning from the callback have issued  the fault.
