### PR TITLE
replace ImGui::SetTooltip maintain the uniformity of the design of  with RsImGui::RsCustomTooltip

### DIFF
--- a/common/calibration-model.cpp
+++ b/common/calibration-model.cpp
@@ -6,6 +6,7 @@
 #include "device-model.h"
 #include "os.h"
 #include "ux-window.h"
+#include <realsense_imgui.h>
 
 #include "../src/ds/d400/d400-private.h"
 
@@ -176,7 +177,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
         if (ImGui::IsItemHovered())
         {
             window.link_hovered();
-            ImGui::SetTooltip("%s", "Load calibration from file");
+            RsImGui::CustomTooltip("%s", "Load calibration from file");
         }
         ImGui::SameLine();
         if (ImGui::Button(u8"\uF0C7 Save As...", ImVec2(100, 30)))
@@ -232,7 +233,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
         if (ImGui::IsItemHovered())
         {
             window.link_hovered();
-            ImGui::SetTooltip("%s", "Save calibration image to file");
+            RsImGui::CustomTooltip("%s", "Save calibration image to file");
         }
         ImGui::SameLine();
         if (_accept)
@@ -263,7 +264,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
             if (ImGui::IsItemHovered())
             {
                 window.link_hovered();
-                ImGui::SetTooltip("%s", "Restore calibration in flash to factory settings");
+                RsImGui::CustomTooltip("%s", "Restore calibration in flash to factory settings");
             }
         }
         else
@@ -274,7 +275,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
             ImGui::Button(u8"\uF275 Restore Factory", ImVec2(115, 30));
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip("%s", "Write selected calibration table to the device. For advanced users");
+                RsImGui::CustomTooltip("%s", "Write selected calibration table to the device. For advanced users");
             }
 
             ImGui::PopStyleColor(2);
@@ -361,7 +362,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
         }
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("%s", "Changing calibration will affect depth quality. Changes are persistent.\nThere is an option to get back to factory calibration, but it maybe worse than current calibration\nBefore writing to flash, we strongly recommend to make a file backup");
+            RsImGui::CustomTooltip("%s", "Changing calibration will affect depth quality. Changes are persistent.\nThere is an option to get back to factory calibration, but it maybe worse than current calibration\nBefore writing to flash, we strongly recommend to make a file backup");
         }
 
         ImGui::SetCursorScreenPos({ (float)(x0 + w - 230), (float)(y0 + h - 30) });
@@ -373,7 +374,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
         if (ImGui::IsItemHovered())
         {
             window.link_hovered();
-            ImGui::SetTooltip("%s", "Close without saving any changes");
+            RsImGui::CustomTooltip("%s", "Close without saving any changes");
         }
         ImGui::SameLine();
 
@@ -403,7 +404,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
             if (ImGui::IsItemHovered())
             {
                 window.link_hovered();
-                ImGui::SetTooltip("%s", "Write selected calibration table to the device");
+                RsImGui::CustomTooltip("%s", "Write selected calibration table to the device");
             }
         }
         else
@@ -414,7 +415,7 @@ void calibration_model::update(ux_window& window, std::string& error_message)
             ImGui::Button(u8"\uF2DB  Write Table", ImVec2(120, 25));
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip("%s", "Write selected calibration table to the device. For advanced users");
+                RsImGui::CustomTooltip("%s", "Write selected calibration table to the device. For advanced users");
             }
 
             ImGui::PopStyleColor(2);

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -582,7 +582,7 @@ namespace rs2
         if (ImGui::IsItemHovered())
         {
             std::string tooltip = rsutils::string::from() << "Step Backwards" << (supports_playback_step ? "" : "(Not available)");
-            ImGui::SetTooltip("%s", tooltip.c_str());
+            RsImGui::CustomTooltip("%s", tooltip.c_str());
         }
         ImGui::SameLine();
         //////////////////// Step Backwards Button ////////////////////
@@ -602,7 +602,7 @@ namespace rs2
         if (ImGui::IsItemHovered())
         {
             std::string tooltip = rsutils::string::from() << "Stop Playback";
-            ImGui::SetTooltip("%s", tooltip.c_str());
+            RsImGui::CustomTooltip("%s", tooltip.c_str());
         }
         ImGui::SameLine();
         //////////////////// Stop Button ////////////////////
@@ -636,7 +636,7 @@ namespace rs2
             }
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip(current_playback_status == RS2_PLAYBACK_STATUS_PAUSED ? "Resume Playback" : "Start Playback");
+                RsImGui::CustomTooltip(current_playback_status == RS2_PLAYBACK_STATUS_PAUSED ? "Resume Playback" : "Start Playback");
             }
         }
         else
@@ -654,7 +654,7 @@ namespace rs2
             }
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip("Pause Playback");
+                RsImGui::CustomTooltip("Pause Playback");
             }
         }
 
@@ -683,7 +683,7 @@ namespace rs2
         if (ImGui::IsItemHovered())
         {
             std::string tooltip = rsutils::string::from() << "Step Forward" << (supports_playback_step ? "" : "(Not available)");
-            ImGui::SetTooltip("%s", tooltip.c_str());
+            RsImGui::CustomTooltip("%s", tooltip.c_str());
         }
         ImGui::SameLine();
         //////////////////// Step Forward Button ////////////////////
@@ -711,7 +711,7 @@ namespace rs2
         if (ImGui::IsItemHovered())
         {
             std::string tooltip = rsutils::string::from() << (_playback_repeat ? "Disable " : "Enable ") << "Repeat ";
-            ImGui::SetTooltip("%s", tooltip.c_str());
+            RsImGui::CustomTooltip("%s", tooltip.c_str());
         }
         ImGui::PopStyleColor(2);
         ImGui::SameLine();
@@ -745,7 +745,7 @@ namespace rs2
         }
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("Change playback speed rate");
+            RsImGui::CustomTooltip("Change playback speed rate");
         }
         ImGui::PopStyleColor(2);
         ImGui::SameLine();
@@ -893,7 +893,7 @@ namespace rs2
                     }
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("Advanced mode is a persistent camera state unlocking calibration formats and depth generation controls\nYou can always reset the camera to factory defaults by disabling advanced mode");
+                        RsImGui::CustomTooltip("Advanced mode is a persistent camera state unlocking calibration formats and depth generation controls\nYou can always reset the camera to factory defaults by disabling advanced mode");
                     }
                     if (show_yes_no_modal)
                     {
@@ -915,6 +915,8 @@ namespace rs2
 
     void device_model::draw_info_icon(ux_window& window, ImFont* font, const ImVec2& size)
     {
+        ImGui::PopFont();
+        ImGui::PushFont(window.get_large_font());
         std::string info_button_name = rsutils::string::from() << textual_icons::info_circle << "##" << id;
         auto info_button_color = show_device_info ? light_blue : light_grey;
         ImGui::PushStyleColor(ImGuiCol_Text, info_button_color);
@@ -923,13 +925,12 @@ namespace rs2
         {
             show_device_info = !show_device_info;
         }
+        ImGui::PopFont();
+        ImGui::PushFont(window.get_font());
         if (ImGui::IsItemHovered())
         {
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-            ImGui::SetTooltip("%s", show_device_info ? "Hide Device Details" : "Show Device Details");
+            RsImGui::CustomTooltip("%s", show_device_info ? "Hide Device Details" : "Show Device Details");
             window.link_hovered();
-            ImGui::PopStyleColor(2);
         }
         ImGui::PopStyleColor(2);
     }
@@ -1260,14 +1261,13 @@ namespace rs2
                 if (path != "") start_recording(path, error_message);
             }
         }}, disable_record_button_logic(is_streaming, is_playback_device));
