### PR TITLE
Fix --exclude-device to support space-separated values and absent product types

### DIFF
--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -77,13 +77,15 @@ def pytest_addoption(parser):
         "--device",
         action="append",
         default=[],
-        help="Include only devices matching pattern (e.g., --device D455). Can be used multiple times."
+        help="Include only devices matching pattern (e.g., --device D455). "
+             "Can be used multiple times or with a space-separated value (--device 'D455 D435')."
     )
     group.addoption(
         "--exclude-device",
         action="append",
         default=[],
-        help="Exclude devices matching pattern (e.g., --exclude-device D455). Can be used multiple times."
+        help="Exclude devices matching pattern (e.g., --exclude-device D455). "
+             "Can be used multiple times or with a space-separated value (--exclude-device 'D555 D585S')."
     )
     group.addoption(
         "--context",

--- a/unit-tests/conftest.py
+++ b/unit-tests/conftest.py
@@ -225,6 +225,14 @@ def pytest_configure(config):
         print(f"-I- Build directory: {repo.build}")
     print(f"-I- {'=' * 80}")
 
+    # Echo CLI device filters once (' '.join handles both repeated-flag and space-separated forms)
+    exclude_list = config.getoption("--exclude-device", default=[])
+    if exclude_list:
+        print(f"-D- excluding devices: {' '.join(exclude_list)}")
+    include_list = config.getoption("--device", default=[])
+    if include_list:
+        print(f"-D- including only devices: {' '.join(include_list)}")
+
     # Query devices early for test parametrization
     try:
         hub_reset = config.getoption("--hub-reset", default=False)

--- a/unit-tests/infra-tests/test_e2e_cli_options.py
+++ b/unit-tests/infra-tests/test_e2e_cli_options.py
@@ -110,6 +110,18 @@ class TestCliOptionsRegistered:
                                "--exclude-device", "D455", "--exclude-device", "D435")
         assert_outcomes(out, passed=1)  # only D401 remains
 
