### PR TITLE
Add platform camera IR sensor (GREY/Y8) support

### DIFF
--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -1342,8 +1342,11 @@ namespace rs2
 
     bool subdevice_model::is_multiple_resolutions_supported() const
     {
-        std::string product_line = dev.get_info(RS2_CAMERA_INFO_PRODUCT_LINE);
-        std::string sensor_name = s->get_info(RS2_CAMERA_INFO_NAME);
+        if( !dev.supports( RS2_CAMERA_INFO_PRODUCT_LINE ) || !s->supports( RS2_CAMERA_INFO_NAME ) )
+            return false;
+
+        std::string product_line = dev.get_info( RS2_CAMERA_INFO_PRODUCT_LINE );
+        std::string sensor_name = s->get_info( RS2_CAMERA_INFO_NAME );
 
         return product_line == "D500" && sensor_name == "Stereo Module";
     }

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -22,11 +22,13 @@ const std::map< fourcc::value_type, rs2_format > platform_color_fourcc_to_rs2_fo
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_FORMAT_YUYV },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_FORMAT_YUYV },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_FORMAT_MJPEG },
+    { fourcc( 'G', 'R', 'E', 'Y' ), RS2_FORMAT_Y8 },
 };
 const std::map< fourcc::value_type, rs2_stream > platform_color_fourcc_to_rs2_stream = {
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_STREAM_COLOR },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_STREAM_COLOR },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_STREAM_COLOR },
+    { fourcc( 'G', 'R', 'E', 'Y' ), RS2_STREAM_INFRARED },
 };
 
 
@@ -66,7 +68,7 @@ private:
 
 void platform_camera::initialize()
 {
-    auto const n_sensors = get_sensors_count();
+        auto const n_sensors = get_sensors_count();
     for (auto i = 0; i < n_sensors; ++i)
     {
         if (auto sensor = dynamic_cast<platform_camera_sensor*>(&(get_sensor(i))))
@@ -142,6 +144,8 @@ platform_camera::platform_camera( std::shared_ptr< const device_info > const & d
                                          []() { return std::make_shared< mjpeg_converter >( RS2_FORMAT_RGB8 ); } );
     color_ep->register_processing_block(
         processing_block_factory::create_id_pbf( RS2_FORMAT_MJPEG, RS2_STREAM_COLOR ) );
+    color_ep->register_processing_block(
+        processing_block_factory::create_id_pbf( RS2_FORMAT_Y8, RS2_STREAM_INFRARED ) );
 
     // Timestamps are given in units set by device which may vary among the OEM vendors.
     // For consistent (msec) measurements use "time of arrival" metadata attribute

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -18,13 +18,13 @@ namespace librealsense {
 namespace {
 
 
-const std::map< fourcc::value_type, rs2_format > platform_color_fourcc_to_rs2_format = {
+const std::map< fourcc::value_type, rs2_format > platform_fourcc_to_rs2_format = {
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_FORMAT_YUYV },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_FORMAT_YUYV },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_FORMAT_MJPEG },
     { fourcc( 'G', 'R', 'E', 'Y' ), RS2_FORMAT_Y8 },
 };
-const std::map< fourcc::value_type, rs2_stream > platform_color_fourcc_to_rs2_stream = {
+const std::map< fourcc::value_type, rs2_stream > platform_fourcc_to_rs2_stream = {
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_STREAM_COLOR },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_STREAM_COLOR },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_STREAM_COLOR },
@@ -37,8 +37,9 @@ class platform_camera_sensor : public synthetic_sensor
 public:
     platform_camera_sensor( device * owner, std::shared_ptr< uvc_sensor > uvc_sensor )
         : synthetic_sensor(
-            "RGB Camera", uvc_sensor, owner, platform_color_fourcc_to_rs2_format, platform_color_fourcc_to_rs2_stream )
-        , _default_stream( new stream( RS2_STREAM_COLOR ) )
+            "RGB Camera", uvc_sensor, owner, platform_fourcc_to_rs2_format, platform_fourcc_to_rs2_stream )
+        , _color_stream( new stream( RS2_STREAM_COLOR ) )
+        , _ir_stream( new stream( RS2_STREAM_INFRARED ) )
     {
     }
 
@@ -50,9 +51,9 @@ public:
 
         for( auto && p : results )
         {
-            // Register stream types
-            assign_stream( _default_stream, p );
-            environment::get_instance().get_extrinsics_graph().register_same_extrinsics( *_default_stream, *p );
+            auto & s = ( p->get_stream_type() == RS2_STREAM_INFRARED ) ? _ir_stream : _color_stream;
+            assign_stream( s, p );
+            environment::get_instance().get_extrinsics_graph().register_same_extrinsics( *s, *p );
         }
 
         return results;
@@ -60,7 +61,8 @@ public:
 
 
 private:
-    std::shared_ptr< stream_interface > _default_stream;
+    std::shared_ptr< stream_interface > _color_stream;
+    std::shared_ptr< stream_interface > _ir_stream;
 };
 
 
@@ -68,7 +70,7 @@ private:
 
 void platform_camera::initialize()
 {
-        auto const n_sensors = get_sensors_count();
+    auto const n_sensors = get_sensors_count();
     for (auto i = 0; i < n_sensors; ++i)
     {
         if (auto sensor = dynamic_cast<platform_camera_sensor*>(&(get_sensor(i))))


### PR DESCRIPTION
## Summary
- Add GREY FourCC mapping to `RS2_FORMAT_Y8` / `RS2_STREAM_INFRARED` for platform cameras, enabling IR webcams (e.g. HP IR Camera) to stream in the viewer
- Register an identity processing block for Y8 so the formats converter produces valid profiles
- Add `supports()` guard before querying `RS2_CAMERA_INFO_PRODUCT_LINE` in `is_multiple_resolutions_supported()` to prevent exceptions on non-RealSense devices

## Test plan
- [x] Verify platform IR camera streams Y8 in the RealSense Viewer
- [ ] Verify existing platform cameras (YUY2/MJPEG) still work
- [x] Verify RealSense devices are unaffected