+        ImGui::PopFont();
+        ImGui::PushFont(window.get_font());
         if (ImGui::IsItemHovered())
         {
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
             std::string record_button_hover_text = get_record_button_hover_text(is_streaming);
-            ImGui::SetTooltip("%s", record_button_hover_text.c_str());
+            RsImGui::CustomTooltip("%s", record_button_hover_text.c_str());
             if (is_streaming) window.link_hovered();
-            ImGui::PopStyleColor(2);
         }
         ImGui::PopStyleColor(2);
         ImGui::SameLine();
@@ -1279,6 +1279,8 @@ namespace rs2
         auto sync_button_color = is_sync_enabled ? light_blue : light_grey;
         ImGui::PushStyleColor(ImGuiCol_Text, sync_button_color);
         ImGui::PushStyleColor(ImGuiCol_TextSelectedBg, sync_button_color);
+        ImGui::PopFont();
+        ImGui::PushFont(window.get_large_font());
         RsImGui::RsImButton([&]() {
         if (ImGui::ButtonEx(sync_button_name.c_str(), device_panel_icons_size))
         {
@@ -1286,12 +1288,11 @@ namespace rs2
         }
         }, true);
         ImGui::PopStyleColor(2);
+        ImGui::PopFont();
+        ImGui::PushFont(window.get_font());
         if (ImGui::IsItemHovered())
         {
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-            ImGui::SetTooltip("%s", is_sync_enabled ? "Disable streams synchronization" : "Enable streams synchronization");
-            ImGui::PopStyleColor(2);
+            RsImGui::CustomTooltip("%s", is_sync_enabled ? "Disable streams synchronization" : "Enable streams synchronization");
         }
         ImGui::SameLine();
         ////////////////////////////////////////
@@ -1305,20 +1306,19 @@ namespace rs2
         ////////////////////////////////////////
         std::string label = rsutils::string::from() << "device_menu" << id;
         std::string bars_button_name = rsutils::string::from() << textual_icons::bars << "##" << id;
+        ImGui::PopFont();
+        ImGui::PushFont(window.get_large_font());
         if (ImGui::Button(bars_button_name.c_str(), device_panel_icons_size))
         {
             ImGui::OpenPopup(label.c_str());
         }
-        if (ImGui::IsItemHovered())
-        {
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-            ImGui::SetTooltip("%s", "Click for more");
-            window.link_hovered();
-            ImGui::PopStyleColor(2);
-        }
         ImGui::PopFont();
         ImGui::PushFont(window.get_font());
+        if (ImGui::IsItemHovered())
+        {
+            RsImGui::CustomTooltip("%s", "Click for more");
+            window.link_hovered();
+        }
         static bool keep_showing_advanced_mode_modal = false;
         bool open_calibration_ui = false;
         if (ImGui::BeginPopup(label.c_str()))
@@ -1371,13 +1371,10 @@ namespace rs2
                     }
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::PushStyleColor(ImGuiCol_Text, white);
-                        ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                         std::string tooltip = rsutils::string::from()
                                            << "Install official signed firmware from file to the device"
                                            << ( is_streaming ? " (Disabled while streaming)" : "" );
-                        ImGui::SetTooltip("%s", tooltip.c_str());
-                        ImGui::PopStyleColor(2);
+                        RsImGui::CustomTooltip("%s", tooltip.c_str());
                     }
 
 
@@ -1400,11 +1397,8 @@ namespace rs2
 
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::PushStyleColor(ImGuiCol_Text, white);
-                        ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                         std::string tooltip = rsutils::string::from() << "Check for SW / FW updates";
-                        ImGui::SetTooltip("%s", tooltip.c_str());
-                        ImGui::PopStyleColor(2);
+                        RsImGui::CustomTooltip("%s", tooltip.c_str());
                     }
                 }
 
@@ -1425,13 +1419,10 @@ namespace rs2
                         }
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::PushStyleColor(ImGuiCol_Text, white);
-                            ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                             std::string tooltip = rsutils::string::from()
                                                << "Install non official unsigned firmware from file to the device"
                                                << ( is_streaming ? " (Disabled while streaming)" : "" );
-                            ImGui::SetTooltip("%s", tooltip.c_str());
-                            ImGui::PopStyleColor(2);
+                            RsImGui::CustomTooltip("%s", tooltip.c_str());
                         }
                     }
                 }
@@ -1959,10 +1950,7 @@ namespace rs2
                         ImGui::Text("Preset: ");
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::PushStyleColor(ImGuiCol_PopupBg, black);
-                            ImGui::PushStyleColor(ImGuiCol_Text, white);
-                            ImGui::SetTooltip("Select a preset configuration (or use the load button)");
-                            ImGui::PopStyleColor(2);
+                            RsImGui::CustomTooltip("Select a preset configuration (or use the load button)");
                         }
 
                         ImGui::SameLine();
@@ -2123,13 +2111,10 @@ namespace rs2
         }}, load_button_disabled);
         if (ImGui::IsItemHovered())
         {
-            ImGui::PushStyleColor(ImGuiCol_PopupBg, black);
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
             std::string tooltip = rsutils::string::from()
                                << "Load pre-configured device settings"
                                << ( is_streaming && ! load_json_if_streaming ? " (Disabled while streaming)" : "" );
-            ImGui::SetTooltip("%s", tooltip.c_str());
-            ImGui::PopStyleColor(2);
+            RsImGui::CustomTooltip("%s", tooltip.c_str());
         }
 
         ImGui::SameLine();
@@ -2158,10 +2143,7 @@ namespace rs2
         }}, buttons_disable);
         if (ImGui::IsItemHovered())
         {
-            ImGui::PushStyleColor(ImGuiCol_PopupBg, black);
-            ImGui::PushStyleColor(ImGuiCol_Text, white);
-            ImGui::SetTooltip("Save current device settings to file");
-            ImGui::PopStyleColor(2);
+            RsImGui::CustomTooltip("Save current device settings to file");
         }
         ImGui::PopStyleColor(2);
         ImGui::SameLine();
@@ -2310,11 +2292,8 @@ namespace rs2
 
             if (ImGui::IsItemHovered())
             {
-                ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-                ImGui::PushStyleColor(ImGuiCol_Text, white);
-                ImGui::SetTooltip("Remove selected device from current view\n(can be restored by clicking Add Source)");
+                RsImGui::CustomTooltip("Remove selected device from current view\n(can be restored by clicking Add Source)");
                 window.link_hovered();
-                ImGui::PopStyleColor(2);
             }
         }
         ImGui::PopStyleColor(4);
@@ -2333,7 +2312,7 @@ namespace rs2
             std::string file_name_and_icon = rsutils::string::from() << " " << textual_icons::file_movie << " File: \"" << filename << "\"";
             ImGui::Text("%s", file_name_and_icon.c_str());
             if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("%s", full_path.c_str());
+                RsImGui::CustomTooltip("%s", full_path.c_str());
             ImGui::PopFont();
         }
         ImGui::SetCursorPos({ 0, pos.y + header_h });
