### PR TITLE
update dds-sniffer with --topics, topic-info

### DIFF
--- a/third-party/realdds/include/realdds/dds-participant.h
+++ b/third-party/realdds/include/realdds/dds-participant.h
@@ -21,6 +21,12 @@ class DomainParticipant;
 class DomainParticipantFactory;
 }  // namespace dds
 }  // namespace fastdds
+namespace fastrtps {
+namespace rtps {
+class WriterProxyData;
+class ReaderProxyData;
+}  // namespace rtps
+}  // namespace fastrtps
 }  // namespace eprosima
 #ifdef BUILD_EASYLOGGINGPP
 namespace el {
@@ -153,9 +159,9 @@ public:
     {
         friend class dds_participant;
 
-        std::function< void( dds_guid, char const* topic_name ) > _on_writer_added;
+        std::function< void( eprosima::fastrtps::rtps::WriterProxyData const & ) > _on_writer_added;
         std::function< void( dds_guid, char const* topic_name ) > _on_writer_removed;
-        std::function< void( dds_guid, char const* topic_name ) > _on_reader_added;
+        std::function< void( eprosima::fastrtps::rtps::ReaderProxyData const & ) > _on_reader_added;
         std::function< void( dds_guid, char const* topic_name ) > _on_reader_removed;
         std::function< void( dds_guid, char const* participant_name ) > _on_participant_added;
         std::function< void( dds_guid, char const* participant_name ) > _on_participant_removed;
@@ -164,7 +170,7 @@ public:
         listener() = default;
 
     public:
-        listener* on_writer_added( std::function< void( dds_guid guid, char const* topic_name ) > callback )
+        listener* on_writer_added( std::function< void( eprosima::fastrtps::rtps::WriterProxyData const & ) > callback )
         {
             _on_writer_added = std::move( callback );
             return this;
@@ -174,7 +180,7 @@ public:
             _on_writer_removed = std::move( callback );
             return this;
         }
-        listener* on_reader_added( std::function< void( dds_guid guid, char const* topic_name ) > callback )
+        listener* on_reader_added( std::function< void( eprosima::fastrtps::rtps::ReaderProxyData const & ) > callback )
         {
             _on_reader_added = std::move( callback );
             return this;
@@ -228,9 +234,9 @@ private:
     std::shared_ptr< listener_impl > _domain_listener;
     std::atomic< uint32_t > _next_entity_id{ 0 };  // for create_guid()
 
-    void on_writer_added( dds_guid, char const * topic_name );
+    void on_writer_added( eprosima::fastrtps::rtps::WriterProxyData const & );
     void on_writer_removed( dds_guid, char const * topic_name );
-    void on_reader_added( dds_guid, char const * topic_name );
+    void on_reader_added( eprosima::fastrtps::rtps::ReaderProxyData const & );
     void on_reader_removed( dds_guid, char const * topic_name );
     void on_participant_added( dds_guid, char const * participant_name );
     void on_participant_removed( dds_guid, char const * participant_name );

--- a/third-party/realdds/include/realdds/dds-serialization.h
+++ b/third-party/realdds/include/realdds/dds-serialization.h
@@ -63,6 +63,23 @@ namespace realdds {
 class dds_participant;
 
 
+struct print_writer_info
+{
+    eprosima::fastrtps::rtps::WriterProxyData const & info;
+    print_writer_info( eprosima::fastrtps::rtps::WriterProxyData const & info ) : info( info ) {}
+};
+std::ostream & operator<<( std::ostream & os, print_writer_info const & );
+
+
+struct print_reader_info
+{
+    eprosima::fastrtps::rtps::ReaderProxyData const & info;
+    print_reader_info( eprosima::fastrtps::rtps::ReaderProxyData const & info ) : info( info ) {}
+};
+std::ostream & operator<<( std::ostream & os, print_reader_info const & );
+
+
+
 eprosima::fastdds::dds::ReliabilityQosPolicyKind reliability_kind_from_string( std::string const & );
 eprosima::fastdds::dds::DurabilityQosPolicyKind durability_kind_from_string( std::string const & );
 eprosima::fastdds::dds::HistoryQosPolicyKind history_kind_from_string( std::string const & );

--- a/third-party/realdds/py/pyrealdds.cpp
+++ b/third-party/realdds/py/pyrealdds.cpp
@@ -46,6 +46,8 @@
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastrtps/types/DynamicType.h>
+#include <fastdds/rtps/builtin/data/WriterProxyData.h>
+#include <fastdds/rtps/builtin/data/ReaderProxyData.h>
 
 #include <rsutils/py/pybind11.h>
 
@@ -248,8 +250,8 @@ PYBIND11_MODULE(NAME, m) {
         .def( FN_FWD( dds_participant::listener,
                       on_writer_added,
                       ( dds_guid guid, char const * topic_name ),
-                      ( dds_guid guid, char const * topic_name ),
-                      callback( guid, topic_name ); ) )
+                      ( eprosima::fastrtps::rtps::WriterProxyData const & data ),
+                      callback( data.guid(), data.topicName().c_str() ); ) )
         .def( FN_FWD( dds_participant::listener,
                       on_writer_removed,
                       ( dds_guid guid, char const * topic_name ),
@@ -258,8 +260,8 @@ PYBIND11_MODULE(NAME, m) {
         .def( FN_FWD( dds_participant::listener,
                       on_reader_added,
                       ( dds_guid guid, char const * topic_name ),
-                      ( dds_guid guid, char const * topic_name ),
-                      callback( guid, topic_name ); ) )
+                      ( eprosima::fastrtps::rtps::ReaderProxyData const & data ),
+                      callback( data.guid(), data.topicName().c_str() ); ) )
         .def( FN_FWD( dds_participant::listener,
                       on_reader_removed,
                       ( dds_guid guid, char const * topic_name ),

--- a/third-party/realdds/src/dds-participant.cpp
+++ b/third-party/realdds/src/dds-participant.cpp
@@ -144,7 +144,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
             /* Process the case when a new publisher was found in the domain */
             LOG_DEBUG( _owner.name() << ": +writer (" << _owner.print( info.info.guid() ) << ") publishing "
                                      << info.info );
-            _owner.on_writer_added( info.info.guid(), info.info.topicName().c_str() );
+            _owner.on_writer_added( info.info );
             break;
 
         case eprosima::fastrtps::rtps::WriterDiscoveryInfo::REMOVED_WRITER:
@@ -163,7 +163,7 @@ struct dds_participant::listener_impl : public eprosima::fastdds::dds::DomainPar
         {
         case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::DISCOVERED_READER:
             LOG_DEBUG( _owner.name() << ": +reader (" << _owner.print( info.info.guid() ) << ") of " << info.info );
-            _owner.on_reader_added( info.info.guid(), info.info.topicName().c_str() );
+            _owner.on_reader_added( info.info );
             break;
 
         case eprosima::fastrtps::rtps::ReaderDiscoveryInfo::REMOVED_READER:
@@ -359,14 +359,14 @@ std::string dds_participant::print( dds_guid const & guid_to_print ) const
 }
 
 
-void dds_participant::on_writer_added( dds_guid guid, char const * topic_name )
+void dds_participant::on_writer_added( eprosima::fastrtps::rtps::WriterProxyData const & data )
 {
     for( auto & wl : _listeners )
     {
         if( auto l = wl.lock() )
         {
             if( l->_on_writer_added )
-                l->_on_writer_added( guid, topic_name );
+                l->_on_writer_added( data );
         }
     }
 }
@@ -385,14 +385,14 @@ void dds_participant::on_writer_removed( dds_guid guid, char const * topic_name 
 }
 
 
-void dds_participant::on_reader_added( dds_guid guid, char const * topic_name )
+void dds_participant::on_reader_added( eprosima::fastrtps::rtps::ReaderProxyData const & data )
 {
     for( auto & wl : _listeners )
     {
         if( auto l = wl.lock() )
         {
             if( l->_on_reader_added )
-                l->_on_reader_added( guid, topic_name );
+                l->_on_reader_added( data );
         }
     }
 }

--- a/third-party/realdds/src/dds-serialization.cpp
+++ b/third-party/realdds/src/dds-serialization.cpp
@@ -416,30 +416,14 @@ std::ostream & operator<<( std::ostream & os, RemoteLocatorsAllocationAttributes
 
 std::ostream & operator<<( std::ostream & os, WriterProxyData const & info )
 {
-    field::group group;
-    os << "'" << info.topicName() << "' " << group;
-    os << /*field::separator << "type" <<*/ field::value << info.typeName();
-    os << /*field::separator << "reliability" << field::group() <<*/ info.m_qos.m_reliability;
-    if( ! ( info.m_qos.m_durability == eprosima::fastdds::dds::DurabilityQosPolicy() ) )
-        os << /*field::separator << "durability" << field::group() <<*/ info.m_qos.m_durability;
-    if( ! ( info.m_qos.m_liveliness == eprosima::fastdds::dds::LivelinessQosPolicy() ) )
-        os << field::separator << "liveliness" << field::value << info.m_qos.m_liveliness;
-    if( info.m_qos.m_publishMode.flow_controller_name
-        && info.m_qos.m_publishMode.flow_controller_name != eprosima::fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT )
-        os << field::separator << "flow-controller" << field::value << "'"
-           << info.m_qos.m_publishMode.flow_controller_name << "'";
+    os << "'" << info.topicName() << "' " << field::group() << realdds::print_writer_info( info );
     return os;
 }
 
 
 std::ostream & operator<<( std::ostream & os, ReaderProxyData const & info )
 {
-    field::group group;
-    os << "'" << info.topicName() << "' " << group;
-    os << /*field::separator << "type" <<*/ field::value << info.typeName();
-    os << /*field::separator << "reliability" << field::group() <<*/ info.m_qos.m_reliability;
-    if( ! ( info.m_qos.m_durability == eprosima::fastdds::dds::DurabilityQosPolicy() ) )
-        os << /*field::separator << "durability" << field::group() <<*/ info.m_qos.m_durability;
+    os << "'" << info.topicName() << "' " << field::group() << realdds::print_reader_info( info );
     return os;
 }
 
@@ -491,6 +475,34 @@ std::ostream & operator<<( std::ostream & os, BuiltinAttributes const & qos )
 
 
 namespace realdds {
+
+
+std::ostream & operator<<( std::ostream & os, print_writer_info const & pwi )
+{
+    auto & info = pwi.info;
+    os << /*field::separator << "type" <<*/ field::value << info.typeName();
+    os << /*field::separator << "reliability" << field::group() <<*/ info.m_qos.m_reliability;
+    if( ! ( info.m_qos.m_durability == eprosima::fastdds::dds::DurabilityQosPolicy() ) )
+        os << /*field::separator << "durability" << field::group() <<*/ info.m_qos.m_durability;
+    if( ! ( info.m_qos.m_liveliness == eprosima::fastdds::dds::LivelinessQosPolicy() ) )
+        os << field::separator << "liveliness" << field::value << info.m_qos.m_liveliness;
+    if( info.m_qos.m_publishMode.flow_controller_name
+        && info.m_qos.m_publishMode.flow_controller_name != eprosima::fastdds::rtps::FASTDDS_FLOW_CONTROLLER_DEFAULT )
+        os << field::separator << "flow-controller" << field::value << "'"
+           << info.m_qos.m_publishMode.flow_controller_name << "'";
+    return os;
+}
+
+
+std::ostream & operator<<( std::ostream & os, print_reader_info const & pri )
+{
+    auto & info = pri.info;
+    os << /*field::separator << "type" <<*/ field::value << info.typeName();
+    os << /*field::separator << "reliability" << field::group() <<*/ info.m_qos.m_reliability;
+    if( ! ( info.m_qos.m_durability == eprosima::fastdds::dds::DurabilityQosPolicy() ) )
+        os << /*field::separator << "durability" << field::group() <<*/ info.m_qos.m_durability;
+    return os;
+}
 
 
 eprosima::fastdds::dds::ReliabilityQosPolicyKind reliability_kind_from_string( std::string const & s )


### PR DESCRIPTION
When doing some ROS work I needed to see topic information but the dds-sniffer output was insufficient. I added so we can now see:

```
$ ./Release/rs-dds-sniffer -d 0 --participants --topics
5898d32b8091.0  rs-dds-adapter
    R  realsense/D455_214623065416/control                               [ realdds::topics::raw::flexible reliable ]
     W realsense/D455_214623065416/metadata                              [ realdds::topics::raw::flexible best-effort ]
     W realsense/D455_214623065416/notification                          [ realdds::topics::raw::flexible reliable ]
     W realsense/device-info                                             [ realdds::topics::raw::flexible reliable ]
    R  rq/realsense/D455_214623065416/describe_parametersRequest         [ rcl_interfaces::srv::dds_::DescribeParameters_Request_ reliable ]
    R  rq/realsense/D455_214623065416/get_parametersRequest              [ rcl_interfaces::srv::dds_::GetParameters_Request_ reliable ]
    R  rq/realsense/D455_214623065416/list_parametersRequest             [ rcl_interfaces::srv::dds_::ListParameters_Request_ reliable ]
    R  rq/realsense/D455_214623065416/set_parametersRequest              [ rcl_interfaces::srv::dds_::SetParameters_Request_ reliable ]
     W rr/realsense/D455_214623065416/describe_parametersReply           [ rcl_interfaces::srv::dds_::DescribeParameters_Response_ reliable ]
     W rr/realsense/D455_214623065416/get_parametersReply                [ rcl_interfaces::srv::dds_::GetParameters_Response_ reliable ]
     W rr/realsense/D455_214623065416/list_parametersReply               [ rcl_interfaces::srv::dds_::ListParameters_Response_ reliable ]
     W rr/realsense/D455_214623065416/set_parametersReply                [ rcl_interfaces::srv::dds_::SetParameters_Response_ reliable ]
     W rt/realsense/D455_214623065416_Color                              [ sensor_msgs::msg::dds_::Image_ best-effort ]
     W rt/realsense/D455_214623065416_Depth                              [ sensor_msgs::msg::dds_::Image_ best-effort ]
     W rt/realsense/D455_214623065416_Infrared_1                         [ sensor_msgs::msg::dds_::Image_ best-effort ]
     W rt/realsense/D455_214623065416_Infrared_2                         [ sensor_msgs::msg::dds_::Image_ best-effort ]
     W rt/realsense/D455_214623065416_Motion                             [ sensor_msgs::msg::dds_::Imu_ best-effort ]
011040e9be1ec39ac5f91813
    RW ros_discovery_info                                                [ rmw_dds_common::msg::dds_::ParticipantEntitiesInfo_ reliable transient-local ]
    R  rq/camera/camera/describe_parametersRequest                       [ rcl_interfaces::srv::dds_::DescribeParameters_Request_ reliable ]
    R  rq/camera/camera/get_parameter_typesRequest                       [ rcl_interfaces::srv::dds_::GetParameterTypes_Request_ reliable ]
    R  rq/camera/camera/get_parametersRequest                            [ rcl_interfaces::srv::dds_::GetParameters_Request_ reliable ]
    R  rq/camera/camera/list_parametersRequest                           [ rcl_interfaces::srv::dds_::ListParameters_Request_ reliable ]
    R  rq/camera/camera/set_parametersRequest                            [ rcl_interfaces::srv::dds_::SetParameters_Request_ reliable ]
    R  rq/camera/camera/set_parameters_atomicallyRequest                 [ rcl_interfaces::srv::dds_::SetParametersAtomically_Request_ reliable ]
     W rr/camera/camera/describe_parametersReply                         [ rcl_interfaces::srv::dds_::DescribeParameters_Response_ reliable ]
     W rr/camera/camera/get_parameter_typesReply                         [ rcl_interfaces::srv::dds_::GetParameterTypes_Response_ reliable ]
     W rr/camera/camera/get_parametersReply                              [ rcl_interfaces::srv::dds_::GetParameters_Response_ reliable ]
     W rr/camera/camera/list_parametersReply                             [ rcl_interfaces::srv::dds_::ListParameters_Response_ reliable ]
     W rr/camera/camera/set_parametersReply                              [ rcl_interfaces::srv::dds_::SetParameters_Response_ reliable ]
     W rr/camera/camera/set_parameters_atomicallyReply                   [ rcl_interfaces::srv::dds_::SetParametersAtomically_Response_ reliable ]
    RW rt/parameter_events                                               [ rcl_interfaces::msg::dds_::ParameterEvent_ reliable ]
     W rt/rosout                                                         [ rcl_interfaces::msg::dds_::Log_ reliable transient-local ]
```

- Had to change `on_writer_added` and `on_reader_added` listener callbacks in dds-participant so they can provide actual QoS
- Then take that QoS and easily stream as a string
- Added `--topics` to rs-dds-sniffer

I actually prefer the output of `--participants --topics` to the default output of `--snapshot`...

