### PR TITLE
fix compilation of python wrapper when librs is a cmake subproject

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -131,6 +131,32 @@ if( BUILD_LEGACY_PYBACKEND )
 
     if(USE_EXTERNAL_USB)
         add_dependencies(pybackend2 libusb)
+endif()
+target_link_libraries(pybackend2 PRIVATE rsutils usb ${CMAKE_THREAD_LIBS_INIT})
+set_target_properties(pybackend2 PROPERTIES
+                        VERSION     ${REALSENSE_VERSION_STRING}
+                        SOVERSION   ${REALSENSE_VERSION_MAJOR})
+set_target_properties( pybackend2
+    PROPERTIES
+        FOLDER Library/Python
+    )
+target_include_directories(pybackend2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+
+if(${FORCE_RSUSB_BACKEND})
+if(APPLE)
+    target_include_directories(pybackend2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../third-party/hidapi/)
+endif()
+endif()
+
+if(${BACKEND} STREQUAL RS2_USE_V4L2_BACKEND)
+    if(UDEV_FOUND)
+        target_sources( pybackend2
+            PRIVATE
+                ../../src/linux/udev-device-watcher.cpp
+                ../../src/linux/udev-device-watcher.h
+            )
+        target_link_libraries( pybackend2 PRIVATE udev )
+        target_compile_definitions( pybackend2 PRIVATE -DUSING_UDEV )
     endif()
     target_link_libraries(pybackend2 PRIVATE rsutils usb ${CMAKE_THREAD_LIBS_INIT})
     set_target_properties(pybackend2 PROPERTIES


### PR DESCRIPTION
librealsense2 does not include the correct directories when compiled as a cmake subproject. Specifically, the python wrapper would include ${CMAKE_SOURCE_DIR}/include which would include the respective include folder of the top project, not the include folder of the librealsense2 project.