### PR TITLE
Add support for Jetson 6.2.2

### DIFF
--- a/scripts/patch-realsense-ubuntu-L4T.sh
+++ b/scripts/patch-realsense-ubuntu-L4T.sh
@@ -92,11 +92,12 @@ case ${JETSON_L4T_VERSION} in
 		[[ $JETSON_L4T_VERSION = "35.1" ]] && RELEASE_STRING="Release"
 		KBASE=./Tegra/kernel/kernel-$KERNEL_RELEASE
 	;;
-	"36.3" | "36.4" | "36.4.3" | "36.4.4" | "36.4.7")
+	"36.3" | "36.4" | "36.4.3" | "36.4.4" | "36.4.7" | "36.5")
 		# 36.3 --> 6.0
 		# 36.4 -> 6.1
 		# 36.4.3 --> 6.2
 		# 36.4.4, 36.4.7 --> 6.2.1
+		# 36.5 --> 6.2.2
 		PATCHES_REV="6.0"
 		KERNEL_RELEASE="5.15"
 		UBUNTU_CODENAME=jammy


### PR DESCRIPTION
Not sure if anything else needs to be updated but this worked for me on a Jetson Orin Nano running 6.2.2.
