### PR TITLE
Disable D401 tests till failure is checked

### DIFF
--- a/unit-tests/live/calib/test-advanced-occ-calibrations.py
+++ b/unit-tests/live/calib/test-advanced-occ-calibrations.py
@@ -19,7 +19,7 @@ from test_calibrations_common import (
 )
 
 # test:donotrun:!nightly
-#test:device D400*
+#test:device D400* !D401
 
 # Constants & thresholds (reintroduce after import fix)
 PIXEL_CORRECTION = -1.0  # pixel shift to apply to principal point

--- a/unit-tests/live/calib/test-occ-calibrations.py
+++ b/unit-tests/live/calib/test-occ-calibrations.py
@@ -7,7 +7,7 @@ import pyrealsense2 as rs
 from rspy import test, log
 from test_calibrations_common import calibration_main, get_calibration_device, is_mipi_device
 
-#test:device D400*
+#test:device D400* !D401
 
 def on_chip_calibration_json(occ_json_file, host_assistance):
     occ_json = None

--- a/unit-tests/live/frames/test-backend-vs-frame-timestamp.py
+++ b/unit-tests/live/frames/test-backend-vs-frame-timestamp.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
 
-# test:device D400*
+# test:device D400* !D401
 # test:device each(D500*)
 
 import pyrealsense2 as rs

--- a/unit-tests/live/frames/test-depth.py
+++ b/unit-tests/live/frames/test-depth.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2023 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:device each(D500*) 
 
 import pyrealsense2 as rs

--- a/unit-tests/live/frames/test-fps-single-stream.py
+++ b/unit-tests/live/frames/test-fps-single-stream.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2022 RealSense, Inc. All Rights Reserved.
 
 # Currently, we exclude D555 as it's failing
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:device each(D500*) !D555
 # test:donotrun:!nightly
 

--- a/unit-tests/live/frames/test-sensor-vs-frame-timestamp.py
+++ b/unit-tests/live/frames/test-sensor-vs-frame-timestamp.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2024 RealSense, Inc. All Rights Reserved.
 
-# test:device D400*
+# test:device D400* !D401
 
 import pyrealsense2 as rs
 from rspy import test

--- a/unit-tests/live/frames/test-t2ff-sensor.py
+++ b/unit-tests/live/frames/test-t2ff-sensor.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2021 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:device each(D500*) 
 
 import pyrealsense2 as rs

--- a/unit-tests/live/image-quality/test-basic-color.py
+++ b/unit-tests/live/image-quality/test-basic-color.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 
 import pyrealsense2 as rs
 from rspy import log, test

--- a/unit-tests/live/image-quality/test-basic-depth.py
+++ b/unit-tests/live/image-quality/test-basic-depth.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:timeout 400  # extra time for page detection
 
 import pyrealsense2 as rs

--- a/unit-tests/live/image-quality/test-texture-mapping.py
+++ b/unit-tests/live/image-quality/test-texture-mapping.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:timeout 1500
 
 # Texture Mapping Test

--- a/unit-tests/live/metadata/test-connection-type-found.py
+++ b/unit-tests/live/metadata/test-connection-type-found.py
@@ -2,7 +2,7 @@
 # Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
 
 
-#test:device each(D400*)
+#test:device each(D400*) !D401
 #test:device each(D500*)
 
 

--- a/unit-tests/live/metadata/test-sync.py
+++ b/unit-tests/live/metadata/test-sync.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:donotrun:!nightly
 
 import pyrealsense2 as rs

--- a/unit-tests/live/options/test-drops-on-set.py
+++ b/unit-tests/live/options/test-drops-on-set.py
@@ -1,9 +1,9 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2020 RealSense, Inc. All Rights Reserved.
 
-# Currently, we exclude D457 and D555 as it's failing
+# Currently, we exclude D457 and D401 as it's failing
 
-# test:device D400* !D457
+# test:device D400* !D457 !D401
 # test:donotrun:!nightly
 
 import platform

--- a/unit-tests/live/options/test-presets.py
+++ b/unit-tests/live/options/test-presets.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2023 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:device each(D500*)
 # test:donotrun:!nightly
 

--- a/unit-tests/live/options/test-rgb-options-metadata-consistency.py
+++ b/unit-tests/live/options/test-rgb-options-metadata-consistency.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2021 RealSense, Inc. All Rights Reserved.
 
-#test:device each(D400*) !D421 !D405
+#test:device each(D400*) !D421 !D405 !D401
 #test:device each(D500*)
 #test:donotrun:!nightly
 

--- a/unit-tests/live/options/test-timestamp-domain.py
+++ b/unit-tests/live/options/test-timestamp-domain.py
@@ -1,7 +1,7 @@
 # License: Apache 2.0. See LICENSE file in root directory.
 # Copyright(c) 2022 RealSense, Inc. All Rights Reserved.
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:device each(D500*) !D555
 # test:donotrun:!nightly
 

--- a/unit-tests/live/rec-play/test-got-playback-frames.py
+++ b/unit-tests/live/rec-play/test-got-playback-frames.py
@@ -3,7 +3,7 @@
 
 # Currently, we exclude D555 as it's failing
 
-# test:device each(D400*)
+# test:device each(D400*) !D401
 # test:device each(D500*) !D555
 
 # test:donotrun:!nightly

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -5,7 +5,7 @@
 #test:priority 1
 #test:timeout 500
 #test:donotrun:gha
-#test:device each(D400*)
+#test:device each(D400*) !D401
 #test:device D555
 
 import sys


### PR DESCRIPTION
Tracked on [RSDSO-21133]

Disabling tests after initial run to check and fix failures
