### PR TITLE
Sleep between t2ff depth and color tests

### DIFF
--- a/unit-tests/live/frames/test-t2ff-pipeline.py
+++ b/unit-tests/live/frames/test-t2ff-pipeline.py
@@ -24,6 +24,8 @@ dev, ctx = test.find_first_device_or_exit()
 # Note, it goes back to idle after streaming ends, no need to sleep between depth and color streaming.
 time.sleep(3)
 
+product_name = dev.get_info(rs.camera_info.name)
+
 max_delay_for_depth_frame = 1
 max_delay_for_color_frame = 1
 
@@ -38,7 +40,7 @@ def time_to_first_frame(config):
 
 
 ################################################################################################
-test.start("Testing pipeline first depth frame delay on " + product_line + " device - " + platform.system() + " OS")
+test.start("Testing pipeline first depth frame delay on " + product_name + " device - " + platform.system() + " OS")
 depth_cfg = rs.config()
 depth_cfg.enable_stream(rs.stream.depth, rs.format.z16, 30)
 frame_delay = time_to_first_frame(depth_cfg)
@@ -46,14 +48,12 @@ print("Delay from pipeline.start() until first depth frame is: {:.3f} [sec] max 
 test.check(frame_delay < max_delay_for_depth_frame)
 test.finish()
 
-product_name = dev.get_info(rs.camera_info.name)
-
 ################################################################################################
 if 'D555' in product_name:
     time.sleep(1) # Allow HKR some time to close the depth pipe completely
 ################################################################################################
 if 'D421' not in product_name and 'D405' not in product_name and 'D430' not in product_name: # Cameras with no color sensor
-    test.start("Testing pipeline first color frame delay on " + product_line + " device - " + platform.system() + " OS")
+    test.start("Testing pipeline first color frame delay on " + product_name + " device - " + platform.system() + " OS")
     color_cfg = rs.config()
     color_cfg.enable_stream(rs.stream.color, rs.format.rgb8, 30)
     frame_delay = time_to_first_frame(color_cfg)

--- a/unit-tests/live/frames/test-t2ff-sensor.py
+++ b/unit-tests/live/frames/test-t2ff-sensor.py
@@ -68,13 +68,13 @@ print("Device creation time is: {:.3f} [sec] max allowed is: {:.1f} [sec] ".form
 test.check(device_creation_time < max_time_for_device_creation)
 test.finish()
 
-product_line = dev.get_info(rs.camera_info.product_line)
+product_name = dev.get_info(rs.camera_info.name)
 max_delay_for_depth_frame = 1
 max_delay_for_color_frame = 1
 
 
 #####################################################################################################
-test.start("Testing first depth frame delay on " + product_line + " device - "+ platform.system() + " OS")
+test.start("Testing first depth frame delay on " + product_name + " device - "+ platform.system() + " OS")
 ds = dev.first_depth_sensor()
 dp = next(p for p in
           ds.profiles if p.fps() == 30
@@ -87,12 +87,11 @@ test.check(first_depth_frame_delay < max_delay_for_depth_frame)
 test.finish()
 
 ################################################################################################
-time.sleep(3) # Allow time for device to get into idle state before starting color stream test
-# We also see D555 needs more time to cleanup the depth stream before starting the color stream
+if 'D555' in product_name:
+    time.sleep(1) # Allow HKR some time to close the depth pipe completely
 #####################################################################################################
 
-test.start("Testing first color frame delay on " + product_line + " device - "+ platform.system() + " OS")
-product_name = dev.get_info(rs.camera_info.name)
+test.start("Testing first color frame delay on " + product_name + " device - "+ platform.system() + " OS")
 cs = None
 try:
     cs = dev.first_color_sensor()


### PR DESCRIPTION
We see D555 color t2ff takes a bit longer due to depth pipe still closing, this is also good for USB test so the power state will get back to idle before we recheck