### PR TITLE
Add NV12 format support for platform camera

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -390,6 +390,7 @@ namespace rs2
         std::shared_ptr<colorizer> colorize;
         std::shared_ptr<yuy_decoder> yuy2rgb;
         std::shared_ptr<m420_decoder> m420_to_rgb;
+        std::shared_ptr<nv12_decoder> nv12_to_rgb;
         std::shared_ptr<y411_decoder> y411;
         bool zoom_preview = false;
         rect curr_preview_rect{};
@@ -542,6 +543,30 @@ namespace rs2
                     if (yuy2rgb)
                     {
                         if (auto colorized_frame = yuy2rgb->process(frame).as<video_frame>())
+                        {
+                            if (!colorized_frame.is<gl::gpu_frame>())
+                            {
+                                glBindTexture(GL_TEXTURE_2D, texture);
+                                data = colorized_frame.get_data();
+
+                                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB,
+                                    colorized_frame.get_width(),
+                                    colorized_frame.get_height(),
+                                    0, GL_RGB, GL_UNSIGNED_BYTE,
+                                    colorized_frame.get_data());
+                            }
+                            rendered_frame = colorized_frame;
+                        }
+                    }
+                    else
+                    {
+                        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, data);
+                    }
+                    break;
+                case RS2_FORMAT_NV12:
+                    if (nv12_to_rgb)
+                    {
+                        if (auto colorized_frame = nv12_to_rgb->process(frame).as<video_frame>())
                         {
                             if (!colorized_frame.is<gl::gpu_frame>())
                             {

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -563,33 +563,6 @@ namespace rs2
                         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, data);
                     }
                     break;
-                case RS2_FORMAT_NV12:
-                    if (nv12_to_rgb)
-                    {
-                        if (auto colorized_frame = nv12_to_rgb->process(frame).as<video_frame>())
-                        {
-                            if (!colorized_frame.is<gl::gpu_frame>())
-                            {
-                                glBindTexture(GL_TEXTURE_2D, texture);
-                                data = colorized_frame.get_data();
-
-                                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB,
-                                    colorized_frame.get_width(),
-                                    colorized_frame.get_height(),
-                                    0, GL_RGB, GL_UNSIGNED_BYTE,
-                                    colorized_frame.get_data());
-                            }
-                            rendered_frame = colorized_frame;
-                        }
-                    }
-                    else
-                    {
-                        // Fallback: upload only the Y (luma) plane as a single-channel texture.
-                        // NV12 layout is Y (width*height bytes) followed by interleaved UV;
-                        // using GL_LUMINANCE ensures OpenGL reads exactly width*height bytes.
-                        glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
-                    }
-                    break;
                 case RS2_FORMAT_Y411:
                     if (y411)
                     {

--- a/common/rendering.h
+++ b/common/rendering.h
@@ -584,7 +584,10 @@ namespace rs2
                     }
                     else
                     {
-                        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, data);
+                        // Fallback: upload only the Y (luma) plane as a single-channel texture.
+                        // NV12 layout is Y (width*height bytes) followed by interleaved UV;
+                        // using GL_LUMINANCE ensures OpenGL reads exactly width*height bytes.
+                        glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, width, height, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
                     }
                     break;
                 case RS2_FORMAT_Y411:

--- a/common/stream-model.cpp
+++ b/common/stream-model.cpp
@@ -170,6 +170,7 @@ namespace rs2
         texture->colorize = d->depth_colorizer;
         texture->yuy2rgb = d->yuy2rgb;
         texture->m420_to_rgb = d->m420_to_rgb;
+        texture->nv12_to_rgb = d->nv12_to_rgb;
         texture->y411 = d->y411;
 
         if (auto vd = p.as<video_stream_profile>())

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -73,6 +73,7 @@ namespace rs2
         depth_colorizer(std::make_shared<rs2::gl::colorizer>()),
         yuy2rgb(std::make_shared<rs2::gl::yuy_decoder>()),
         m420_to_rgb(std::make_shared<rs2::gl::m420_decoder>()),
+        nv12_to_rgb(std::make_shared<rs2::nv12_decoder>()),
         y411(std::make_shared<rs2::gl::y411_decoder>()),
         viewer(viewer),
         detected_objects(device_detected_objects),
