### PR TITLE
fix wrong string compare on python device repr

### DIFF
--- a/wrappers/python/pyrs_device.cpp
+++ b/wrappers/python/pyrs_device.cpp
@@ -63,7 +63,7 @@ void init_device(py::module &m) {
                 auto connection_type = self.get_info(RS2_CAMERA_INFO_CONNECTION_TYPE);
                 ss << "  on ";
                 ss << connection_type;
-                if (connection_type == "USB")
+                if (strcmp(connection_type, "USB") == 0)
                     if (self.supports(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR))
                         ss << self.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR);
             }


### PR DESCRIPTION
Wrong string comparation cause the condition to fail.
We compared char * to "USB" and not used proper string comparation

Before:
```
>>> dev
<pyrealsense2.device: D455 (S/N: 114222251272  FW: 5.17.0.10  UNLOCKED  on USB)>
```
After:
```
>>> dev
<pyrealsense2.device: D455 (S/N: 114222251272  FW: 5.17.0.10  UNLOCKED  on USB3.2)>
```