### PR TITLE
fix(test-eth-config): restore link.timeout after version-5 validation tests

### DIFF
--- a/unit-tests/live/config/test-eth-config.py
+++ b/unit-tests/live/config/test-eth-config.py
@@ -64,6 +64,7 @@ with test.closure("Test link timeout configuration"):
             test.check_exception( e, ValueError, "Link timeout must be divisible by 100. Current 2345" )
         else:
             test.unreachable()
+    new_config.link.timeout = orig_config.link.timeout # Restore field that might fail other tests, depending header version.
 
 with test.closure("Test MTU configuration"):
     new_config.link.mtu = 4000


### PR DESCRIPTION
## Problem

`test-eth-config.py` fails on three tests after PR [soc-rs-soc-io-drivers#172](https://github.com/RealSenseAI-Internal/soc-rs-soc-io-drivers/pull/172) bumps `ETH_CONFIG_VERSION` from 4 → 5:

- **Test MTU configuration**  
- **Test transmission delay configuration**  
- **Test UDP TTL configuration**  

All fail with:
```
ValueError: Link timeout must be divisible by 100. Current 2345
```

## Root Cause

The `Test link timeout configuration` closure, when `header.version >= 5`, tests invalid timeout values including `2345`. After each `set_eth_config()` call raises `ValueError`, the exception path is caught correctly—but `new_config.link.timeout` is **left at 2345** (never restored).

Previously this code path was unreachable (`header.version` was 4), so the bug was dormant. With version 5, the block is now executed, leaving the config object in an invalid state for all subsequent closures.

Every later closure calls `set_eth_config(new_config)` → `build_command()` → `validate()`, which rejects the stale invalid `link.timeout` before reaching the field each test actually changes.

## Fix

Add a restore line at the end of the link timeout closure, consistent with the pattern used by MTU, transmission\_delay, and udp\_ttl closures:

```python
new_config.link.timeout = orig_config.link.timeout  # Restore field that might fail other tests, depending header version.
```

Note: This is a latent bug in the test, not in the firmware or the io-drivers PR itself.