### PR TITLE
fix potential infinite loop in rs2_project_color_pixel_to_depth_pixel

### DIFF
--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -4299,6 +4299,13 @@ void rs2_project_color_pixel_to_depth_pixel(float to_pixel[2],
             to_pixel[0] = p[0];
             to_pixel[1] = p[1];
         }
+
+        // this is needed to avoid floating point precision issues when p is equal to end_pixel
+        // in this case the next_pixel_in_line can jump back and forth and cause an infinite loop
+        // example: start=(0,0), end=(30,2)
+        if (p[0] == end_pixel[0] && p[1] == end_pixel[1]) {
+            break;
+        }
     }
 }
 NOEXCEPT_RETURN(, to_pixel)


### PR DESCRIPTION
The current implementation of next_pixel_in_line and is_pixel_in_line means a loop may fall into an infinite loop if start/end's Y difference is an integer. 

example:
```c
    float start[2] = {0, 0};
    float end[2] = {30, 2};
    float cur[2] = {0, 0};
    for(; is_pixel_in_line(cur, start, end); next_pixel_in_line(cur, start, end)) {
        printf("%f, %f\n", cur[0], cur[1]);
    }
```

This PR fixed it. 
