### PR TITLE
GHA fail due to deprecate v3 version for checkout plugin

### DIFF
--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
 
       - name: Install 
         shell: bash
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
 
       - name: "Install Dependencies"
         run: |
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
 
       - name: Build docs 
         run: |

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -64,7 +64,7 @@ jobs:
             &&  echo "No diffs found in cppcheck_run.parsed.log"
 
       - name: Upload logs
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 #v3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 #v4
         with: 
           name: cppcheck_log
           path: |


### PR DESCRIPTION
fix this current error and future error since both GHA plugins are deprecated and need an upgrade
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ 
```