### PR TITLE
RSDSO-21295: Detect flash lock and validate FW update result in test-fw-update

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -272,23 +272,22 @@ del device, ctx
 log.d( 'running:', cmd )
 sys.stdout.flush()
 result = subprocess.run( cmd )   # may throw
+
+# Wait for the camera to finish rebooting before doing anything else;
+# the test exit flow may cut USB power (hub port disable) so we must not exit mid-reboot
+wait_for_reboot( same_version )
+
 if result.returncode != 0:
     log.e( 'rs-fw-update returned exit code', result.returncode )
     test.check( False, description='rs-fw-update should return exit code 0' )
-    # rs-fw-update may have already triggered a device reboot before failing;
-    # wait so the camera finishes rebooting before exit (hub may cut power on cleanup)
-    wait_for_reboot( same_version )
     test.finish()
     test.print_results_and_exit()
-
-wait_for_reboot( same_version )
 
 # make sure update worked and check FW version and update counter
 device, ctx = test.find_first_device_or_exit()
 current_fw_version = rsutils.version( device.get_info( rs.camera_info.firmware_version ))
 
 # Detect flash lock: if the device reports a camera_locked status other than UNLOCKED,
-# the update may have locked the flash (GVD offset 25). Log a warning so CI can flag it.
 if device.supports( rs.camera_info.camera_locked ):
     try:
         camera_locked_info = device.get_info( rs.camera_info.camera_locked )


### PR DESCRIPTION
Fix test-fw-update.py to prevent silent FW update failures that leave D457 GMSL cameras flash-locked (GVD offset 25).

Changes:

Check rs-fw-update exit code; fail early if non-zero instead of proceeding to version assertion
Detect flash lock after FW update by checking for UNLOCKED in device string and log a warning

Root cause: On D457 GMSL, rs-fw-update reported "Firmware update done" but the FW version didn't change (downgrade silently rejected). The test continued and failed on version mismatch, while the camera was left flash-locked.