### PR TITLE
DDS device implements calibration_change_device API

### DIFF
--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -443,6 +443,9 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
             {
                 for( auto & profile : it->second )
                     set_video_profile_intrinsics( profile, video_stream );
+
+                for( const auto & cb : _calib_changed_callbacks )
+                    cb->on_calibration_change( rs2_calibration_status::RS2_CALIBRATION_SUCCESSFUL );
             }
             else
             {

--- a/src/dds/rs-dds-device-proxy.h
+++ b/src/dds/rs-dds-device-proxy.h
@@ -8,10 +8,12 @@
 #include "sid_index.h"
 #include "rsdds-serializable.h"
 #include <src/auto-calibrated-proxy.h>
+#include <src/device-calibration.h>
 
 #include <rsutils/json-fwd.h>
 #include <memory>
 #include <vector>
+#include <set>
 
 
 namespace realdds {
@@ -45,6 +47,7 @@ class dds_device_proxy
     , public update_device_interface  // signed, recovery-mode
     , public dds_serializable
     , public auto_calibrated_proxy
+    , public calibration_change_device
 {
     std::shared_ptr< realdds::dds_device > _dds_dev;
     std::map< std::string, std::vector< std::shared_ptr< stream_profile_interface > > > _stream_name_to_profiles;
@@ -75,6 +78,16 @@ public:
     void tag_profiles( stream_profiles profiles ) const override;
 
     void hardware_reset() override;
+
+    // calibration_change_device
+public:
+    void register_calibration_change_callback( rs2_calibration_change_callback_sptr callback ) override
+    {
+        _calib_changed_callbacks.insert( callback );
+    }
+
+private:
+    std::set< rs2_calibration_change_callback_sptr > _calib_changed_callbacks;
 
     // debug_interface
 private:


### PR DESCRIPTION
Tracked on [RSDEV-3293]

DDS devices implements `calibration_change_device` interface. Expected, for example, by `pointcloud` to update cached intrinsics on calibration updates.