### PR TITLE
Avoid out-of-bounds access on global data

### DIFF
--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -853,7 +853,8 @@ namespace rs2
                     + "99-realsense-libusb.rules";
 
                 std::ofstream out(tmp_filename.c_str());
-                out << realsense_udev_rules;
+                std::string tmp = std::string(realsense_udev_rules, sizeof(realsense_udev_rules));
+                out << tmp;
                 out.close();
             }
         }


### PR DESCRIPTION
After enabling address sanitizer at debug build, global_buffer_overflow is observed while launching the Viewer version 2.56.5. This change is to address the out-of-bound issue.

<!--
    Pull requests should go to the development branch:
    https://github.com/IntelRealSense/librealsense/tree/development/

    If this is still a work-in-progress, please open it as DRAFT.

    For further details, please see our contribution guidelines:
    https://github.com/IntelRealSense/librealsense/blob/master/CONTRIBUTING.md
-->
