### PR TITLE
Fix stop_wrapper masking real test failures

### DIFF
--- a/.github/skills/git-workflow.md
+++ b/.github/skills/git-workflow.md
@@ -5,6 +5,7 @@
 - **Base branch**: `origin/development`
 - **PR target**: `origin/development`
 - **Push to**: `fork` remote (if no `fork` remote ask the user where to push to and remember the answer for next time)
+- **Branch naming**: short descriptive name, no username prefix (e.g. `stop-wrapper-error`, `add-safety-test`)
 
 ## Commit Messages
 

--- a/unit-tests/py/rspy/tests_wrapper.py
+++ b/unit-tests/py/rspy/tests_wrapper.py
@@ -5,6 +5,7 @@
 # Don't remove this file even if current implementation is empty...
 
 import pyrealsense2 as rs
+from rspy import log
 
 # Many operations, such as setting options, can take place only in safety service mode
 def start_wrapper( dev = None ):
@@ -14,5 +15,8 @@ def start_wrapper( dev = None ):
 
 def stop_wrapper( dev = None ):
     if "D585S" in dev.get_info(rs.camera_info.name):
-        safety_sensor = dev.first_safety_sensor()
-        safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        try:
+            safety_sensor = dev.first_safety_sensor()
+            safety_sensor.set_option(rs.option.safety_mode, rs.safety_mode.run)
+        except Exception as e:
+            log.e(f"Cleanup failed: could not set safety_mode back to run: {e}")


### PR DESCRIPTION
## Summary
- `stop_wrapper` could throw when resetting `safety_mode` back to `run`, and in `finally` blocks this exception replaced the original test failure (e.g. FPS assertion errors were masked by `RuntimeError: Failed to set the option to value 0`)
- Wrapped the cleanup in try/except so failures are logged clearly without hiding the real test error

## Test plan
- [ ] Run `pytest-ah-configurations` on D585S — verify FPS assertion errors propagate correctly when cleanup also fails
- [ ] Verify `stop_wrapper` cleanup failure is logged with `-E- Cleanup failed: could not set safety_mode back to run: ...`