### PR TITLE
Remove Intel branding from wrappers docs and comments

### DIFF
--- a/wrappers/android/readme.md
+++ b/wrappers/android/readme.md
@@ -1,5 +1,5 @@
 #  Build RealSense SDK for Android OS
-This document describes how to build the Intel® RealSense™ SDK 2.0 including headless tools and examples for Android devices.
+This document describes how to build the RealSense SDK 2.0 including headless tools and examples for Android devices.
 
 > Read about Android support [here](../../doc/android.md).
 

--- a/wrappers/dlib/readme.md
+++ b/wrappers/dlib/readme.md
@@ -1,5 +1,5 @@
 # Dlib Samples for RealSense cameras
-Examples in this folder are designed to complement existing [SDK examples](../../examples) and demonstrate how Intel RealSense cameras can be used together with `dlib` in domain of computer-vision.
+Examples in this folder are designed to complement existing [SDK examples](../../examples) and demonstrate how RealSense cameras can be used together with `dlib` in domain of computer-vision.
 
 > RealSense examples have been designed and tested with dlib version 19.17,
 > Working with newer version may require code changes.

--- a/wrappers/open3d/cpp/RealSenseBagReader.cpp
+++ b/wrappers/open3d/cpp/RealSenseBagReader.cpp
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
     return true;
   });
 
-  vis.CreateVisualizerWindow("Open3D Intel RealSense bag player", 1920, 540);
+  vis.CreateVisualizerWindow("Open3D RealSense bag player", 1920, 540);
   utility::LogInfo("Starting to play. Press [SPACE] to pause. Press [ESC] to "
                    "exit.");
 

--- a/wrappers/opencv/dnn/readme.md
+++ b/wrappers/opencv/dnn/readme.md
@@ -1,7 +1,7 @@
 # rs-dnn Sample
 
 ## Overview
