### PR TITLE
Disable all hub ports after device discovery

### DIFF
--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -313,6 +313,13 @@ def query( monitor_changes=True, hub_reset=False, recycle_ports=True, disable_dd
 
     log.debug_unindent()
     #
+    # Disable all ports after discovery so tests start from a clean state.
+    # Without this, unmapped ports (e.g. loose cables) remain enabled and
+    # rogue devices can appear mid-test.
+    if hub:
+        hub.disable_ports()
+        wait_until_all_ports_disabled()
+    #
     if monitor_changes:
         _context.set_devices_changed_callback( _device_change_callback )
 

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -167,6 +167,10 @@ def map_unknown_ports():
     global _device_by_sn
     devices_with_unknown_ports = [device for device in _device_by_sn.values() if device.port is None]
     if not devices_with_unknown_ports:
+        # All ports are known, but still enabled from query(). Disable all so unmapped ports
+        # (e.g. loose cables) can't produce rogue devices mid-test.
+        hub.disable_ports()
+        wait_until_all_ports_disabled()
         return
     #
     ports = hub.ports()
@@ -224,6 +228,9 @@ def map_unknown_ports():
             hub.disable_ports( [port] )
             wait_until_all_ports_disabled()
     finally:
+        # Disable all ports so tests start from a clean state
+        hub.disable_ports()
+        wait_until_all_ports_disabled()
         log.debug_unindent()
 
 
@@ -312,13 +319,6 @@ def query( monitor_changes=True, hub_reset=False, recycle_ports=True, disable_dd
         rs.log_to_console(rs.log_severity.none) # disable debug logging
 
     log.debug_unindent()
-    #
-    # Disable all ports after discovery so tests start from a clean state.
-    # Without this, unmapped ports (e.g. loose cables) remain enabled and
-    # rogue devices can appear mid-test.
-    if hub:
-        hub.disable_ports()
-        wait_until_all_ports_disabled()
     #
     if monitor_changes:
         _context.set_devices_changed_callback( _device_change_callback )


### PR DESCRIPTION
## Summary
- After `query()` discovers devices, all hub ports are left enabled
- A device on an unmapped port (e.g. loose cable on port 4) can appear mid-test and interfere — the test grabs the wrong device
- Fix: disable all ports at the end of `query()` so tests start from a clean state
- Each test's `enable_only()` then enables only the port it needs

## Root cause
Build [#111290](https://rsjenkins.realsenseai.com/job/LRS_windows_compile_pipeline/111290/) on rsdsk255: D585S safety tests failed because a D435 on USB2.1 (loose cable, unmapped port) appeared during the test. The test found the D435 instead of D585S → `RuntimeError: Could not find requested sensor type!`

## Test plan
- [x] Verified cached `enabled()` state is consistent (all devices marked `_removed` after disable)
- [ ] CI run on rsdsk255 with D585S safety tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)