### PR TITLE
Implement GLSL rendering for M420 and NV12

### DIFF
--- a/common/rendering.h
+++ b/common/rendering.h
@@ -563,6 +563,46 @@ namespace rs2
                         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height, 0, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, data);
                     }
                     break;
+                case RS2_FORMAT_M420:
+                    if (m420_to_rgb)
+                    {
+                        if (auto colorized_frame = m420_to_rgb->process(frame).as<video_frame>())
+                        {
+                            if (!colorized_frame.is<gl::gpu_frame>())
+                            {
+                                glBindTexture(GL_TEXTURE_2D, texture);
+                                data = colorized_frame.get_data();
+
+                                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB,
+                                    colorized_frame.get_width(),
+                                    colorized_frame.get_height(),
+                                    0, GL_RGB, GL_UNSIGNED_BYTE,
+                                    colorized_frame.get_data());
+                            }
+                            rendered_frame = colorized_frame;
+                        }
+                    }
+                    break;
+                case RS2_FORMAT_NV12:
+                    if (nv12_to_rgb)
+                    {
+                        if (auto colorized_frame = nv12_to_rgb->process(frame).as<video_frame>())
+                        {
+                            if (!colorized_frame.is<gl::gpu_frame>())
+                            {
+                                glBindTexture(GL_TEXTURE_2D, texture);
+                                data = colorized_frame.get_data();
+
+                                glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB,
+                                    colorized_frame.get_width(),
+                                    colorized_frame.get_height(),
+                                    0, GL_RGB, GL_UNSIGNED_BYTE,
+                                    colorized_frame.get_data());
+                            }
+                            rendered_frame = colorized_frame;
+                        }
+                    }
+                    break;
                 case RS2_FORMAT_Y411:
                     if (y411)
                     {

--- a/common/subdevice-model.cpp
+++ b/common/subdevice-model.cpp
@@ -73,7 +73,7 @@ namespace rs2
         depth_colorizer(std::make_shared<rs2::gl::colorizer>()),
         yuy2rgb(std::make_shared<rs2::gl::yuy_decoder>()),
         m420_to_rgb(std::make_shared<rs2::gl::m420_decoder>()),
-        nv12_to_rgb(std::make_shared<rs2::nv12_decoder>()),
+        nv12_to_rgb(std::make_shared<rs2::gl::nv12_decoder>()),
         y411(std::make_shared<rs2::gl::y411_decoder>()),
         viewer(viewer),
         detected_objects(device_detected_objects),

--- a/common/viewer.cpp
+++ b/common/viewer.cpp
@@ -1776,7 +1776,7 @@ namespace rs2
             stream_mv.show_stream_footer(font1, stream_rect, mouse, streams, *this);
 
 
-            if (val_in_range(stream_mv.profile.format(), { RS2_FORMAT_RAW10 , RS2_FORMAT_RAW16, RS2_FORMAT_MJPEG, RS2_FORMAT_M420, RS2_FORMAT_NV12 }))
+            if (val_in_range(stream_mv.profile.format(), { RS2_FORMAT_RAW10 , RS2_FORMAT_RAW16, RS2_FORMAT_MJPEG }))
             {
                 show_rendering_not_supported(font2, static_cast<int>(stream_rect.x), static_cast<int>(stream_rect.y), static_cast<int>(stream_rect.w),
                     static_cast<int>(stream_rect.h), stream_mv.profile.format());

--- a/include/librealsense2-gl/rs_processing_gl.h
+++ b/include/librealsense2-gl/rs_processing_gl.h
@@ -85,6 +85,14 @@ rs2_processing_block* rs2_gl_create_m420_decoder(int api_version, rs2_error** er
 
 
 /**
+* Creates a processing block that can efficiently convert NV12 image format to RGB variants
+* This is specifically useful for rendering the RGB frame to the screen (since the output is ready for rendering on the GPU)
+* \param[in] api_version Users are expected to pass their version of \c RS2_API_VERSION to make sure they are running the correct librealsense version.
+* \param[out] error  if non-null, receives any error that occurs during this call, otherwise, errors are ignored
+*/
+rs2_processing_block* rs2_gl_create_nv12_decoder(int api_version, rs2_error** error);
+
+/**
 * Creates y411 decoder processing block. This block accepts raw y411 frames and outputs frames in RGB8.
 *     https://www.fourcc.org/pixel-format/yuv-y411/
 * Y411 is disguised as NV12 to allow Linux compatibility. Both are 12bpp encodings that allow high-resolution

--- a/include/librealsense2-gl/rs_processing_gl.hpp
+++ b/include/librealsense2-gl/rs_processing_gl.hpp
@@ -164,6 +164,28 @@ namespace rs2
         };
 
         /**
+        * nv12_decoder can be used for NV12->RGB conversion
+        * Similar in functionality to rs2::nv12_decoder but performed on the GPU
+        */
+        class nv12_decoder : public rs2::nv12_decoder
+        {
+        public:
+            nv12_decoder() : rs2::nv12_decoder(init()) { }
+
+        private:
+            std::shared_ptr<rs2_processing_block> init()
+            {
+                rs2_error* e = nullptr;
+                auto block = std::shared_ptr<rs2_processing_block>(
+                    rs2_gl_create_nv12_decoder(RS2_API_VERSION, &e),
+                    rs2_delete_processing_block);
+                error::handle(e);
+
+                return block;
+            }
+        };
+
+        /**
          * Similar in functionality (Y411->RGB8 conversion) to rs2::y411_decoder but performed on the GPU.
          */
         class y411_decoder : public rs2::y411_decoder

--- a/src/gl/CMakeLists.txt
+++ b/src/gl/CMakeLists.txt
@@ -12,6 +12,8 @@ set(REALSENSE_GL_CPP
     yuy2rgb-gl.cpp
     m420-to-rgb-gl.h
     m420-to-rgb-gl.cpp
+    nv12-to-rgb-gl.h
+    nv12-to-rgb-gl.cpp
     y4112rgb-gl.h
     y4112rgb-gl.cpp
     pointcloud-gl.h

--- a/src/gl/m420-to-rgb-gl.cpp
+++ b/src/gl/m420-to-rgb-gl.cpp
@@ -146,7 +146,7 @@ rs2::frame m420_to_rgb::process_frame(const rs2::frame_source& src, const rs2::f
 
         auto gf = dynamic_cast<gpu_addon_interface*>((frame_interface*)res.get());
         if (!gf)
-            throw invalid_value_exception("null pointer recieved from dynamic pointer casting.");
+            throw invalid_value_exception("dynamic_cast to gpu_addon_interface returned null.");
 
         // M420 is 12bpp: upload as single-channel R8 texture, width x (height * 3/2)
         int tex_h = _height * 3 / 2;

--- a/src/gl/nv12-to-rgb-gl.cpp
+++ b/src/gl/nv12-to-rgb-gl.cpp
@@ -1,12 +1,12 @@
 // License: Apache 2.0. See LICENSE file in root directory.
-// Copyright(c) 2022 RealSense, Inc. All Rights Reserved.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
 
 #include <librealsense2/hpp/rs_sensor.hpp>
 #include <librealsense2/hpp/rs_processing.hpp>
 #include <librealsense2-gl/rs_processing_gl.hpp>
 
 #include "../proc/synthetic-stream.h"
-#include "m420-to-rgb-gl.h"
+#include "nv12-to-rgb-gl.h"
 #include "../option.h"
 
 #ifndef NOMINMAX
@@ -21,11 +21,9 @@
 
 #include "synthetic-stream-gl.h"
 
-// M420 layout (uploaded as GL_R8, width x tex_height where tex_height = height * 1.5):
-//   For every pair of output rows, 3 texture rows:
-//     row group*3+0 : Y for first row  (width bytes)
-//     row group*3+1 : Y for second row (width bytes)
-//     row group*3+2 : interleaved UV   (U0 V0 U1 V1 ... width bytes)
+// NV12 layout (uploaded as GL_R8, width x tex_height where tex_height = height * 1.5):
+//   rows 0..height-1            : Y plane (one Y per pixel, full resolution)
+//   rows height..height*1.5-1   : interleaved UV plane (U0 V0 U1 V1 ... half vertical resolution)
 //   Each UV pair covers a 2x2 block of Y pixels.
 static const char* fragment_shader_text =
 "#version 110\n"
@@ -37,10 +35,8 @@ static const char* fragment_shader_text =
 "    float tex_h = height * 1.5;\n"
 "    float px = floor(gl_FragCoord.x);\n"
 "    float py = floor(gl_FragCoord.y);\n"
-"    float group = floor(py / 2.0);\n"
-"    float row_in_group = py - group * 2.0;\n"
-"    float y_row = group * 3.0 + row_in_group;\n"
-"    float uv_row = group * 3.0 + 2.0;\n"
+"    float y_row = py;\n"
+"    float uv_row = height + floor(py / 2.0);\n"
 "    float y = texture2D(textureSampler, vec2((px + 0.5) / width, (y_row + 0.5) / tex_h)).r;\n"
 "    float u_col = floor(px / 2.0) * 2.0;\n"
 "    float v_col = u_col + 1.0;\n"
@@ -56,12 +52,12 @@ static const char* fragment_shader_text =
 using namespace rs2;
 using namespace librealsense::gl;
 
-class m420_to_rgb_shader : public texture_2d_shader
+class nv12_to_rgb_shader : public texture_2d_shader
 {
 public:
-    m420_to_rgb_shader()
+    nv12_to_rgb_shader()
         : texture_2d_shader(shader_program::load(
-            texture_2d_shader::default_vertex_shader(), 
+            texture_2d_shader::default_vertex_shader(),
             fragment_shader_text, "position", "textureCoords"))
     {
         _width_location = _shader->get_uniform_location("width");
@@ -79,33 +75,33 @@ private:
     uint32_t _height_location;
 };
 
-void m420_to_rgb::cleanup_gpu_resources()
+void nv12_to_rgb::cleanup_gpu_resources()
 {
     _viz.reset();
     _fbo.reset();
     _enabled = 0;
 }
 
-void m420_to_rgb::create_gpu_resources()
+void nv12_to_rgb::create_gpu_resources()
 {
-    _viz = std::make_shared<visualizer_2d>(std::make_shared<m420_to_rgb_shader>());
+    _viz = std::make_shared<visualizer_2d>(std::make_shared<nv12_to_rgb_shader>());
     _fbo = std::make_shared<fbo>(_width, _height);
     _enabled = glsl_enabled() ? 1 : 0;
 }
 
-m420_to_rgb::m420_to_rgb()
-    : stream_filter_processing_block("M420 Converter (GLSL)")
+nv12_to_rgb::nv12_to_rgb()
+    : stream_filter_processing_block("NV12 Converter (GLSL)")
 {
     _source.add_extension<gpu_video_frame>(RS2_EXTENSION_VIDEO_FRAME_GL);
 
     auto opt = std::make_shared<librealsense::ptr_option<int>>(
-        0, 1, 0, 1, &_enabled, "GLSL enabled"); 
+        0, 1, 0, 1, &_enabled, "GLSL enabled");
     register_option(RS2_OPTION_COUNT, opt);
 
     initialize();
 }
 
-m420_to_rgb::~m420_to_rgb()
+nv12_to_rgb::~nv12_to_rgb()
 {
     try {
         perform_gl_action([&]()
@@ -118,7 +114,7 @@ m420_to_rgb::~m420_to_rgb()
     }
 }
 
-rs2::frame m420_to_rgb::process_frame(const rs2::frame_source& src, const rs2::frame& f)
+rs2::frame nv12_to_rgb::process_frame(const rs2::frame_source& src, const rs2::frame& f)
 {
     if (f.get_profile().get() != _input_profile.get())
     {
@@ -148,7 +144,7 @@ rs2::frame m420_to_rgb::process_frame(const rs2::frame_source& src, const rs2::f
         if (!gf)
             throw invalid_value_exception("null pointer recieved from dynamic pointer casting.");
 
-        // M420 is 12bpp: upload as single-channel R8 texture, width x (height * 3/2)
+        // NV12 is 12bpp: upload as single-channel R8 texture, width x (height * 3/2)
         int tex_h = _height * 3 / 2;
         uint32_t input_texture;
 
@@ -184,11 +180,11 @@ rs2::frame m420_to_rgb::process_frame(const rs2::frame_source& src, const rs2::f
         glClearColor(1, 0, 0, 1);
         glClear(GL_COLOR_BUFFER_BIT);
 
-        auto& shader = (m420_to_rgb_shader&)_viz->get_shader();
+        auto& shader = (nv12_to_rgb_shader&)_viz->get_shader();
         shader.begin();
         shader.set_size(_width, _height);
         shader.end();
-        
+
         _viz->draw_texture(input_texture);
 
         _fbo->unbind();
@@ -199,10 +195,10 @@ rs2::frame m420_to_rgb::process_frame(const rs2::frame_source& src, const rs2::f
         {
             glDeleteTextures(1, &input_texture);
         }
-    }, 
+    },
     [this]{
         _enabled = false;
-    }); 
+    });
 
     return res;
 }

--- a/src/gl/nv12-to-rgb-gl.cpp
+++ b/src/gl/nv12-to-rgb-gl.cpp
@@ -142,7 +142,7 @@ rs2::frame nv12_to_rgb::process_frame(const rs2::frame_source& src, const rs2::f
 
         auto gf = dynamic_cast<gpu_addon_interface*>((frame_interface*)res.get());
         if (!gf)
-            throw invalid_value_exception("null pointer recieved from dynamic pointer casting.");
+            throw invalid_value_exception("dynamic_cast to gpu_addon_interface returned null.");
 
         // NV12 is 12bpp: upload as single-channel R8 texture, width x (height * 3/2)
         int tex_h = _height * 3 / 2;

--- a/src/gl/nv12-to-rgb-gl.h
+++ b/src/gl/nv12-to-rgb-gl.h
@@ -1,0 +1,48 @@
+// License: Apache 2.0. See LICENSE file in root directory.
+// Copyright(c) 2026 RealSense, Inc. All Rights Reserved.
+
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include "../proc/synthetic-stream.h"
+#include "synthetic-stream-gl.h"
+
+#include <librealsense2/rs.hpp>
+#include "opengl3.h"
+
+#include <memory>
+
+namespace rs2
+{
+    class stream_profile;
+    class visualizer_2d;
+}
+
+namespace librealsense
+{
+    namespace gl
+    {
+        class nv12_to_rgb : public stream_filter_processing_block, public gpu_processing_object
+        {
+        public:
+            nv12_to_rgb();
+            ~nv12_to_rgb() override;
+
+            void cleanup_gpu_resources() override;
+            void create_gpu_resources() override;
+
+            rs2::frame process_frame(const rs2::frame_source& source, const rs2::frame& f) override;
+        private:
+            int _enabled = 0;
+            rs2::stream_profile _input_profile;
+            rs2::stream_profile _output_profile;
+
+            int _width, _height;
+
+            std::shared_ptr<rs2::visualizer_2d> _viz;
+            std::shared_ptr<rs2::fbo> _fbo;
+        };
+    }
+}

--- a/src/gl/realsense-gl.def
+++ b/src/gl/realsense-gl.def
@@ -7,6 +7,7 @@ EXPORTS
     rs2_gl_create_camera_renderer
     rs2_gl_create_yuy_decoder
     rs2_gl_create_m420_decoder
+    rs2_gl_create_nv12_decoder
     rs2_gl_create_y411_decoder
     rs2_gl_create_uploader
     rs2_gl_create_colorizer

--- a/src/gl/rs-gl.cpp
+++ b/src/gl/rs-gl.cpp
@@ -5,6 +5,7 @@
 #include "synthetic-stream-gl.h"
 #include "yuy2rgb-gl.h"
 #include "m420-to-rgb-gl.h"
+#include "nv12-to-rgb-gl.h"
 #include "y4112rgb-gl.h"
 #include "align-gl.h"
 #include "pointcloud-gl.h"
@@ -88,6 +89,19 @@ rs2_processing_block* rs2_gl_create_m420_decoder(int api_version, rs2_error** er
 
     auto block = std::make_shared<librealsense::gl::m420_to_rgb>();
     auto backup = std::make_shared<librealsense::m420_converter>(RS2_FORMAT_RGB8);
+    auto dual = std::make_shared<librealsense::gl::dual_processing_block>();
+    dual->add(block);
+    dual->add(backup);
+    return new rs2_processing_block{ dual };
+}
+NOARGS_HANDLE_EXCEPTIONS_AND_RETURN(nullptr)
+
+rs2_processing_block* rs2_gl_create_nv12_decoder(int api_version, rs2_error** error) BEGIN_API_CALL
+{
+    verify_version_compatibility(api_version);
+
+    auto block = std::make_shared<librealsense::gl::nv12_to_rgb>();
+    auto backup = std::make_shared<librealsense::nv12_converter>(RS2_FORMAT_RGB8);
     auto dual = std::make_shared<librealsense::gl::dual_processing_block>();
     dual->add(block);
     dual->add(backup);


### PR DESCRIPTION
## Summary
- Implement working GLSL fragment shader for M420 format (was previously throwing "cannot be rendered with GLSL yet")
- Add new NV12 GLSL renderer with full pipeline: shader, C/C++ API, dual processing block with CPU fallback
- Add M420 and NV12 rendering cases to the viewer upload path
- Remove M420 and NV12 from the "rendering not supported" list

## Test plan
- [x] Verified NV12 GLSL rendering with platform camera — image displays correctly
- [x] Verified M420 GLSL rendering — image displays correctly
- [x] Confirmed GLSL shader is active by injecting deliberate color change
- [x] Verified CPU fallback works when GLSL for rendering is unchecked
- [x] Build passes on Windows (Debug)

M420 on D585S
<img width="791" height="308" alt="image" src="https://github.com/user-attachments/assets/dd2306da-7680-45e6-afa8-dd58326461cf" />

NV12 on platform camera
<img width="787" height="328" alt="image" src="https://github.com/user-attachments/assets/0cc8c965-e960-4915-a6bf-5de77c3b0a5f" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)