### PR TITLE
Save IQ failure snapshots to test log directory

### DIFF
--- a/unit-tests/live/image-quality/iq_helper.py
+++ b/unit-tests/live/image-quality/iq_helper.py
@@ -159,6 +159,9 @@ def save_failure_snapshot( test_file, pipeline, annotated_image=None ):
         filename = f"{name}_{dev_name}.png"
     except:
         filename = f"{name}.png"
+    logdir = os.path.join( os.path.dirname( rs.__file__ ), 'unit-tests' )
+    if os.path.isdir( logdir ):
+        filename = os.path.join( logdir, filename )
     cv2.imwrite( filename, image )
     log.i( f"Saved failure snapshot: {filename}" )
     _snapshot_saved = True


### PR DESCRIPTION
Comes with https://github.com/RealSenseAI-Internal/librealsense-deploy/pull/84

Passing build: [LRS_libci_pipeline #14969](https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/14969/)

Image-quality tests' `save_failure_snapshot` now saves PNGs next to the test log directory (`os.path.dirname(rs.__file__)/unit-tests/`) instead of the workspace root. This lets the Jenkins pipeline archive them with a flat glob, avoiding a 5-second Ant scanner timeout that produced long stack traces in the build log.