### PR TITLE
Fix MIPI FW update silent failure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,7 @@ Detailed how-to guides for common tasks are maintained as skill files under `.gi
 | `.github/skills/build.md` | Building the project (CMake configure, compile, flags) |
 | `.github/skills/testing.md` | Running, filtering, and debugging unit tests |
 | `.github/skills/pytest-infra.md` | Migrating tests to pytest, modifying pytest/hub infrastructure, verifying Jenkins CI results |
+| `.github/skills/git-workflow.md` | Branch/PR conventions, commit message style, push remotes |
 
 If a skill file exists for the task at hand, follow its instructions precisely. New skills may be added to this folder over time — check its contents before assuming none applies.
 

--- a/.github/skills/git-workflow.md
+++ b/.github/skills/git-workflow.md
@@ -4,7 +4,7 @@
 
 - **Base branch**: `origin/development`
 - **PR target**: `origin/development`
-- **Push to**: `fork` remote
+- **Push to**: `fork` remote (if no `fork` remote ask the user where to push to and remember the answer for next time)
 
 ## Commit Messages
 

--- a/.github/skills/git-workflow.md
+++ b/.github/skills/git-workflow.md
@@ -1,0 +1,13 @@
+# Git Workflow
+
+## Branch & PR Conventions
+
+- **Base branch**: `origin/development`
+- **PR target**: `origin/development`
+- **Push to**: `fork` remote
+
+## Commit Messages
+
+- Keep commit messages short — one sentence
+- Do not include Co-Authored-By or any AI agent attribution
+- Use plain `git commit -m "message"`

--- a/src/ds/d400/d400-mipi-device.cpp
+++ b/src/ds/d400/d400-mipi-device.cpp
@@ -67,6 +67,7 @@ namespace librealsense
                     (RS2_CAMERA_INFO_PHYSICAL_PORT):(RS2_CAMERA_INFO_DFU_DEVICE_PATH);
 
         // Write signed firmware to appropriate file descriptor
+        LOG_INFO("MIPI FW update DFU path: " << get_info(_dfu_port_info));
         std::ofstream fw_path_in_device(get_info(_dfu_port_info), std::ios::binary);
         if (fw_path_in_device)
         {
@@ -89,8 +90,7 @@ namespace librealsense
         }
         else
         {
-            LOG_WARNING("Firmware Update failed - wrong path or permissions missing");
-            return;
+            throw std::runtime_error("Firmware Update failed - wrong path or permissions missing");
         }
         LOG_INFO("FW update process completed successfully.");
         fw_path_in_device.close();

--- a/src/ds/d400/d400-mipi-device.cpp
+++ b/src/ds/d400/d400-mipi-device.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <fstream>
 #include "d400-mipi-device.h"
+#include "librealsense-exception.h"
 
 namespace librealsense
 {
@@ -67,7 +68,8 @@ namespace librealsense
                     (RS2_CAMERA_INFO_PHYSICAL_PORT):(RS2_CAMERA_INFO_DFU_DEVICE_PATH);
 
         // Write signed firmware to appropriate file descriptor
-        std::ofstream fw_path_in_device(get_info(_dfu_port_info), std::ios::binary);
+        std::string dfu_path = get_info(_dfu_port_info);
+        std::ofstream fw_path_in_device(dfu_path, std::ios::binary);
         if (fw_path_in_device)
         {
             bool burn_done = false;
@@ -89,8 +91,8 @@ namespace librealsense
         }
         else
         {
-            throw std::runtime_error("Firmware Update failed - DFU path: "
-                + std::string(get_info(_dfu_port_info)) + " - wrong path or permissions missing");
+            throw librealsense::io_exception("Firmware Update failed - DFU path: " + dfu_path
+                + " - wrong path or permissions missing");
         }
         LOG_INFO("FW update process completed successfully.");
         fw_path_in_device.close();

--- a/src/ds/d400/d400-mipi-device.cpp
+++ b/src/ds/d400/d400-mipi-device.cpp
@@ -67,7 +67,6 @@ namespace librealsense
                     (RS2_CAMERA_INFO_PHYSICAL_PORT):(RS2_CAMERA_INFO_DFU_DEVICE_PATH);
 
         // Write signed firmware to appropriate file descriptor
-        LOG_INFO("MIPI FW update DFU path: " << get_info(_dfu_port_info));
         std::ofstream fw_path_in_device(get_info(_dfu_port_info), std::ios::binary);
         if (fw_path_in_device)
         {
@@ -90,7 +89,8 @@ namespace librealsense
         }
         else
         {
-            throw std::runtime_error("Firmware Update failed - wrong path or permissions missing");
+            throw std::runtime_error("Firmware Update failed - DFU path: "
+                + std::string(get_info(_dfu_port_info)) + " - wrong path or permissions missing");
         }
         LOG_INFO("FW update process completed successfully.");
         fw_path_in_device.close();

--- a/src/ds/d400/d400-mipi-device.cpp
+++ b/src/ds/d400/d400-mipi-device.cpp
@@ -43,7 +43,7 @@ namespace librealsense
                     {
                         strong->invoke_devices_changed_callbacks(devs, {});
                         // MIPI devices do not re-enumerate so we need to give them some time to restart
-                        std::this_thread::sleep_for(std::chrono::milliseconds(3000));
+                        std::this_thread::sleep_for(std::chrono::seconds(5));
                     }
                     if (auto strong = ctx.lock())
                         strong->invoke_devices_changed_callbacks({}, devs);

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -269,15 +269,15 @@ log.d( 'running:', cmd )
 sys.stdout.flush()
 result = subprocess.run( cmd )   # may throw
 
-# Wait for the camera to finish rebooting before doing anything else;
-# the test exit flow may cut USB power (hub port disable) so we must not exit mid-reboot
-wait_for_reboot( same_version )
-
 if result.returncode != 0:
     log.e( 'rs-fw-update returned exit code', result.returncode )
     test.check( False, description='rs-fw-update should return exit code 0' )
     test.finish()
     test.print_results_and_exit()
+
+# Wait for the camera to finish rebooting before doing anything else;
+# the test exit flow may cut USB power (hub port disable) so we must not exit mid-reboot
+wait_for_reboot( same_version )
 
 # make sure update worked and check FW version and update counter
 device, ctx = test.find_first_device_or_exit()

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -269,15 +269,15 @@ log.d( 'running:', cmd )
 sys.stdout.flush()
 result = subprocess.run( cmd )   # may throw
 
+# Wait for the camera to finish rebooting before doing anything else;
+# the test exit flow may cut USB power (hub port disable) so we must not exit mid-reboot
+wait_for_reboot( same_version )
+
 if result.returncode != 0:
     log.e( 'rs-fw-update returned exit code', result.returncode )
     test.check( False, description='rs-fw-update should return exit code 0' )
     test.finish()
     test.print_results_and_exit()
-
-# Wait for the camera to finish rebooting before doing anything else;
-# the test exit flow may cut USB power (hub port disable) so we must not exit mid-reboot
-wait_for_reboot( same_version )
 
 # make sure update worked and check FW version and update counter
 device, ctx = test.find_first_device_or_exit()


### PR DESCRIPTION
## Summary
- MIPI signed firmware update silently returns on failure instead of throwing — `rs-fw-update` reports success and exits 0 even when the DFU write fails
- Now throws `std::runtime_error` with the DFU path included in the error message (matches `fw-update-device.cpp` pattern)
- Check `rs-fw-update` exit code before waiting 60s for reboot in `test-fw-update.py`
- Add git workflow skill and update copilot instructions
Tracked [RSDSO-21342]