@@ -2489,21 +2468,14 @@ namespace rs2
                                 {
                                     if (ImGui::IsItemHovered())
                                     {
-                                        ImGui::PushStyleColor(ImGuiCol_Text, white);
-                                        ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-                                        // ImGui::SetTooltip("Selected configuration (FPS, Resolution) is not supported");
-                                        ImGui::SetTooltip("Selected value is not supported");
-                                        ImGui::PopStyleColor(2);
+                                        RsImGui::CustomTooltip("Selected value is not supported");
                                     }
                                 }
                                 else
                                 {
                                     if (ImGui::IsItemHovered())
                                     {
-                                        ImGui::PushStyleColor(ImGuiCol_Text, white);
-                                        ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-                                        ImGui::SetTooltip("No stream selected");
-                                        ImGui::PopStyleColor(2);
+                                        RsImGui::CustomTooltip("No stream selected");
                                     }
                                 }
                             }
@@ -2545,11 +2517,8 @@ namespace rs2
                             }
                             if (ImGui::IsItemHovered())
                             {
-                                ImGui::PushStyleColor(ImGuiCol_Text, white);
-                                ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                                 window.link_hovered();
-                                ImGui::SetTooltip("Start streaming data from this sensor");
-                                ImGui::PopStyleColor(2);
+                                RsImGui::CustomTooltip("Start streaming data from this sensor");
                             }
                         }
                     }
@@ -2583,11 +2552,8 @@ namespace rs2
                         }
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::PushStyleColor(ImGuiCol_Text, white);
-                            ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                             window.link_hovered();
-                            ImGui::SetTooltip("Stop streaming data from selected sub-device");
-                            ImGui::PopStyleColor(2);
+                            RsImGui::CustomTooltip("Stop streaming data from selected sub-device");
                         }
                     }
 
@@ -2770,11 +2736,8 @@ namespace rs2
                                 }
                                 if (ImGui::IsItemHovered())
                                 {
-                                    ImGui::PushStyleColor(ImGuiCol_Text, white);
-                                    ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-                                    ImGui::SetTooltip("Enable post-processing filters");
+                                    RsImGui::CustomTooltip("Enable post-processing filters");
                                     window.link_hovered();
-                                    ImGui::PopStyleColor(2);
                                 }
                             }
                             else
@@ -2800,11 +2763,8 @@ namespace rs2
                                 }
                                 if (ImGui::IsItemHovered())
                                 {
-                                    ImGui::PushStyleColor(ImGuiCol_Text, white);
-                                    ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-                                    ImGui::SetTooltip("Disable post-processing filters");
+                                    RsImGui::CustomTooltip("Disable post-processing filters");
                                     window.link_hovered();
-                                    ImGui::PopStyleColor(2);
                                 }
                             }
                             ImGui::PopStyleColor(5);
@@ -2885,12 +2845,9 @@ namespace rs2
                                             }
                                             if (ImGui::IsItemHovered())
                                             {
-                                                ImGui::PushStyleColor(ImGuiCol_Text, white);
-                                                ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                                                 label = rsutils::string::from() << "Enable " << pb->get_name() << " post-processing filter";
-                                                ImGui::SetTooltip("%s", label.c_str());
+                                                RsImGui::CustomTooltip("%s", label.c_str());
                                                 window.link_hovered();
-                                                ImGui::PopStyleColor(2);
                                             }
                                         }
                                         else
@@ -2909,13 +2866,10 @@ namespace rs2
                                             }
                                             if (ImGui::IsItemHovered())
                                             {
-                                                ImGui::PushStyleColor(ImGuiCol_Text, white);
-                                                ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                                                 label = rsutils::string::from()
                                                      << "Disable " << pb->get_name() << " post-processing filter";
-                                                ImGui::SetTooltip("%s", label.c_str());
+                                                RsImGui::CustomTooltip("%s", label.c_str());
                                                 window.link_hovered();
-                                                ImGui::PopStyleColor(2);
                                             }
                                         }
                                     }
@@ -3129,7 +3083,7 @@ namespace rs2
                     }
                 }
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("This will improve the depth noise.\n"
+                    RsImGui::CustomTooltip("This will improve the depth noise.\n"
                         "Point at a scene that normally would have > 50 %% valid depth pixels,\n"
                         "then press calibrate."
                         "The health-check will be calculated.\n"
@@ -3186,7 +3140,7 @@ namespace rs2
                     }
                 }
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("Focal length calibration is used to adjust camera focal length with specific target.");
+                    RsImGui::CustomTooltip("Focal length calibration is used to adjust camera focal length with specific target.");
 
                 if (ImGui::Selectable("Tare Calibration"))
                 {
@@ -3219,7 +3173,7 @@ namespace rs2
                     }
                 }
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("Tare calibration is used to adjust camera absolute distance to flat target.\n"
+                    RsImGui::CustomTooltip("Tare calibration is used to adjust camera absolute distance to flat target.\n"
                         "User needs either to enter the known ground truth or use the get button\n"
                         "with specific target to get the ground truth.");
 
@@ -3314,7 +3268,7 @@ namespace rs2
                         _calib_model.open();
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Access low level camera calibration parameters");
+                        RsImGui::CustomTooltip("Access low level camera calibration parameters");
                 }
 
                 if (auto fwlogger = dev.as<rs2::firmware_logger>())
@@ -3388,7 +3342,7 @@ namespace rs2
                         }
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Recovers last set of firmware logs prior to camera shutdown / disconnect");
+                        RsImGui::CustomTooltip("Recovers last set of firmware logs prior to camera shutdown / disconnect");
                 }
 
                 has_autocalib = true;
@@ -3467,7 +3421,7 @@ namespace rs2
                                   "with projector on";
                     else
                         tooltip = rsutils::string::from() << "On-Chip Calibration" << (streaming ? " (Disabled while streaming)" : "");
-                    ImGui::SetTooltip("%s", tooltip.c_str());
+                    RsImGui::CustomTooltip("%s", tooltip.c_str());
                 }
 
                 if( !is_d555 )
@@ -3502,7 +3456,7 @@ namespace rs2
                         std::string tooltip = rsutils::string::from()
                                            << "Dry Run On-Chip Calibration"
                                            << ( streaming ? " (Disabled while streaming)" : "" );
-                        ImGui::SetTooltip("%s", tooltip.c_str());
+                        RsImGui::CustomTooltip("%s", tooltip.c_str());
                     }
                 }
                 else
@@ -3544,7 +3498,7 @@ namespace rs2
                         }
                     }
                     if( ImGui::IsItemHovered() )
-                        ImGui::SetTooltip( "Focal length calibration is used to adjust camera focal length with specific target." );
+                        RsImGui::CustomTooltip( "Focal length calibration is used to adjust camera focal length with specific target." );
 
                     if( ImGui::Selectable( "Tare Calibration" ) )
                     {
@@ -3572,7 +3526,7 @@ namespace rs2
                         }
                     }
                     if( ImGui::IsItemHovered() )
-                        ImGui::SetTooltip( "Tare calibration is used to adjust camera absolute distance to flat target.\n"
+                        RsImGui::CustomTooltip( "Tare calibration is used to adjust camera absolute distance to flat target.\n"
                                            "User needs either to enter the known ground truth or use the get button\n"
                                            "with specific target to get the ground truth." );
                 }

--- a/common/fw-update-helper.cpp
+++ b/common/fw-update-helper.cpp
@@ -4,6 +4,7 @@
 #include "fw-update-helper.h"
 #include "model-views.h"
 #include "viewer.h"
+#include <realsense_imgui.h>
 #include "ux-window.h"
 
 #include <rsutils/os/special-folder.h>
@@ -509,7 +510,7 @@ namespace rs2
 
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "New firmware will be flashed to the device");
+                    RsImGui::CustomTooltip("%s", "New firmware will be flashed to the device");
                 }
             }
             else if (update_state == RS2_FWU_STATE_IN_PROGRESS)
