### PR TITLE
disable test-depth_ae_convergence

### DIFF
--- a/unit-tests/live/d400/test-depth_ae_convergence.py
+++ b/unit-tests/live/d400/test-depth_ae_convergence.py
@@ -3,7 +3,7 @@
 
 # Currently, we exclude D457 as it's failing
 # test:device each(D400*) !D457
-# test:donotrun:!nightly
+# test:donotrun
 # test:timeout 600
 # CI timeout set to 10 minutes to accommodate comprehensive testing of all
 # supported depth profiles


### PR DESCRIPTION
Tracked on RSDSO-20937
Disabled until stabilized
@ttkhuong / @ymodlin  FYI