### PR TITLE
scripts/Tegra: add GitLab fallback for deprecated nv-tegra.nvidia.com

### DIFF
--- a/scripts/Tegra/sync.sh
+++ b/scripts/Tegra/sync.sh
@@ -59,10 +59,10 @@ LDK_DIR=$SCRIPT_DIR
 
 # Git server constants.
 # nv-tegra.nvidia.com is being deprecated by NVIDIA in favour of GitLab.
-# detect_git_server() probes both and selects whichever responds first.
+# detect_git_server() probes both in priority order and selects the first reachable server.
 NV_TEGRA_HOST="nv-tegra.nvidia.com"
-GITLAB_HOST="gitlab.com/nvidia/nv-tegra"
-GIT_SERVER="${NV_TEGRA_HOST}"
+GITLAB_BASE="gitlab.com/nvidia/nv-tegra"  # host + org path prefix, not just a hostname
+GIT_SERVER="${NV_TEGRA_HOST}"  # default; overwritten by detect_git_server()
 # info about sources.
 # NOTE: *Add only kernel repos here. Add new repos separately below. Keep related repos together*
 # NOTE: nvethrnetrm.git should be listed after "linux-nv-oot.git" due to nesting of sync path
@@ -146,7 +146,11 @@ function UpdateTags {
 }
 
 function detect_git_server {
-	local SERVERS=("${GITLAB_HOST}" "${NV_TEGRA_HOST}")
+	if ! which curl > /dev/null 2>&1; then
+		echo -e "\e[33mWarning: curl not found; skipping git server detection, defaulting to ${GIT_SERVER}\e[0m" >&2
+		return 0
+	fi
+	local SERVERS=("${GITLAB_BASE}" "${NV_TEGRA_HOST}")
 	local SERVER
 	echo "Detecting available git server…"
 	for SERVER in "${SERVERS[@]}"; do
@@ -159,8 +163,7 @@ function detect_git_server {
 			return 0
 		fi
 	done
-	echo -e "\e[31mERROR: Could not reach any git server. Check your network connection and try again.\e[0m" >&2
-	exit 1
+	echo -e "\e[33mWarning: Could not reach either git server; defaulting to ${GIT_SERVER}. Network operations may fail.\e[0m" >&2
 }
 
 function DownloadAndSync {


### PR DESCRIPTION
## Problem

NVIDIA is deprecating \
v-tegra.nvidia.com\ in favour of their GitLab mirror at \gitlab.com/nvidia/nv-tegra\. The old server is intermittently unreachable, causing \patch-realsense-ubuntu-L4T.sh\ to fail on Jetson Thor (L4T 38.4) and potentially other platforms when it tries to clone kernel sources.

Customer reports:
- https://forums.developer.nvidia.com/t/cant-connect-to-nv-tegra-nvidia-com-port-443/363538

NVIDIA confirmed in their [Jetson AGX Thor FAQ](https://forums.developer.nvidia.com/t/jetson-agx-thor-faq/346561):
> We are deprecating nv-tegra website and move to nv-tegra GitLab. The nv-tegra website shall be online till end of 2026 but it may be down occasionally.

## Solution

Add a \detect_git_server()\ function to \scripts/Tegra/sync.sh\ that probes both servers before starting any downloads and selects whichever responds:

1. \gitlab.com/nvidia/nv-tegra\ — tested first (new primary per NVIDIA)
2. \
v-tegra.nvidia.com\ — fallback (still online until end of 2026)

Detection uses \curl --max-time 15\ and accepts any HTTP 2xx/3xx response. The selected host is substituted at runtime into each repo URL via bash parameter expansion, so the \.repos\ files are unchanged.

## Testing

Tested by tracing the URL substitution. Full end-to-end validation requires a Jetson Thor target running L4T 38.4.