+    def test_exclude_device_space_separated(self):
+        """--exclude-device 'D455 D435' (single flag, space-separated) — Jenkins TEST_EXCLUDE_DEVICES form."""
+        rc, out, *_ = run_e2e("pytest-cli.py", "-k", "test_multi_exclude",
+                               "--exclude-device", "D455 D435")
+        assert_outcomes(out, passed=1)  # only D401 remains
+
+    def test_device_space_separated(self):
+        """--device 'D455 D435' (single flag, space-separated) must include both devices."""
+        rc, out, *_ = run_e2e("pytest-cli.py", "-k", "test_multi_include",
+                               "--device", "D455 D435")
+        assert_outcomes(out, passed=2)
+
     def test_device_and_exclude_combined(self):
         """--device and --exclude-device can be combined."""
         rc, out, *_ = run_e2e("pytest-cli.py", "-k", "test_combined",

--- a/unit-tests/py/rspy/pytest/device_helpers.py
+++ b/unit-tests/py/rspy/pytest/device_helpers.py
@@ -11,6 +11,19 @@ from rspy import devices
 log = logging.getLogger('librealsense')
 
 
+def split_cli_patterns(patterns):
+    """Flatten a list of patterns by splitting each entry on whitespace.
+
+    Supports both repeated flags (``--exclude-device D555 --exclude-device D585S``)
+    and a single flag with a space-separated value (``--exclude-device 'D555 D585S'``),
+    matching the legacy run-unit-tests.py behavior.
+    """
+    out = []
+    for p in patterns or []:
+        out.extend(p.split())
+    return out
+
+
 def find_matching_devices(device_markers, each=True, cli_includes=None, cli_excludes=None):
     """Resolve device markers + CLI filters into a list of matching serial numbers.
 
@@ -21,10 +34,9 @@ def find_matching_devices(device_markers, each=True, cli_includes=None, cli_excl
     matching_sns = []
     had_candidates = False
 
-    if cli_includes is None:
-        cli_includes = []
-    if cli_excludes is None:
-        cli_excludes = []
+    # Flatten whitespace-separated entries so "D555 D585S" works as well as repeated flags
+    cli_includes = split_cli_patterns(cli_includes)
+    cli_excludes = split_cli_patterns(cli_excludes)
 
     # Resolve exclusion patterns (markers + CLI) to a set of excluded serial numbers
     exclude_patterns = []
@@ -87,14 +99,14 @@ def resolve_device_each_serials(metafunc):
     # Resolve exclusion patterns (markers + CLI) to a set of excluded serial numbers
     exclude_markers = [m for m in metafunc.definition.iter_markers("device_exclude")]
     exclude_patterns = [m.args[0] for m in exclude_markers if m.args]
-    cli_excludes = metafunc.config.getoption("--exclude-device", default=[])
+    cli_excludes = split_cli_patterns(metafunc.config.getoption("--exclude-device", default=[]))
     exclude_patterns.extend(cli_excludes)
     excluded_sns = set()
     for pattern in exclude_patterns:
         excluded_sns.update(devices.by_spec(pattern, []))
 
     # Resolve CLI --device includes to a set of allowed serial numbers (None = no filter)
-    cli_includes = metafunc.config.getoption("--device", default=[])
+    cli_includes = split_cli_patterns(metafunc.config.getoption("--device", default=[]))
     included_sns = None
     if cli_includes:
         included_sns = set()

--- a/unit-tests/run-unit-tests.py
+++ b/unit-tests/run-unit-tests.py
@@ -55,8 +55,10 @@ def usage():
     print( '        --repeat <#>         Repeat each test <#> times' )
     print( '        --retry <#>          Retry each test <#> times (unless test specified more)' )
     print( '        --config <>          Ignore test configurations; use the one provided' )
-    print( '        --device <>          Run only on the specified devices; ignore any test that does not match (implies --live)' )
-    print( '        --exclude-device <>  Exclude the specified devices from testing (space-separated list)' )
+    print( '        --device <>          Run only on the specified devices; ignore any test that does not match (implies --live).' )
+    print( '                             Can be repeated or given a space-separated list, e.g. --device "D455 D435".' )
+    print( '        --exclude-device <>  Exclude the specified devices from testing.' )
+    print( '                             Can be repeated or given a space-separated list, e.g. --exclude-device "D555 D585S".' )
     print( '        --no-reset           Do not try to reset any devices, with or without a hub' )
     print( '        --hub-reset          If a hub is available, reset the hub itself' )
     print( '        --custom-fw-d400          If custom fw provided flash it if its different that the current fw installed' )
@@ -155,9 +157,13 @@ for opt, arg in opts:
             log.e( "--device and --not-live are mutually exclusive" )
             usage()
         only_live = True
-        device_set = arg.split()
+        if device_set is None:
+            device_set = []
+        device_set.extend( arg.split() )
     elif opt == '--exclude-device':
-        exclude_device_set = arg.split()
+        if exclude_device_set is None:
+            exclude_device_set = []
+        exclude_device_set.extend( arg.split() )
     elif opt == '--no-reset':
         no_reset = True
     elif opt == '--hub-reset':
@@ -578,27 +584,20 @@ try:
         #
         if exclude_device_set is not None:
             excluded_sns = set()  # convert the list of exclude specs to a list of serial numbers
-            ignored_list = list()
             for spec in exclude_device_set:
-                excluded_devices = [sn for sn in devices.by_spec( spec, ignored_list )]
-                excluded_sns.update( excluded_devices )
-            
-            if excluded_sns:
-                log.d( f'excluding devices: {serial_numbers_to_string( excluded_sns )}' )
-                if device_set is not None:
-                    # Remove excluded devices from the included device set
-                    device_set = device_set - excluded_sns
-                    if not device_set:
-                        log.f( 'All specified devices were excluded; no devices left to test' )
-                    log.d( f'final device set after exclusions: {serial_numbers_to_string( device_set )}' )
-                else:
-                    # If no device_set was specified, we need to discover all devices and exclude the specified ones
-                    all_devices = set(devices.all())
-                    device_set = all_devices - excluded_sns
-                    if not device_set:
-                        log.f( 'All discovered devices were excluded; no devices left to test' )
-                    else:
-                        log.d( f'using all devices except excluded ones: {serial_numbers_to_string( device_set )}' )
+                excluded_sns.update( devices.by_spec( spec, [] ) )
+            log.d( f'excluding devices: {serial_numbers_to_string( excluded_sns ) if excluded_sns else "(none connected match " + str(exclude_device_set) + ")"}' )
+
+            # Always narrow device_set to "connected minus excluded" — even when no connected device
+            # matches the exclude pattern. This makes `inclusions` truthy in devices.by_configuration,
+            # so configurations requiring an excluded product type are silently ignored instead of
+            # erroring with "no device matches configuration".
+            base = device_set if device_set is not None else set(devices.all())
+            if base:
+                device_set = base - excluded_sns
+                if not device_set:
+                    log.f( 'All devices were excluded; no devices left to test' )
+                log.d( f'using devices: {serial_numbers_to_string( device_set )}' )
         #
         log.progress()
     #


### PR DESCRIPTION
## Summary

`--exclude-device 'D555 D585S'` (the `TEST_EXCLUDE_DEVICES` form Jenkins uses) stopped working after the pytest migration, and on Windows it produced spurious `-E- no device matches configuration` errors for the excluded product types. Two fixes:

1. **Space-separated values**: Both `run-unit-tests.py` and the pytest `conftest.py` now accept either repeated flags (`--exclude-device D555 --exclude-device D585S`) or a single space-separated value (`--exclude-device 'D555 D585S'`), matching legacy behavior.
2. **Absent excluded products** (run-unit-tests.py): When `--exclude-device` names a product that isn't connected, the runner now still narrows `device_set` to "connected minus excluded" so configurations referencing those products are silently ignored instead of raising `RuntimeError`. This eliminates the false `-E-` errors seen on the Windows Jenkins agent (rig has only D455/D435, not D555/D585S).

Context: Jenkins build [LRS_libci_pipeline #14927](https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/14927/) on `rsdsk254.ger.corp.intel.com` surfaced both issues.

## Changes

- `unit-tests/conftest.py` — updated help text for `--device` / `--exclude-device` to document both forms.
- `unit-tests/py/rspy/pytest/device_helpers.py` — added `split_cli_patterns()` helper; applied in `find_matching_devices()` and `device_each` metafunc so each CLI entry is whitespace-flattened.
- `unit-tests/run-unit-tests.py` — `--device`/`--exclude-device` now accumulate across repeated flags + still space-split each value. Exclusion block simplified to always narrow `device_set` to "connected minus excluded" (fixes Windows `-E-` false errors).
- `unit-tests/infra-tests/test_e2e_cli_options.py` — added `test_exclude_device_space_separated` and `test_device_space_separated` e2e regression tests that reproduce the Jenkins invocation shape.

## Test plan

- [x] `pytest unit-tests/infra-tests/test_e2e_cli_options.py` — all 17 tests pass, including the two new ones.
- [x] `pytest unit-tests/infra-tests/test_device_helpers.py` — existing 10 tests pass.
- [x] Trigger Jenkins build with `TEST_EXCLUDE_DEVICES="D555 D585S"` on Windows agent; verify no `-E- no device matches configuration "D555"` / `"D585S"` in log and build reaches unit-test stage cleanly.
- [x] Trigger same on Linux agent; verify D585S is excluded (existing behavior preserved) with clean `-D- excluding devices: D585S_...` / `-D- using devices: ...` log lines.

reference build that used the --exclude-device flag: https://rsjenkins.realsenseai.com/job/LRS_libci_pipeline/14940/