### PR TITLE
Update GHA ROS build timeout

### DIFF
--- a/.github/workflows/build-ROS2-package-CI.yaml
+++ b/.github/workflows/build-ROS2-package-CI.yaml
@@ -12,7 +12,7 @@ jobs:
 
   build_lrs_ros2_package:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         ros_distribution:


### PR DESCRIPTION
We see sometimes the build takes more than 30 min, increase to 45