### PR TITLE
fix env var missing error on Unifi

### DIFF
--- a/unit-tests/py/rspy/device_hub.py
+++ b/unit-tests/py/rspy/device_hub.py
@@ -185,6 +185,8 @@ def _create_unifi():
         return unifi.UniFiSwitch()
     except ModuleNotFoundError:
         return None
+    except EnvironmentError:
+        return None
     except unifi.NoneFoundError:
         return None
     except BaseException as e:

--- a/unit-tests/py/rspy/unifi.py
+++ b/unit-tests/py/rspy/unifi.py
@@ -36,6 +36,10 @@ except ModuleNotFoundError:
     log.d( 'no paramiko library is available' )
     raise
 
+
+if "UNIFI_SSH_PASSWORD" not in os.environ:
+    log.d("no unifi credentials set")
+    raise EnvironmentError("Environment variable UNIFI_SSH_PASSWORD not set")
 SWITCH_IP = "192.168.11.20"
 SWITCH_SSH_USER = "admin"
 SWITCH_SSH_PASS = os.environ["UNIFI_SSH_PASSWORD"]


### PR DESCRIPTION
We found that if you have the paramiko library installed, but you do not have the environment variable set to use the unifi, run-unit-tests will fail, this PR should fix that by handling that case