### PR TITLE
Disable test-y16-calibration-format for D457 until fixed

### DIFF
--- a/unit-tests/live/streaming/test-y16-calibration-format.py
+++ b/unit-tests/live/streaming/test-y16-calibration-format.py
@@ -1,7 +1,8 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2023 RealSense, Inc. All Rights Reserved.
 
-# test:device D400*
+# disable D457 unril this issue is resolved on driver side RSDSO-20168
+# test:device D400* !D457
 # test:device each(D555)
 # This test checks streaming y16 profile
 


### PR DESCRIPTION
Tracked on [RSDSO-20168]