@@ -82,6 +83,7 @@ namespace rs2
         restore_processing_block("colorizer", depth_colorizer);
         restore_processing_block("yuy2rgb", yuy2rgb);
         restore_processing_block("m420_to_rgb", m420_to_rgb);
+        restore_processing_block("nv12_to_rgb", nv12_to_rgb);
         restore_processing_block("y411", y411);
 
         post_processing_enabled = is_post_processing_enabled_in_config_file();
@@ -1698,6 +1700,7 @@ namespace rs2
             save_processing_block_to_config_file("colorizer", depth_colorizer);
             save_processing_block_to_config_file("yuy2rgb", yuy2rgb);
             save_processing_block_to_config_file("m420_to_rgb", m420_to_rgb);
+            save_processing_block_to_config_file("nv12_to_rgb", nv12_to_rgb);
             save_processing_block_to_config_file("y411", y411);
 
             for (auto&& pbm : post_processing) pbm->save_to_config_file();

--- a/common/subdevice-model.h
+++ b/common/subdevice-model.h
@@ -209,6 +209,7 @@ namespace rs2
         std::shared_ptr<rs2::colorizer> depth_colorizer;
         std::shared_ptr<rs2::yuy_decoder> yuy2rgb;
         std::shared_ptr<rs2::m420_decoder> m420_to_rgb;
+        std::shared_ptr<rs2::nv12_decoder> nv12_to_rgb;
         std::shared_ptr<rs2::y411_decoder> y411;
 
         std::vector<std::shared_ptr<processing_block_model>> post_processing;

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1776,7 +1776,7 @@ namespace rs2
             stream_mv.show_stream_footer(font1, stream_rect, mouse, streams, *this);
 
 
-            if (val_in_range(stream_mv.profile.format(), { RS2_FORMAT_RAW10 , RS2_FORMAT_RAW16, RS2_FORMAT_MJPEG, RS2_FORMAT_M420 }))
+            if (val_in_range(stream_mv.profile.format(), { RS2_FORMAT_RAW10 , RS2_FORMAT_RAW16, RS2_FORMAT_MJPEG, RS2_FORMAT_M420, RS2_FORMAT_NV12 }))
             {
                 show_rendering_not_supported(font2, static_cast<int>(stream_rect.x), static_cast<int>(stream_rect.y), static_cast<int>(stream_rect.w),
                     static_cast<int>(stream_rect.h), stream_mv.profile.format());

--- a/include/librealsense2/h/rs_processing.h
+++ b/include/librealsense2/h/rs_processing.h
@@ -67,6 +67,15 @@ rs2_processing_block* rs2_create_yuy_decoder(rs2_error** error);
 rs2_processing_block* rs2_create_m420_decoder(rs2_error** error);
 
 /**
+* Creates NV12 decoder processing block.
+* This block accepts raw NV12 frames and outputs frames of other formats.
+* NV12 is a semi-planar YUV 4:2:0 format: a full-resolution Y plane followed by
+* an interleaved half-resolution U,V plane. 12 bits per pixel.
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+rs2_processing_block* rs2_create_nv12_decoder(rs2_error** error);
+
+/**
 * Creates y411 decoder processing block. This block accepts raw y411 frames and outputs frames in RGB8.
 *     https://www.fourcc.org/pixel-format/yuv-y411/
 * Y411 is disguised as NV12 to allow Linux compatibility. Both are 12bpp encodings that allow high-resolution

--- a/include/librealsense2/h/rs_sensor.h
+++ b/include/librealsense2/h/rs_sensor.h
@@ -101,6 +101,7 @@ typedef enum rs2_format
     RS2_FORMAT_Y16I            , /**< 12-bit per pixel interleaved. 12-bit left, 12-bit right. */
     RS2_FORMAT_M420            , /**< 24-bit for every pixel: y for each pixel, and u,v data for every four pixels - packed as 2 lines of y, 1 line of u,v */
     RS2_FORMAT_COMBINED_MOTION , /**< Combined motion data, as in the combined_motion structure */
+    RS2_FORMAT_NV12            , /**< Semi-planar YUV 4:2:0: full-resolution Y plane followed by interleaved half-resolution U,V plane. 12 bits per pixel. */
     RS2_FORMAT_COUNT             /**< Number of enumeration values. Not a valid input: intended to be used in for-loops. */
 } rs2_format;
 const char* rs2_format_to_string(rs2_format format);

