### PR TITLE
minimize frame skip so FPS will be calculated ASAP

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -76,7 +76,7 @@ namespace rs2
             std::lock_guard<std::mutex> lock(_mtx);
             if (++_counter >= _skip_frames)
             {
-                if (std::abs(_last_timestamp) > std::numeric_limits<double>::epsilon() && frame_counter > _last_frame_counter)
+                if (_last_timestamp != 0 && frame_counter > _last_frame_counter)
                 {
                     _delta = timestamp - _last_timestamp;
                     _num_of_frames = frame_counter - _last_frame_counter;

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -58,8 +58,10 @@ namespace rs2
         fps_calc()
             : _counter(0),
             _delta(0),
-            _last_timestamp(0),
-            _num_of_frames(0)
+            _last_timestamp(0.0),
+            _num_of_frames(0),
+            _skip_frames(0),//initialiy set to zero in order to minimize the time where _delta and _num_of_frames are uninitialized and the display on screen will be NA.
+            _last_frame_counter(0)
         {}
 
         fps_calc(const fps_calc& other)
@@ -75,10 +77,11 @@ namespace rs2
             std::lock_guard<std::mutex> lock(_mtx);
             if (++_counter >= _skip_frames)
             {
-                if (_last_timestamp != 0)
+                if (_last_timestamp > std::numeric_limits<double>::epsilon() && frame_counter > _last_frame_counter)
                 {
                     _delta = timestamp - _last_timestamp;
                     _num_of_frames = frame_counter - _last_frame_counter;
+                    _skip_frames = _skip_frames_default;// now that _delta and _num_of_frames are initialized we can recover to default value.
                 }
 
                 _last_frame_counter = frame_counter;
@@ -90,7 +93,7 @@ namespace rs2
         double get_fps() const
         {
             std::lock_guard<std::mutex> lock(_mtx);
-            if (_delta == 0)
+            if (_delta < std::numeric_limits<double>::epsilon())
                 return 0;
 
             return (static_cast<double>(_numerator) * _num_of_frames) / _delta;
@@ -98,7 +101,8 @@ namespace rs2
 
     private:
         static const int _numerator = 1000;
-        static const int _skip_frames = 5;
+        static const int _skip_frames_default = 5;
+        int _skip_frames;
         int _counter;
         double _delta;
         double _last_timestamp;

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -60,7 +60,7 @@ namespace rs2
             _delta(0),
             _last_timestamp(0),
             _num_of_frames(0),
-			_last_frame_counter(0)
+            _last_frame_counter(0)
         {}
 
         fps_calc(const fps_calc& other)
@@ -76,7 +76,7 @@ namespace rs2
             std::lock_guard<std::mutex> lock(_mtx);
             if (++_counter >= _skip_frames)
             {
-                if (abs(_last_timestamp) > std::numeric_limits<double>::epsilon() && frame_counter > _last_frame_counter)
+                if (std::abs(_last_timestamp) > std::numeric_limits<double>::epsilon() && frame_counter > _last_frame_counter)
                 {
                     _delta = timestamp - _last_timestamp;
                     _num_of_frames = frame_counter - _last_frame_counter;
@@ -91,7 +91,7 @@ namespace rs2
         double get_fps() const
         {
             std::lock_guard<std::mutex> lock(_mtx);
-            if (abs(_delta) < std::numeric_limits<double>::epsilon())
+            if (std::abs(_delta) < std::numeric_limits<double>::epsilon())
                 return 0;
 
             return (static_cast<double>(_numerator) * _num_of_frames) / _delta;

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -58,10 +58,9 @@ namespace rs2
         fps_calc()
             : _counter(0),
             _delta(0),
-            _last_timestamp(0.0),
+            _last_timestamp(0),
             _num_of_frames(0),
-            _skip_frames(0),//initialiy set to zero in order to minimize the time where _delta and _num_of_frames are uninitialized and the display on screen will be NA.
-            _last_frame_counter(0)
+			_last_frame_counter(0)
         {}
 
         fps_calc(const fps_calc& other)
@@ -77,11 +76,10 @@ namespace rs2
             std::lock_guard<std::mutex> lock(_mtx);
             if (++_counter >= _skip_frames)
             {
-                if (_last_timestamp > std::numeric_limits<double>::epsilon() && frame_counter > _last_frame_counter)
+                if (abs(_last_timestamp) > std::numeric_limits<double>::epsilon() && frame_counter > _last_frame_counter)
                 {
                     _delta = timestamp - _last_timestamp;
                     _num_of_frames = frame_counter - _last_frame_counter;
-                    _skip_frames = _skip_frames_default;// now that _delta and _num_of_frames are initialized we can recover to default value.
                 }
 
                 _last_frame_counter = frame_counter;
@@ -93,7 +91,7 @@ namespace rs2
         double get_fps() const
         {
             std::lock_guard<std::mutex> lock(_mtx);
-            if (_delta < std::numeric_limits<double>::epsilon())
+            if (abs(_delta) < std::numeric_limits<double>::epsilon())
                 return 0;
 
             return (static_cast<double>(_numerator) * _num_of_frames) / _delta;
@@ -101,8 +99,7 @@ namespace rs2
 
     private:
         static const int _numerator = 1000;
-        static const int _skip_frames_default = 5;
-        int _skip_frames;
+        static const int _skip_frames = 5;
         int _counter;
         double _delta;
         double _last_timestamp;

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -847,14 +847,11 @@ namespace rs2
         stream_details.push_back(
             { "Pixel Format", rsutils::string::from() << rs2_format_to_string( profile.format() ), "" } );
 
-        double fps_tmp = fps.get_fps();
-        std::string fps_value = (fps_tmp > 0) ? (rsutils::string::from() << std::setprecision(2) << std::fixed << fps_tmp).str() : std::string("--");
-
         stream_details.push_back(
             { "Hardware FPS",
-              fps_value,
+              rsutils::string::from() << std::setprecision( 2 ) << std::fixed << fps.get_fps(),
               "Hardware FPS captures the number of frames per second produced by the device.\n"
-              "It is possible and likely that not all of these frames will make it to the application." });        
+              "It is possible and likely that not all of these frames will make it to the application." } );
 
         stream_details.push_back(
             { "Viewer FPS",

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -847,11 +847,14 @@ namespace rs2
         stream_details.push_back(
             { "Pixel Format", rsutils::string::from() << rs2_format_to_string( profile.format() ), "" } );
 
+        double fps_tmp = fps.get_fps();
+        std::string fps_value = (fps_tmp > 0) ? (rsutils::string::from() << std::setprecision(2) << std::fixed << fps_tmp).str() : std::string("--");
+
         stream_details.push_back(
             { "Hardware FPS",
-              rsutils::string::from() << std::setprecision( 2 ) << std::fixed << fps.get_fps(),
+              fps_value,
               "Hardware FPS captures the number of frames per second produced by the device.\n"
-              "It is possible and likely that not all of these frames will make it to the application." } );
+              "It is possible and likely that not all of these frames will make it to the application." });        
 
         stream_details.push_back(
             { "Viewer FPS",


### PR DESCRIPTION
The root cause is the unsigned long underflow when we playback a bag file.
when we finish the file and go back to the first frame, the current frame - last frame turns out to be negative (underflow) which cases the invalid value display on the UI


Tracked on [RSDSO-19945]