-This example shows how to use Intel RealSense cameras with existing [Deep Neural Network](https://en.wikipedia.org/wiki/Deep_learning) algorithms. The demo is derived from [MobileNet Single-Shot Detector example](https://github.com/opencv/opencv/blob/3.4.0/samples/dnn/ssd_mobilenet_object_detection.cpp) provided with `opencv`. We modify it to work with Intel RealSense cameras and take advantage of depth data (in a very basic way). 
+This example shows how to use RealSense cameras with existing [Deep Neural Network](https://en.wikipedia.org/wiki/Deep_learning) algorithms. The demo is derived from [MobileNet Single-Shot Detector example](https://github.com/opencv/opencv/blob/3.4.0/samples/dnn/ssd_mobilenet_object_detection.cpp) provided with `opencv`. We modify it to work with RealSense cameras and take advantage of depth data (in a very basic way). 
 
 
 The demo will load existing [Caffe model](https://github.com/chuanqi305/MobileNet-SSD) (see another tutorial [here](https://docs.opencv.org/3.3.0/d5/de7/tutorial_dnn_googlenet.html)) and use it to classify objects within the RGB image. Once object is detected, the demo will calculate approximate distance to the object using the depth data:

--- a/wrappers/opencv/dnn/rs-dnn.cpp
+++ b/wrappers/opencv/dnn/rs-dnn.cpp
@@ -1,5 +1,5 @@
 // This example is derived from the ssd_mobilenet_object_detection opencv demo
-// and adapted to be used with Intel RealSense Cameras
+// and adapted to be used with RealSense Cameras
 // Please see https://github.com/opencv/opencv/blob/master/LICENSE
 
 #include <opencv2/dnn.hpp>
@@ -27,7 +27,7 @@ int main(int argc, char** argv) try
     Net net = readNetFromCaffe("MobileNetSSD_deploy.prototxt", 
                                "MobileNetSSD_deploy.caffemodel");
 
-    // Start streaming from Intel RealSense Camera
+    // Start streaming from RealSense Camera
     pipeline pipe;
     auto config = pipe.start();
     auto profile = config.get_stream(RS2_STREAM_COLOR)

--- a/wrappers/opencv/imshow/readme.md
+++ b/wrappers/opencv/imshow/readme.md
@@ -1,7 +1,7 @@
 # rs-imshow Sample
 
 ## Overview
-This example is a "hello-world" code snippet for Intel RealSense cameras integration with OpenCV. The sample will open an OpenCV UI window and render colorized depth stream to it. 
+This example is a "hello-world" code snippet for RealSense cameras integration with OpenCV. The sample will open an OpenCV UI window and render colorized depth stream to it. 
 The following code snippet is used to create `cv::Mat` from `rs2::frame`:
 ```cpp
 // Query frame size (width and height)

--- a/wrappers/opencv/kinfu/readme.md
+++ b/wrappers/opencv/kinfu/readme.md
@@ -13,7 +13,7 @@ Install `OpenCV` and `opencv_contrib` as described in the [official guide](https
 
 In step 5, along with configuring `OPENCV_EXTRA_MODULES_PATH`, check the `OPENCV_ENABLE_NONFREE` option.
 
-For additional guidelines on building librealsene with OpenCV please follow [OpenCV Samples for RealSense cameras](https://github.com/realsenseai/librealsense/blob/master/wrappers/opencv/readme.md). 
+For additional guidelines on building librealsense with OpenCV please follow [OpenCV Samples for RealSense cameras](https://github.com/realsenseai/librealsense/blob/master/wrappers/opencv/readme.md). 
 
 When configuring CMake for librealsense, in addition to checking `BUILD_CV_EXAMPLES`, check the `BUILD_CV_KINFU_EXAMPLE` flag. Also, ensure that `BUILD_GRAPHICAL_EXAMPLES` is checked.
 

--- a/wrappers/opencv/kinfu/readme.md
+++ b/wrappers/opencv/kinfu/readme.md
@@ -13,7 +13,7 @@ Install `OpenCV` and `opencv_contrib` as described in the [official guide](https
 
 In step 5, along with configuring `OPENCV_EXTRA_MODULES_PATH`, check the `OPENCV_ENABLE_NONFREE` option.
 
-For additional guidelines on building librealsene with OpenCV please follow [OpenCV Samples for Intel RealSense cameras](https://github.com/realsenseai/librealsense/blob/master/wrappers/opencv/readme.md). 
+For additional guidelines on building librealsene with OpenCV please follow [OpenCV Samples for RealSense cameras](https://github.com/realsenseai/librealsense/blob/master/wrappers/opencv/readme.md). 
 
 When configuring CMake for librealsense, in addition to checking `BUILD_CV_EXAMPLES`, check the `BUILD_CV_KINFU_EXAMPLE` flag. Also, ensure that `BUILD_GRAPHICAL_EXAMPLES` is checked.
 

--- a/wrappers/opencv/readme.md
+++ b/wrappers/opencv/readme.md
@@ -8,7 +8,7 @@ Examples in this folder are designed to complement existing [SDK examples](../..
 1. [ImShow](./imshow) - Minimal OpenCV application for visualizing depth data
 2. [GrabCuts](./grabcuts) - Simple background removal using the GrabCut algorithm
 3. [Latency-Tool](./latency-tool) - Basic latency estimation using computer vision
-4. [DNN](./dnn) - Intel RealSense camera used for real-time object-detection
+4. [DNN](./dnn) - RealSense camera used for real-time object-detection
 5. [Depth Filter](./depth-filter) - Depth Filtering for Collision Avoidance
 6. [Rotate](./rotate-pointcloud) - Rotate point cloud before visualization
 

--- a/wrappers/openvino/readme.md
+++ b/wrappers/openvino/readme.md
@@ -1,6 +1,6 @@
 ﻿# OpenVINO Samples for RealSense cameras
 Examples in this folder are designed to complement existing
-[SDK examples](../../examples) and demonstrate how Intel RealSense cameras can
+[SDK examples](../../examples) and demonstrate how RealSense cameras can
 be used together with the OpenVINO™ toolkit in the domain of computer-vision.
 
 > RealSense examples have been designed and tested with the following OpenVINO versions

--- a/wrappers/pcl/pcl-color/readme.md
+++ b/wrappers/pcl/pcl-color/readme.md
@@ -1,6 +1,6 @@
 # rs-pcl-color Sample
 
 ## Overview
-This example provides color support to PCL for Intel RealSense cameras. The demo will capture a single depth frame from the camera, convert it to `pcl::PointCloud` object and perform basic `PassThrough` filter, but will capture the frame using a tuple for RGB color support. All points that passed the filter (with Z less than 1 meter) will be removed with the final result in a Captured_Frame.pcd ASCII file format. Below is an example of the final output.
+This example provides color support to PCL for RealSense cameras. The demo will capture a single depth frame from the camera, convert it to `pcl::PointCloud` object and perform basic `PassThrough` filter, but will capture the frame using a tuple for RGB color support. All points that passed the filter (with Z less than 1 meter) will be removed with the final result in a Captured_Frame.pcd ASCII file format. Below is an example of the final output.
 
 <p align="center"><img src="../res/5.PNG" /></p>

--- a/wrappers/pcl/pcl-color/rs-pcl-color.cpp
+++ b/wrappers/pcl/pcl-color/rs-pcl-color.cpp
@@ -3,7 +3,7 @@
  *          Liam Gogley
  * 
  * Purpose: The following .cpp file will utilize the
- *          RealSense camera to stream and capture frame
+ *          RealSense camera to stream and capture frames
  *          data of the environment. Color is then applied
  *          and a point cloud is generated and saved to
  *          a point cloud data format (.pcd).

--- a/wrappers/pcl/pcl-color/rs-pcl-color.cpp
+++ b/wrappers/pcl/pcl-color/rs-pcl-color.cpp
@@ -2,8 +2,8 @@
  * Author:  Daniel Tran
  *          Liam Gogley
  * 
- * Purpose: The following .cpp file will utilize the Intel
- *          realsense camera to stream and capture frame
+ * Purpose: The following .cpp file will utilize the
+ *          RealSense camera to stream and capture frame
  *          data of the environment. Color is then applied
  *          and a point cloud is generated and saved to
  *          a point cloud data format (.pcd).
@@ -21,7 +21,7 @@
 #include <boost/thread/thread.hpp>
 #include <string>
 
-// Intel Realsense Headers
+// RealSense Headers
 #include <librealsense2/rs.hpp> // Include RealSense Cross Platform API
 
 // PCL Headers

--- a/wrappers/pcl/pcl/readme.md
+++ b/wrappers/pcl/pcl/readme.md
@@ -1,5 +1,5 @@
 # rs-pcl Sample
 
 ## Overview
-This example is a "hello-world" code snippet for Intel RealSense cameras integration with PCL. The demo will capture a single depth frame from the camera, convert it to `pcl::PointCloud` object and perform basic `PassThrough` filter. All points that passed the filter (with Z less than 1 meter) will be marked in green while the rest will be marked in red. 
+This example is a "hello-world" code snippet for RealSense cameras integration with PCL. The demo will capture a single depth frame from the camera, convert it to `pcl::PointCloud` object and perform basic `PassThrough` filter. All points that passed the filter (with Z less than 1 meter) will be marked in green while the rest will be marked in red. 
 

--- a/wrappers/pcl/readme.md
+++ b/wrappers/pcl/readme.md
@@ -1,5 +1,5 @@
-# PCL Samples for Intel® RealSense™ cameras
-Examples in this folder are designed to complement existing [SDK examples](../../examples) and demonstrate how Intel RealSense cameras can be used together with `PCL` (Point-Cloud Library). 
+# PCL Samples for RealSense cameras
+Examples in this folder are designed to complement existing [SDK examples](../../examples) and demonstrate how RealSense cameras can be used together with `PCL` (Point-Cloud Library). 
  
 ## List of Samples:
 1. [PCL](./pcl) - Minimal Point-cloud viewer that includes PCL processing

--- a/wrappers/pointcloud/pointcloud-stitching/doc/pointcloud-stitching-demo.md
+++ b/wrappers/pointcloud/pointcloud-stitching/doc/pointcloud-stitching-demo.md
@@ -196,7 +196,7 @@ rs-pointcloud-stitching.exe C:\pc_stitching_ws calibration_60m.cfg
 [Download Full Resolution video](https://librealsense.realsenseai.com/rs-tests/TestData/pc-stitching-demo-guide/rs-pointcloud-stitching.mp4)
 </br>
 You can now see live depth and color images as if taken from the virtual device.
-The application project the original images onto the virtual device. You can record this device and play it back using Intel's realsense-viewer app.
+The application project the original images onto the virtual device. You can record this device and play it back using the realsense-viewer app.
 Use the "Record" button to start and stop a recording session. It starts recording when its caption is changed to "Stop Recording" suggesting that the next press on it will stop the recording process.
 The file ["record.bag"](https://librealsense.realsenseai.com/rs-tests/TestData/pc-stitching-demo-guide/record.bag) is saved under the given working directory. In this example: `C:\pc_stitching_ws\record.bag`</br>
 You can now open realsense-viewer, choose "Add source->Load recorded sequence" and choose `C:\pc_stitching_ws\record.bag`. Switch to 3D view and watch the pointcloud of the extended scene.

--- a/wrappers/python/examples/box_dimensioner_multicam/readme.md
+++ b/wrappers/python/examples/box_dimensioner_multicam/readme.md
@@ -26,7 +26,7 @@ Note: To keep the demo simpler, the clipping of the usable point cloud is done b
 
 ## Example Output
 Once the calibration is done and the target object's dimensions are calculated, the application will open as many windows as the number of devices connected each displaying a color image along with an overlay of the calculated bounding box.
-In the following example we've used two Intel® RealSense™ Depth Cameras D435 pointing at a common object placed on a 6 x 9 chessboard (checked-in with this demo folder).
+In the following example we've used two RealSense Depth Cameras D435 pointing at a common object placed on a 6 x 9 chessboard (checked-in with this demo folder).
 [sampleSetupAndOutput](https://github.com/realsenseai/librealsense/blob/master/wrappers/python/examples/box_dimensioner_multicam/samplesetupandoutput.jpg)
 
 ## References

--- a/wrappers/python/examples/readme.md
+++ b/wrappers/python/examples/readme.md
@@ -1,4 +1,4 @@
-# Sample Code for Intel® RealSense™ Python Wrapper
+# Sample Code for RealSense Python Wrapper
 
 These Examples demonstrate how to use the python wrapper of the SDK.
 

--- a/wrappers/readme.md
+++ b/wrappers/readme.md
@@ -1,4 +1,4 @@
-# Wrappers for Intel® RealSense™ Technology
+# Wrappers for RealSense Technology
 
 * [Python](./python/) - Supports Python 3
 * [ROS](https://github.com/intel-ros/realsense/releases) - Integration with Robot Operating System

--- a/wrappers/rest-api/README.md
+++ b/wrappers/rest-api/README.md
@@ -1,7 +1,7 @@
 # LibRS Rest API server
 ## Overview
 
-This Python library provides a convenient wrapper to interact with the [RealSense REST API], a FastAPI-based service that exposes the functionality of the Intel RealSense SDK (librealsense) over a network.
+This Python library provides a convenient wrapper to interact with the [RealSense REST API], a FastAPI-based service that exposes the functionality of the RealSense SDK (librealsense) over a network.
 
 It simplifies remote control and data streaming from RealSense devices by handling communication protocols for:
 

--- a/wrappers/tensorflow/README.md
+++ b/wrappers/tensorflow/README.md
@@ -1,8 +1,8 @@
-# TensorFlow with Intel RealSense Cameras
+# TensorFlow with RealSense Cameras
 
 ## Introduction
 
-TensorFlow is extremely popular open source platform for machine learning. This tutorial series will highlight different ways TensorFlow-based machine learning can be applied with Intel RealSense Depth Cameras. We'll be using python as language of choice, but same concepts can be easily ported to other languages.
+TensorFlow is extremely popular open source platform for machine learning. This tutorial series will highlight different ways TensorFlow-based machine learning can be applied with RealSense Depth Cameras. We'll be using python as language of choice, but same concepts can be easily ported to other languages.
 
 ## Installation
 
@@ -16,10 +16,10 @@ We'll need the following components:
 
 > **Note on GPU Support**: In order to run TensorFlow with GPU acceleration on NVidia GPUs you need to install `tensorflow-gpu` python package and compatible versions of CUDA and cuDNN libraries. [List of compatible combinations](https://www.tensorflow.org/install/source_windows#gpu)
 
-We assume you are already familiar with the basics of operating Intel RealSense devices in python. Please see [official documentation](https://github.com/realsenseai/librealsense/tree/development/wrappers/python#python-wrapper) for more information and code samples. 
+We assume you are already familiar with the basics of operating RealSense devices in python. Please see [official documentation](https://github.com/realsenseai/librealsense/tree/development/wrappers/python#python-wrapper) for more information and code samples. 
 
 ## Part 1 - Object Detection and Classification
-Intel RealSense Camera can be used for object detection and classification with TensorFlow like any other video source. [Example 1](example1%20-%20object%20detection.py) is showing standard object detection using TensorFlow and data from the RGB sensor. 
+RealSense Camera can be used for object detection and classification with TensorFlow like any other video source. [Example 1](example1%20-%20object%20detection.py) is showing standard object detection using TensorFlow and data from the RGB sensor. 
 
 In order to run this example, you will need model file. Please download and extract one of the models from [TensorFlow-Object-Detection-API](https://github.com/opencv/opencv/wiki/TensorFlow-Object-Detection-API#use-existing-config-file-for-your-model) page. We are using [Faster-RCNN Inception v2](https://arxiv.org/pdf/1611.10012.pdf) for this example, but other networks can be easily swapped-in. Extracted `frozen_inference_graph.pb` is expected to be in the working directory when running the script. 
 
@@ -108,7 +108,7 @@ Expected output:
 
 ## Part 2 - Augmenting output using Depth data
 
-Since Intel RealSense Cameras also offer per-pixel depth information, we can use this extra data to solve additional problems related to our detection and classification example. In [Example 2](example2%20-%20person%20height.py) we'll use color data to detect people and depth data to quickly estimate the height of each person.
+Since RealSense Cameras also offer per-pixel depth information, we can use this extra data to solve additional problems related to our detection and classification example. In [Example 2](example2%20-%20person%20height.py) we'll use color data to detect people and depth data to quickly estimate the height of each person.
 
 In this example we will configure depth stream in addition to color:
 ```py
@@ -212,5 +212,5 @@ The output is a BAG file that could be opened by RealSense viewer.
 
 ## Conclusions
 
-This article is showing small number of examples for using deep learning together with Intel RealSense hardware. It is intended to be further extended and you are welcomed to propose enhancements and new code samples. You are also free to use provided sample code, dataset and model for research or commercial use, in compliance with Intel RealSense SDK 2.0 [License](https://github.com/realsenseai/librealsense/blob/master/LICENSE)
+This article is showing small number of examples for using deep learning together with RealSense hardware. It is intended to be further extended and you are welcomed to propose enhancements and new code samples. You are also free to use provided sample code, dataset and model for research or commercial use, in compliance with RealSense SDK 2.0 [License](https://github.com/realsenseai/librealsense/blob/master/LICENSE)
 


### PR DESCRIPTION
## Summary
- Remove "Intel" branding from documentation and code comments across wrapper folders (dlib, pcl, opencv, openvino, android, open3d)
- Leaves C# `Intel.RealSense` namespace/assembly names unchanged (would break compilation)
- Leaves copyright notices, CPU product names, device name strings, and SDK install paths unchanged

## Files changed
- `wrappers/dlib/readme.md`
- `wrappers/pcl/readme.md`, `pcl/readme.md`, `pcl-color/readme.md`, `pcl-color/rs-pcl-color.cpp`
- `wrappers/opencv/readme.md`, `imshow/readme.md`, `dnn/readme.md`, `dnn/rs-dnn.cpp`, `kinfu/readme.md`
- `wrappers/openvino/readme.md`
- `wrappers/android/readme.md`
- `wrappers/open3d/cpp/RealSenseBagReader.cpp`