### PR TITLE
MIPI Enabling IR metadata - [BREAKING CHANGE]

### DIFF
--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -11,8 +11,9 @@
 # mipi	0	      depth	  Metadata	/dev/video1	/dev/video-rs-depth-md-0
 # mipi	0	      color	  Streaming	/dev/video2	/dev/video-rs-color-0
 # mipi	0	      color	  Metadata	/dev/video3	/dev/video-rs-color-md-0
-# mipi	0	      ir	    Streaming	/dev/video4	/dev/video-rs-ir-0
-# mipi	0	      imu	    Streaming	/dev/video5	/dev/video-rs-imu-0
+# mipi	0	      ir	  Streaming	/dev/video4	/dev/video-rs-ir-0
+# mipi	0	      ir	  Metadata	/dev/video5	/dev/video-rs-ir-md-0
+# mipi	0	      imu	  Streaming	/dev/video6	/dev/video-rs-imu-0
 #
 # Alderlake:
 #$ ./rs-enum.sh 
@@ -80,10 +81,10 @@ fi
 mux_list=${mux_param:-'a b c d e f g h'}
 
 declare -A camera_idx=( [a]=0 [b]=1 [c]=2 [d]=3 [e]=4 [f]=5 [g]=6 [h]=7)
-declare -A d4xx_vc_named=([depth]=1 [rgb]=3 [ir]=5 [imu]=6)
+declare -A d4xx_vc_named=([depth]=1 [rgb]=3 [ir]=5 [imu]=7)
 declare -A camera_names=( [depth]=depth [rgb]=color [ir]=ir [imu]=imu )
 
-camera_vid=("depth" "depth-md" "color" "color-md" "ir" "imu")
+camera_vid=("depth" "depth-md" "color" "color-md" "ir" "ir-md" "imu")
 
 
 mdev=$(${v4l2_util} --list-devices | grep -A1 tegra | grep media)
@@ -127,8 +128,6 @@ for dfuid_x in ${dfuid[*]}; do # for all physical cameras one by one.
 
       sens_id=$((sens_id+1))
       # find metadata
-      # skip IR and imu metadata node for now.
-      [[ ${sensor_name} == 'ir' ]] && continue
       [[ ${sensor_name} == 'imu' ]] && continue
 
       i=$((i+1)) # metadata video index next to the video node always

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1018,7 +1018,7 @@ namespace librealsense
             static int  first_video_index = ind;
 
             // Use camera_video_nodes as number of /dev/video[%d] for each camera sensor subset
-            const int camera_video_nodes = 6;
+            const int camera_video_nodes = 7;
             int cam_id = ind / camera_video_nodes;
             ind = (ind - first_video_index) % camera_video_nodes; // offset from first mipi video node and assume 6 nodes per mipi camera
             if (ind == 0 || ind == 2 || ind == 4)

--- a/src/linux/backend-v4l2.cpp
+++ b/src/linux/backend-v4l2.cpp
@@ -1011,8 +1011,8 @@ namespace librealsense
             //  D457 exposes (assuming first_video_index = 0):
             // - video0 for Depth and video1 for Depth's md.
             // - video2 for RGB and video3 for RGB's md.
-            // - video4 for IR stream. IR's md is currently not available.
-            // - video5 for IMU (accel or gyro TBD)
+            // - video4 for IR and video5 for IR's md.
+            // - video6 for IMU (accel or gyro TBD)
             // next several lines permit to use D457 even if a usb device has already "taken" the video0,1,2 (for example)
             // further development is needed to permit use of several mipi devices
             static int  first_video_index = ind;
@@ -1023,9 +1023,9 @@ namespace librealsense
             ind = (ind - first_video_index) % camera_video_nodes; // offset from first mipi video node and assume 6 nodes per mipi camera
             if (ind == 0 || ind == 2 || ind == 4)
                 mi = 0; // video node indicator
-            else if (ind == 1 | ind == 3)
+            else if (ind == 1 | ind == 3 || ind == 5)
                 mi = 3; // metadata node indicator
-            else if (ind == 5)
+            else if (ind == 6)
                 mi = 4; // IMU node indicator
             else
             {


### PR DESCRIPTION
Tracked on [RSDEV-3072]

Not that this is coupled to a matching FW + MIPI driver version as the IMU index is shifted from index 5 to index 6