@@ -557,7 +558,7 @@ namespace rs2
             if (ImGui::IsItemHovered())
             {
                 win.link_hovered();
-                ImGui::SetTooltip("%s", "Internet connection required");
+                RsImGui::CustomTooltip("%s", "Internet connection required");
             }
         }
     }

--- a/common/notifications.cpp
+++ b/common/notifications.cpp
@@ -9,6 +9,7 @@
 
 #include "notifications.h"
 #include <imgui_internal.h>
+#include <realsense_imgui.h>
 #include "model-views.h"
 #include "os.h"
 #include "viewer.h"
@@ -148,7 +149,7 @@ namespace rs2
             if (pbar.contains(mouse.cursor))
             {
                 std::string progress_str = rsutils::string::from() << progress << "%";
-                ImGui::SetTooltip("%s", progress_str.c_str());
+                RsImGui::CustomTooltip("%s", progress_str.c_str());
             }
         }
 
@@ -640,7 +641,7 @@ namespace rs2
                             glfwSetClipboardString(win, clip.c_str());
                         }
                         if (ImGui::IsItemActive())
-                            ImGui::SetTooltip("Paste the copied commands to a terminal and enter your password to run");
+                            RsImGui::CustomTooltip("Paste the copied commands to a terminal and enter your password to run");
                     }
                 }
 
@@ -718,7 +719,7 @@ namespace rs2
         if (ImGui::IsItemHovered())
         {
             win.link_hovered();
-            ImGui::SetTooltip("Open the Release Notes. Internet connection is required");
+            RsImGui::CustomTooltip("Open the Release Notes. Internet connection is required");
         }
         ImGui::SameLine();
         ImGui::SetCursorPosX(ImGui::GetCursorPosX() - 5);
@@ -1003,7 +1004,7 @@ namespace rs2
 
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("%s", "Enables metadata on connected devices (you may be prompted for administrator privileges)");
+            RsImGui::CustomTooltip("%s", "Enables metadata on connected devices (you may be prompted for administrator privileges)");
         }
     }
 
@@ -1108,7 +1109,7 @@ namespace rs2
         if (ImGui::IsItemHovered())
         {
             win.link_hovered();
-            ImGui::SetTooltip("Internet connection required");
+            RsImGui::CustomTooltip("Internet connection required");
         }
         ImGui::PopStyleColor(2);
     }

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <condition_variable>
 #include <model-views.h>
+#include <realsense_imgui.h>
 #include <viewer.h>
 #include "calibration-model.h"
 #include "os.h"
@@ -1669,7 +1670,7 @@ namespace rs2
         }
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("%s", "Calibrate intrinsic parameters of the camera");
+            RsImGui::CustomTooltip("%s", "Calibrate intrinsic parameters of the camera");
         }
         ImGui::SetCursorScreenPos({ float(x + 135), float(y + 35 + ImGui::GetTextLineHeightWithSpacing()) });
 
@@ -1681,7 +1682,7 @@ namespace rs2
         }
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("%s", "Calibrate extrinsic parameters between left and right cameras");
+            RsImGui::CustomTooltip("%s", "Calibrate extrinsic parameters between left and right cameras");
         }
 
         get_manager().intrinsic_scan = intrinsic;
@@ -1788,7 +1789,7 @@ namespace rs2
                 ImGui::Checkbox("Px/Py only", &get_manager().py_px_only);
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Calibrate: {Fx/Fy/Px/Py}/{Px/Py}");
+                    RsImGui::CustomTooltip("%s", "Calibrate: {Fx/Fy/Px/Py}/{Px/Py}");
                 }
 
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + height - 25) });
@@ -1809,7 +1810,7 @@ namespace rs2
                 }
 
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "Begin UV-Mapping calibration after adjusting camera position");
+                    RsImGui::CustomTooltip("%s", "Begin UV-Mapping calibration after adjusting camera position");
                 ImGui::PopStyleColor(2);
 
                 string id = rsutils::string::from() << "Py Px Calibration only##py_px_only" << index;
@@ -1825,7 +1826,7 @@ namespace rs2
                 ImGui::Text("%s", "Target Width:");
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "The width of the rectangle in millimeter inside the specific target");
+                    RsImGui::CustomTooltip("%s", "The width of the rectangle in millimeter inside the specific target");
                 }
 
                 const int MAX_SIZE = 256;
@@ -1850,7 +1851,7 @@ namespace rs2
                 ImGui::Text("%s", "Target Height:");
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "The height of the rectangle in millimeter inside the specific target");
+                    RsImGui::CustomTooltip("%s", "The height of the rectangle in millimeter inside the specific target");
                 }
 
                 ImGui::SetCursorScreenPos({ float(x + 135), float(y + 40 + 2 * ImGui::GetTextLineHeightWithSpacing()) });
@@ -1902,7 +1903,7 @@ namespace rs2
 
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Begin calculating Tare Calibration/Distance to Target");
+                    RsImGui::CustomTooltip("%s", "Begin calculating Tare Calibration/Distance to Target");
                 }
             }
             else if (update_state == RS2_CALIB_STATE_GET_TARE_GROUND_TRUTH_IN_PROCESS)
@@ -1944,7 +1945,7 @@ namespace rs2
 
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Retry calculating ground truth");
+                    RsImGui::CustomTooltip("%s", "Retry calculating ground truth");
                 }
             }
             else if (update_state == RS2_CALIB_STATE_TARE_INPUT || update_state == RS2_CALIB_STATE_TARE_INPUT_ADVANCED)
@@ -1963,9 +1964,9 @@ namespace rs2
                 if (ImGui::IsItemHovered())
                 {
                     if (update_state == RS2_CALIB_STATE_TARE_INPUT)
-                        ImGui::SetTooltip("%s", "More Options...");
+                        RsImGui::CustomTooltip("%s", "More Options...");
                     else
-                        ImGui::SetTooltip("%s", "Less Options...");
+                        RsImGui::CustomTooltip("%s", "Less Options...");
                 }
 
                 ImGui::PopStyleColor(2);
@@ -1975,7 +1976,7 @@ namespace rs2
                     ImGui::Text("%s", "Avg Step Count:");
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Number of frames to average, Min = 1, Max = 30, Default = 20");
+                        RsImGui::CustomTooltip("%s", "Number of frames to average, Min = 1, Max = 30, Default = 20");
                     }
                     ImGui::SetCursorScreenPos({ float(x + 135), float(y + 30) });
 
@@ -1990,7 +1991,7 @@ namespace rs2
                     ImGui::Text("%s", "Step Count:");
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Max iteration steps, Min = 5, Max = 30, Default = 20");
+                        RsImGui::CustomTooltip("%s", "Max iteration steps, Min = 5, Max = 30, Default = 20");
                     }
                     ImGui::SetCursorScreenPos({ float(x + 135), float(y + 35 + ImGui::GetTextLineHeightWithSpacing()) });
 
@@ -2006,7 +2007,7 @@ namespace rs2
                     ImGui::Text("%s", "Accuracy:");
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Subpixel accuracy level, Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%)");
+                        RsImGui::CustomTooltip("%s", "Subpixel accuracy level, Very high = 0 (0.025%), High = 1 (0.05%), Medium = 2 (0.1%), Low = 3 (0.2%), Default = Very high (0.025%)");
                     }
 
                     ImGui::SetCursorScreenPos({ float(x + 135), float(y + 40 + 2 * ImGui::GetTextLineHeightWithSpacing()) });
