### PR TITLE
Disable FastDDS third party compilation warnings

### DIFF
--- a/CMake/external_fastdds.cmake
+++ b/CMake/external_fastdds.cmake
@@ -60,6 +60,9 @@ function(get_fastdds)
 
     add_library(dds INTERFACE)
     target_link_libraries( dds INTERFACE fastcdr fastrtps )
+    
+    disable_third_party_warnings(fastcdr)  
+    disable_third_party_warnings(fastrtps)  
 
     add_definitions(-DBUILD_WITH_DDS)
 

--- a/CMake/security_flags_helper_functions.cmake
+++ b/CMake/security_flags_helper_functions.cmake
@@ -18,3 +18,27 @@ macro(unset_security_flags_for_executable) # replace flag fPIE (Position-Indepen
     string(REPLACE "-fPIE" "-fPIC" CMAKE_C_FLAGS  "${CMAKE_C_FLAGS}")
 endmacro()
 
+macro(disable_third_party_warnings target)
+    if (TARGET ${target})  # Ensure the target exists
+        get_target_property(target_type ${target} TYPE)
+        
+        if (target_type STREQUAL "INTERFACE_LIBRARY")
+            if (WIN32)
+                target_compile_options(${target} INTERFACE /W0)
+            else()
+                target_compile_options(${target} INTERFACE -w)
+            endif()
+        else()
+            if (WIN32)
+                target_compile_options(${target} PRIVATE /W0)
+            else()
+                target_compile_options(${target} PRIVATE -w)
+            endif()
+        endif()
+    else()
+        message(WARNING "Target '${target}' does not exist.")
+    endif()
+endmacro()
+
+
+


### PR DESCRIPTION
We do not want to see third party compilation warnings as we cannot handle them.