### PR TITLE
disable test-depth_ae_convergence.py until stabilized

### DIFF
--- a/unit-tests/live/d400/test-depth_ae_convergence.py
+++ b/unit-tests/live/d400/test-depth_ae_convergence.py
@@ -3,6 +3,7 @@
 
 # test:device each(D400*)
 # test:timeout 600
+# test:donotrun
 # CI timeout set to 10 minutes to accommodate comprehensive testing of all
 # supported depth profiles
 


### PR DESCRIPTION
Disable #14621 until stabilized.
@ipilchin1  FYI
```
-D- found <pyrealsense2.device: D435 (S/N: 727212070191  FW: 5.17.1.7  UNLOCKED  on USB3.2)>
-D- in <module 'pyrealsense2' from '/home/jenkins/workspace/LRS_linux_compile_lib_ci_build/x86_64/static/Release/pyrealsense2.cpython-310-x86_64-linux-gnu.so'>

___
-I- Test: Intra-camera depth-color synchronization with MASTER sync mode
-I- Using profiles: Depth 640x480@30fps, Color 640x480@30fps
-I- Enabling global time on both sensors...
-I- Global time enabled on depth sensor
-I- Global time enabled on color sensor
-I- Setting depth sensor to MASTER sync mode (inter_cam_sync_mode=1)...
-I- Started intra-camera multi-stream capture
-I- Stabilization period: 2.0 seconds...
-I- Collecting synchronized frames for 10.0 seconds...
-I- Collected 300 depth frames and 300 color frames
-I- Synchronization analysis results:
-I-   Max timestamp gap: 12.973 ms
-I-   95th percentile gap: 12.805 ms
-I-   Average timestamp gap: 10.722 ms
-I-   Sync percentage: 0.0%
-I-   Total frame pairs: 300
-I-   Synced pairs (within 3.0ms): 0
-I- First few aligned frame pairs:
-I-   Pair 1: Gap 12.973ms, Depth#57, Color#47, HW gap: 13.142ms
-I-   Pair 2: Gap 12.946ms, Depth#58, Color#48, HW gap: 13.126ms
-I-   Pair 3: Gap 12.920ms, Depth#59, Color#49, HW gap: 13.110ms
-I-   Pair 4: Gap 12.893ms, Depth#60, Color#50, HW gap: 13.094ms
-I-   Pair 5: Gap 12.867ms, Depth#61, Color#51, HW gap: 13.078ms
-I-   Pair 6: Gap 12.840ms, Depth#62, Color#52, HW gap: 13.062ms
-I-   Pair 7: Gap 12.813ms, Depth#63, Color#53, HW gap: 13.046ms
-I-   Pair 8: Gap 12.787ms, Depth#64, Color#54, HW gap: 13.030ms
-I-   Pair 9: Gap 12.761ms, Depth#65, Color#55, HW gap: 13.014ms
-I-   Pair 10: Gap 12.734ms, Depth#66, Color#56, HW gap: 12.998ms
-E- Traceback (most recent call last):
      File "/home/jenkins/workspace/LRS_linux_compile_lib_ci_build/unit-tests/live/camera-sync/test-intra-camera-sync.py", line 356, in <module>
        test.check(sync_results['p95_gap'] <= SYNC_GAP_THRESHOLD_MS,
    95th percentile timestamp gap 12.805ms <= 3.0ms threshold
-W- Note: Max gap (12.973ms) exceeds threshold but p95 is within bounds
-E- Traceback (most recent call last):
      File "/home/jenkins/workspace/LRS_linux_compile_lib_ci_build/unit-tests/live/camera-sync/test-intra-camera-sync.py", line 362, in <module>
        test.check(sync_results['sync_percentage'] >= 95.0,
    Synchronization percentage 0.0% >= 95%
-I- Frame continuity analysis:
-I-   Depth sensor: 300 frames, 0 discontinuities
-I-   Color sensor: 300 frames, 0 discontinuities
-E- Test failed
```