### PR TITLE
fix compilation of python wrapper when librs is a cmake subproject

### DIFF
--- a/wrappers/python/CMakeLists.txt
+++ b/wrappers/python/CMakeLists.txt
@@ -140,11 +140,11 @@ if( BUILD_LEGACY_PYBACKEND )
         PROPERTIES
             FOLDER Library/Python
         )
-    target_include_directories(pybackend2 PRIVATE ${PROJECT_SOURCE_DIR}/include)
+    target_include_directories(pybackend2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 
     if(${FORCE_RSUSB_BACKEND})
         if(APPLE)
-            target_include_directories(pybackend2 PRIVATE ${PROJECT_SOURCE_DIR}/third-party/hidapi/)
+            target_include_directories(pybackend2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../third-party/hidapi/)
         endif()
     endif()
 


### PR DESCRIPTION
Using updated development branch for [PR#14526](https://github.com/realsenseai/librealsense/pull/14526) by @alexswerner.

Fixes CMake issue when using librealsense as a subproject.