### PR TITLE
Add test to detect DDS camera on CI runs

### DIFF
--- a/unit-tests/live/d500/test-detect-D555.py
+++ b/unit-tests/live/d500/test-detect-D555.py
@@ -1,5 +1,5 @@
 # License: Apache 2.0. See LICENSE file in root directory.
-# Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
+# Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 # test:device D555
 # test:donotrun:!dds


### PR DESCRIPTION
As some recent runs did not detect missing camera.