--- a/include/librealsense2/hpp/rs_processing.hpp
+++ b/include/librealsense2/hpp/rs_processing.hpp
@@ -557,6 +557,33 @@ namespace rs2
         }
     };
 
+    class nv12_decoder : public filter
+    {
+    public:
+        /**
+        * Creates NV12 decoder processing block.
+        * This block accepts raw NV12 frames and outputs frames of other formats.
+        * NV12 is a semi-planar YUV 4:2:0 format: a full-resolution Y plane followed by
+        * an interleaved half-resolution U,V plane. 12 bits per pixel.
+        */
+        nv12_decoder() : filter(init(), 1) { }
+
+    protected:
+        nv12_decoder(std::shared_ptr<rs2_processing_block> block) : filter(block, 1) {}
+
+    private:
+        std::shared_ptr<rs2_processing_block> init()
+        {
+            rs2_error* e = nullptr;
+            auto block = std::shared_ptr<rs2_processing_block>(
+                rs2_create_nv12_decoder(&e),
+                rs2_delete_processing_block);
+            error::handle(e);
+
+            return block;
+        }
+    };
+
     class y411_decoder : public filter
     {
     public:

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -206,6 +206,11 @@ std::vector< rs2_format > device::map_supported_color_formats( rs2_format source
         target_formats.push_back(RS2_FORMAT_Y16);
         target_formats.push_back(RS2_FORMAT_Y8);
         break;
+    case RS2_FORMAT_NV12:
+        target_formats.push_back(RS2_FORMAT_NV12);
+        target_formats.push_back(RS2_FORMAT_Y16);
+        target_formats.push_back(RS2_FORMAT_Y8);
+        break;
     case RS2_FORMAT_YUYV:
         break;
     case RS2_FORMAT_UYVY:

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -28,6 +28,7 @@ namespace librealsense
         case RS2_FORMAT_XYZ32F: return 12 * 8;
         case RS2_FORMAT_YUYV:  return 16;
         case RS2_FORMAT_M420:  return 12; // 16 pixels are represented with 24 bytes (16 of Y and 8 of Cr, Cb) - 24 / 16 * 8 = 12
+        case RS2_FORMAT_NV12:  return 12; // Semi-planar YUV 4:2:0: Y plane (W*H) + interleaved UV plane (W*H/2) = 12 bpp
         case RS2_FORMAT_RGB8: return 24;
         case RS2_FORMAT_BGR8: return 24;
         case RS2_FORMAT_RGBA8: return 32;

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -22,13 +22,15 @@ const std::map< fourcc::value_type, rs2_format > platform_fourcc_to_rs2_format =
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_FORMAT_YUYV },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_FORMAT_YUYV },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_FORMAT_MJPEG },
-    { fourcc( 'G', 'R', 'E', 'Y' ), RS2_FORMAT_Y8 },
+    { fourcc( 'N', 'V', '1', '2' ), RS2_FORMAT_NV12 },
+	{ fourcc( 'G', 'R', 'E', 'Y' ), RS2_FORMAT_Y8 },
 };
-const std::map< fourcc::value_type, rs2_stream > platform_fourcc_to_rs2_stream = {
+const std::map< fourcc::value_type, rs2_stream > platform_color_fourcc_to_rs2_stream = {
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_STREAM_COLOR },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_STREAM_COLOR },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_STREAM_COLOR },
-    { fourcc( 'G', 'R', 'E', 'Y' ), RS2_STREAM_INFRARED },
+    { fourcc( 'N', 'V', '1', '2' ), RS2_STREAM_COLOR },
+	{ fourcc( 'G', 'R', 'E', 'Y' ), RS2_STREAM_INFRARED },
 };
 
 
@@ -141,6 +143,10 @@ platform_camera::platform_camera( std::shared_ptr< const device_info > const & d
         processing_block_factory::create_pbf_vector< yuy2_converter >( RS2_FORMAT_YUYV,
                                                                        map_supported_color_formats( RS2_FORMAT_YUYV ),
                                                                        RS2_STREAM_COLOR ) );
+    color_ep->register_processing_block(
+        processing_block_factory::create_pbf_vector< nv12_converter >( RS2_FORMAT_NV12,
+                                                                       map_supported_color_formats( RS2_FORMAT_NV12 ),
+                                                                       RS2_STREAM_COLOR ) );
     color_ep->register_processing_block( { { RS2_FORMAT_MJPEG } },
                                          { { RS2_FORMAT_RGB8, RS2_STREAM_COLOR } },
                                          []() { return std::make_shared< mjpeg_converter >( RS2_FORMAT_RGB8 ); } );
