### PR TITLE
Relax json setting enforcement

### DIFF
--- a/CMake/external_json.cmake
+++ b/CMake/external_json.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.8)
 include(ExternalProject)
 
 

--- a/CMake/external_pybind11.cmake
+++ b/CMake/external_pybind11.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.8)
 include(ExternalProject)
 
 

--- a/CMake/windows_config.cmake
+++ b/CMake/windows_config.cmake
@@ -1,5 +1,5 @@
 message(STATUS "Setting Windows configurations")
-cmake_minimum_required(VERSION 3.6.0) #Required by list(FILTER ...
+cmake_minimum_required(VERSION 3.8)
 config_crt()
 
 macro(os_set_flags)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -35,6 +35,10 @@ namespace librealsense {
         auto const filename = rsutils::os::get_special_folder( rsutils::os::special_folder::app_data ) + RS2_CONFIG_FILENAME;
         auto config = rsutils::json_config::load_from_file( filename );
 
+        if (config.is_discarded())
+        {
+            LOG_ERROR( "No valid configuration file found at : " << filename << " loading defaults" );
+        }
         // Take only the 'context' part of it
         config = rsutils::json_config::load_settings( config, "context", "config-file" );
 
@@ -45,8 +49,6 @@ namespace librealsense {
 
 
     context::context( json const & settings )
-        : _settings( load_settings( settings ) )  // global | application | local
-        , _device_mask( _settings.nested( "device-mask" ).default_value< unsigned >( RS2_PRODUCT_LINE_ANY ) )
     {
         static bool version_logged = false;
         if( ! version_logged )
@@ -54,6 +56,9 @@ namespace librealsense {
             version_logged = true;
             LOG_DEBUG( "Librealsense VERSION: " << RS2_API_FULL_VERSION_STR );
         }
+
+         _settings = load_settings( settings );  // global | application | local
+         _device_mask = _settings.nested( "device-mask" ).default_value< unsigned >( RS2_PRODUCT_LINE_ANY );
     }
 
 
@@ -88,7 +93,12 @@ namespace librealsense {
 
     /*static*/ std::shared_ptr< context > context::make( char const * json_settings )
     {
-        return make( ( ! json_settings || ! *json_settings ) ? json::object() : json::parse( json_settings ) );
+        if ( ! json_settings || ! *json_settings )
+            return make(json::object());
+
+        json raw_j = json::parse(json_settings, nullptr, false);
+
+        return make(raw_j);
     }
 
 

--- a/src/context.h
+++ b/src/context.h
@@ -79,7 +79,7 @@ namespace librealsense
             _devices_changed;
 
         rsutils::json _settings; // Save operation settings
-        unsigned const _device_mask;
+        unsigned _device_mask;
 
         std::vector< std::shared_ptr< device_factory > > _factories;
     };

--- a/third-party/rsutils/src/json.cpp
+++ b/third-party/rsutils/src/json.cpp
@@ -116,8 +116,8 @@ json json_config::load_from_file( std::string const & filename )
             ::nlohmann::detail::parser< json, input_stream_adapter >( input_stream_adapter( f ), nullptr, false ).parse( false, result );
             return result;
         }
-        // Even that we sent allow_exceptions = false, we add an extra protection that if it will
-        // throws we catch it here and fallback to return missing_json.
+        // Even that we set allow_exceptions = false, we add an extra protection that if it will
+        // throw we catch it here and fallback to return missing_json.
         catch( ... ) {}
     }
     return missing_json;

--- a/third-party/rsutils/src/json.cpp
+++ b/third-party/rsutils/src/json.cpp
@@ -103,8 +103,7 @@ public:
 
 // Load the contents of a file into a JSON object.
 // 
-// Throws if any errors are encountered with the file or its contents.
-// Returns the contents. If the file wasn't there, returns missing_json.
+// Returns the contents. If the file wasn't there or corrupted, returns missing_json.
 //
 json json_config::load_from_file( std::string const & filename )
 {
@@ -114,18 +113,15 @@ json json_config::load_from_file( std::string const & filename )
         try
         {
             json result;
-            ::nlohmann::detail::parser< json, input_stream_adapter >( input_stream_adapter( f ) ).parse( true, result );
+            ::nlohmann::detail::parser< json, input_stream_adapter >( input_stream_adapter( f ), nullptr, false ).parse( false, result );
             return result;
         }
-        catch( std::exception const & e )
-        {
-            throw std::runtime_error( "failed to load configuration file (" + filename
-                                      + "): " + std::string( e.what() ) );
-        }
+        // Even that we sent allow_exceptions = false, we add an extra protection that if it will
+        // throws we catch it here and fallback to return missing_json.
+        catch( ... ) {}
     }
     return missing_json;
 }
-
 
 
 // Loads configuration settings from 'global' content (loaded by load_from_file()?).

--- a/tools/dds/dds-config/CMakeLists.txt
+++ b/tools/dds/dds-config/CMakeLists.txt
@@ -1,6 +1,6 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2024 Intel Corporation. All Rights Reserved.
-cmake_minimum_required( VERSION 3.1.0 )
+cmake_minimum_required(VERSION 3.8)
 project( rs-dds-config )
 
 add_executable( ${PROJECT_NAME} )


### PR DESCRIPTION
Writing to the configuration is not an atomic operation and sometimes when the viewer is closed in the middle of the configuration writing the file is corrupted.

On this case until the user fix/delete the file the SDK context will throw an exception.
On this PR on such case, the context will start with default settings.

It will override the user's setting, yes.. but at least the SDK will be more robust to failures.

Upgrade minimal CMake version to 3.8 as GitHub Actions fail on lower cmake versions

Tracked on [LRS-1250]