### PR TITLE
Fix UI slider_float edit mode

### DIFF
--- a/common/realsense-ui-advanced-mode.h
+++ b/common/realsense-ui-advanced-mode.h
@@ -144,10 +144,10 @@ inline void slider_float(std::string& error_message, const char* id, T* val, S T
         if (ImGui::InputText(slider_id.c_str(), buff, TEXT_BUFF_SIZE,
             ImGuiInputTextFlags_EnterReturnsTrue))
         {
-            int new_value = 0;
-            if (!rsutils::string::string_to_value<int>(buff, new_value))
+            float new_value = 0;
+            if (!rsutils::string::string_to_value<float>(buff, new_value))
             {
-                error_message = "Invalid integer input!";
+                error_message = "Invalid numeric input!";
             }
             else
             {


### PR DESCRIPTION
Tracked on [RSDEV-4453]

Originally a function called `string_to_int` was here. Despite the name it also converted floats.
Over time and refactors it have rolled into `rsutils::string::string_to_value<int>`, with a wrong type.
