### PR TITLE
Avoid transitive includes

### DIFF
--- a/src/linux/backend-hid.h
+++ b/src/linux/backend-hid.h
@@ -7,6 +7,7 @@
 
 #include <limits.h>
 #include <list>
+#include <fstream>
 
 namespace librealsense
 {

--- a/third-party/rsutils/src/network-adapter-watcher.cpp
+++ b/third-party/rsutils/src/network-adapter-watcher.cpp
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <poll.h>
+#include <thread>
 
 #endif
 #endif  // ! __APPLE__ && ! __ANDROID__


### PR DESCRIPTION
I've been trying to wrap the SDK for Zig and I found that, while compiling for Linux x86_64 the compilation would fail due to undefined templates/incompatible binary operators being used in `src/linux/backend-hid.h` and `third-party/rsutils/src/network-adapter-watcher.cpp`:

- `librealsense/src/linux/backend-hid.h` uses `std::fstream` and `std::ifstream` without including `<fstream>`
- `librealsense/third-party/rsutils/src/network-adapter-watcher.cpp` uses `std::thread` without including `<thread>`

Both files rely on transitive includes that may not be available across different build environments, causing compilation failures when the header dependency chain changes.

I haven't dug enough around to see if there are other places where this happens, I hope this PR brings the underlying issue to the attention of the core developers and encourages a more thorough audit of the codebase for similar missing includes.