### PR TITLE
Increase MIPI hw reset sleep from 3 to 8 seconds

### DIFF
--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -712,7 +712,7 @@ def hw_reset( serial_numbers, timeout = MAX_ENUMERATION_TIME ):
     else:
         # normally we will get here with a mipi device,
         # we want to allow some time for the device to reinitialize as it was not disconnected
-        time.sleep(3)
+        time.sleep(8)
     #
     return _wait_for( serial_numbers, timeout = timeout )
 


### PR DESCRIPTION
## Summary
- Increase the Python-side sleep after MIPI hardware reset from 3 to 8 seconds
- MIPI devices (e.g. D457) don't physically disconnect/reconnect — the C++ layer simulates a 3s reconnect in `d400-mipi-device.cpp`, but the Python wait was too short for reliable re-enumeration on some machines

## Test plan
- [ ] Run hw-reset tests on a GMSL/MIPI machine to verify devices come back online reliably