### PR TITLE
Avoid out-of-bounds access on global data

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -815,7 +815,8 @@ namespace rs2
                 const std::string str((std::istreambuf_iterator<char>(f)),
                                  std::istreambuf_iterator<char>());
 
-                std::string tmp = realsense_udev_rules;
+                // The generated array 'realsense_udev_rules' is not NUL-terminated...
+                std::string tmp = std::string(realsense_udev_rules, sizeof(realsense_udev_rules));
                 tmp.erase(tmp.find_last_of("\n") + 1);
                 const std::string udev = tmp;
                 float udev_file_ver{0}, built_in_file_ver{0};


### PR DESCRIPTION
The issue can be easily seen with the address sanitizer. 'realsense_udev_rules' is a generated char[] that is not NUL-terminated. Assigning to a std::string involves a strlen() call. Obviously, that call cannot find the NUL in the char array and thus accesses at least one byte outside of that buffer.

We could alternatively ensure that the generated buffer is NUL-terminated (not sure, whether there are other such generated char arrays), or we could provide the actual length to the constructor.

I have chosen the latter one here, because it avoids the strlen() call (roughly 10KB to scan).

This fixes the issue 14356.