### PR TITLE
Skip downgrade counter reset on unsigned FW

### DIFF
--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -244,7 +244,9 @@ if (current_fw_version == bundled_fw_version and not custom_fw_path) or \
 
 downgrade_counter = get_downgrade_counter( device )
 log.d( 'downgrade counter:', downgrade_counter )
-if downgrade_counter >= 19:
+if downgrade_counter == 0xFFFF:
+    log.d( 'downgrade counter is uninitialized (0xFFFF), skipping reset' )
+elif downgrade_counter >= 19:
     log.d( 'resetting downgrade counter (was', str(downgrade_counter) + ')' )
     reset_downgrade_counter( device )
     log.d( 'sleeping for 3 sec...' )

--- a/unit-tests/test-fw-update.py
+++ b/unit-tests/test-fw-update.py
@@ -246,6 +246,7 @@ downgrade_counter = get_downgrade_counter( device )
 log.d( 'downgrade counter:', downgrade_counter )
 if downgrade_counter == 0xFFFF:
     log.d( 'downgrade counter is uninitialized (0xFFFF), skipping reset' )
+    downgrade_counter = 0
 elif downgrade_counter >= 19:
     log.d( 'resetting downgrade counter (was', str(downgrade_counter) + ')' )
     reset_downgrade_counter( device )


### PR DESCRIPTION
## Summary
- On unsigned/UNLOCKED firmware the downgrade counter reads as 0xFFFF (uninitialized flash), which triggers the reset path (`>= 19`)
- The reset writes 0 to the flash payload header, which may corrupt unsigned firmware state
- Skip the reset when counter is 0xFFFF
- After a real reset, sleep 3s and verify the counter was actually set to 0

## Test plan
- [ ] Run fw-update test on MIPI D457 with unsigned FW — verify counter reset is skipped
- [ ] Run fw-update test on locked device with counter >= 19 — verify reset still works