### PR TITLE
Enable DDS unit test retries in LibCI

### DIFF
--- a/unit-tests/dds/test-control-reply.py
+++ b/unit-tests/dds/test-control-reply.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 import pyrealdds as dds

--- a/unit-tests/dds/test-device-discovery.py
+++ b/unit-tests/dds/test-device-discovery.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 import pyrealdds as dds

--- a/unit-tests/dds/test-device-init.py
+++ b/unit-tests/dds/test-device-init.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 import pyrealdds as dds
 from rspy import log, test

--- a/unit-tests/dds/test-librs-connections.py
+++ b/unit-tests/dds/test-librs-connections.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 log.nested = 'C  '

--- a/unit-tests/dds/test-librs-device-properties.py
+++ b/unit-tests/dds/test-librs-device-properties.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 log.nested = 'C  '

--- a/unit-tests/dds/test-librs-extrinsics.py
+++ b/unit-tests/dds/test-librs-extrinsics.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 log.nested = 'C  '

--- a/unit-tests/dds/test-librs-formats-conversion.py
+++ b/unit-tests/dds/test-librs-formats-conversion.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 from rspy import librs as rs

--- a/unit-tests/dds/test-librs-intrinsics.py
+++ b/unit-tests/dds/test-librs-intrinsics.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 

--- a/unit-tests/dds/test-librs-options.py
+++ b/unit-tests/dds/test-librs-options.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 with test.remote.fork( nested_indent=None ) as remote:

--- a/unit-tests/dds/test-md-syncer.py
+++ b/unit-tests/dds/test-md-syncer.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2023 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 import pyrealdds as dds
 from rspy import log, test

--- a/unit-tests/dds/test-metadata.py
+++ b/unit-tests/dds/test-metadata.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2023-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 # We disable under Linux for now, pending feedback from FastDDS team:
 # Having two participants in the same process ("client" and "librs" below) usually works, but in this case the former

--- a/unit-tests/dds/test-options.py
+++ b/unit-tests/dds/test-options.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 import pyrealdds as dds
 from rspy import log, test

--- a/unit-tests/dds/test-participant.py
+++ b/unit-tests/dds/test-participant.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022-4 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 import pyrealdds as dds

--- a/unit-tests/dds/test-query-option.py
+++ b/unit-tests/dds/test-query-option.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2024 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 from rspy import log, test
 import pyrealdds as dds

--- a/unit-tests/dds/test-streaming.py
+++ b/unit-tests/dds/test-streaming.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022 Intel Corporation. All Rights Reserved.
 
 #test:donotrun:!dds
-#test:retries:gha 2
+#test:retries 2
 
 import pyrealdds as dds
 from rspy import log, test


### PR DESCRIPTION
As we start running DDS tests on our nightly CI, we encountered some instable tests that fail occasionally - due to Python test thread timing issues. Adding retries on our CI machines, not only GHA.

To solve the client-server timing issues we need to develop a more robust interthread communication mechanism. Currently it's based on CLI prompts. Logging from other threads can interfere with the prompts.