@@ -173,8 +179,8 @@ std::vector< tagged_profile > platform_camera::get_profiles_tags() const
     std::vector< tagged_profile > markers;
     markers.push_back( { RS2_STREAM_COLOR,
                          -1,
-                         640,
-                         480,
+                         1280,
+                         720,
                          RS2_FORMAT_RGB8,
                          30,
                          profile_tag::PROFILE_TAG_SUPERSET | profile_tag::PROFILE_TAG_DEFAULT } );

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -25,7 +25,7 @@ const std::map< fourcc::value_type, rs2_format > platform_fourcc_to_rs2_format =
     { fourcc( 'N', 'V', '1', '2' ), RS2_FORMAT_NV12 },
 	{ fourcc( 'G', 'R', 'E', 'Y' ), RS2_FORMAT_Y8 },
 };
-const std::map< fourcc::value_type, rs2_stream > platform_color_fourcc_to_rs2_stream = {
+const std::map< fourcc::value_type, rs2_stream > platform_fourcc_to_rs2_stream = {
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_STREAM_COLOR },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_STREAM_COLOR },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_STREAM_COLOR },

--- a/src/platform-camera.cpp
+++ b/src/platform-camera.cpp
@@ -23,14 +23,14 @@ const std::map< fourcc::value_type, rs2_format > platform_fourcc_to_rs2_format =
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_FORMAT_YUYV },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_FORMAT_MJPEG },
     { fourcc( 'N', 'V', '1', '2' ), RS2_FORMAT_NV12 },
-	{ fourcc( 'G', 'R', 'E', 'Y' ), RS2_FORMAT_Y8 },
+    { fourcc( 'G', 'R', 'E', 'Y' ), RS2_FORMAT_Y8 },
 };
 const std::map< fourcc::value_type, rs2_stream > platform_fourcc_to_rs2_stream = {
     { fourcc( 'Y', 'U', 'Y', '2' ), RS2_STREAM_COLOR },
     { fourcc( 'Y', 'U', 'Y', 'V' ), RS2_STREAM_COLOR },
     { fourcc( 'M', 'J', 'P', 'G' ), RS2_STREAM_COLOR },
     { fourcc( 'N', 'V', '1', '2' ), RS2_STREAM_COLOR },
-	{ fourcc( 'G', 'R', 'E', 'Y' ), RS2_STREAM_INFRARED },
+    { fourcc( 'G', 'R', 'E', 'Y' ), RS2_STREAM_INFRARED },
 };
 
 

--- a/src/proc/color-formats-converter.cpp
+++ b/src/proc/color-formats-converter.cpp
@@ -815,6 +815,162 @@ namespace librealsense
     }
 
     /////////////////////////////