@@ -2046,7 +2047,7 @@ namespace rs2
                 }
 
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "Distance in millimeter to the flat wall, between 60 and 10000.");
+                    RsImGui::CustomTooltip("%s", "Distance in millimeter to the flat wall, between 60 and 10000.");
 
                 std::string id = rsutils::string::from() << "##ground_truth_for_tare" << index;
                 get_manager().ground_truth = config_file::instance().get_or_default(configurations::viewer::ground_truth_r, 1200.0f);
@@ -2085,7 +2086,7 @@ namespace rs2
                     get_manager().start_gt_viewer();
                 }
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "Calculate ground truth for the specific target");
+                    RsImGui::CustomTooltip("%s", "Calculate ground truth for the specific target");
 
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + height - ImGui::GetTextLineHeightWithSpacing() - 30) });
                 get_manager().host_assistance = (get_manager().device_name_string ==  std::string("Intel RealSense D457") ); // To be used for MIPI SKU only
@@ -2093,7 +2094,7 @@ namespace rs2
                 if (ImGui::Checkbox("Host Assistance", &assistance))
                     get_manager().host_assistance = (assistance ? 1 : 0);
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "check = host assitance for statistics data, uncheck = no host assistance");
+                    RsImGui::CustomTooltip("%s", "check = host assitance for statistics data, uncheck = no host assistance");
 
                 std::string button_name = rsutils::string::from() << "Calibrate" << "##tare" << index;
 
@@ -2117,7 +2118,7 @@ namespace rs2
 
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Begin Tare Calibration");
+                    RsImGui::CustomTooltip("%s", "Begin Tare Calibration");
                 }
             }
             else if (update_state == RS2_CALIB_STATE_SELF_INPUT)
@@ -2188,7 +2189,7 @@ namespace rs2
                 bool assistance = (get_manager().host_assistance != 0);
                 ImGui::Checkbox("Host Assistance", &assistance);
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "check = host assitance for statistics data, uncheck = no host assistance");
+                    RsImGui::CustomTooltip("%s", "check = host assitance for statistics data, uncheck = no host assistance");
 
                 auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
                 ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
@@ -2212,7 +2213,7 @@ namespace rs2
                 ImGui::PopStyleColor(2);
 
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "Begin On-Chip Calibration");
+                    RsImGui::CustomTooltip("%s", "Begin On-Chip Calibration");
             }
             else if (update_state == RS2_CALIB_STATE_FL_INPUT)
             {
@@ -2223,7 +2224,7 @@ namespace rs2
                 ImGui::Text("%s", "Target Width (mm):");
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "The width of the rectangle in millimeters inside the specific target");
+                    RsImGui::CustomTooltip("%s", "The width of the rectangle in millimeters inside the specific target");
                 }
 
                 const int MAX_SIZE = 256;
@@ -2248,7 +2249,7 @@ namespace rs2
                 ImGui::Text("%s", "Target Height (mm):");
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "The height of the rectangle in millimeters inside the specific target");
+                    RsImGui::CustomTooltip("%s", "The height of the rectangle in millimeters inside the specific target");
                 }
 
                 ImGui::SetCursorScreenPos({ float(x + 145), float(y + 77 + 2 * ImGui::GetTextLineHeightWithSpacing()) });
@@ -2271,7 +2272,7 @@ namespace rs2
                 if (ImGui::Checkbox("Adjust both sides focal length", &adj_both))
                     get_manager().adjust_both_sides = (adj_both ? 1 : 0);
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "check = adjust both sides, uncheck = adjust right side only");
+                    RsImGui::CustomTooltip("%s", "check = adjust both sides, uncheck = adjust right side only");
 
                 ImGui::SetCursorScreenPos({ float(x + 9), float(y + height - 25) });
                 auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
@@ -2296,7 +2297,7 @@ namespace rs2
                     enable_dismiss = false;
                 }
                 if (ImGui::IsItemHovered())
-                    ImGui::SetTooltip("%s", "Start focal length calibration after setting up camera position correctly.");
+                    RsImGui::CustomTooltip("%s", "Start focal length calibration after setting up camera position correctly.");
                 ImGui::PopStyleColor(2);
             }
             else if (update_state == RS2_CALIB_STATE_FAILED)
@@ -2349,7 +2350,7 @@ namespace rs2
                     ImGui::PopStyleColor(2);
 
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("%s", "Retry on-chip calibration process");
+                        RsImGui::CustomTooltip("%s", "Retry on-chip calibration process");
                 }
             }
             else if (update_state == RS2_CALIB_STATE_CALIB_COMPLETE)
@@ -2383,7 +2384,7 @@ namespace rs2
                     std::string text_name_1 = rsutils::string::from() << "##notification_text_1_" << index;
                     ImGui::InputTextMultiline(text_name_1.c_str(), const_cast<char*>(health_str.c_str()), strlen(health_str.c_str()) + 1, { 86, ImGui::GetTextLineHeight() + 6 }, ImGuiInputTextFlags_ReadOnly);
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("%s", "Health check for PX");
+                        RsImGui::CustomTooltip("%s", "Health check for PX");
 
                     ImGui::SetCursorScreenPos({ float(x + 220), float(y + 35) + ImGui::GetTextLineHeightWithSpacing() });
                     std::stringstream ss_2;
@@ -2392,7 +2393,7 @@ namespace rs2
                     std::string text_name_2 = rsutils::string::from() << "##notification_text_2_" << index;
                     ImGui::InputTextMultiline(text_name_2.c_str(), const_cast<char*>(health_str.c_str()), strlen(health_str.c_str()) + 1, { 86, ImGui::GetTextLineHeight() + 6 }, ImGuiInputTextFlags_ReadOnly);
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("%s", "Health check for PY");
+                        RsImGui::CustomTooltip("%s", "Health check for PY");
 
                     ImGui::SetCursorScreenPos({ float(x + 220), float(y + 40) + 2 * ImGui::GetTextLineHeightWithSpacing() });
                     std::stringstream ss_3;
@@ -2401,7 +2402,7 @@ namespace rs2
                     std::string text_name_3 = rsutils::string::from() << "##notification_text_3_" << index;
                     ImGui::InputTextMultiline(text_name_3.c_str(), const_cast<char*>(health_str.c_str()), strlen(health_str.c_str()) + 1, { 86, ImGui::GetTextLineHeight() + 6 }, ImGuiInputTextFlags_ReadOnly);
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("%s", "Health check for FX");
+                        RsImGui::CustomTooltip("%s", "Health check for FX");
 
                     ImGui::SetCursorScreenPos({ float(x + 220), float(y + 45) + 3 * ImGui::GetTextLineHeightWithSpacing() });
                     std::stringstream ss_4;
@@ -2410,7 +2411,7 @@ namespace rs2
                     std::string text_name_4 = rsutils::string::from() << "##notification_text_4_" << index;
                     ImGui::InputTextMultiline(text_name_4.c_str(), const_cast<char*>(health_str.c_str()), strlen(health_str.c_str()) + 1, { 86, ImGui::GetTextLineHeight() + 6 }, ImGuiInputTextFlags_ReadOnly);
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("%s", "Health check for FY");
+                        RsImGui::CustomTooltip("%s", "Health check for FY");
 
                     ImGui::PopStyleColor(7);
 
