### PR TITLE
Fix test-dds-control-reply

### DIFF
--- a/unit-tests/dds/test-control-reply.py
+++ b/unit-tests/dds/test-control-reply.py
@@ -139,6 +139,5 @@ with test.remote.fork( nested_indent=None ) as remote:
         test.check_equal( reply_count[device.guid()], dev1_replies + 1 )
         test.check_equal( reply_count[device2.guid()], dev2_replies + 1 )
 
-    device = None
-
 test.print_results()
+


### PR DESCRIPTION
Setting device to None might happen before `device.on_notification` have returned, keeping DDS participant alive and preventing the server from exiting gracefully.