+    // NV12 unpacking routines //
+    /////////////////////////////
+    // This templated function unpacks NV12 into Y8/Y16/RGB8/RGBA8/BGR8/BGRA8, depending on the compile-time parameter FORMAT.
+    // NV12 is a semi-planar YUV 4:2:0 format:
+    //   - Y plane: width*height bytes at offset 0 (one Y per pixel)
+    //   - UV plane: width*(height/2) bytes at offset width*height (interleaved U,V pairs at half resolution)
+    // Each pair of U,V values covers a 2x2 block of pixels.
+    // The per-line UV layout (UVUVUV...) is identical to M420, only the plane arrangement differs.
+    template<rs2_format FORMAT> void unpack_nv12( uint8_t * const d[], const uint8_t * s, int width, int height, int actual_size)
+    {
+        auto n = width * height;
+        assert(n % 16 == 0);
+
+#if defined __SSSE3__ && ! defined ANDROID
+        static bool do_avx = has_avx();
+
+        auto src = reinterpret_cast<const __m128i*>(s);
+        auto dst = reinterpret_cast<__m128i*>(d[0]);
+
+        // Y plane starts at offset 0, UV plane starts at offset width*height
+        auto y_plane = reinterpret_cast<const __m128i*>(s);
+        auto uv_plane = reinterpret_cast<const __m128i*>(s + width * height);
+
+        __m128i* source_chunks_y = new __m128i[2 * width / 16];
+        __m128i* source_chunks_uv = new __m128i[width / 16];
+
+#pragma omp parallel for
+        for (int j = 0; j < height / 2; ++j)
+        {
+            // Load 2 lines of Y from the Y plane
+#pragma omp parallel for
+            for (int i = 0; i < 2 * width / 16; ++i)
+            {
+                auto y_offset = (2 * j * width) / 16;
+                source_chunks_y[i] = _mm_loadu_si128(&y_plane[y_offset + i]);
+
+                if (FORMAT == RS2_FORMAT_Y8)
+                {
+                    auto dst_offset = (2 * width * j) / 16;
+                    _mm_storeu_si128(&dst[dst_offset + i], source_chunks_y[i]);
+                    continue;
+                }
+
+                if (FORMAT == RS2_FORMAT_Y16)
+                {
+                    auto bpp = 2;
+                    auto dst_offset = (2 * width * j) / 16 * bpp;
+                    const __m128i zero = _mm_set1_epi8(0);
+                    __m128i y16__0_7 = _mm_unpacklo_epi8(source_chunks_y[i], zero);
+                    __m128i y16__8_F = _mm_unpackhi_epi8(source_chunks_y[i], zero);
+                    __m128i y16_0_7_epi_16 = _mm_slli_epi16(y16__0_7, 8);
+                    __m128i y16_8_F_epi_16 = _mm_slli_epi16(y16__8_F, 8);
+                    _mm_storeu_si128(&dst[dst_offset + i * 2], y16_0_7_epi_16);
+                    _mm_storeu_si128(&dst[dst_offset + i * 2 + 1], y16_8_F_epi_16);
+                    continue;
+                }
+
+                // Load UV line from the UV plane (one UV row per pair of Y rows)
+                if ( i < width / 16)
+                {
+                    auto uv_offset = (j * width) / 16;
+                    source_chunks_uv[i] = _mm_load_si128(&uv_plane[uv_offset + i]);
+                }
+            }
+
+            if (FORMAT == RS2_FORMAT_RGB8 || FORMAT == RS2_FORMAT_RGBA8 || FORMAT == RS2_FORMAT_BGR8 || FORMAT == RS2_FORMAT_BGRA8)
+            {
+                int bpp = 3;
+                if (FORMAT == RS2_FORMAT_RGBA8 || FORMAT == RS2_FORMAT_BGRA8)
+                    bpp = 4;
+
+                auto offset_to_current_first_line_for_dst = (2 * width * j) / 16 * bpp;
+                auto offset_to_current_second_line_for_dst = offset_to_current_first_line_for_dst + width * bpp / 16;
+
+                auto line_length = width / 16;
+                auto first_line_y = source_chunks_y;
+                auto second_line_y = source_chunks_y + line_length;
+
+                m420_sse_parse_one_line<FORMAT>(first_line_y, source_chunks_uv, &dst[offset_to_current_first_line_for_dst], line_length);
+                m420_sse_parse_one_line<FORMAT>(second_line_y, source_chunks_uv, &dst[offset_to_current_second_line_for_dst], line_length);
+            }
+        }
+
+        delete[] source_chunks_y;
+        delete[] source_chunks_uv;
+
+#else
+        auto src = reinterpret_cast<const uint8_t*>(s);
+        auto dst = reinterpret_cast<uint8_t*>(d[0]);
+
+        // Y plane at offset 0, UV plane at offset width*height
+        auto y_start = src;
+        auto uv_start = src + width * height;
+
+        if (FORMAT == RS2_FORMAT_Y8)
+        {
+            // Just copy the entire Y plane
+            std::memcpy( dst, y_start, width * height );
+            return;
+        }
+        if (FORMAT == RS2_FORMAT_Y16)
+        {
+            for (int pix = 0; pix < width * height; pix += 16)
+            {
+                uint16_t y[16];
+                for (int i = 0; i < 16; ++i)
+                {
+                    y[i] = y_start[pix + i] << 8;
+                }
+                std::memcpy( dst, y, sizeof y );
+                dst += sizeof y;
+            }
+            return;
+        }
+        for (int j = 0; j < height; j += 2)
+        {
+            auto y_row0 = y_start + j * width;
+            auto y_row1 = y_start + (j + 1) * width;
+            auto uv_row = uv_start + (j / 2) * width;
+
+            m420_parse_one_line<FORMAT>(y_row0, uv_row, &dst, width);
+            m420_parse_one_line<FORMAT>(y_row1, uv_row, &dst, width);
+        }
+        return;
+#endif // __SSSE3__
+    }
+
+    void unpack_nv12(rs2_format dst_format, rs2_stream dst_stream, uint8_t * const d[], const uint8_t * s, int w, int h, int actual_size)
+    {
+        switch (dst_format)
+        {
+        case RS2_FORMAT_Y8:
+            unpack_nv12<RS2_FORMAT_Y8>(d, s, w, h, actual_size);
+            break;
+        case RS2_FORMAT_Y16:
+            unpack_nv12<RS2_FORMAT_Y16>(d, s, w, h, actual_size);
+            break;
+        case RS2_FORMAT_RGB8:
+            unpack_nv12<RS2_FORMAT_RGB8>(d, s, w, h, actual_size);
+            break;
+        case RS2_FORMAT_RGBA8:
+            unpack_nv12<RS2_FORMAT_RGBA8>(d, s, w, h, actual_size);
+            break;
+        case RS2_FORMAT_BGR8:
+            unpack_nv12<RS2_FORMAT_BGR8>(d, s, w, h, actual_size);
+            break;
+        case RS2_FORMAT_BGRA8:
+            unpack_nv12<RS2_FORMAT_BGRA8>(d, s, w, h, actual_size);
+            break;
+        default:
+            LOG_ERROR("Unsupported format for NV12 conversion.");
+            break;
+        }
+    }
+
+    /////////////////////////////
     // UYVY unpacking routines //
     /////////////////////////////
     // This templated function unpacks UYVY into RGB8/RGBA8/BGR8/BGRA8, depending on the compile-time parameter FORMAT.