@@ -2436,7 +2437,7 @@ namespace rs2
 
                     ImGui::PopStyleColor(2);
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("%s", "New calibration values will be saved in device");
+                        RsImGui::CustomTooltip("%s", "New calibration values will be saved in device");
                 }
                 else
                 {
@@ -2488,7 +2489,7 @@ namespace rs2
                             ImGui::PopStyleColor(7);
 
                             if (ImGui::IsItemHovered())
-                                ImGui::SetTooltip("%s", "Health-check number before Tare Calibration");
+                                RsImGui::CustomTooltip("%s", "Health-check number before Tare Calibration");
 
                             ImGui::SetCursorScreenPos({ float(x + 10), float(y + 38) + ImGui::GetTextLineHeightWithSpacing() });
                             ImGui::Text("%s", "Health-Check After Calibration: ");
@@ -2511,7 +2512,7 @@ namespace rs2
                             ImGui::PopStyleColor(7);
 
                             if (ImGui::IsItemHovered())
-                                ImGui::SetTooltip("%s", "Health-check number after Tare Calibration");
+                                RsImGui::CustomTooltip("%s", "Health-check number after Tare Calibration");
                         }
                     }
                     else if (get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_OB_CALIB)
@@ -2556,7 +2557,7 @@ namespace rs2
 
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::SetTooltip("%s", "OCC Health-Check captures how far camera calibration is from the optimal one\n"
+                            RsImGui::CustomTooltip("%s", "OCC Health-Check captures how far camera calibration is from the optimal one\n"
                                 "[0, 0.25) - Good\n"
                                 "[0.25, 0.75) - Can be Improved\n"
                                 "[0.75, ) - Requires Calibration");
@@ -2603,7 +2604,7 @@ namespace rs2
 
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::SetTooltip("%s", "OCC-FL Health-Check captures how far camera calibration is from the optimal one\n"
+                            RsImGui::CustomTooltip("%s", "OCC-FL Health-Check captures how far camera calibration is from the optimal one\n"
                                 "[0, 0.15) - Good\n"
                                 "[0.15, 0.75) - Can be Improved\n"
                                 "[0.75, ) - Requires Calibration");
@@ -2695,14 +2696,14 @@ namespace rs2
                         {
                             if (get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_CALIB)
                             {
-                                ImGui::SetTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
+                                RsImGui::CustomTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
                                     "[0, 0.25) - Good\n"
                                     "[0.25, 0.75) - Can be Improved\n"
                                     "[0.75, ) - Requires Calibration");
                             }
                             else
                             {
-                                ImGui::SetTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
+                                RsImGui::CustomTooltip("%s", "Calibration Health-Check captures how far camera calibration is from the optimal one\n"
                                     "[0, 0.15) - Good\n"
                                     "[0.15, 0.75) - Can be Improved\n"
                                     "[0.75, ) - Requires Calibration");
@@ -2874,7 +2875,7 @@ namespace rs2
                         ImGui::PopStyleColor(2);
 
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("%s", "New calibration values will be saved in device");
+                        RsImGui::CustomTooltip("%s", "New calibration values will be saved in device");
                 }
             }
 
@@ -2923,7 +2924,7 @@ namespace rs2
 
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Keep the camera pointing at an object or a wall");
+                    RsImGui::CustomTooltip("%s", "Keep the camera pointing at an object or a wall");
                 }
             }
             else if (update_state == RS2_CALIB_STATE_GET_TARE_GROUND_TRUTH_IN_PROCESS)

--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -126,7 +126,7 @@ bool option_model::draw( std::string & error_message,
             ImGui::PopStyleColor();
 
             if( ImGui::IsItemHovered() )
-                ImGui::SetTooltip( "Select custom region of interest for the auto-exposure "
+                RsImGui::CustomTooltip( "Select custom region of interest for the auto-exposure "
                                    "algorithm\nClick the button, then draw a rect on the frame" );
         }
     }
@@ -250,7 +250,7 @@ bool option_model::draw_combobox( notifications_model & model,
     ImGui::Text( "%s", txt.c_str() );
     if( ImGui::IsItemHovered() && description )
     {
-        ImGui::SetTooltip( "%s", description );
+        RsImGui::CustomTooltip( "%s", description );
     }
 
     ImGui::SameLine();
@@ -348,7 +348,7 @@ bool option_model::draw_slider( notifications_model & model,
     ImGui::PopStyleColor( 5 );
     if( ImGui::IsItemHovered() && description )
     {
-        ImGui::SetTooltip( "%s", description );
+        RsImGui::CustomTooltip( "%s", description );
     }
 
     if( ! read_only )
@@ -369,7 +369,7 @@ bool option_model::draw_slider( notifications_model & model,
             }
             if( ImGui::IsItemHovered() )
             {
-                ImGui::SetTooltip( "Enter text-edit mode" );
+                RsImGui::CustomTooltip( "Enter text-edit mode" );
             }
             ImGui::PopStyleColor( 4 );
         }
@@ -386,7 +386,7 @@ bool option_model::draw_slider( notifications_model & model,
             }
             if( ImGui::IsItemHovered() )
             {
-                ImGui::SetTooltip( "Exit text-edit mode" );
+                RsImGui::CustomTooltip( "Exit text-edit mode" );
             }
             ImGui::PopStyleColor( 4 );
         }
@@ -610,7 +610,7 @@ bool option_model::draw_checkbox( notifications_model & model,
     }
     if( ImGui::IsItemHovered() && description )
     {
-        ImGui::SetTooltip( "%s", description );
+        RsImGui::CustomTooltip( "%s", description );
     }
     return checkbox_was_clicked;
 }

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -842,7 +842,7 @@ namespace rs2
         auto streaming_tooltip = [&]() {
             if ((!allow_change_resolution_while_streaming && streaming)
                 && ImGui::IsItemHovered())
-                ImGui::SetTooltip("Can't modify while streaming");
+                RsImGui::CustomTooltip("Can't modify while streaming");
         };
 
         auto col0 = ImGui::GetCursorPosX();

--- a/common/updates-model.cpp
+++ b/common/updates-model.cpp
@@ -7,6 +7,7 @@
 #include "ux-window.h"
 #include "os.h"
 #include <stb_image.h>
+#include <realsense_imgui.h>
 #include "sw-update/http-downloader.h"
 #include <rsutils/easylogging/easyloggingpp.h>
 
@@ -182,11 +183,8 @@ void updates_model::draw(std::shared_ptr<notifications_model> not_model, ux_wind
             }
             if (ImGui::IsItemHovered())
             {
-                ImGui::PushStyleColor(ImGuiCol_Text, white);
-                ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
-                ImGui::SetTooltip("To close this window you must install all essential update\n"
+                RsImGui::CustomTooltip("To close this window you must install all essential update\n"
                     "or agree to the warning of closing without it");
-                ImGui::PopStyleColor(2);
             }
             ImGui::PopStyleColor(2);
         }
@@ -444,11 +442,9 @@ bool updates_model::draw_software_section(const char * window_name, update_profi
 
             if (ImGui::IsItemHovered())
             {
-                ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
                 std::string tooltip = "This will redirect you to download the selected software from:\n" + selected_software_update.download_link;
-                ImGui::SetTooltip("%s", tooltip.c_str());
+                RsImGui::CustomTooltip("%s", tooltip.c_str());
                 window.link_hovered();
-                ImGui::PopStyleColor();
             }
 
             ImGui::PopStyleColor(3);
@@ -737,7 +733,7 @@ bool updates_model::draw_firmware_section(std::shared_ptr<notifications_model> n
         }
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("This will download selected firmware and install it to the device");
+            RsImGui::CustomTooltip("This will download selected firmware and install it to the device");
             window.link_hovered();
         }
         ImGui::PopStyleColor(2);

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -137,7 +137,7 @@ namespace rs2
                 {
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("Enable meshing to allow vertex normals calculation");
+                        RsImGui::CustomTooltip("Enable meshing to allow vertex normals calculation");
                     }
                     ImGui::PopStyleColor(2);
                     ImGui::PopStyleVar();
