### PR TITLE
Fix device_each to skip instead of fail when no matching device

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -345,10 +345,13 @@ def module_device_setup(request):
                                                   cli_excludes=request.config.getoption("--exclude-device", default=[]))
 
         if not serial_numbers:
+            has_required = any(m.name == 'device' for m in device_markers)
             if had_candidates:
                 pytest.skip("All matching devices were excluded")
-            else:
+            elif has_required:
                 pytest.fail("No devices found matching requirements")
+            else:
+                pytest.skip("No devices found matching requirements")
 
         serial_number = serial_numbers[0]
         log.debug(f"Test will use first matching device: {serial_number}")


### PR DESCRIPTION
## Summary
- PR #14854 changed `pytest.skip` to `pytest.fail` when a required device is missing, which is correct for `device()` marker
- But it also affected `device_each()` which should skip when no matching device exists (e.g. D585S on a Jetson with only D401)
- Fix: only `pytest.fail` when a `device()` marker is present; `device_each()`-only tests skip gracefully

## Test plan
- [x] `pytest-ah-configurations.py` (device_each D585S) skips when no D585S connected
- [x] `pytest-backend-vs-frame-timestamp.py` (device D400*) fails when no D400 connected