@@ -1142,6 +1298,11 @@ namespace librealsense
     void m420_converter::process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size)
     {
         unpack_m420(_target_format, _target_stream, dest, source, width, height, actual_size);
+    }
+
+    void nv12_converter::process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size)
+    {
+        unpack_nv12(_target_format, _target_stream, dest, source, width, height, actual_size);
     }
 
     void uyvy_to_yuyv::process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size)

--- a/src/proc/color-formats-converter.cpp
+++ b/src/proc/color-formats-converter.cpp
@@ -825,27 +825,24 @@ namespace librealsense
     // The per-line UV layout (UVUVUV...) is identical to M420, only the plane arrangement differs.
     template<rs2_format FORMAT> void unpack_nv12( uint8_t * const d[], const uint8_t * s, int width, int height, int actual_size)
     {
-        auto n = width * height;
-        assert(n % 16 == 0);
+        assert(width % 16 == 0);
+        assert(height % 2 == 0);
 
 #if defined __SSSE3__ && ! defined ANDROID
-        static bool do_avx = has_avx();
-
-        auto src = reinterpret_cast<const __m128i*>(s);
         auto dst = reinterpret_cast<__m128i*>(d[0]);
 
         // Y plane starts at offset 0, UV plane starts at offset width*height
         auto y_plane = reinterpret_cast<const __m128i*>(s);
         auto uv_plane = reinterpret_cast<const __m128i*>(s + width * height);
 
-        __m128i* source_chunks_y = new __m128i[2 * width / 16];
-        __m128i* source_chunks_uv = new __m128i[width / 16];
-
 #pragma omp parallel for
         for (int j = 0; j < height / 2; ++j)
         {
+            // Per-iteration buffers to avoid data races across threads
+            auto source_chunks_y = new __m128i[2 * width / 16];
+            auto source_chunks_uv = new __m128i[width / 16];
+
             // Load 2 lines of Y from the Y plane
-#pragma omp parallel for
             for (int i = 0; i < 2 * width / 16; ++i)
             {
                 auto y_offset = (2 * j * width) / 16;
@@ -876,7 +873,7 @@ namespace librealsense
                 if ( i < width / 16)
                 {
                     auto uv_offset = (j * width) / 16;
-                    source_chunks_uv[i] = _mm_load_si128(&uv_plane[uv_offset + i]);
+                    source_chunks_uv[i] = _mm_loadu_si128(&uv_plane[uv_offset + i]);
                 }
             }
 
@@ -896,10 +893,10 @@ namespace librealsense
                 m420_sse_parse_one_line<FORMAT>(first_line_y, source_chunks_uv, &dst[offset_to_current_first_line_for_dst], line_length);
                 m420_sse_parse_one_line<FORMAT>(second_line_y, source_chunks_uv, &dst[offset_to_current_second_line_for_dst], line_length);
             }
-        }
 
