### PR TITLE
combine shared data function

### DIFF
--- a/common/graph-model.cpp
+++ b/common/graph-model.cpp
@@ -7,7 +7,7 @@ using namespace rs2;
 
 void graph_model::process_frame(rs2::frame f)
 {
-    write_shared_data(
+    shared_data_access::write_shared_data(
         [&]()
         {
             if (!_paused && f && f.is< rs2::motion_frame >()
@@ -42,7 +42,7 @@ void graph_model::process_frame(rs2::frame f)
 
                 }
             }
-        });
+        }, _m);
 }
 
 void graph_model::draw(rect stream_rect)
@@ -56,13 +56,13 @@ void graph_model::draw(rect stream_rect)
         time_index[i] = static_cast<float>(i);
 
     // Read shared history data
-    auto x_hist = read_shared_data<std::vector<float>>([&]() { return _x_history; });
-    auto y_hist = read_shared_data<std::vector<float>>([&]() { return _y_history; });
-    auto z_hist = read_shared_data<std::vector<float>>([&]() { return _z_history; });
+    auto x_hist = shared_data_access::read_shared_data<std::vector<float>>([&]() { return _x_history; }, _m);
+    auto y_hist = shared_data_access::read_shared_data<std::vector<float>>([&]() { return _y_history; }, _m);
+    auto z_hist = shared_data_access::read_shared_data<std::vector<float>>([&]() { return _z_history; }, _m);
 
     std::vector<float> n_hist;
     if(_show_n_value) 
-        n_hist = read_shared_data<std::vector<float>>([&]() { return _n_history; });
+        n_hist = shared_data_access::read_shared_data<std::vector<float>>([&]() { return _n_history; }, _m);
 
     ImGui::BeginChild(_name.c_str(), ImVec2(stream_rect.w + 2, stream_rect.h));
 
@@ -83,7 +83,7 @@ void graph_model::draw(rect stream_rect)
 
 void graph_model::clear()
 {
-    write_shared_data(
+    shared_data_access::write_shared_data(
         [&]()
         {
             _x_history.clear();
@@ -99,7 +99,7 @@ void graph_model::clear()
                 if(_show_n_value)
                     _n_history.push_back(0);
             }
-        });
+        }, _m);
 }
 
 void graph_model::pause()

--- a/common/graph-model.h
+++ b/common/graph-model.h
@@ -7,11 +7,9 @@
 #include <implot.h> 
 #include <mutex>
 #include <vector>
-#include <GLFW/glfw3.h>
 #include <rsutils/time/periodic-timer.h>
-#include "rect.h"
 
-#include <librealsense2/rs.hpp>
+#include "output-model.h"
 
 namespace rs2
 {
@@ -33,19 +31,7 @@ namespace rs2
         void pause();
         void resume();
         bool is_paused();
-    protected:
-        template<class T>
-        T read_shared_data(std::function<T()> action)
-        {
-            std::lock_guard<std::mutex> lock(_m);
-            T res = action();
-            return res;
-        }
-        void write_shared_data(std::function<void()> action)
-        {
-            std::lock_guard<std::mutex> lock(_m);
-            action();
-        }
+
     private:
         float _x_value = 0.0f, _y_value = 0.0f, _z_value = 0.0f, _n_value = 0.0f;
         bool _show_n_value;

--- a/common/output-model.cpp
+++ b/common/output-model.cpp
@@ -1204,7 +1204,7 @@ void stream_dashboard::draw_dashboard(ux_window& win, rect& r)
 
 void frame_drops_dashboard::process_frame(rs2::frame f)
 {
-    write_shared_data([&](){
+    shared_data_access::write_shared_data([&](){
         double ts = glfwGetTime();
         if (method == 1) ts = f.get_timestamp() / 1000.f;
         auto it = stream_to_time.find(f.get_profile().unique_id());
@@ -1236,12 +1236,12 @@ void frame_drops_dashboard::process_frame(rs2::frame f)
         }
 
         stream_to_time[f.get_profile().unique_id()] = ts;
-    });
+    }, m );
 }
 
 void frame_drops_dashboard::draw(ux_window& win, rect r)
 {
-    auto hist = read_shared_data<std::deque<int>>([&](){ return drops_history; });
+    auto hist = shared_data_access::read_shared_data<std::deque<int>>([&](){ return drops_history; }, m);
     for (int i = 0; i < hist.size(); i++)
     {
         add_point((float)i, (float)hist[i]);
@@ -1277,7 +1277,7 @@ int frame_drops_dashboard::get_height() const
 
 void frame_drops_dashboard::clear(bool full)
 {
-    write_shared_data([&](){
+    shared_data_access::write_shared_data([&](){
         stream_to_time.clear();
         last_time = 0;
         *total = 0;
@@ -1288,5 +1288,5 @@ void frame_drops_dashboard::clear(bool full)
             for (int i = 0; i < 100; i++)
                 drops_history.push_back(0);
         }
-    });
+    }, m);
 }


### PR DESCRIPTION
I refactored the `write_shared_data` and `read_shared_data` functions, which were previously used separately in both the `output-model `and `graph-model` class, by creating a new class that contains these functions for shared use.