### PR TITLE
Add <stdexcept>.

### DIFF
--- a/src/core/matcher-factory.cpp
+++ b/src/core/matcher-factory.cpp
@@ -6,6 +6,7 @@
 #include "stream-interface.h"
 
 #include <src/sync.h>
+#include <stdexcept>
 
 
 namespace librealsense {

--- a/src/core/options-registry.cpp
+++ b/src/core/options-registry.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <mutex>
 #include <map>
+#include <stdexcept>
 
 
 namespace librealsense {


### PR DESCRIPTION
For use of std::runtime_error.

This resolves build failures on Ubuntu 24.04 like the following:

```console
/usr/bin/c++ -DCOM_MULTITHREADED -DEASYLOGGINGPP_ASYNC -DELPP_THREAD_SAFE -DENFORCE_METADATA -DHWM_OVER_XU -DRS2_USE_V4L2_BACKEND -DUNICODE -DUSING_UDEV -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/src -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/console_bridge/include -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/cpp_common/include -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/rosbag_storage/include -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/roscpp_serialization/include -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/rostime/include -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/roscpp_traits/include -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/roslz4/include -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/rosbag/msgs -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/realsense-file/lz4/lib -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/include -I/vcpkg/installed/x64-linux/debug/lib/pkgconfig/../../../include/libusb-1.0 -I/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/third-party/rsutils/include -isystem /vcpkg/installed/x64-linux/include -fPIC -pedantic -Wno-missing-field-initializers -Wno-switch -Wno-multichar -Wsequence-point -Wformat -Wformat-security -mssse3 -pthread  -g -fPIC -MD -MT CMakeFiles/realsense2.dir/src/core/options-registry.cpp.o -MF CMakeFiles/realsense2.dir/src/core/options-registry.cpp.o.d -o CMakeFiles/realsense2.dir/src/core/options-registry.cpp.o -c /vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/src/core/options-registry.cpp
/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/src/core/options-registry.cpp: In function ‘size_t librealsense::by_name::new_index()’:
/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/src/core/options-registry.cpp:59:20: error: ‘runtime_error’ is not a member of ‘std’
   59 |         throw std::runtime_error( "reached option limit of 1000" );
      |                    ^~~~~~~~~~~~~
/vcpkg/buildtrees/realsense2/src/v2.56.3-fa124c44e5.clean/src/core/options-registry.cpp:10:1: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
    9 | #include <map>
  +++ |+#include <stdexcept>
   10 | 
```
