### PR TITLE
Viewer - update control from slider only, after dragging it

### DIFF
--- a/common/option-model.cpp
+++ b/common/option-model.cpp
@@ -31,6 +31,7 @@ namespace rs2
         option.supported = opt->is_valid;  // i.e., supported-and-enabled!
         option.range = options->get_option_range( opt->id );
         option.read_only = options->is_option_read_only( opt->id );
+        option.last_slider_hold_stopwatch.reset( {} ); // Avoids seeming as if a slider was dragged and just released.
         return option;
     }
 }
@@ -162,6 +163,10 @@ void option_model::update_all_fields( std::string & error_message, notifications
 {
     try
     {
+        // After slider was dragged value updated using set_option, don't update value again here
+        if( last_slider_hold_stopwatch.get_elapsed_ms() < 500 )
+            return;
+
         value = endpoint->get_option_value( opt );
         supported = value->is_valid;
         if( supported )
@@ -511,23 +516,18 @@ bool option_model::draw_slider( notifications_model & model,
             auto int_value = static_cast< int >( value_as_float() );
 
             if( RsImGui::SliderIntWithSteps( id.c_str(),
-                                           &int_value,
-                                           static_cast< int >( range.min ),
-                                           static_cast< int >( range.max ),
-                                           static_cast< int >( range.step )) )
+                                             &int_value,
+                                             static_cast< int >( range.min ),
+                                             static_cast< int >( range.max ),
+                                             static_cast< int >( range.step ) ) )
             {
                 // TODO: Round to step?
-                slider_clicked = slider_selected( opt,
-                                                  static_cast< float >( int_value ),
-                                                  error_message,
-                                                  model );
+                slider_clicked = slider_selected( opt, static_cast< float >( int_value ), error_message, model );
+                last_slider_hold_stopwatch.reset(); // While sliding the control, avoid other means of updating value
             }
             else
             {
-                slider_clicked = slider_unselected( opt,
-                                                    static_cast< float >( int_value ),
-                                                    error_message,
-                                                    model );
+                slider_clicked = slider_unselected( opt, static_cast< float >( int_value ), error_message, model );
             }
         }
         else
@@ -656,8 +656,7 @@ bool option_model::slider_unselected( rs2_option opt,
                                       notifications_model & model )
 {
     bool res = false;
-    // Slider unselected, if last value was ignored, set with last value if the value was
-    // changed.
+    // Slider unselected, if last value was ignored, set with last value if the value was changed.
     if( have_unset_value )
     {
         if( value != unset_value )
@@ -731,4 +730,13 @@ bool option_model::set_option(rs2_option opt,
     }
 
     return true;
+}
+
+void option_model::update_value( const rs2::option_value & updated_value, notifications_model & model )
+{
+    // After slider was dragged, don't update value from outside (usually on_options_changed callback)
+    if( last_slider_hold_stopwatch.get_elapsed_ms() < 1000 )
+        return;
+
+    value = updated_value;
 }

--- a/common/option-model.h
+++ b/common/option-model.h
@@ -27,12 +27,15 @@ namespace rs2
         std::string value_as_string() const;
         float value_as_float() const;
 
+        void update_value( const rs2::option_value & updated_value, notifications_model & model );
+
         rs2_option opt;
         option_range range;
         std::shared_ptr<options> endpoint;
         float unset_value = 0;
         bool have_unset_value = false;
         rsutils::time::stopwatch last_set_stopwatch;
+        rsutils::time::stopwatch last_slider_hold_stopwatch;
         bool* invalidate_flag = nullptr;
         bool supported = false;
         bool read_only = false;

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -45,7 +45,7 @@ namespace rs2
                     auto it = options_metadata.find( changed_option->id );
                     if( it != options_metadata.end() && ! _destructing ) // Callback runs in different context, check options_metadata still valid
                     {
-                        it->second.value = changed_option;
+                        it->second.update_value( changed_option, *viewer.not_model );
                     }
                 }
             } );


### PR DESCRIPTION
Tracked on [RSDEV-3186]

There are several mechanisms of control value update. This caused a jump in the slider GUI, shortly reflecting wrong values (metadata shows correct values).