### PR TITLE
Fixed Resource Leak In Point Cloud Example

### DIFF
--- a/wrappers/csharp/Documentation/cookbook.md
+++ b/wrappers/csharp/Documentation/cookbook.md
@@ -281,8 +281,8 @@ pipe.Start();
 
 using (var frames = pipe.WaitForFrames())
 using (var depth = frames.DepthFrame)
-using (var frame = pc.Process(depth))
-using (var points = frame.As<Points>())
+using (var pc_frame = pc.Process(depth))
+using (var points = pc_frame.As<Points>())
 {
     // CopyVertices is extensible, any of these will do:
     var vertices = new float[points.Count * 3];

--- a/wrappers/csharp/Documentation/cookbook.md
+++ b/wrappers/csharp/Documentation/cookbook.md
@@ -281,7 +281,8 @@ pipe.Start();
 
 using (var frames = pipe.WaitForFrames())
 using (var depth = frames.DepthFrame)
-using (var points = pc.Process(depth).As<Points>())
+using (var frame = pc.Process(depth))
+using (var points = frame.As<Points>())
 {
     // CopyVertices is extensible, any of these will do:
     var vertices = new float[points.Count * 3];


### PR DESCRIPTION
Following this example for point clouds led to a resource leak.

As documented in the section on casting:
> // As<T> creates a new object, both need to be disposed

Fixed this.