### PR TITLE
rs-enum: use media-ctl for Tegra stream type identification

### DIFF
--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -131,16 +131,19 @@ get_video_devices_for_rs() {
   '
 }
 
-# Helper function: get ordered stream types for a camera from the media controller graph.
+# Helper function: get ordered stream types for cameras from the media controller graph.
 # Queries media-ctl --print-dot to find D4XX entity names (e.g. "D4XX depth", "D4XX rgb")
 # and their port connections to the DS5 mux, returning types in port order.
 # Entity names are set by the driver and unambiguously identify the stream type,
 # unlike pixel format heuristics which can be ambiguous (e.g. GREY is used by both IR and safety).
-# Input: I2C address (e.g. "30-001a")
-# Output: space-separated stream types in port order (e.g. "depth color ir imu")
+# Handles multi-cam on single deserializer: cameras share the same I2C bus but have
+# different device addresses (e.g. 9-001a and 9-002a). Returns types for ALL cameras
+# on the bus, sorted by I2C address.
+# Input: I2C address (e.g. "9-001a")
+# Output: space-separated stream types in port order (e.g. "depth color ir imu depth color ir imu")
 get_stream_types() {
   local i2c_addr="$1"
-  local -A port_to_type
+  local i2c_bus="${i2c_addr%%-*}"  # Extract bus number (e.g. "9" from "9-001a")
 
   if [ -z "${media_util}" ]; then
     echo "Error: media-ctl not found, install with: sudo apt install v4l-utils" >&2
@@ -160,28 +163,41 @@ get_stream_types() {
     return 1
   fi
 
-  # Find all D4XX entity lines for this I2C address and extract port connections
-  while IFS= read -r line; do
-    local entity_node=$(echo "${line}" | awk '{print $1}')
-    local type=$(echo "${line}" | grep -oP 'D4XX \K\w+')
-    [[ -z "${entity_node}" || -z "${type}" ]] && continue
+  # Find all unique I2C addresses with D4XX entities on this bus.
+  # Multi-cam on single deserializer: multiple addresses share the same bus (e.g. 9-001a, 9-002a)
+  local all_addrs=$(echo "${dot}" | grep -oP "D4XX \w+ \K${i2c_bus}-[0-9a-fA-F]+" | sort -u)
+  if [ -z "${all_addrs}" ]; then
+    echo "Error: No D4XX entities found on I2C bus ${i2c_bus}" >&2
+    return 1
+  fi
 
-    # Find the connection: <entity>:port0 -> <mux>:portN, extract target port number
-    local port=$(echo "${dot}" | grep -F "${entity_node}:port0 ->" | head -1 | grep -oP -- '-> \S+:port\K[0-9]+')
+  # For each camera (I2C address), extract stream types in port order
+  for addr in ${all_addrs}; do
+    unset port_to_type
+    declare -A port_to_type
 
-    if [[ -n "${port}" ]]; then
-      # Map entity type to link name (rgb -> color) using camera_names
-      if [[ -n "${camera_names[${type}]+_}" ]]; then
-        port_to_type[${port}]="${camera_names[${type}]}"
-      else
-        port_to_type[${port}]="${type}"
+    while IFS= read -r line; do
+      local entity_node=$(echo "${line}" | awk '{print $1}')
+      local type=$(echo "${line}" | grep -oP 'D4XX \K\w+')
+      [[ -z "${entity_node}" || -z "${type}" ]] && continue
+
+      # Find the connection: <entity>:port0 -> <mux>:portN, extract target port number
+      local port=$(echo "${dot}" | grep -F "${entity_node}:port0 ->" | head -1 | grep -oP -- '-> \S+:port\K[0-9]+')
+
+      if [[ -n "${port}" ]]; then
+        # Map entity type to link name (rgb -> color) using camera_names
+        if [[ -n "${camera_names[${type}]+_}" ]]; then
+          port_to_type[${port}]="${camera_names[${type}]}"
+        else
+          port_to_type[${port}]="${type}"
+        fi
       fi
-    fi
-  done < <(echo "${dot}" | grep "D4XX .* ${i2c_addr}")
+    done < <(echo "${dot}" | grep "D4XX .* ${addr}")
 
-  # Return types sorted by port number
-  for port in $(echo "${!port_to_type[@]}" | tr ' ' '\n' | sort -n); do
-    echo -n "${port_to_type[${port}]} "
+    # Append types sorted by port number
+    for port in $(echo "${!port_to_type[@]}" | tr ' ' '\n' | sort -n); do
+      echo -n "${port_to_type[${port}]} "
+    done
   done
 }
 

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -131,66 +131,43 @@ get_video_devices_for_rs() {
   '
 }
 
-# Helper function: identifies if a video device is depth/color/ir/imu using v4l-ctl
-# The decision tree is:
-# - If Bytes per line == 64 -> imu
-# - Otherwise:
-# -- If pixel format == Z16 -> depth
-# -- If pixel format == GREY/Y8I/Y12I/Y16I -> ir
-# -- Else -> color (This allows for RGB main format to change in the future with no impact)
-identify_dev_type() {
-  local DEVICE="$1"
-  OUTPUT=$(${v4l2_util} -d "$DEVICE" -V 2>/dev/null)
-
-  if [ $? -ne 0 ]; then
-    echo "Error: Failed to query device $DEVICE"
-    exit 1
-  fi
-
-  # Extract Bytes per Line
-  BYTES_PER_LINE=$(echo "$OUTPUT" | grep -oP 'Bytes per Line\s*:\s*\K[0-9]+')
-  # Check if IMU (Bytes per Line = 64)
-  if [ "$BYTES_PER_LINE" = "64" ]; then
-    echo "imu"
-    exit 0
-  fi
-
-  # Extract Pixel Format
-  PIXEL_FORMAT=$(echo "$OUTPUT" | grep -oP "Pixel Format\s*:\s*'\K[^']+")
-
-  # Check Pixel Format
-  if [[ "$PIXEL_FORMAT" == *"Z16"* ]]; then
-    echo "depth"
-  elif [[ "$PIXEL_FORMAT" == *"GREY"* || "$PIXEL_FORMAT" == *"Y8I "* || "$PIXEL_FORMAT" == *"Y12I"* || "$PIXEL_FORMAT" == *"Y16I"* ]]; then
-    echo "ir"
-  else
-    echo "color"
-  fi
-}
-
-# Helper function: discover stream types from media-ctl graph for a given I2C address
-# Parses the cached media-ctl --print-dot output to find D4XX entity names
+# Helper function: get ordered stream types for a camera from the media controller graph.
+# Queries media-ctl --print-dot to find D4XX entity names (e.g. "D4XX depth", "D4XX rgb")
 # and their port connections to the DS5 mux, returning types in port order.
-# This is more reliable than pixel format heuristics since entity names are
-# set by the driver and unambiguously identify the stream type.
-# Input: I2C address (e.g. "30-001a"), uses global tegra_dot
+# Entity names are set by the driver and unambiguously identify the stream type,
+# unlike pixel format heuristics which can be ambiguous (e.g. GREY is used by both IR and safety).
+# Input: I2C address (e.g. "30-001a")
 # Output: space-separated stream types in port order (e.g. "depth color ir imu")
-discover_stream_types() {
+get_stream_types() {
   local i2c_addr="$1"
   local -A port_to_type
 
-  # Find all D4XX entity lines for this I2C address
-  while IFS= read -r line; do
-    # Extract entity node ID (e.g. "n000000c7")
-    local entity_node=$(echo "${line}" | awk '{print $1}')
-    # Extract stream type from "D4XX <type> <i2c>"
-    local type=$(echo "${line}" | grep -oP 'D4XX \K\w+')
+  if [ -z "${media_util}" ]; then
+    echo "Error: media-ctl not found, install with: sudo apt install v4l-utils" >&2
+    return 1
+  fi
 
+  # Find the Tegra media device
+  local mdev=$(${v4l2_util} --list-devices | grep -A1 -i tegra | grep '/dev/media' | head -1 | tr -d '[:space:]')
+  if [ -z "${mdev}" ]; then
+    echo "Error: No Tegra media device found" >&2
+    return 1
+  fi
+
+  local dot=$(${media_util} -d ${mdev} --print-dot 2>/dev/null | grep -v dashed)
+  if [ -z "${dot}" ]; then
+    echo "Error: Failed to read media-ctl graph from ${mdev}" >&2
+    return 1
+  fi
+
+  # Find all D4XX entity lines for this I2C address and extract port connections
+  while IFS= read -r line; do
+    local entity_node=$(echo "${line}" | awk '{print $1}')
+    local type=$(echo "${line}" | grep -oP 'D4XX \K\w+')
     [[ -z "${entity_node}" || -z "${type}" ]] && continue
 
     # Find the connection: <entity>:port0 -> <mux>:portN, extract target port number
-    # Use head -1 to ensure a single match in case of duplicate edges
-    local port=$(echo "${tegra_dot}" | grep "${entity_node}:port0 ->" | head -1 | grep -oP '-> \S+:port\K[0-9]+')
+    local port=$(echo "${dot}" | grep "${entity_node}:port0 ->" | head -1 | grep -oP '-> \S+:port\K[0-9]+')
 
     if [[ -n "${port}" ]]; then
       # Map entity type to link name (rgb -> color) using camera_names
@@ -200,7 +177,7 @@ discover_stream_types() {
         port_to_type[${port}]="${type}"
       fi
     fi
-  done < <(echo "${tegra_dot}" | grep "D4XX .* ${i2c_addr}")
+  done < <(echo "${dot}" | grep "D4XX .* ${i2c_addr}")
 
   # Return types sorted by port number
   for port in $(echo "${!port_to_type[@]}" | tr ' ' '\n' | sort -n); do
@@ -259,10 +236,12 @@ create_video_link() {
 }
 
 # Helper function: process video devices for a RS camera
-# Processes all video devices for one RealSense camera, determining device types
-# Maps devices to sensors based on driver names (tegra-video=streaming, tegra-embedded=metadata)
-# When media-ctl data is available (tegra_dot), uses entity names for reliable type identification.
-# Falls back to pixel format heuristics (identify_dev_type) when media-ctl is unavailable.
+# Processes all video devices for one RealSense camera, determining device types.
+# Uses media-ctl entity names to identify stream types (depth/color/ir/imu) reliably.
+# Maps devices to sensors based on driver names (tegra-video=streaming, tegra-embedded=metadata).
+# On Tegra, the media graph doesn't expose per-stream video node mappings — individual
+# /dev/videoN nodes aren't linked to specific D4XX entities. The driver creates video nodes
+# in deterministic DS5 mux port order, so positional assignment by streaming node index works.
 # Expected device order: depth, depth-md, color, color-md, ir, ir-md, imu
 # Input: "$vid_devices" "$i2c_addr"
 process_rs_video_devices() {
@@ -273,20 +252,15 @@ process_rs_video_devices() {
   local vid_dev_arr=(${vid_devices})
   echo "DEBUG: Video device array: ${vid_dev_arr[*]}"
 
-  # Try media-ctl discovery for stream type ordering
-  local stream_types=()
-  local stream_type_idx=0
-  local use_media_ctl=0
-  if [[ -n "${tegra_dot}" && -n "${i2c_addr}" ]]; then
-    local types_str=$(discover_stream_types "${i2c_addr}")
-    if [[ -n "${types_str}" ]]; then
-      stream_types=(${types_str})
-      use_media_ctl=1
-      echo "DEBUG: Discovered stream types from media-ctl: ${stream_types[*]}"
-    else
-      echo "DEBUG: media-ctl discovery returned no types for ${i2c_addr}, falling back to pixel format"
-    fi
+  # Get ordered stream types from media-ctl for this camera
+  local types_str=$(get_stream_types "${i2c_addr}")
+  if [[ -z "${types_str}" ]]; then
+    echo "Error: Could not discover stream types for ${i2c_addr}"
+    return 1
   fi
+  local stream_types=(${types_str})
+  local stream_type_idx=0
+  echo "DEBUG: Stream types from media-ctl: ${stream_types[*]}"
 
   # Process each video device in the expected order
   local bus="mipi"
@@ -301,23 +275,13 @@ process_rs_video_devices() {
     echo "DEBUG: Video device ${vid} driver name: ${dev_name}"
     # Handle streaming devices
     if [ "${dev_name}" = "tegra-video" ]; then
-      # Use media-ctl discovered types when available, fall back to pixel format heuristics.
-      # On Tegra, the media graph doesn't expose per-stream video node mappings — individual
-      # /dev/videoN nodes aren't linked to specific D4XX entities in the graph. The driver
-      # creates video nodes in deterministic DS5 mux port order, so positional assignment
-      # (indexed only on streaming nodes, skipping metadata) is the correct approach.
-      if [[ ${use_media_ctl} -eq 1 && ${stream_type_idx} -lt ${#stream_types[@]} ]]; then
-        sensor_name="${stream_types[${stream_type_idx}]}"
-        stream_type_idx=$((stream_type_idx+1))
-        echo "DEBUG: Stream type from media-ctl: ${sensor_name}"
-      else
-        sensor_name=$(identify_dev_type $vid)
-        echo "DEBUG: Stream type from pixel format: ${sensor_name}"
-      fi
-      if [[ -z "$sensor_name" ]]; then
-        echo "DEBUG: Could not identify sensor type for ${vid}, skipping"
+      if [[ ${stream_type_idx} -ge ${#stream_types[@]} ]]; then
+        echo "DEBUG: More streaming nodes than expected stream types, skipping ${vid}"
         continue
       fi
+      sensor_name="${stream_types[${stream_type_idx}]}"
+      stream_type_idx=$((stream_type_idx+1))
+      echo "DEBUG: Stream type for ${vid}: ${sensor_name}"
       sensor_idx=$(get_dev_num $sensor_name)
       local dev_ln="/dev/video-rs-${sensor_name}-${sensor_idx}"
       create_video_link "$vid" "$dev_ln" "$bus" "$sensor_idx" "$sensor_name" "Streaming"
@@ -407,17 +371,6 @@ rs_devices=$(detect_rs_devices)
 # For Jetson we have `simple` method
 if [ -n "${rs_devices}" ]; then
   echo "DEBUG: Tegra RS devices detected"
-
-  # Cache media-ctl output for stream type discovery (if available)
-  tegra_dot=""
-  if [ -n "${media_util}" ]; then
-    tegra_mdev=$(${v4l2_util} --list-devices | grep -A1 -i tegra | grep '/dev/media' | head -1 | tr -d '[:space:]')
-    if [ -n "${tegra_mdev}" ]; then
-      tegra_dot=$(${media_util} -d ${tegra_mdev} --print-dot 2>/dev/null | grep -v dashed)
-      echo "DEBUG: Cached media-ctl output from ${tegra_mdev}"
-    fi
-  fi
-
   [[ $quiet -eq 0 ]] && printf "Bus\tCamera\tSensor\tNode Type\tVideo Node\tRS Link\n"
   
   # Parse each RS mux device

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -167,7 +167,7 @@ get_stream_types() {
     [[ -z "${entity_node}" || -z "${type}" ]] && continue
 
     # Find the connection: <entity>:port0 -> <mux>:portN, extract target port number
-    local port=$(echo "${dot}" | grep "${entity_node}:port0 ->" | head -1 | grep -oP '-> \S+:port\K[0-9]+')
+    local port=$(echo "${dot}" | grep -F "${entity_node}:port0 ->" | head -1 | grep -oP -- '-> \S+:port\K[0-9]+')
 
     if [[ -n "${port}" ]]; then
       # Map entity type to link name (rgb -> color) using camera_names

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -141,10 +141,11 @@ get_video_devices_for_rs() {
 # different device addresses (e.g. 9-001a and 9-002a). Returns types for ALL cameras
 # on the bus, sorted by I2C address.
 # Input: I2C address (e.g. "9-001a")
-# Output: space-separated stream types in port order (e.g. "depth color ir imu depth color ir imu")
+# Sets global: stream_types_result (space-separated types), camera_i2c_addrs (appended)
 get_stream_types() {
   local i2c_addr="$1"
   local i2c_bus="${i2c_addr%%-*}"  # Extract bus number (e.g. "9" from "9-001a")
+  stream_types_result=""
 
   if [ -z "${media_util}" ]; then
     echo "Error: media-ctl not found, install with: sudo apt install v4l-utils" >&2
@@ -200,7 +201,7 @@ get_stream_types() {
 
     # Append types sorted by port number
     for port in $(echo "${!port_to_type[@]}" | tr ' ' '\n' | sort -n); do
-      echo -n "${port_to_type[${port}]} "
+      stream_types_result+="${port_to_type[${port}]} "
     done
   done
 }
@@ -273,12 +274,13 @@ process_rs_video_devices() {
   echo "DEBUG: Video device array: ${vid_dev_arr[*]}"
 
   # Get ordered stream types from media-ctl for this camera
-  local types_str=$(get_stream_types "${i2c_addr}")
-  if [[ -z "${types_str}" ]]; then
+  # Called directly (not in subshell) so global camera_i2c_addrs is populated for DFU matching
+  get_stream_types "${i2c_addr}"
+  if [[ -z "${stream_types_result}" ]]; then
     echo "Error: Could not discover stream types for ${i2c_addr}"
     return 1
   fi
-  local stream_types=(${types_str})
+  local stream_types=(${stream_types_result})
   local stream_type_idx=0
   echo "DEBUG: Stream types from media-ctl: ${stream_types[*]}"
 

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -189,7 +189,8 @@ discover_stream_types() {
     [[ -z "${entity_node}" || -z "${type}" ]] && continue
 
     # Find the connection: <entity>:port0 -> <mux>:portN, extract target port number
-    local port=$(echo "${tegra_dot}" | grep "${entity_node}:port0 ->" | grep -oP '-> \S+:port\K[0-9]+')
+    # Use head -1 to ensure a single match in case of duplicate edges
+    local port=$(echo "${tegra_dot}" | grep "${entity_node}:port0 ->" | head -1 | grep -oP '-> \S+:port\K[0-9]+')
 
     if [[ -n "${port}" ]]; then
       # Map entity type to link name (rgb -> color) using camera_names
@@ -300,7 +301,11 @@ process_rs_video_devices() {
     echo "DEBUG: Video device ${vid} driver name: ${dev_name}"
     # Handle streaming devices
     if [ "${dev_name}" = "tegra-video" ]; then
-      # Use media-ctl discovered types when available, fall back to pixel format heuristics
+      # Use media-ctl discovered types when available, fall back to pixel format heuristics.
+      # On Tegra, the media graph doesn't expose per-stream video node mappings — individual
+      # /dev/videoN nodes aren't linked to specific D4XX entities in the graph. The driver
+      # creates video nodes in deterministic DS5 mux port order, so positional assignment
+      # (indexed only on streaming nodes, skipping metadata) is the correct approach.
       if [[ ${use_media_ctl} -eq 1 && ${stream_type_idx} -lt ${#stream_types[@]} ]]; then
         sensor_name="${stream_types[${stream_type_idx}]}"
         stream_type_idx=$((stream_type_idx+1))

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -90,6 +90,7 @@ depth_dev_counter=0
 color_dev_counter=0
 ir_dev_counter=0
 imu_dev_counter=0
+camera_i2c_addrs=()  # Track camera I2C addresses in discovery order for DFU matching
 
 # Helper function: detect RS devices
 # Searches v4l2-ctl output for RealSense DS5 mux devices on Tegra platforms
@@ -170,6 +171,9 @@ get_stream_types() {
     echo "Error: No D4XX entities found on I2C bus ${i2c_bus}" >&2
     return 1
   fi
+
+  # Record I2C addresses in order for DFU device matching
+  camera_i2c_addrs+=(${all_addrs})
 
   # For each camera (I2C address), extract stream types in port order
   for addr in ${all_addrs}; do
@@ -317,36 +321,32 @@ process_rs_video_devices() {
 }
 
 # Helper function: create DFU device link
-# Creates symbolic link for firmware update (DFU) device based on camera index
-# Maps d4xx class devices to standardized names for firmware operations
-# Input example: create_dfu_link "0"
-# Creates: /dev/d4xx-dfu-0 -> /dev/d4xx-dfu-a (if d4xx-dfu-a exists)
+# Creates symbolic link for firmware update (DFU) device based on camera I2C address
+# Matches the DFU device by I2C address to ensure correct camera-to-DFU mapping
+# Input: cam_id (e.g. "0"), i2c_addr (e.g. "9-001a")
+# Creates: /dev/d4xx-dfu-0 -> /dev/d4xx-dfu-9-001a
 create_dfu_link() {
   local cam_id="$1"
-  
-  echo "DEBUG: Looking for DFU device for camera ${cam_id}"
-  
-  # Look for d4xx class devices that might match
-  local dfu_candidates=$(ls -1 /sys/class/d4xx-class/ 2>/dev/null || true)
-  echo "DEBUG: DFU candidates: ${dfu_candidates}"
-  
-  if [[ -n "${dfu_candidates}" ]]; then
-    # For now, map cameras by order found
-    local dfu_array=(${dfu_candidates})
-    if [[ ${cam_id} -lt ${#dfu_array[@]} ]]; then
-      local i2cdev="${dfu_array[${cam_id}]}"
-      local dev_dfu_name="/dev/${i2cdev}"
-      local dev_dfu_ln="/dev/d4xx-dfu-${cam_id}"
-      
-      echo "DEBUG: Creating DFU link: ${dev_dfu_name} -> ${dev_dfu_ln}"
-      
-      if [[ $info -eq 0 ]]; then
-        [[ -e $dev_dfu_ln ]] && unlink $dev_dfu_ln
-        ln -s $dev_dfu_name $dev_dfu_ln
-      fi
-      [[ $quiet -eq 0 ]] && printf '%s\t%d\t%s\tFirmware \t%s\t%s\n' " i2c " ${cam_id} "d4xx   " $dev_dfu_name $dev_dfu_ln
-    fi
+  local i2c_addr="$2"
+
+  local dfu_dev="d4xx-dfu-${i2c_addr}"
+  local dev_dfu_name="/dev/${dfu_dev}"
+  local dev_dfu_ln="/dev/d4xx-dfu-${cam_id}"
+
+  echo "DEBUG: Looking for DFU device for camera ${cam_id} (${i2c_addr})"
+
+  if [[ ! -e "/sys/class/d4xx-class/${dfu_dev}" ]]; then
+    echo "DEBUG: DFU device ${dfu_dev} not found for camera ${cam_id}"
+    return
   fi
+
+  echo "DEBUG: Creating DFU link: ${dev_dfu_name} -> ${dev_dfu_ln}"
+
+  if [[ $info -eq 0 ]]; then
+    [[ -e $dev_dfu_ln ]] && unlink $dev_dfu_ln
+    ln -s $dev_dfu_name $dev_dfu_ln
+  fi
+  [[ $quiet -eq 0 ]] && printf '%s\t%d\t%s\tFirmware \t%s\t%s\n' " i2c " ${cam_id} "d4xx   " $dev_dfu_name $dev_dfu_ln
 }
 
 # Helper function: process a single RS device
@@ -398,9 +398,11 @@ if [ -n "${rs_devices}" ]; then
     process_single_rs_device "$rs_line"
   done <<< "${rs_devices}"
 
-  # Create DFU device links for all detected cameras
+  # Create DFU device links for all detected cameras, matched by I2C address
   for ((i=0; i<${depth_dev_counter}; i++)); do
-    create_dfu_link "$i"
+    if [[ ${i} -lt ${#camera_i2c_addrs[@]} ]]; then
+      create_dfu_link "$i" "${camera_i2c_addrs[$i]}"
+    fi
   done
 
   echo "DEBUG: Processed ${depth_dev_counter} Tegra cameras"

--- a/scripts/rs-enum.sh
+++ b/scripts/rs-enum.sh
@@ -168,6 +168,45 @@ identify_dev_type() {
   fi
 }
 
+# Helper function: discover stream types from media-ctl graph for a given I2C address
+# Parses the cached media-ctl --print-dot output to find D4XX entity names
+# and their port connections to the DS5 mux, returning types in port order.
+# This is more reliable than pixel format heuristics since entity names are
+# set by the driver and unambiguously identify the stream type.
+# Input: I2C address (e.g. "30-001a"), uses global tegra_dot
+# Output: space-separated stream types in port order (e.g. "depth color ir imu")
+discover_stream_types() {
+  local i2c_addr="$1"
+  local -A port_to_type
+
+  # Find all D4XX entity lines for this I2C address
+  while IFS= read -r line; do
+    # Extract entity node ID (e.g. "n000000c7")
+    local entity_node=$(echo "${line}" | awk '{print $1}')
+    # Extract stream type from "D4XX <type> <i2c>"
+    local type=$(echo "${line}" | grep -oP 'D4XX \K\w+')
+
+    [[ -z "${entity_node}" || -z "${type}" ]] && continue
+
+    # Find the connection: <entity>:port0 -> <mux>:portN, extract target port number
+    local port=$(echo "${tegra_dot}" | grep "${entity_node}:port0 ->" | grep -oP '-> \S+:port\K[0-9]+')
+
+    if [[ -n "${port}" ]]; then
+      # Map entity type to link name (rgb -> color) using camera_names
+      if [[ -n "${camera_names[${type}]+_}" ]]; then
+        port_to_type[${port}]="${camera_names[${type}]}"
+      else
+        port_to_type[${port}]="${type}"
+      fi
+    fi
+  done < <(echo "${tegra_dot}" | grep "D4XX .* ${i2c_addr}")
+
+  # Return types sorted by port number
+  for port in $(echo "${!port_to_type[@]}" | tr ' ' '\n' | sort -n); do
+    echo -n "${port_to_type[${port}]} "
+  done
+}
+
 # Helper function: get the number of devices of specific type identified
 get_dev_num() {
   local DEVICE="$1"
@@ -221,15 +260,33 @@ create_video_link() {
 # Helper function: process video devices for a RS camera
 # Processes all video devices for one RealSense camera, determining device types
 # Maps devices to sensors based on driver names (tegra-video=streaming, tegra-embedded=metadata)
+# When media-ctl data is available (tegra_dot), uses entity names for reliable type identification.
+# Falls back to pixel format heuristics (identify_dev_type) when media-ctl is unavailable.
 # Expected device order: depth, depth-md, color, color-md, ir, ir-md, imu
-# Input example: "/dev/video0 /dev/video1 /dev/video2"
+# Input: "$vid_devices" "$i2c_addr"
 process_rs_video_devices() {
   local vid_devices="$1"
-  
+  local i2c_addr="$2"
+
   # Convert video devices to array
   local vid_dev_arr=(${vid_devices})
   echo "DEBUG: Video device array: ${vid_dev_arr[*]}"
-  
+
+  # Try media-ctl discovery for stream type ordering
+  local stream_types=()
+  local stream_type_idx=0
+  local use_media_ctl=0
+  if [[ -n "${tegra_dot}" && -n "${i2c_addr}" ]]; then
+    local types_str=$(discover_stream_types "${i2c_addr}")
+    if [[ -n "${types_str}" ]]; then
+      stream_types=(${types_str})
+      use_media_ctl=1
+      echo "DEBUG: Discovered stream types from media-ctl: ${stream_types[*]}"
+    else
+      echo "DEBUG: media-ctl discovery returned no types for ${i2c_addr}, falling back to pixel format"
+    fi
+  fi
+
   # Process each video device in the expected order
   local bus="mipi"
   local sensor_name=""
@@ -237,13 +294,21 @@ process_rs_video_devices() {
 
   for vid in "${vid_dev_arr[@]}"; do
     [[ ! -c "${vid}" ]] && echo "DEBUG: Video device ${vid} not found, skipping" && continue
-    
+
     # Check if this is a valid tegra video device
     local dev_name=$(${v4l2_util} -d ${vid} -D 2>/dev/null | grep 'Driver name' | head -n1 | awk -F' : ' '{print $2}')
     echo "DEBUG: Video device ${vid} driver name: ${dev_name}"
     # Handle streaming devices
     if [ "${dev_name}" = "tegra-video" ]; then
-      sensor_name=$(identify_dev_type $vid)
+      # Use media-ctl discovered types when available, fall back to pixel format heuristics
+      if [[ ${use_media_ctl} -eq 1 && ${stream_type_idx} -lt ${#stream_types[@]} ]]; then
+        sensor_name="${stream_types[${stream_type_idx}]}"
+        stream_type_idx=$((stream_type_idx+1))
+        echo "DEBUG: Stream type from media-ctl: ${sensor_name}"
+      else
+        sensor_name=$(identify_dev_type $vid)
+        echo "DEBUG: Stream type from pixel format: ${sensor_name}"
+      fi
       if [[ -z "$sensor_name" ]]; then
         echo "DEBUG: Could not identify sensor type for ${vid}, skipping"
         continue
@@ -252,7 +317,7 @@ process_rs_video_devices() {
       local dev_ln="/dev/video-rs-${sensor_name}-${sensor_idx}"
       create_video_link "$vid" "$dev_ln" "$bus" "$sensor_idx" "$sensor_name" "Streaming"
       increment_dev_num $sensor_name
-    # Handle metadata devices  
+    # Handle metadata devices
     elif [ "${dev_name}" = "tegra-embedded" ]; then
       if [[ -z "$sensor_name" ]]; then
         echo "DEBUG: Could not identify sensor type for ${vid}, skipping"
@@ -328,7 +393,7 @@ process_single_rs_device() {
   fi
   
   # Process video devices
-  process_rs_video_devices "$vid_devices"
+  process_rs_video_devices "$vid_devices" "$i2c_addr"
 }
 
 # Check for Tegra devices by looking for RS mux in v4l2-ctl output
@@ -337,6 +402,17 @@ rs_devices=$(detect_rs_devices)
 # For Jetson we have `simple` method
 if [ -n "${rs_devices}" ]; then
   echo "DEBUG: Tegra RS devices detected"
+
+  # Cache media-ctl output for stream type discovery (if available)
+  tegra_dot=""
+  if [ -n "${media_util}" ]; then
+    tegra_mdev=$(${v4l2_util} --list-devices | grep -A1 -i tegra | grep '/dev/media' | head -1 | tr -d '[:space:]')
+    if [ -n "${tegra_mdev}" ]; then
+      tegra_dot=$(${media_util} -d ${tegra_mdev} --print-dot 2>/dev/null | grep -v dashed)
+      echo "DEBUG: Cached media-ctl output from ${tegra_mdev}"
+    fi
+  fi
+
   [[ $quiet -eq 0 ]] && printf "Bus\tCamera\tSensor\tNode Type\tVideo Node\tRS Link\n"
   
   # Parse each RS mux device


### PR DESCRIPTION
## Summary

Replace pixel format heuristics with media-ctl entity name discovery for identifying stream types on Tegra/Jetson.

### Problem
The previous approach identified streams by pixel format (Z16=depth, GREY=ir, etc.). This is fragile:
- D585S safety stream uses GREY format → misidentified as IR
- Some IR streams produce color formats → misidentified as color
- Every new format requires script changes

### Solution
Parse D4XX entity names from the media controller graph (`media-ctl --print-dot`). The driver registers entities like `D4XX depth`, `D4XX rgb`, `D4XX ir`, `D4XX imu` which unambiguously identify the stream type.

### Changes
- **`get_stream_types()`** — new function replacing `identify_dev_type()`. Queries media-ctl for D4XX entity names and their DS5 mux port connections. Returns stream types in port order. Handles multi-cam on single deserializer by discovering all I2C addresses on the same bus.
- **`process_rs_video_devices()`** — uses `get_stream_types()` for positional stream type assignment (streaming nodes only, skipping metadata). On Tegra, individual `/dev/videoN` nodes aren't linked to specific D4XX entities in the media graph — the driver creates them in deterministic DS5 mux port order.
- **`create_dfu_link()`** — fixed DFU device matching by I2C address instead of alphabetical `ls` order, which could swap DFU assignments when bus numbers don't sort lexically (e.g. bus 10 before bus 9).
- IPU6 path is untouched.

### Adding new stream types (e.g. safety)
When the driver registers a new entity (e.g. `D4XX safety`), support requires:
1. **`scripts/rs-enum.sh`**: Add the mapping to `camera_names` (e.g. `[safety]=safety`), add a counter (`safety_dev_counter`), and update `get_dev_num()`/`increment_dev_num()`. The media-ctl discovery picks up the new entity automatically.
2. **`src/linux/backend-v4l2.cpp`**: Add `"safety"` to the `video_sensors` vector in `get_mipi_rs_enum_nodes()` (line 1282) and set the appropriate `info.mi` value.

## Test plan
- [x] Single cam, single deserializer (D457 on Intel Des)
- [x] Multi-cam, single deserializer (2× D457 on FangZhu)
- [x] Multi-cam, multi deserializer (2× D457 on separate FangZhu deserializers)
- [x] DFU links correctly matched by I2C address
- [ ] Verify no regression on IPU6 platform (code path untouched)

### Test results

D457 on single Intel Des
<img width="373" height="85" alt="image" src="https://github.com/user-attachments/assets/76099a1c-9216-49c5-91fa-2f8cd09146ea" />

FangZhu with 2 cam on 1 des
● Both cameras enumerated correctly:
  - Camera 0 (9-001a): depth, color, ir, imu + metadata + DFU
  - Camera 1 (9-002a): depth, color, ir, imu + metadata + DFU

<img width="557" height="246" alt="image" src="https://github.com/user-attachments/assets/684b79a2-5872-49a0-9b59-092129ed3b3b" />

FungZhu 2 cam each on a different des
<img width="343" height="158" alt="image" src="https://github.com/user-attachments/assets/43a3ce91-64d7-4f9e-ba7c-59f9fb4f47db" />