### PR TITLE
Defer hub creation so discovery prints are visible in pytest

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -207,6 +207,9 @@ def pytest_configure(config):
         print(f"-I- Build directory: {repo.build}")
     print(f"-I- {'=' * 80}")
 
+    # Create hub after logging is configured so discovery prints are visible
+    devices.init_hub()
+
     # Query devices early for test parametrization
     try:
         hub_reset = config.getoption("--hub-reset", default=False)

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -43,14 +43,20 @@ from rspy import device_hub
 try:
     import pyrealsense2 as rs
     log.d( rs )
-    hub = device_hub.create() # if there's no hub, this will hold None
     sys.path = sys.path[:-1]  # remove what we added
 except ModuleNotFoundError:
     log.w( 'No pyrealsense2 library is available! Running as if no cameras available...' )
     import sys
     log.d( 'sys.path=', sys.path )
     rs = None
-    hub = None
+
+hub = None
+
+def init_hub():
+    """Create the hub instance. Call after logging is configured so discovery prints are visible."""
+    global hub
+    if hub is None:
+        hub = device_hub.create()
 
 import time
 
@@ -807,6 +813,7 @@ if __name__ == '__main__':
     if args:
         usage()
     try:
+        init_hub()
         if hub:
             if not hub.is_connected():
                 hub.connect()

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -43,7 +43,6 @@ from rspy import device_hub
 try:
     import pyrealsense2 as rs
     log.d( rs )
-    sys.path = sys.path[:-1]  # remove what we added
 except ModuleNotFoundError:
     log.w( 'No pyrealsense2 library is available! Running as if no cameras available...' )
     import sys
@@ -57,6 +56,7 @@ def init_hub():
     global hub
     if hub is None:
         hub = device_hub.create()
+        sys.path = sys.path[:-1]  # remove what we added (pyrs_dir)
 
 import time
 

--- a/unit-tests/py/rspy/devices.py
+++ b/unit-tests/py/rspy/devices.py
@@ -50,13 +50,17 @@ except ModuleNotFoundError:
     rs = None
 
 hub = None
+_hub_attempted = False
 
 def init_hub():
     """Create the hub instance. Call after logging is configured so discovery prints are visible."""
-    global hub
-    if hub is None:
-        hub = device_hub.create()
-        sys.path = sys.path[:-1]  # remove what we added (pyrs_dir)
+    global hub, _hub_attempted
+    if _hub_attempted:
+        return
+    _hub_attempted = True
+    hub = device_hub.create()
+    if pyrs_dir in sys.path:
+        sys.path.remove( pyrs_dir )
 
 import time
 
@@ -252,6 +256,7 @@ def query( monitor_changes=True, hub_reset=False, recycle_ports=True, disable_dd
     global rs
     if not rs:
         return
+    init_hub()
     #
     # Before we can start a context and query devices, we need to enable all the ports
     # on the hub, if any:
@@ -873,6 +878,7 @@ if __name__ == '__main__':
             hub.recycle_ports()
     finally:
         # Disconnect from the hub -- if we don't it might crash on Linux...
-        hub.disconnect()
+        if hub:
+            hub.disconnect()
 
 

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -544,6 +544,7 @@ try:
         if pyrs:
             sys.path.insert( 1, pyrs_path )  # Make sure we pick up the right pyrealsense2!
         from rspy import devices
+        devices.init_hub()
         register_signal_handlers(close_hubs)
         disable_dds = "dds" not in context
         devices.query( hub_reset = hub_reset, disable_dds = disable_dds, rslog = rslog ) #resets the device


### PR DESCRIPTION
## Summary
- Hub discovery (`device_hub.create()`) was running at `devices.py` import time, before pytest's logging was configured — so the debug prints (Acroname, YKUSH, UniFi discovery, CombinedHub port mapping) were swallowed by pytest's stdout capture
- Moved hub creation into an explicit `init_hub()` function called after logging is ready
- Both pytest (`conftest.py`) and the legacy runner (`run-unit-tests.py`) now call `devices.init_hub()` before using the hub

Motvation was to see the hub prints at the start of pytest like we see it for run-unit-tests.py
## Test plan
- [x] `python -m pytest --debug --collect-only` — hub discovery prints now visible
- [x] `python run-unit-tests.py --help` — loads without errors
- [x] Jenkins CI build to verify full output on a machine with actual hubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)