### PR TITLE
Refactor backend-v4l::named_mutex

### DIFF
--- a/src/linux/backend-v4l2.h
+++ b/src/linux/backend-v4l2.h
@@ -105,17 +105,10 @@ namespace librealsense
             bool try_lock();
 
         private:
-            void acquire();
-            void release();
-
             std::string _device_path;
             uint32_t _timeout;
             int _fildes;
-            static std::recursive_mutex _init_mutex;
-            static std::map<std::string, std::recursive_mutex> _dev_mutex;
-            static std::map<std::string, int> _dev_mutex_cnt;
-            int _object_lock_counter;
-            std::mutex _mutex;
+            std::atomic< int > _lock_counter;
         };
         static int xioctl(int fh, unsigned long request, void *arg);
 


### PR DESCRIPTION
Tracked on [RSDSO-20187]

`named_mutex` holding file descriptor (RAII).
Removed unnecessary locks and counters for file descriptor open/close.
Using atomic int as lock counter.