@@ -226,7 +226,7 @@ namespace rs2
             }
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip("%s", "Save settings and export file");
+                RsImGui::CustomTooltip("%s", "Save settings and export file");
             }
             ImGui::SameLine();
             if( ImGui::Button( "Cancel", ImVec2( font_size * 8.f, 0 ) ) )
@@ -235,7 +235,7 @@ namespace rs2
             }
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip("%s", "Close window without saving any changes to the settings");
+                RsImGui::CustomTooltip("%s", "Close window without saving any changes to the settings");
             }
 
             ImGui::PopStyleColor(3);
@@ -304,14 +304,11 @@ namespace rs2
         ImGui::PopFont();
         hovered = hovered || ImGui::IsItemHovered();
 
-        ImGui::PushStyleColor(ImGuiCol_Text,white);
-        ImGui::PushStyleColor(ImGuiCol_PopupBg, dark_window_background);
         if (hovered)
         {
             win.link_hovered();
-            ImGui::SetTooltip("%s", description);
+            RsImGui::CustomTooltip("%s", description);
         }
-        ImGui::PopStyleColor(2);
 
         if (clicked && !disabled)
         {
@@ -1101,7 +1098,7 @@ namespace rs2
         ImGui::Text("%s", text);
         ImGui::PopStyleColor();
         if (ImGui::IsItemHovered() && tooltip != "")
-            ImGui::SetTooltip("%s", tooltip.c_str());
+            RsImGui::CustomTooltip("%s", tooltip.c_str());
 
     }
     void viewer_model::show_paused_icon(ImFont* font_18, int x, int y, int id)
@@ -1502,7 +1499,7 @@ namespace rs2
             auto relative_mouse_y = ImGui::GetMousePos().y - top_y_ruler;
             auto y = (bottom_y_ruler - top_y_ruler) - relative_mouse_y;
             ss << std::fixed << std::setprecision(2) << (y / ratio) << ruler_units;
-            ImGui::SetTooltip("%s", ss.str().c_str());
+            RsImGui::CustomTooltip("%s", ss.str().c_str());
             colored_ruler_opac = 1.f;
             numbered_ruler_background_opac = hovered_numbered_ruler_opac;
         }
@@ -2302,10 +2299,10 @@ namespace rs2
         {
             ImGui::OpenPopup("More Options");
         }
-
+        ImGui::PopFont();
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("%s", "More Options...");
+            RsImGui::CustomTooltip("%s", "More Options...");
         }
 
         if (window.is_fullscreen())
@@ -2322,13 +2319,12 @@ namespace rs2
             }
             if (ImGui::IsItemHovered())
             {
-                ImGui::SetTooltip("Exit the App");
+                RsImGui::CustomTooltip("Exit the App");
                 window.link_hovered();
             }
             ImGui::PopStyleColor(3);
         }
 
-        ImGui::PopFont();
 
         ImGui::PushStyleColor(ImGuiCol_Text, black);
         ImGui::PushStyleColor(ImGuiCol_PopupBg, almost_white_bg);
@@ -2532,7 +2528,7 @@ namespace rs2
                     int font_samples = temp_cfg.get(configurations::performance::font_oversample);
                     ImGui::Text("Font Samples: ");
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Increased font samples produce nicer text, but require more GPU memory, sometimes resulting in boxes instead of font characters");
+                        RsImGui::CustomTooltip("Increased font samples produce nicer text, but require more GPU memory, sometimes resulting in boxes instead of font characters");
 
                     ImGui::SameLine();
                     ImGui::PushItemWidth(80);
@@ -2549,7 +2545,7 @@ namespace rs2
                     int font_size = temp_cfg.get( configurations::window::font_size );
                     ImGui::Text( "Font Size: " );
                     if( ImGui::IsItemHovered() )
-                        ImGui::SetTooltip( "Viewer Font Size" );
+                        RsImGui::CustomTooltip( "Viewer Font Size" );
                     
                     ImGui::SameLine();
                     ImGui::PushItemWidth( 80 );
@@ -2570,7 +2566,7 @@ namespace rs2
                         temp_cfg.set(configurations::performance::glsl_for_rendering, gpu_rendering);
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Using OpenGL 3 shaders is a widely supported way to boost rendering speeds on modern GPUs.");
+                        RsImGui::CustomTooltip("Using OpenGL 3 shaders is a widely supported way to boost rendering speeds on modern GPUs.");
 
                     bool gpu_processing = temp_cfg.get(configurations::performance::glsl_for_processing);
                     if (ImGui::Checkbox("Use GLSL for Processing", &gpu_processing))
@@ -2579,7 +2575,7 @@ namespace rs2
                         temp_cfg.set(configurations::performance::glsl_for_processing, gpu_processing);
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Using OpenGL 3 shaders for depth data processing can reduce CPU utilisation.");
+                        RsImGui::CustomTooltip("Using OpenGL 3 shaders for depth data processing can reduce CPU utilisation.");
 
                     if (gpu_processing && !gpu_rendering)
                     {
@@ -2595,7 +2591,7 @@ namespace rs2
                         temp_cfg.set(configurations::performance::enable_msaa, msaa);
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("MSAA will improve the rendering quality of edges at expense of greater GPU memory utilisation.");
+                        RsImGui::CustomTooltip("MSAA will improve the rendering quality of edges at expense of greater GPU memory utilisation.");
 
                     if (msaa)
                     {
@@ -2617,7 +2613,7 @@ namespace rs2
                         temp_cfg.set(configurations::performance::show_fps, show_fps);
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Show application refresh rate in window title\nThis rate is unrelated to camera FPS and measures application responsivness");
+                        RsImGui::CustomTooltip("Show application refresh rate in window title\nThis rate is unrelated to camera FPS and measures application responsivness");
 
 
                     bool vsync = temp_cfg.get(configurations::performance::vsync);
@@ -2627,7 +2623,7 @@ namespace rs2
                         temp_cfg.set(configurations::performance::vsync, vsync);
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Vertical sync will try to synchronize application framerate to the monitor refresh-rate (usually limiting the framerate to 60)");
+                        RsImGui::CustomTooltip("Vertical sync will try to synchronize application framerate to the monitor refresh-rate (usually limiting the framerate to 60)");
 
                     bool fullscreen = temp_cfg.get(configurations::window::is_fullscreen);
                     if (ImGui::Checkbox("Fullscreen (F8)", &fullscreen))
@@ -2642,7 +2638,7 @@ namespace rs2
                         temp_cfg.set(configurations::performance::show_skybox, show_skybox);
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("When enabled, this option provides background to the 3D view, instead of leaving it blank.\nThis is purely cosmetic");
+                        RsImGui::CustomTooltip("When enabled, this option provides background to the 3D view, instead of leaving it blank.\nThis is purely cosmetic");
 
                     bool enable_occlusion_invalidation = temp_cfg.get(configurations::performance::occlusion_invalidation);
                     if (ImGui::Checkbox("Perform Occlusion Invalidation", &enable_occlusion_invalidation))
@@ -2650,7 +2646,7 @@ namespace rs2
                         temp_cfg.set(configurations::performance::occlusion_invalidation, enable_occlusion_invalidation);
                     }
                     if (ImGui::IsItemHovered())
-                        ImGui::SetTooltip("Occlusions are a natural side-effect of having multiple sensors\nWhen this option is enabled, the SDK will filter out occluded pixels");
+                        RsImGui::CustomTooltip("Occlusions are a natural side-effect of having multiple sensors\nWhen this option is enabled, the SDK will filter out occluded pixels");
                 }
 
                 if( tab == 2 )
