### PR TITLE
Enable UV mapping when rotating frames

### DIFF
--- a/src/proc/rotation-filter.h
+++ b/src/proc/rotation-filter.h
@@ -36,6 +36,7 @@ namespace librealsense
         uint16_t                  _rotated_width;     
         uint16_t                  _rotated_height;
         float _value;
+        float _last_rotation_value = 0;
     };
     MAP_EXTENSION( RS2_EXTENSION_ROTATION_FILTER, librealsense::rotation_filter );
     }


### PR DESCRIPTION
1. cloning profile only once per rotation angle
2. update intrinsic 

Limitation: UV mapping works when both sensors are rotated at the same angle.