### PR TITLE
Better handling of DDS streams information

### DIFF
--- a/include/librealsense2/h/rs_frame.h
+++ b/include/librealsense2/h/rs_frame.h
@@ -263,6 +263,14 @@ int rs2_get_frame_points_count(const rs2_frame* frame, rs2_error** error);
 const rs2_stream_profile* rs2_get_frame_stream_profile(const rs2_frame* frame, rs2_error** error);
 
 /**
+ * Returns the stream profile name
+ * \param[in] profile     stream profile whose name we want to get
+ * \param[out] error      If non-null, receives any error that occurs during this call, otherwise, errors are ignored
+ * \return                Stream name, as a null terminated string
+ */
+const char * rs2_get_stream_profile_name( const rs2_stream_profile * profile, rs2_error ** error );
+
+/**
 * Test if the given frame can be extended to the requested extension
 * \param[in]  frame             Realsense frame
 * \param[in]  extension_type    The extension to which the frame should be tested if it is extendable

--- a/include/librealsense2/hpp/rs_frame.hpp
+++ b/include/librealsense2/hpp/rs_frame.hpp
@@ -112,10 +112,19 @@ namespace rs2
         */
         std::string stream_name() const
         {
-            std::stringstream ss;
-            ss << rs2_stream_to_string(stream_type());
-            if (stream_index() != 0) ss << " " << stream_index();
-            return ss.str();
+            rs2_error * e = nullptr;
+            std::string name = rs2_get_stream_profile_name( _profile, &e );
+
+            if( name.empty() )
+            {
+                std::stringstream ss;
+                ss << rs2_stream_to_string( stream_type() );
+                if( stream_index() != 0 )
+                    ss << " " << stream_index();
+                name = ss.str();
+            }
+
+            return name;
         }
 
         /**

--- a/src/core/stream-profile-interface.h
+++ b/src/core/stream-profile-interface.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 #include <iosfwd>
+#include <string>
 
 
 namespace librealsense {
@@ -28,6 +29,9 @@ public:
 
     virtual int get_tag() const = 0;
     virtual void tag_profile( int tag ) = 0;
+
+    virtual const char * get_name() = 0;
+    virtual void set_name( const std::string & name ) = 0;
 
     virtual std::shared_ptr< stream_profile_interface > clone() const = 0;
     virtual rs2_stream_profile * get_c_wrapper() const = 0;

--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -260,7 +260,7 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
                         auto video_profile = std::static_pointer_cast< realdds::dds_video_stream_profile >( profile );
                         auto raw_stream_profile = sensor.add_video_stream(
                             to_rs2_video_stream( stream_type, sidx, video_profile, video_stream->get_intrinsics() ),
-                            profile == default_profile );
+                            profile == default_profile, stream->name() );
                         _stream_name_to_profiles[stream->name()].push_back( raw_stream_profile );
                     }
                     else if( motion_stream )
@@ -268,7 +268,7 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
                         auto motion_profile = std::static_pointer_cast< realdds::dds_motion_stream_profile >( profile );
                         auto raw_stream_profile = sensor.add_motion_stream(
                             to_rs2_motion_stream( stream_type, sidx, motion_profile, motion_stream->get_gyro_intrinsics() ),
-                            profile == default_profile );
+                            profile == default_profile, stream->name() );
                         _stream_name_to_profiles[stream->name()].push_back( raw_stream_profile );
                     }
                 }

--- a/src/dds/rs-dds-device-proxy.h
+++ b/src/dds/rs-dds-device-proxy.h
@@ -55,6 +55,8 @@ class dds_device_proxy
     rsutils::subscription _metadata_subscription;
 
     int get_index_from_stream_name( const std::string & name ) const;
+    int get_unique_index_in_sensor( const std::shared_ptr< dds_sensor_proxy > & sensor,
+                                    const std::string & stream_name, rs2_stream stream_type ) const;
     void set_profile_intrinsics( std::shared_ptr< stream_profile_interface > const & profile,
                                  const std::shared_ptr< realdds::dds_stream > & stream ) const;
     void set_video_profile_intrinsics( std::shared_ptr< stream_profile_interface > const & profile,

--- a/src/dds/rs-dds-sensor-proxy.cpp
+++ b/src/dds/rs-dds-sensor-proxy.cpp
@@ -79,45 +79,6 @@ void dds_sensor_proxy::add_dds_stream( sid_index sidx, std::shared_ptr< realdds:
 }
 
 
-std::shared_ptr< stream_profile_interface > dds_sensor_proxy::add_video_stream( rs2_video_stream video_stream,
-                                                                                bool is_default )
-{
-    auto profile = std::make_shared< video_stream_profile >();
-    profile->set_dims( video_stream.width, video_stream.height );
-    profile->set_format( video_stream.fmt );
-    profile->set_framerate( video_stream.fps );
-    profile->set_stream_index( video_stream.index );
-    profile->set_stream_type( video_stream.type );
-    profile->set_unique_id( video_stream.uid );
-    profile->set_intrinsics( [=]() {  //
-        return video_stream.intrinsics;
-    } );
-    if( is_default )
-        profile->tag_profile( profile_tag::PROFILE_TAG_DEFAULT );
-    _sw_profiles.push_back( profile );
-
-    return profile;
-}
-
-
-std::shared_ptr< stream_profile_interface > dds_sensor_proxy::add_motion_stream( rs2_motion_stream motion_stream,
-                                                                                 bool is_default )
-{
-    auto profile = std::make_shared< motion_stream_profile >();
-    profile->set_format( motion_stream.fmt );
-    profile->set_framerate( motion_stream.fps );
-    profile->set_stream_index( motion_stream.index );
-    profile->set_stream_type( motion_stream.type );
-    profile->set_unique_id( motion_stream.uid );
-    profile->set_intrinsics( [=]() { return motion_stream.intrinsics; } );
-    if( is_default )
-        profile->tag_profile( profile_tag::PROFILE_TAG_DEFAULT );
-    _sw_profiles.push_back( profile );
-
-    return profile;
-}
-
-
 stream_profiles dds_sensor_proxy::init_stream_profiles()
 {
     auto profiles = get_raw_stream_profiles();

--- a/src/dds/rs-dds-sensor-proxy.h
+++ b/src/dds/rs-dds-sensor-proxy.h
@@ -75,8 +75,6 @@ public:
     const std::string & get_name() const { return _name; }
 
     void add_dds_stream( sid_index sidx, std::shared_ptr< realdds::dds_stream > const & stream );
-    std::shared_ptr<stream_profile_interface> add_video_stream( rs2_video_stream video_stream, bool is_default ) override;
-    std::shared_ptr<stream_profile_interface> add_motion_stream( rs2_motion_stream motion_stream, bool is_default ) override;
 
     void open( const stream_profiles & profiles ) override;
     void start( rs2_frame_callback_sptr callback ) override;

--- a/src/proc/formats-converter.cpp
+++ b/src/proc/formats-converter.cpp
@@ -123,6 +123,11 @@ stream_profiles formats_converter::get_all_possible_profiles( const stream_profi
                         cloned_profile->set_format( target.format );
                         cloned_profile->set_stream_index( target.index );
                         cloned_profile->set_stream_type( target.stream );
+                        // UVC raw profile name is not set, default name can be created based on type and index, but raw UVC index is always 0.
+                        // Use temporary variable to generate name without changing original raw_profile object.
+                        auto && tmp_raw_profile = std::dynamic_pointer_cast< stream_profile_base >( raw_profile ).get();
+                        tmp_raw_profile->set_stream_index( target.index );
+                        cloned_profile->set_name( tmp_raw_profile->get_name() );
 
                         auto cloned_vsp = As< video_stream_profile, stream_profile_interface >( cloned_profile );
                         if( cloned_vsp )

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -76,6 +76,7 @@ EXPORTS
     rs2_get_frame_stride_in_bytes
     rs2_get_frame_bits_per_pixel
     rs2_get_frame_stream_profile
+    rs2_get_stream_profile_name
     rs2_get_frame_vertices
     rs2_get_frame_texture_coordinates
     rs2_get_frame_points_count

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -1422,6 +1422,13 @@ const rs2_stream_profile* rs2_get_frame_stream_profile(const rs2_frame* frame_re
 }
 HANDLE_EXCEPTIONS_AND_RETURN(nullptr, frame_ref)
 
+const char * rs2_get_stream_profile_name( const rs2_stream_profile * profile, rs2_error ** error ) BEGIN_API_CALL
+{
+    VALIDATE_NOT_NULL( profile );
+    return profile->profile->get_name();
+}
+HANDLE_EXCEPTIONS_AND_RETURN( nullptr, profile )
+
 int rs2_get_frame_bits_per_pixel(const rs2_frame* frame_ref, rs2_error** error) BEGIN_API_CALL
 {
     VALIDATE_NOT_NULL(frame_ref);

--- a/src/software-sensor.cpp
+++ b/src/software-sensor.cpp
@@ -83,7 +83,7 @@ software_sensor::~software_sensor()
 
 
 std::shared_ptr< stream_profile_interface > software_sensor::add_video_stream( rs2_video_stream video_stream,
-                                                                               bool is_default )
+                                                                               bool is_default, std::string name )
 {
     auto profile = std::make_shared< video_stream_profile >();
     profile->set_dims( video_stream.width, video_stream.height );
@@ -93,6 +93,7 @@ std::shared_ptr< stream_profile_interface > software_sensor::add_video_stream( r
     profile->set_stream_type( video_stream.type );
     profile->set_unique_id( video_stream.uid );
     profile->set_intrinsics( [=]() { return video_stream.intrinsics; } );
+    profile->set_name( name );
     if( is_default )
         profile->tag_profile( profile_tag::PROFILE_TAG_DEFAULT );
     _sw_profiles.push_back( profile );
@@ -102,7 +103,7 @@ std::shared_ptr< stream_profile_interface > software_sensor::add_video_stream( r
 
 
 std::shared_ptr< stream_profile_interface > software_sensor::add_motion_stream( rs2_motion_stream motion_stream,
-                                                                                bool is_default )
+                                                                                bool is_default, std::string name )
 {
     auto profile = std::make_shared< motion_stream_profile >();
     profile->set_format( motion_stream.fmt );
@@ -111,16 +112,16 @@ std::shared_ptr< stream_profile_interface > software_sensor::add_motion_stream( 
     profile->set_stream_type( motion_stream.type );
     profile->set_unique_id( motion_stream.uid );
     profile->set_intrinsics( [=]() { return motion_stream.intrinsics; } );
+    profile->set_name( name );
     if( is_default )
         profile->tag_profile( profile_tag::PROFILE_TAG_DEFAULT );
     _sw_profiles.push_back( profile );
 
-    return std::move( profile );
+    return profile;
 }
 
 
-std::shared_ptr< stream_profile_interface > software_sensor::add_pose_stream( rs2_pose_stream pose_stream,
-                                                                              bool is_default )
+std::shared_ptr< stream_profile_interface > software_sensor::add_pose_stream( rs2_pose_stream pose_stream, bool is_default, std::string name )
 {
     auto profile = std::make_shared< pose_stream_profile >();
     if( ! profile )
@@ -131,6 +132,7 @@ std::shared_ptr< stream_profile_interface > software_sensor::add_pose_stream( rs
     profile->set_stream_index( pose_stream.index );
     profile->set_stream_type( pose_stream.type );
     profile->set_unique_id( pose_stream.uid );
+    profile->set_name( name );
     if( is_default )
         profile->tag_profile( profile_tag::PROFILE_TAG_DEFAULT );
     _sw_profiles.push_back( profile );

--- a/src/software-sensor.h
+++ b/src/software-sensor.h
@@ -25,11 +25,11 @@ public:
     ~software_sensor();
 
     virtual std::shared_ptr< stream_profile_interface > add_video_stream( rs2_video_stream video_stream,
-                                                                          bool is_default = false );
+                                                                          bool is_default = false, std::string name = "" );
     virtual std::shared_ptr< stream_profile_interface > add_motion_stream( rs2_motion_stream motion_stream,
-                                                                           bool is_default = false );
+                                                                           bool is_default = false, std::string name = "" );
     virtual std::shared_ptr< stream_profile_interface > add_pose_stream( rs2_pose_stream pose_stream,
-                                                                         bool is_default = false );
+                                                                         bool is_default = false, std::string name = "" );
 
     bool extend_to( rs2_extension extension_type, void ** ptr ) override;
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -83,6 +83,9 @@ namespace librealsense
             _uid = uid;
         };
 
+        const char * get_name() override { return _name.c_str(); }
+        void set_name( const std::string & name ) override { _name = name; }
+
         rs2_stream_profile* get_c_wrapper() const override;
 
         void set_c_wrapper(rs2_stream_profile* wrapper) override;
@@ -99,6 +102,7 @@ namespace librealsense
         int _tag = profile_tag::PROFILE_TAG_ANY;
         rs2_stream_profile _c_wrapper;
         rs2_stream_profile* _c_ptr = nullptr;
+        std::string _name;
     };
 
     class video_stream_profile : public virtual video_stream_profile_interface, public stream_profile_base, public extension_snapshot

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -88,7 +88,7 @@ int dds_video_encoding::to_rs2() const
         { "RGBA", RS2_FORMAT_RGBA8 },
         { "RGB2", RS2_FORMAT_BGR8 },
         { "BGRA", RS2_FORMAT_BGRA8 },
-        { "MJPG", RS2_FORMAT_MJPEG },
+        { "jpeg", RS2_FORMAT_MJPEG }, // ROS2-compatible for compressed images
         { "CNF4", RS2_FORMAT_RAW8 },
         { "BYR2", RS2_FORMAT_RAW16 },
         { "R10", RS2_FORMAT_RAW10 },
@@ -120,7 +120,7 @@ dds_video_encoding dds_video_encoding::from_rs2( int rs2_format )
     case RS2_FORMAT_RGBA8: encoding = "RGBA"; break;  // todo
     case RS2_FORMAT_BGR8: encoding = "RGB2"; break;
     case RS2_FORMAT_BGRA8: encoding = "BGRA"; break;  // todo
-    case RS2_FORMAT_MJPEG: encoding = "MJPG"; break;
+    case RS2_FORMAT_MJPEG: encoding = "jpeg"; break;
     case RS2_FORMAT_RAW8: encoding = "CNF4"; break;
     case RS2_FORMAT_RAW16: encoding = "BYR2"; break;
     case RS2_FORMAT_RAW10: encoding = "R10"; break;

--- a/third-party/realdds/src/dds-stream-profile.cpp
+++ b/third-party/realdds/src/dds-stream-profile.cpp
@@ -98,7 +98,7 @@ int dds_video_encoding::to_rs2() const
     std::string s = to_string();
     auto it = fcc_to_rs2.find( s );
     if( it == fcc_to_rs2.end() )
-        DDS_THROW( runtime_error, "invalid encoding '" + s + "'" );
+        DDS_THROW( runtime_error, "Invalid encoding '" + s + "'" );
     return it->second;
 }
 


### PR DESCRIPTION
Tracked on [RSDEV-3114]

- Does not throw on device constructor error. Will allow device to be shown in viewer, with partial capabilities and error messages. Before if there was an error the device was not shown and user cannot know if it is attached to the network or not.
- Preparations for compressed streams support. Better handling of several streams of same type in sensor.