### PR TITLE
Add more logs to fps test

### DIFF
--- a/unit-tests/live/frames/fps_helper.py
+++ b/unit-tests/live/frames/fps_helper.py
@@ -157,6 +157,7 @@ def perform_fps_test(sensor_profiles_arr, streams_combinations):
     for streams_to_test in streams_combinations:
         partial_dict = get_dict_for_streams(sensor_profiles_arr, streams_to_test)
         with test.closure("Testing", get_tested_profiles_string(partial_dict)):
+            log.i(partial_dict)
             expected_fps_dict = get_expected_fps_dict(partial_dict)
             log.d(get_test_details_str(partial_dict))
             fps_dict = measure_fps(partial_dict)

--- a/unit-tests/live/frames/fps_helper.py
+++ b/unit-tests/live/frames/fps_helper.py
@@ -160,6 +160,8 @@ def perform_fps_test(sensor_profiles_arr, streams_combinations):
             expected_fps_dict = get_expected_fps_dict(partial_dict)
             log.d(get_test_details_str(partial_dict))
             fps_dict = measure_fps(partial_dict)
+            log.i("Expected: ", expected_fps_dict)
+            log.i("Got: ", fps_dict)
             test.check(check_fps_dict(fps_dict, expected_fps_dict))
 
 

--- a/unit-tests/live/frames/test-fps-permutations.py
+++ b/unit-tests/live/frames/test-fps-permutations.py
@@ -50,7 +50,7 @@ def get_sensors_and_profiles(device):
                 sensor.set_option(rs.option.enable_auto_exposure, 1)
             if sensor.supports(rs.option.auto_exposure_priority):
                 sensor.set_option(rs.option.auto_exposure_priority, 0)  # AE priority should be 0 for constant FPS
-            profile = fps_helper.get_profile(sensor, rs.stream.color)
+            profile = fps_helper.get_profile(sensor, rs.stream.color, HD_RESOLUTION)
         elif sensor.is_motion_sensor():
             sensor_profiles_arr.append((sensor, fps_helper.get_profile(sensor, rs.stream.accel)))
             sensor_profiles_arr.append((sensor, fps_helper.get_profile(sensor, rs.stream.gyro)))


### PR DESCRIPTION
Add more information to the test even when debug logs are off.
![image](https://github.com/user-attachments/assets/94d0d7d7-e9b6-4496-a685-34967615a48a)
