### PR TITLE
D415 OCC handling

### DIFF
--- a/common/on-chip-calib.cpp
+++ b/common/on-chip-calib.cpp
@@ -30,8 +30,6 @@ namespace rs2
         if (dev.supports(RS2_CAMERA_INFO_NAME))
         {
             device_name_string = _dev.get_info( RS2_CAMERA_INFO_NAME );
-            if( val_in_range( device_name_string, { std::string( "Intel RealSense D415" ) } ) )
-                speed = 4;
         }
 
         if( dev.supports( RS2_CAMERA_INFO_CONNECTION_TYPE ) )

--- a/src/ds/d400/d400-auto-calibration.cpp
+++ b/src/ds/d400/d400-auto-calibration.cpp
@@ -316,12 +316,6 @@ namespace librealsense
             if (interactive_scan_v3)
                 p4 |= (1 << 9);
 
-            if( speed == ds_calib_common::SPEED_WHITE_WALL && apply_preset )
-            {
-                preset_recover = change_preset();
-                std::this_thread::sleep_for(std::chrono::milliseconds(200));
-            }
-
             // Begin auto-calibration
             if (host_assistance == host_assistance_type::no_assistance || host_assistance == host_assistance_type::assistance_start)
             {
@@ -419,12 +413,6 @@ namespace librealsense
                 p4 |= (1 << 8);
             if (interactive_scan_v3)
                 p4 |= (1 << 9);
-
-            if( speed == ds_calib_common::SPEED_WHITE_WALL && apply_preset )
-            {
-                preset_recover = change_preset();
-                std::this_thread::sleep_for(std::chrono::milliseconds(200));
-            }
 
             if( host_assistance == host_assistance_type::no_assistance || host_assistance == host_assistance_type::assistance_start )
             {
@@ -541,12 +529,6 @@ namespace librealsense
                 p4 |= (1 << 8);
             if (interactive_scan_v3)
                 p4 |= (1 << 9);
-
-            if( speed == ds_calib_common::SPEED_WHITE_WALL && apply_preset )
-            {
-                preset_recover = change_preset();
-                std::this_thread::sleep_for(std::chrono::milliseconds(200));
-            }
 
             // Begin auto-calibration
             if (host_assistance == host_assistance_type::no_assistance || host_assistance == host_assistance_type::assistance_start)


### PR DESCRIPTION
Tracked on [RSDSO-20539]

Aligning D415 handling to calibrations white paper. Using white wall speed is not the recommended way. Viewer will support recommended medium speed.
White wall mode can be activated using API/wrappers by users who might want to use it.