### PR TITLE
Fix LibCI failure counter

### DIFF
--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -467,7 +467,6 @@ def test_wrapper( test, configuration=None, repetition=1, serial_numbers=None ):
         if test_wrapper_( test, configuration, repetition, retry, test.config.retries, serial_numbers ):
             return True
 
-    log._n_errors += 1
     return False
 
 # Run all tests


### PR DESCRIPTION
Following [PR#13817](https://github.com/IntelRealSense/librealsense/pull/13817)

LibCI counts failed tests number erroneously. Error counter should be handled via `log` module calls only.