-        delete[] source_chunks_y;
-        delete[] source_chunks_uv;
+            delete[] source_chunks_y;
+            delete[] source_chunks_uv;
+        }
 
 #else
         auto src = reinterpret_cast<const uint8_t*>(s);

--- a/src/proc/color-formats-converter.h
+++ b/src/proc/color-formats-converter.h
@@ -74,6 +74,18 @@ namespace librealsense
         void process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size) override;
     };
 
+    class LRS_EXTENSION_API nv12_converter : public color_converter
+    {
+    public:
+        nv12_converter(rs2_format target_format) :
+            nv12_converter("NV12 Converter", target_format) {};
+
+    protected:
+        nv12_converter(const char* name, rs2_format target_format) :
+            color_converter(name, target_format) {};
+        void process_function( uint8_t * const dest[], const uint8_t * source, int width, int height, int actual_size, int input_size) override;
+    };
+
     class LRS_EXTENSION_API uyvy_to_yuyv : public color_converter
     {
     public:

--- a/src/realsense.def
+++ b/src/realsense.def
@@ -217,6 +217,7 @@ EXPORTS
     rs2_create_colorizer
     rs2_create_yuy_decoder
     rs2_create_m420_decoder
+    rs2_create_nv12_decoder
     rs2_create_threshold
     rs2_create_units_transform
     rs2_create_decimation_filter_block

--- a/src/rs.cpp
+++ b/src/rs.cpp
@@ -2915,6 +2915,12 @@ rs2_processing_block* rs2_create_m420_decoder(rs2_error** error) BEGIN_API_CALL
 }
 NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(nullptr)
 
+rs2_processing_block* rs2_create_nv12_decoder(rs2_error** error) BEGIN_API_CALL
+{
+    return new rs2_processing_block{ std::make_shared<nv12_converter>(RS2_FORMAT_RGB8) };
+}
+NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(nullptr)
+
 rs2_processing_block* rs2_create_y411_decoder(rs2_error** error) BEGIN_API_CALL
 {
     return new rs2_processing_block{ std::make_shared<y411_converter>(RS2_FORMAT_RGB8) };

--- a/src/to-string.cpp
+++ b/src/to-string.cpp
@@ -669,6 +669,7 @@ const char * get_string( rs2_format value )
     CASE( Y411 )
     CASE( Y16I )
     CASE( M420 )
+    CASE( NV12 )
     default:
         assert( ! is_valid( value ) );
         return UNKNOWN_VALUE;

--- a/tools/depth-quality/depth-quality-model.cpp
+++ b/tools/depth-quality/depth-quality-model.cpp
@@ -995,6 +995,7 @@ namespace rs2
                     _viewer_model.streams[profile.unique_id()].texture->colorize = sub->depth_colorizer;
                     _viewer_model.streams[profile.unique_id()].texture->yuy2rgb = sub->yuy2rgb;
                     _viewer_model.streams[profile.unique_id()].texture->m420_to_rgb = sub->m420_to_rgb;
+                    _viewer_model.streams[profile.unique_id()].texture->nv12_to_rgb = sub->nv12_to_rgb;
                     _viewer_model.streams[profile.unique_id()].texture->y411 = sub->y411;
 
                     if (profile.stream_type() == RS2_STREAM_DEPTH)


### PR DESCRIPTION
## Summary
- Add `RS2_FORMAT_NV12` (semi-planar YUV 4:2:0, 12bpp) to the format enum and all supporting infrastructure (string conversion, bpp, C/C++ API, exports)
- Implement NV12-to-RGB/BGR/RGBA/BGRA/Y8/Y16 converter with both SSE and scalar paths, reusing the M420 per-line conversion logic
- Register NV12 FourCC mapping and processing block in the platform camera so non-Intel UVC cameras advertising NV12 work out of the box
- Add NV12 rendering support in the viewer (realsense-viewer, depth-quality tool)
- Update default platform camera resolution to 1280x720

## Test plan
- [x] Verified with a platform camera streaming NV12 — image displays correctly in realsense-viewer
- [x] Verified RGB8, BGR8 output formats render with correct colors
- [ ] CI build