### PR TITLE
disable OCC when RGB streaming

### DIFF
--- a/common/calibration-model.cpp
+++ b/common/calibration-model.cpp
@@ -536,7 +536,8 @@ void calibration_model::d400_update(ux_window& window, std::string& error_messag
         }
         ImGui::SameLine();
 
-        if (_accept)
+        auto streams = dev.query_sensors()[0].get_active_streams();
+        if (_accept && streams.size())
         {
             if (ImGui::Button(u8"\uF2DB  Write Table", ImVec2(120, 25)))
             {
@@ -572,7 +573,7 @@ void calibration_model::d400_update(ux_window& window, std::string& error_messag
             ImGui::Button(u8"\uF2DB  Write Table", ImVec2(120, 25));
             if (ImGui::IsItemHovered())
             {
-                RsImGui::CustomTooltip("%s", "Write selected calibration table to the device. For advanced users");
+                RsImGui::CustomTooltip("%s", "Write selected calibration table to the device. Requires Stereo Module to be on. For advanced users");
             }
 
             ImGui::PopStyleColor(2);
@@ -587,7 +588,6 @@ void calibration_model::d400_update(ux_window& window, std::string& error_messag
             {
                 try
                 {
-                    auto streams = dev.query_sensors()[0].get_active_streams();
                     dev.query_sensors()[0].close();
                     dev.query_sensors()[0].open(streams);
                     dev.as<rs2::auto_calibrated_device>().set_calibration_table(_calibration);

--- a/common/calibration-model.cpp
+++ b/common/calibration-model.cpp
@@ -536,7 +536,7 @@ void calibration_model::d400_update(ux_window& window, std::string& error_messag
         }
         ImGui::SameLine();
 
-        auto streams = dev.query_sensors()[0].get_active_streams();
+        auto streams = dev.first<rs2::depth_sensor>().get_active_streams();
         if (_accept && streams.size())
         {
             if (ImGui::Button(u8"\uF2DB  Write Table", ImVec2(120, 25)))
@@ -573,7 +573,7 @@ void calibration_model::d400_update(ux_window& window, std::string& error_messag
             ImGui::Button(u8"\uF2DB  Write Table", ImVec2(120, 25));
             if (ImGui::IsItemHovered())
             {
-                RsImGui::CustomTooltip("%s", "Write selected calibration table to the device. Requires Stereo Module to be on. For advanced users");
+                RsImGui::CustomTooltip("%s", "Write selected calibration table to the device. Requires \"Stereo Module\" stream to be on.For advanced users");
             }
 
             ImGui::PopStyleColor(2);

--- a/common/calibration-model.cpp
+++ b/common/calibration-model.cpp
@@ -536,7 +536,17 @@ void calibration_model::d400_update(ux_window& window, std::string& error_messag
         }
         ImGui::SameLine();
 
-        auto streams = dev.first<rs2::depth_sensor>().get_active_streams();
+        rs2::sensor depth_sensor;
+        try 
+        {
+            depth_sensor = dev.first<rs2::depth_sensor>();
+        }
+        catch (const std::exception& ex)
+        {
+            error_message = ex.what();
+            ImGui::CloseCurrentPopup();
+        }
+        auto streams = depth_sensor.get_active_streams();
         if (_accept && streams.size())
         {
             if (ImGui::Button(u8"\uF2DB  Write Table", ImVec2(120, 25)))

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2192,6 +2192,21 @@ namespace rs2
         });
     }
 
+    bool rs2::device_model::is_color_streaming() const
+    {
+        for( const auto & sub : subdevices )
+        {
+            if( ! sub.get()->streaming )
+                continue;
+
+            auto profiles = sub->get_selected_profiles();
+            for( const auto & profile : profiles )
+                if( profile.stream_type() == RS2_STREAM_COLOR )
+                    return true;
+        }
+        return false;
+    }
+
     void device_model::draw_controls(float panel_width, float panel_height,
         ux_window& window,
         std::string& error_message,
@@ -3060,6 +3075,10 @@ namespace rs2
         std::string& error_message)
     {
         bool has_autocalib = false;
+
+        bool rgb_streaming = is_color_streaming();
+        ImGuiSelectableFlags avoid_selection_flag = (rgb_streaming) ? ImGuiSelectableFlags_Disabled : 0;
+
         for (auto&& sub : subdevices)
         {
             if (sub->supports_on_chip_calib() && !has_autocalib)
@@ -3073,7 +3092,7 @@ namespace rs2
                 bool disable_fl_cal = (((device_pid == "0B5C") || show_disclaimer) &&
                     (!starts_with(device_usb_type, "3."))); // D410/D15/D455@USB2
 
-                if (ImGui::Selectable("On-Chip Calibration"))
+                if (ImGui::Selectable("On-Chip Calibration", false , avoid_selection_flag))
                 {
                     try
                     {

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -2196,13 +2196,8 @@ namespace rs2
     {
         for( const auto & sub : subdevices )
         {
-            if( ! sub.get()->streaming )
-                continue;
-
-            auto profiles = sub->get_selected_profiles();
-            for( const auto & profile : profiles )
-                if( profile.stream_type() == RS2_STREAM_COLOR )
-                    return true;
+            if (sub->s->is<color_sensor>() && sub->streaming)
+                return true;
         }
         return false;
     }
@@ -3076,8 +3071,8 @@ namespace rs2
     {
         bool has_autocalib = false;
 
-        bool rgb_streaming = is_color_streaming();
-        ImGuiSelectableFlags avoid_selection_flag = (rgb_streaming) ? ImGuiSelectableFlags_Disabled : 0;
+        bool color_streaming = is_color_streaming();
+        ImGuiSelectableFlags avoid_selection_flag = (color_streaming) ? ImGuiSelectableFlags_Disabled : 0;
 
         for (auto&& sub : subdevices)
         {

--- a/common/device-model.cpp
+++ b/common/device-model.cpp
@@ -3181,7 +3181,7 @@ namespace rs2
                 if (ImGui::IsItemHovered())
                     RsImGui::CustomTooltip("Focal length calibration is used to adjust camera focal length with specific target.");
 
-                if (ImGui::Selectable("Tare Calibration"))
+                if (ImGui::Selectable("Tare Calibration", false, avoid_selection_flag))
                 {
                     try
                     {

--- a/common/device-model.h
+++ b/common/device-model.h
@@ -384,6 +384,7 @@ namespace rs2
         std::shared_ptr<syncer_model> syncer;
         std::shared_ptr<rs2::asynchronous_syncer> dev_syncer;
         bool is_streaming() const;
+        bool is_color_streaming() const;
         bool metadata_supported = false;
         bool get_curr_advanced_controls = true;
         device dev;

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -2194,8 +2194,10 @@ namespace rs2
 
                 if( get_manager().get_device_model().is_color_streaming() )
                 {
-                    update_state = RS2_CALIB_STATE_FAILED;
-                    _error_message = "Turn off RGB Camera streaming before using on-chip calibration.";
+                    dismiss(false);
+                    ImGui::PopStyleColor(7);
+                    ImGui::PopFont();
+                    throw std::runtime_error("Turn off \"RGB Camera\" streaming before using on-chip calibration.");
                 }
                 else 
                 {
@@ -2332,17 +2334,9 @@ namespace rs2
                         ImGui::Text("%s", (get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_FL_CALIB ? "OCC FL calibraton cannot work with this camera!" : "OCC Extended calibraton cannot work with this camera!"));
                     }
                 }
-                else if( get_manager().get_device_model().is_color_streaming() )
-                {
-                    ImGui::PushTextWrapPos( 0.0f );
-                    ImGui::Text( "%s", _error_message.c_str() );
-                    ImGui::PopTextWrapPos();
-                }
                 else
                 {
-                    ImGui::PushTextWrapPos(0.0f);
                     ImGui::Text("%s", _error_message.c_str());
-                    ImGui::PopTextWrapPos();
 
                     auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -2192,30 +2192,37 @@ namespace rs2
                 //if (ImGui::IsItemHovered())
                 //    RsImGui::CustomTooltip("%s", "On-Chip Calibration Extended");
 
-
-                auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
-                ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
-                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
-
-                std::string button_name = rsutils::string::from() << "Calibrate" << "##self" << index;
-
-                ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 28) });
-                if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
+                if( get_manager().get_device_model().is_color_streaming() )
                 {
-                    get_manager().restore_workspace([this](std::function<void()> a) { a(); });
-                    get_manager().reset();
-                    get_manager().retry_times = 0;
-                    auto _this = shared_from_this();
-                    auto invoke = [_this](std::function<void()> action) {_this->invoke(action);};
-                    get_manager().start(invoke);
-                    update_state = RS2_CALIB_STATE_CALIB_IN_PROCESS;
-                    enable_dismiss = false;
+                    update_state = RS2_CALIB_STATE_FAILED;
+                    _error_message = "Turn off RGB Camera streaming before using on-chip calibration.";
                 }
+                else 
+                {
+                    auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
+                    ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
+                    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
 
-                ImGui::PopStyleColor(2);
+                    std::string button_name = rsutils::string::from() << "Calibrate" << "##self" << index;
 
-                if (ImGui::IsItemHovered())
-                    RsImGui::CustomTooltip("%s", "Begin On-Chip Calibration");
+                    ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 28) });
+                    if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
+                    {
+                        get_manager().restore_workspace([this](std::function<void()> a) { a(); });
+                        get_manager().reset();
+                        get_manager().retry_times = 0;
+                        auto _this = shared_from_this();
+                        auto invoke = [_this](std::function<void()> action) {_this->invoke(action); };
+                        get_manager().start(invoke);
+                        update_state = RS2_CALIB_STATE_CALIB_IN_PROCESS;
+                        enable_dismiss = false;
+                    }
+
+                    ImGui::PopStyleColor(2);
+
+                    if (ImGui::IsItemHovered())
+                        RsImGui::CustomTooltip("%s", "Begin On-Chip Calibration");
+                }
             }
             else if (update_state == RS2_CALIB_STATE_FL_INPUT)
             {
@@ -2325,9 +2332,17 @@ namespace rs2
                         ImGui::Text("%s", (get_manager().action == on_chip_calib_manager::RS2_CALIB_ACTION_ON_CHIP_FL_CALIB ? "OCC FL calibraton cannot work with this camera!" : "OCC Extended calibraton cannot work with this camera!"));
                     }
                 }
+                else if( get_manager().get_device_model().is_color_streaming() )
+                {
+                    ImGui::PushTextWrapPos( 0.0f );
+                    ImGui::Text( "%s", _error_message.c_str() );
+                    ImGui::PopTextWrapPos();
+                }
                 else
                 {
+                    ImGui::PushTextWrapPos(0.0f);
                     ImGui::Text("%s", _error_message.c_str());
+                    ImGui::PopTextWrapPos();
 
                     auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
 

--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -1428,6 +1428,10 @@ namespace rs2
         if (action == RS2_CALIB_ACTION_FL_CALIB || action == RS2_CALIB_ACTION_UVMAPPING_CALIB || action == RS2_CALIB_ACTION_FL_PLUS_CALIB)
             stop_viewer(invoke);
 
+        if( action == RS2_CALIB_ACTION_ON_CHIP_CALIB || action == RS2_CALIB_ACTION_TARE_CALIB )
+            if( _model.is_color_streaming() )
+                throw std::runtime_error( "Turn off RGB Camera streaming before calibrating." );
+
         update_last_used();
 
         if (action == RS2_CALIB_ACTION_ON_CHIP_FL_CALIB || action == RS2_CALIB_ACTION_FL_CALIB)
@@ -2192,39 +2196,30 @@ namespace rs2
                 //if (ImGui::IsItemHovered())
                 //    RsImGui::CustomTooltip("%s", "On-Chip Calibration Extended");
 
-                if( get_manager().get_device_model().is_color_streaming() )
+
+                auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
+                ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
+
+                std::string button_name = rsutils::string::from() << "Calibrate" << "##self" << index;
+
+                ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 28) });
+                if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
                 {
-                    dismiss(false);
-                    ImGui::PopStyleColor(7);
-                    ImGui::PopFont();
-                    throw std::runtime_error("Turn off \"RGB Camera\" streaming before using on-chip calibration.");
+                    get_manager().restore_workspace([this](std::function<void()> a) { a(); });
+                    get_manager().reset();
+                    get_manager().retry_times = 0;
+                    auto _this = shared_from_this();
+                    auto invoke = [_this](std::function<void()> action) {_this->invoke(action);};
+                    get_manager().start(invoke);
+                    update_state = RS2_CALIB_STATE_CALIB_IN_PROCESS;
+                    enable_dismiss = false;
                 }
-                else 
-                {
-                    auto sat = 1.f + sin(duration_cast<milliseconds>(system_clock::now() - created_time).count() / 700.f) * 0.1f;
-                    ImGui::PushStyleColor(ImGuiCol_Button, saturate(sensor_header_light_blue, sat));
-                    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, saturate(sensor_header_light_blue, 1.5f));
 
-                    std::string button_name = rsutils::string::from() << "Calibrate" << "##self" << index;
+                ImGui::PopStyleColor(2);
 
-                    ImGui::SetCursorScreenPos({ float(x + 5), float(y + height - 28) });
-                    if (ImGui::Button(button_name.c_str(), { float(bar_width), 20.f }))
-                    {
-                        get_manager().restore_workspace([this](std::function<void()> a) { a(); });
-                        get_manager().reset();
-                        get_manager().retry_times = 0;
-                        auto _this = shared_from_this();
-                        auto invoke = [_this](std::function<void()> action) {_this->invoke(action); };
-                        get_manager().start(invoke);
-                        update_state = RS2_CALIB_STATE_CALIB_IN_PROCESS;
-                        enable_dismiss = false;
-                    }
-
-                    ImGui::PopStyleColor(2);
-
-                    if (ImGui::IsItemHovered())
-                        RsImGui::CustomTooltip("%s", "Begin On-Chip Calibration");
-                }
+                if (ImGui::IsItemHovered())
+                    RsImGui::CustomTooltip("%s", "Begin On-Chip Calibration");
             }
             else if (update_state == RS2_CALIB_STATE_FL_INPUT)
             {

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -122,8 +122,6 @@ namespace rs2
         void stop_viewer();
         void reset_device() { _dev.hardware_reset(); }
 
-        const device_model& get_device_model() const { return _model; }
-
     private:
         void save_laser_emitter_state();
         void save_thermal_loop_state();

--- a/common/on-chip-calib.h
+++ b/common/on-chip-calib.h
@@ -122,6 +122,8 @@ namespace rs2
         void stop_viewer();
         void reset_device() { _dev.hardware_reset(); }
 
+        const device_model& get_device_model() const { return _model; }
+
     private:
         void save_laser_emitter_state();
         void save_thermal_loop_state();


### PR DESCRIPTION
Tracked on : [RSDSO-19732]
In case of RGB streaming On-Chip Calibration option is disabled:
![image](https://github.com/user-attachments/assets/3c921899-b592-48c3-9ec4-3305dbf75053)
In addition, in case of RGB streaming when On-Chip Calibration window is up, the user will get this exception error message:
![image](https://github.com/user-attachments/assets/2a3c5508-8f45-4cca-8354-2d8917202954)
