### PR TITLE
Fix signal handler re-entrancy and hang on Ctrl+C

### DIFF
--- a/unit-tests/py/rspy/signals.py
+++ b/unit-tests/py/rspy/signals.py
@@ -2,17 +2,23 @@
 # Copyright(c) 2025 RealSense, Inc. All Rights Reserved.
 
 from rspy import log
-import sys, signal
+import os, sys, signal
 
 signal_handler = lambda: log.d("Signal handler not set")
+_cleanup_in_progress = False
 
 
 def register_signal_handlers(on_signal=None):
     def handle_abort(signum, _):
-        global signal_handler
+        global signal_handler, _cleanup_in_progress
+        if _cleanup_in_progress:
+            # Second signal during cleanup — force-exit immediately so we don't hang
+            log.w("got signal", signum, "during cleanup — force-exiting")
+            os._exit(1)
+        _cleanup_in_progress = True
         log.w("got signal", signum, "aborting... ")
         signal_handler()
-        sys.exit(1)
+        os._exit(1)
 
     global signal_handler
     signal_handler = on_signal or signal_handler


### PR DESCRIPTION
## Summary
- Prevent re-entrant signal handling: a `_cleanup_in_progress` guard ensures a second Ctrl+C (or SIGTERM) during cleanup force-exits immediately via `os._exit(1)` instead of recursing into `_cleanup_devices` again
- Use `os._exit(1)` instead of `sys.exit(1)` after cleanup to avoid hanging on BrainStem USB hub threads that block `SystemExit`

## Test plan
- [ ] On Windows: run pytest with an Acroname hub, press Ctrl+C — verify ports disable and process exits cleanly
- [ ] On Linux: same test with Ctrl+C
- [ ] Jenkins abort (SIGTERM): verify graceful shutdown without hang
- [ ] Press Ctrl+C twice rapidly — verify second signal force-exits immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)