### PR TITLE
[build] add option to use externally build LZ4 library

### DIFF
--- a/CMake/lrs_options.cmake
+++ b/CMake/lrs_options.cmake
@@ -54,4 +54,4 @@ option(BUILD_PC_STITCHING "Build pointcloud-stitching example" OFF)
 option(BUILD_WITH_DDS "Access camera devices through DDS topics (requires CMake 3.16.3)" OFF)
 option(BUILD_RS2_ALL "Build realsense2-all static bundle containing all realsense libraries (with BUILD_SHARED_LIBS=OFF)" ON)
 option(ENABLE_SECURITY_FLAGS "Enable additional compiler security flags to enhance the build's security" OFF)
- 
+option(USE_EXTERNAL_LZ4 "Use externally build LZ4 library instead of building and using the in this repo provided version" OFF)

--- a/third-party/realsense-file/CMakeLists.txt
+++ b/third-party/realsense-file/CMakeLists.txt
@@ -5,20 +5,24 @@ project(realsense-file)
 include(config.cmake)
 
 FILE(GLOB_RECURSE AllSources
-        ${LZ4_DIR}/lz4.h
-        ${LZ4_DIR}/lz4.c
         ${ROSBAG_DIR}/*.h
         ${ROSBAG_DIR}/*.cpp
         ${ROSBAG_DIR}/*.c
         )
 
+if (USE_EXTERNAL_LZ4)
+        find_package(lz4 REQUIRED)
+else()
+        LIST(APPEND AllSources ${LZ4_DIR}/lz4.h ${LZ4_DIR}/lz4.c)
+        source_group("Header Files\\lz4" FILES
+                lz4/lz4.h
+        )
+        source_group("Source Files\\lz4" FILES
+                lz4/lz4.c
+        )
+endif()
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-source_group("Header Files\\lz4" FILES
-        lz4/lz4.h
-        )
-source_group("Source Files\\lz4" FILES
-        lz4/lz4.c
-        )
 
 add_library(${PROJECT_NAME} STATIC
     ${AllSources}
@@ -31,8 +35,12 @@ target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 
 target_include_directories(${PROJECT_NAME} PRIVATE
         ${ROSBAG_HEADER_DIRS}
-        ${LZ4_INCLUDE_PATH}
-        )
+        $<$<NOT:$<BOOL:${USE_EXTERNAL_LZ4}>>:${LZ4_INCLUDE_PATH}>
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+        $<$<BOOL:${USE_EXTERNAL_LZ4}>:lz4::lz4>
+)
 
 #set_target_properties(${PROJECT_NAME} PROPERTIES VERSION "${LIBVERSION}" SOVERSION "${LIBSOVERSION}")
 


### PR DESCRIPTION
This PR adds a CMake option with which you can control if the SDK should be building its own version of LZ4 compression library or should use a prebuild library that can be found in the build environment.

This enables to use of a statically build RealSense SDK in combination with other statically build libraries that use LZ4.

Related issue #13796 