### PR TITLE
add pixel temporal noise metric

### DIFF
--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -812,7 +812,7 @@ namespace rs2
             const plane p,
             const rs2::region_of_interest roi,
             const float baseline_mm,
-            const float focal_length_pixels,
+            const rs2_intrinsics* intrin,
             const int ground_thruth_mm,
             const bool plane_fit,
             const float plane_fit_to_ground_truth_mm,

--- a/tools/depth-quality/depth-metrics.h
+++ b/tools/depth-quality/depth-metrics.h
@@ -54,7 +54,7 @@ namespace rs2
             const plane p,
             const rs2::region_of_interest roi,
             const float baseline_mm,
-            const float focal_length_pixels,
+            const rs2_intrinsics* intrin,
             const int ground_thruth_mm,
             const bool plane_fit,
             const float plane_fit_to_ground_truth_mm,
@@ -164,6 +164,7 @@ namespace rs2
             std::mutex m;
 
             std::vector<rs2::float3> roi_pixels;
+            std::vector<rs2::float3> roi_deprojected_points;
 
 //#pragma omp parallel for - TODO optimization envisaged
             for (int y = roi.min_y; y < roi.max_y; ++y)
@@ -177,19 +178,19 @@ namespace rs2
                         float pixel[2] = { float(x), float(y) };
                         float point[3];
                         auto distance = depth_raw * units;
-
-                        rs2_deproject_pixel_to_point(point, intrin, pixel, distance);
+                        rs2_deproject_pixel_to_point(point, intrin, pixel, distance);// transform from pixels to metric units (meters) according to intrinsics.
 
                         std::lock_guard<std::mutex> lock(m);
-                        roi_pixels.push_back({ point[0], point[1], point[2] });
+                        roi_pixels.push_back({ pixel[0], pixel[1], distance });
+                        roi_deprojected_points.push_back({ point[0], point[1], point[2] });
                     }
                 }
 