@@ -2685,7 +2681,7 @@ namespace rs2
                         ImGui::PopStyleVar();
                         if( ImGui::IsItemHovered() )
                         {
-                            ImGui::SetTooltip( "%s", "--debug was specified; this cannot be applied without a restart" );
+                            RsImGui::CustomTooltip( "%s", "--debug was specified; this cannot be applied without a restart" );
                         }
                     }
                     bool log_to_file = temp_cfg.get(configurations::viewer::log_to_file);
@@ -2825,7 +2821,7 @@ namespace rs2
                     }
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "When firmware of the device is below the version bundled with this software release\nsuggest firmware update");
+                        RsImGui::CustomTooltip("%s", "When firmware of the device is below the version bundled with this software release\nsuggest firmware update");
                     }
 #ifdef CHECK_FOR_UPDATES
                     ImGui::Separator();
@@ -2833,7 +2829,7 @@ namespace rs2
                     ImGui::Text("%s", "SW/FW Updates From Server:");
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Select the server URL of the SW/FW updates information");
+                        RsImGui::CustomTooltip("%s", "Select the server URL of the SW/FW updates information");
                     }
                     ImGui::SameLine();
 
@@ -2860,7 +2856,7 @@ namespace rs2
                     }
                     if (ImGui::IsItemHovered())
                     {
-                        ImGui::SetTooltip("%s", "Add file:// prefix to use a local DB file ");
+                        RsImGui::CustomTooltip("%s", "Add file:// prefix to use a local DB file ");
                     }
 
                     if (!official_url)
@@ -2908,7 +2904,7 @@ namespace rs2
                 }
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Save settings and close");
+                    RsImGui::CustomTooltip("%s", "Save settings and close");
                 }
                 ImGui::SameLine();
 
@@ -2922,7 +2918,7 @@ namespace rs2
                 ImGui::PopStyleColor(2);
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Save settings");
+                    RsImGui::CustomTooltip("%s", "Save settings");
                 }
                 ImGui::SameLine();
                 if (ImGui::Button("Cancel", ImVec2(120, 0)))
@@ -2931,7 +2927,7 @@ namespace rs2
                 }
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("%s", "Close window without saving any changes to the settings");
+                    RsImGui::CustomTooltip("%s", "Close window without saving any changes to the settings");
                 }
                 ImGui::PopStyleColor(2);
                 ImGui::PopStyleVar();

--- a/third-party/imgui/realsense_imgui.cpp
+++ b/third-party/imgui/realsense_imgui.cpp
@@ -368,3 +368,18 @@ void RsImGui::RsImButton(const std::function<void()>& f, bool disable_button)
     if (disable_button)
         ImGui::EndDisabled();
 }
+
+void RsImGui::CustomTooltip( const char * fmt, const char * label )
+{
+    ImGui::PushStyleColor( ImGuiCol_Text, ImVec4( 0.90f, 0.90f, 0.90f, 1.00f ) );
+    ImGui::PushStyleColor( ImGuiCol_PopupBg, ImVec4( 0.05f, 0.05f, 0.10f, 0.90f ) );
+    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, ImVec2( 8, 8 ) );
+    ImGui::SetTooltip( fmt, label );
+    ImGui::PopStyleColor( 2 );
+    ImGui::PopStyleVar();
+}
+
+void RsImGui::CustomTooltip( const char * label )
+{
+    RsImGui::CustomTooltip( "%s", label );
+}

--- a/third-party/imgui/realsense_imgui.h
+++ b/third-party/imgui/realsense_imgui.h
@@ -36,7 +36,9 @@ namespace RsImGui
     void          PushNewFrame();
     void          PopNewFrame();
     void          RsImButton(const std::function<void()> &f, bool disable_button = false);
-}
+    void          CustomTooltip( const char * fmt, const char * label );
+    void          CustomTooltip( const char * label );
+    }
 
 // Macros to create unique function names using the current line number (__LINE__)
 #define IMGUI_CONCAT_(x,y) x##y

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include "depth-quality-model.h"
 #include <librealsense2/rs_advanced_mode.hpp>
+#include <realsense_imgui.h>
 #include "model-views.h"
 #include "viewer.h"
 #include "os.h"
@@ -667,7 +668,7 @@ namespace rs2
 
                                 if (ImGui::IsItemHovered())
                                 {
-                                    ImGui::SetTooltip(
+                                    RsImGui::CustomTooltip(
                                         "%s",
                                         ds.get_option_description(
                                             RS2_OPTION_ENABLE_IR_REFLECTIVITY ) );
@@ -685,7 +686,7 @@ namespace rs2
                         ImGui::Text("Distance:");
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::SetTooltip("Estimated distance to an average within the ROI of the target (wall) in mm");
+                            RsImGui::CustomTooltip("Estimated distance to an average within the ROI of the target (wall) in mm");
                         }
                         ImGui::SameLine(); ImGui::SetCursorPosX(col1);
 
@@ -713,7 +714,7 @@ namespace rs2
                         }
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::SetTooltip("True measured distance to the wall in mm");
+                            RsImGui::CustomTooltip("True measured distance to the wall in mm");
                         }
                         ImGui::SameLine(); ImGui::SetCursorPosX(col1);
                         if (_use_ground_truth)
@@ -739,7 +740,7 @@ namespace rs2
                         ImGui::Text("Angle:");
                         if (ImGui::IsItemHovered())
                         {
-                            ImGui::SetTooltip("Estimated angle to the wall in degrees");
+                            RsImGui::CustomTooltip("Estimated angle to the wall in degrees");
                         }
                         ImGui::SameLine(); ImGui::SetCursorPosX(col1);
                         static float prev_metric_angle = 0;
@@ -789,7 +790,7 @@ namespace rs2
 
                             if (ImGui::IsItemHovered())
                             {
-                                ImGui::SetTooltip("Save Metrics snapshot. This will create:\nPNG image with the depth frame\nPLY 3D model with the point cloud\nJSON file with camera settings you can load later\nand a CSV with metrics recent values");
+                                RsImGui::CustomTooltip("Save Metrics snapshot. This will create:\nPNG image with the depth frame\nPLY 3D model with the point cloud\nJSON file with camera settings you can load later\nand a CSV with metrics recent values");
                             }
                         }
 
@@ -1170,7 +1171,7 @@ namespace rs2
                 ImGui::Text(u8"\uf102");
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("This metric shows positive trend");
+                    RsImGui::CustomTooltip("This metric shows positive trend");
                 }
                 ImGui::PopFont();
                 ImGui::SameLine(); ImGui::SetCursorPos(col0);
@@ -1186,7 +1187,7 @@ namespace rs2
                 ImGui::Text(u8"\uf103");
                 if (ImGui::IsItemHovered())
                 {
-                    ImGui::SetTooltip("This metric shows negative trend");
+                    RsImGui::CustomTooltip("This metric shows negative trend");
                 }
                 ImGui::PopFont();
                 ImGui::SameLine(); ImGui::SetCursorPos(col0);


### PR DESCRIPTION
To maintain the tooltip design uniformity within the GUI I created a helper function RsImGui::RsCustomTooltip to use instead of ImGui::SetTooltip.

This will make the tooltip background similar to the previous version of ImGui