### PR TITLE
Fix CMake 4.0 compatibility for third-party deps

### DIFF
--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -311,11 +311,17 @@ jobs:
             name: U22
           - os: ubuntu-24.04
             name: U24
-    name: ${{ matrix.name }}_ST_Py_EX_CfU 
+    name: ${{ matrix.name }}_ST_Py_EX_CfU
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
-    
+
+    - name: Install CMake 4
+      if: matrix.os == 'ubuntu-24.04'
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '4.x'
+
     - name: Prebuild
       shell: bash
       run: |
@@ -491,7 +497,13 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4
-          
+
+    - name: Install CMake 4
+      if: matrix.os == 'ubuntu-24.04'
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '4.x'
+
     - name: Prebuild
       shell: bash
       run: |

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -318,7 +318,7 @@ jobs:
 
     - name: Install CMake 4
       if: matrix.os == 'ubuntu-24.04'
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
       with:
         cmake-version: '4.x'
 

--- a/.github/workflows/buildsCI.yaml
+++ b/.github/workflows/buildsCI.yaml
@@ -500,7 +500,7 @@ jobs:
 
     - name: Install CMake 4
       if: matrix.os == 'ubuntu-24.04'
-      uses: jwlawson/actions-setup-cmake@v2
+      uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
       with:
         cmake-version: '4.x'
 

--- a/CMake/external_fastcdr.cmake
+++ b/CMake/external_fastcdr.cmake
@@ -26,10 +26,6 @@ function(get_fastcdr_only)
     # Set special values for fastcdr build
     set(BUILD_SHARED_LIBS OFF)
 
-    # FastCDR v1.0.25 has cmake_minimum_required(VERSION 2.x) which CMake 4.0+ rejects.
-    # Override the minimum policy version so the old cmake_minimum_required is accepted.
-    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
-
     add_subdirectory(${FASTCDR_SOURCE_DIR} ${CMAKE_BINARY_DIR}/third-party/fastcdr-build EXCLUDE_FROM_ALL)
 
     # Place fastcdr with other 3rd-party projects

--- a/CMake/external_fastcdr.cmake
+++ b/CMake/external_fastcdr.cmake
@@ -28,7 +28,7 @@ function(get_fastcdr_only)
 
     # FastCDR v1.0.25 has cmake_minimum_required(VERSION 2.x) which CMake 4.0+ rejects.
     # Override the minimum policy version so the old cmake_minimum_required is accepted.
-    set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
     add_subdirectory(${FASTCDR_SOURCE_DIR} ${CMAKE_BINARY_DIR}/third-party/fastcdr-build EXCLUDE_FROM_ALL)
 

--- a/CMake/external_fastcdr.cmake
+++ b/CMake/external_fastcdr.cmake
@@ -26,6 +26,10 @@ function(get_fastcdr_only)
     # Set special values for fastcdr build
     set(BUILD_SHARED_LIBS OFF)
 
+    # FastCDR v1.0.25 has cmake_minimum_required(VERSION 2.x) which CMake 4.0+ rejects.
+    # Override the minimum policy version so the old cmake_minimum_required is accepted.
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
     add_subdirectory(${FASTCDR_SOURCE_DIR} ${CMAKE_BINARY_DIR}/third-party/fastcdr-build EXCLUDE_FROM_ALL)
 
     # Place fastcdr with other 3rd-party projects

--- a/CMake/external_fastcdr.cmake
+++ b/CMake/external_fastcdr.cmake
@@ -26,6 +26,10 @@ function(get_fastcdr_only)
     # Set special values for fastcdr build
     set(BUILD_SHARED_LIBS OFF)
 
+    # FastCDR v1.0.25 has cmake_minimum_required(VERSION 2.x) which CMake 4.0+ rejects.
+    # Override the minimum policy version so the old cmake_minimum_required is accepted.
+    set(CMAKE_POLICY_VERSION_MINIMUM 3.10)
+
     add_subdirectory(${FASTCDR_SOURCE_DIR} ${CMAKE_BINARY_DIR}/third-party/fastcdr-build EXCLUDE_FROM_ALL)
 
     # Place fastcdr with other 3rd-party projects


### PR DESCRIPTION
## Summary
- Set `CMAKE_POLICY_VERSION_MINIMUM` for FastCDR to fix build error on CMake 4.0+ (which removed compatibility with cmake_minimum_required < 3.5)
- Use `jwlawson/actions-setup-cmake` to run Ubuntu 24 CI jobs with CMake 4.x to catch compatibility issues early

## Test plan
- [x] Verify Ubuntu 24 CI jobs pass with CMake 4.x
- [x] Verify Ubuntu 22 CI jobs still pass with system CMake
- [ ] 
Verified the GHA failed before the fix
<img width="1722" height="745" alt="image" src="https://github.com/user-attachments/assets/30401c48-f23d-471f-a306-176e15e19d09" />