-            if (roi_pixels.size() < 3) { // Not enough pixels in RoI to fit a plane
+            if (roi_deprojected_points.size() < 3) { // Not enough pixels in RoI to fit a plane
                 return result;
             }
 
-            plane p = plane_from_points(roi_pixels);
+            plane p = plane_from_points(roi_deprojected_points);
 
             if (p == plane{ 0, 0, 0, 0 }) { // The points in RoI don't span a valid plane
                 return result;
@@ -212,7 +213,7 @@ namespace rs2
             // Angle can be calculated from param C
             result.angle = static_cast<float>(std::acos(std::abs(p.c)) / M_PI * 180.);
 
-            callback(roi_pixels, p, roi, baseline_mm, intrin->fx, ground_truth_mm, plane_fit_present,
+            callback(roi_pixels, p, roi, baseline_mm, intrin, ground_truth_mm, plane_fit_present,
                 plane_fit_to_gt_offset_mm, result.distance, record, samples);
 
             // Calculate normal

--- a/tools/depth-quality/readme.md
+++ b/tools/depth-quality/readme.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This application allows you to test the camera’s depth quality, including: Z-Accuracy, Sub-Pixel and Z RMS errors (spatial noise) and Fill Rate.
+This application allows you to test the camera’s depth quality, including: Z-Accuracy, Sub-Pixel, Z RMS errors (spatial noise), Fill Rate and Temporal Noise.
 You should be able to easily get and interpret several of the depth quality metrics, or record and save the data for offline analysis.
 <br>Please refer to [RealSense DepthQualityTesting White Paper](https://www.intel.com/content/dam/support/us/en/documents/emerging-technologies/intel-realsense-technology/RealSense_DepthQualityTesting.pdf) for further information.
 
@@ -29,6 +29,7 @@ You should be able to easily get and interpret several of the depth quality metr
     * Sub-Pixel RMS Error
   * Fill-Rate
   * Distance to target
+  * Temporal Noise
 * Export metrics and device configuration
 * Depth Sensor controls
 
@@ -70,6 +71,14 @@ _D'<sub>i</sub>_ - Z-error: Distance (signed) from the rotated _D<sub>i</sub>_ c
 _GT_ - Ground Truth distance to the wall (mm)  
 ![](./res/z_accuracy_d_rotated.gif)  
 ![](./res/z_accuracy_percentage.gif)
+
+### Temporal Noise
+_STD<sub>n</sub>_ - Matrix of Standard deviation calculated per pixel over N images (N is set to 40 images).  
+_Median<sub>n</sub>_ - Matrix of Median calculated per pixel over N images.  
+Division - Matrix consist of Division of _STD<sub>n</sub>_ by _Median<sub>n</sub>_ per pixel.  
+Temporal Noise (%)  is calculated as the median of the Division matrix, multiplied by 100 to get the percentage.
+
+
 <!---
 Math expressions generated with
 http://www.numberempire.com/texequationeditor/equationeditor.php

--- a/tools/depth-quality/rs-depth-quality.cpp
+++ b/tools/depth-quality/rs-depth-quality.cpp
@@ -1,4 +1,6 @@
-﻿// License: Apache 2.0. See LICENSE file in root directory.
+﻿
+
+// License: Apache 2.0. See LICENSE file in root directory.
 // Copyright(c) 2015-24 Intel Corporation. All Rights Reserved.
 
 #include "depth-quality-model.h"
@@ -7,6 +9,114 @@
 
 #include <librealsense2/rs.hpp>
 #include <numeric>
+#include <rs-config.h>
+
+static const float TO_MM = 1000.f;
+static const float TO_PERCENT = 100.f;
+using namespace rs2::depth_quality;
+
+static void calculate_temporal_noise(const std::vector<rs2::float3>& points, const rs2::region_of_interest& roi, const int roi_width, const int roi_height, metric temporal_noise, bool record, std::vector<single_metric_data>& samples)
+{
+    // Calculate Temporal Noise
+    const int NUM_IMAGES = 40;
+
+    static std::deque<std::vector<rs2::float3>> depth_images; // FIFO buffer for depth images
+
+    // Add the current depth image to the FIFO buffer
+    depth_images.push_back(points);
+    //start calculate only once we accumulate 'NUM_IMAGES'
+    if (depth_images.size() >= NUM_IMAGES) {
+        depth_images.pop_front();
+
+        // Create Depth_Tensor ==> vector of 'NUM_IMAGES' images.
+        std::vector<std::vector<std::vector<float>>> depth_tensor(roi_width, std::vector<std::vector<float>>(roi_height, std::vector<float>(depth_images.size(), 0.0f)));
+
+        // Fill Depth_Tensor with depth images
+        for (size_t n = 0; n < depth_images.size(); ++n) {
+            for (const auto& point : depth_images[n]) {
+                int x = static_cast<int>(point.x);
+                int y = static_cast<int>(point.y);
+                if (x >= roi.min_x && x < roi.max_x && y >= roi.min_y && y < roi.max_y) {
+                    depth_tensor[x - roi.min_x][y - roi.min_y][n] = point.z * TO_MM;
+                }
+            }
+        }
+
+        // Remove all zeros from Depth_Tensor
+        for (int y = 0; y < roi_height; ++y) {
+            for (int x = 0; x < roi_width; ++x) {
+                depth_tensor[x][y].erase(std::remove(depth_tensor[x][y].begin(), depth_tensor[x][y].end(), 0.0f), depth_tensor[x][y].end());
+            }
+        }
+
+
+        std::vector<std::vector<float>> std_matrix(roi_width, std::vector<float>(roi_height, 0.0f));
+        std::vector<std::vector<float>> median_matrix(roi_width, std::vector<float>(roi_height, 0.0f));
+        std::vector<std::vector<float>> division_matrix(roi_width, std::vector<float>(roi_height, 0.0f));
+
+        for (int y = 0; y < roi_height; ++y) {
+            for (int x = 0; x < roi_width; ++x) {
+                if (!depth_tensor[x][y].empty()) {
+                    float mean = std::accumulate(depth_tensor[x][y].begin(), depth_tensor[x][y].end(), 0.0f) / depth_tensor[x][y].size();
+                    float variance = 0.0f;
+
+                    // Compute STD_Matrix
+                    for (float value : depth_tensor[x][y]) {
+                        variance += (value - mean) * (value - mean);
+                    }
+                    variance /= depth_tensor[x][y].size();
+                    std_matrix[x][y] = std::sqrt(variance);
+
+                    // Compute median
+                    std::vector<float> sorted_values = depth_tensor[x][y];
+                    std::sort(sorted_values.begin(), sorted_values.end());
+                    size_t size = sorted_values.size();
+                    if (size % 2 == 0) {
+                        median_matrix[x][y] = (sorted_values[size / 2 - 1] + sorted_values[size / 2]) / 2.0f;
+                    }
+                    else {
+                        median_matrix[x][y] = sorted_values[size / 2];
+                    }
+
+                    // Compute division of std_matrix by median_matrix
+                    if (median_matrix[x][y] != 0) { // Avoid division by zero
+                        division_matrix[x][y] = std_matrix[x][y] / median_matrix[x][y];
+                    }
+                    else {
+                        division_matrix[x][y] = 0.0f; // Handle division by zero case
+                    }
+                }
+            }
+        }
+
+        // Flatten the division_matrix into a single vector
+        std::vector<float> flattened_division_matrix;
+        for (const auto& row : division_matrix) {
+            for (float value : row) {
+                flattened_division_matrix.push_back(value);
+            }
+        }
+
+        // Sort the flattened vector
+        std::sort(flattened_division_matrix.begin(), flattened_division_matrix.end());
+
+        // Find the median of the flattened vector
+        float division_median;
+        size_t flattened_size = flattened_division_matrix.size();
+        if (flattened_size % 2 == 0) {
+            division_median = (flattened_division_matrix[flattened_size / 2 - 1] + flattened_division_matrix[flattened_size / 2]) / 2.0f;
+        }
+        else {
+            division_median = flattened_division_matrix[flattened_size / 2];
+        }
+
+        temporal_noise->add_value(division_median * 100);
+
+        if (record) {
+            samples.push_back({ temporal_noise->get_name(), division_median * 100 });
+        }
+    }
+}
 
 int main(int argc, const char * argv[]) try
 {
@@ -22,8 +132,6 @@ int main(int argc, const char * argv[]) try
     bool const disable_log_to_console = false;
 #endif
     rs2::depth_quality::tool_model model( ctx, disable_log_to_console );
-
-    using namespace rs2::depth_quality;
 
     // ===============================
     //       Metrics Definitions
@@ -74,6 +182,22 @@ int main(int argc, const char * argv[]) try
                  "RMS = SQRT((SUM(Di-Dpi)^2)/n)\n"
                  "             i=1    ");
 
+    metric temporal_noise = model.make_metric(
+        "Temporal Noise", 0.f, 100.f, true, "%",
+        "Temporal Noise .\n"
+        "This metric provides the depth temporal noise\n"
+        "and is calculated as follows:\n"
+        "Input - N images of Depth_Image\n"
+        "Loop over the N images and create Depth_Tensor\n"
+        "Depth_Tensor = (Depth_Image, N)\n"
+        "Remove all zeros from Depth_Tensor\n"
+        "COMPUTE STD_Matrix = STD of Depth_Tensor(x, y, all)\n"
+        "COMPUTE Median_Matrix = Median of Depth_Tensor(x, y, all)\n"
+        "COMPUTE Division_Matrix = STD_Matrix /Median_Matrix\n"
+        "COMPUTE Median_Devision_Matrix = 50% percentile value of Devision_Matrix\n"
+        "Temporal Noise = Median_Devision_Matrix multiply by 100 to get percentage\n");
+
+
     // ===============================
     //       Metrics Calculation
     // ===============================
@@ -83,7 +207,7 @@ int main(int argc, const char * argv[]) try
         const rs2::plane p,
         const rs2::region_of_interest roi,
         const float baseline_mm,
-        const float focal_length_pixels,
+        const rs2_intrinsics* intrin,
         const int ground_truth_mm,
         const bool plane_fit,
         const float plane_fit_to_ground_truth_mm,
@@ -92,19 +216,27 @@ int main(int argc, const char * argv[]) try
         std::vector<single_metric_data>& samples)
     {
         float TO_METERS = model.get_depth_scale();
-        static const float TO_MM = 1000.f;
-        static const float TO_PERCENT = 100.f;
+        const int roi_width = roi.max_x - roi.min_x;
+        const int roi_height = roi.max_y - roi.min_y;
 
         // Calculate fill rate relative to the ROI
-        auto fill_rate = points.size() / float((roi.max_x - roi.min_x)*(roi.max_y - roi.min_y)) * TO_PERCENT;
+        auto fill_rate = points.size() / float((roi_width)*(roi_height)) * TO_PERCENT;
         fill->add_value(fill_rate);
         if(record) samples.push_back({fill->get_name(),  fill_rate });
 
         if (!plane_fit) return;
 
-        const float bf_factor = baseline_mm * focal_length_pixels * TO_METERS; // also convert point units from mm to meter
+        const float bf_factor = baseline_mm * intrin->fx * TO_METERS; // also convert point units from mm to meter
 
-        std::vector<rs2::float3> points_set = points;
+        std::vector<rs2::float3> deprojected_points;
+        for (auto point : points)
+        {
+            float pixel[2] = { point.x, point.y };
+            float pt[3];
+            rs2_deproject_pixel_to_point(pt, intrin, pixel, point.z);
+            deprojected_points.push_back({ pt[0], pt[1], pt[2] });
+        }
+        
         std::vector<float> distances;
         std::vector<float> disparities;
         std::vector<float> gt_errors;
@@ -115,15 +247,15 @@ int main(int argc, const char * argv[]) try
         if (ground_truth_mm) gt_errors.reserve(points.size());
 
         // Remove outliers [below 0.5% and above 99.5%)
-        std::sort(points_set.begin(), points_set.end(), [](const rs2::float3& a, const rs2::float3& b) { return a.z < b.z; });
-        size_t outliers = points_set.size() / 200;
-        points_set.erase(points_set.begin(), points_set.begin() + outliers); // crop min 0.5% of the dataset
-        points_set.resize(points_set.size() - outliers); // crop max 0.5% of the dataset
+        std::sort(deprojected_points.begin(), deprojected_points.end(), [](const rs2::float3& a, const rs2::float3& b) { return a.z < b.z; });
+        size_t outliers = deprojected_points.size() / 200;
+        deprojected_points.erase(deprojected_points.begin(), deprojected_points.begin() + outliers); // crop min 0.5% of the dataset
+        deprojected_points.resize(deprojected_points.size() - outliers); // crop max 0.5% of the dataset
 
         // Convert Z values into Depth values by aligning the Fitted plane with the Ground Truth (GT) plane
         // Calculate distance and disparity of Z values to the fitted plane.
         // Use the rotated plane fit to calculate GT errors
-        for (auto point : points_set)
+        for (auto point : deprojected_points)
         {
             // Find distance from point to the reconstructed plane
             auto dist2plane = p.a*point.x + p.b*point.y + p.c*point.z + p.d;
@@ -169,8 +301,9 @@ int main(int argc, const char * argv[]) try
         {
             samples.push_back({ plane_fit_rms_error->get_name(),  rms_error_val_per });
             samples.push_back({ plane_fit_rms_error->get_name() + " mm",  rms_error_val });
-        }
+        }  
 
+        calculate_temporal_noise(points, roi, roi_width, roi_height, temporal_noise, record, samples);
     });
 
     // ===============================


### PR DESCRIPTION
add pixel temporal noise metric
tracked by DQT RSDSO-7359
update readme file

use upper case for num images

revert code which takes N frames parameter from config file. fix deprojection issue
set the depth tensor size to be as the ROI size.

change pixel noise from mm to %

change default number of images (N) from 10 to 40. start the noise calculation only once we have reached N images
* pending definition of % is regards of pixel noise (instead of mm)



<!--
    Pull requests should go to the development branch:
    https://github.com/IntelRealSense/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/IntelRealSense/librealsense/blob/master/CONTRIBUTING.md
-->
