### PR TITLE
Fix D555 recovery mode not recognized

### DIFF
--- a/src/dds/rs-dds-device-proxy.cpp
+++ b/src/dds/rs-dds-device-proxy.cpp
@@ -417,10 +417,12 @@ dds_device_proxy::dds_device_proxy( std::shared_ptr< const device_info > const &
         }
     }
 
-    // Call after seneors have been initialized
-    ds_advanced_mode_base::initialize_advanced_mode( this ); // Call even if not enabled, so API calls won't throw
-    device_specific_initialization();
-
+    if( ! dev->device_info().is_recovery() )
+    {
+        // Call after seneors have been initialized
+        ds_advanced_mode_base::initialize_advanced_mode( this );  // Call even if not enabled, so API calls won't throw
+        device_specific_initialization();
+    }
     // Use the default D400 matchers:
     // Depth & IR matched by frame-number, time-stamp-matched to color.
     // Motion streams will not get synced.

--- a/src/ds/advanced_mode/advanced_mode.cpp
+++ b/src/ds/advanced_mode/advanced_mode.cpp
@@ -43,7 +43,7 @@ namespace librealsense
             if( dynamic_cast< depth_sensor * >( base ) )
                 _depth_sensor = base;
         }
-        if( !_depth_sensor && !dynamic_cast<update_device_interface *> (dev) )
+        if( !_depth_sensor )
             throw std::runtime_error( "Advanced mode expects camera to have a depth sensor" );
 
         for( size_t i = 0; i < _dev->get_sensors_count(); ++i )


### PR DESCRIPTION
Fix for PR https://github.com/IntelRealSense/librealsense/pull/14313, specifically commit 0b8683bda860d665e387b2f020583efdd17b052e, after which DDS devices in recovery mode would throw an error in the viewer and would not show in viewer

Seems like removing the <lazy> caused it indirectly