### PR TITLE
Fix -r flag support in pytest

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -35,7 +35,7 @@ from rspy.pytest.logging_setup import (
     setup_test_logging, bridge_rspy_log, ensure_newline, configure_logging,
     start_test_log, stop_test_log, print_terminal_summary,
 )
-from rspy.pytest.cli import consume_legacy_flags
+from rspy.pytest.cli import consume_legacy_flags, apply_pending_flags
 from rspy.pytest.device_helpers import find_matching_devices, resolve_device_each_serials
 from rspy.pytest.collection import filter_and_sort_items
 
@@ -132,6 +132,8 @@ context_list = []
 def pytest_configure(config):
     """Early setup: register markers, configure defaults, and query connected devices."""
     global context_list
+
+    apply_pending_flags(config)
 
     # Parse and store context
     context_str = config.getoption("--context", default="")

--- a/unit-tests/py/rspy/pytest/cli.py
+++ b/unit-tests/py/rspy/pytest/cli.py
@@ -30,3 +30,16 @@ def consume_legacy_flags():
     # TODO: remove -r/--regex bridge once old infra (run-unit-tests.py) is fully retired;
     #       users can switch to pytest's native -k flag directly
     _consume_flag_with_arg(['-r', '--regex'], '-k')  # -r/--regex -> pytest's -k (keyword filter)
+
+
+def apply_pending_flags(config):
+    """Apply -k filter that consume_legacy_flags() added to sys.argv.
+
+    pytest consumes -r as a built-in flag before conftest.py loads, so the -k
+    added to sys.argv by consume_legacy_flags() is never parsed. This function
+    applies it directly to pytest's config. Call from pytest_configure().
+    """
+    if '-k' in sys.argv and not config.option.keyword:
+        idx = sys.argv.index('-k')
+        if idx + 1 < len(sys.argv):
+            config.option.keyword = sys.argv[idx + 1]


### PR DESCRIPTION
Noticed the -r flag didn't work right for me, this is a fix for it

In short - consume_legacy_flags is turning -r to -k and adding it to sys.argv, but by the time we reach there pytest had already consumed the variables on